### PR TITLE
A scheduler can be authorized on its own name, on the API and on the dashboard

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -793,11 +793,16 @@ puts it correctly: allowing users to define whatever job they want "effectively 
 all sorts of vulnerabilities comparable/equivalent to Command Injection Attacks as defined by OWASP
 and MITRE". Offer a fixed set of job types and validate their parameters.
 
-The same caution applies to the management surfaces. The dashboard has a single authorization policy
-and a single read-only flag, and 4.x's HTTP API serves every scheduler in the container behind one
-uniformly applied policy. There is no per-scheduler policy; if different people should reach
-different schedulers, enforce that outside Quartz.NET. See
-[Tenancy Patterns](tenancy-patterns.md#what-quartz-net-does-not-give-you).
+The same caution applies to the management surfaces. On 3.x the dashboard has a single authorization
+policy and a single read-only flag, and there is no per-scheduler policy: if different people should
+reach different schedulers, enforce that outside Quartz.NET. On 4.x both surfaces take a
+`SchedulerAuthorizationPolicy` — `QuartzDashboardOptions` and `QuartzHttpApiOptions` — evaluated per
+request against a `SchedulerResource` naming the scheduler, so one
+`AuthorizationHandler<TRequirement, SchedulerResource>` holds each caller to its own scheduler. What
+a caller may *do* to the scheduler it reaches is still process-wide, through the dashboard's read-only
+flag. See
+[Authorizing a tenant on its own scheduler](quartz-4.x/multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler)
+and [Tenancy Patterns](tenancy-patterns.md#what-quartz-net-does-not-give-you).
 
 ## What to watch
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6230,6 +6230,36 @@ says nothing about a scheduler that has gone quiet — it keeps whatever it last
 shows executions from an arbitrary distance in the past. The window is measured on the scheduler's
 `TimeProvider` and applied when history is read as well as when it is written.
 
+## A scheduler can be authorized on its own name
+
+Both management surfaces served every scheduler in the process behind one uniformly applied policy, so a
+tenant who could reach one scheduler could reach all of them. Each now takes a policy of its own that is
+evaluated per request against the scheduler the request is for.
+
+| 4.0 preview | 4.0 |
+|---|---|
+| — | `Quartz.SchedulerResource(string SchedulerName)`, in `Quartz.AspNetCore` (new) |
+| — | `QuartzHttpApiOptions.SchedulerAuthorizationPolicy` (new, `null`) |
+| — | `QuartzDashboardOptions.SchedulerAuthorizationPolicy` (new, `null`) |
+
+Nothing is removed and nothing changes for an application that leaves them null: the API is still whatever
+`RequireAuthorization(…)` the application put on the mapped group, and the dashboard is still whatever
+`QuartzDashboardOptions.AuthorizationPolicy` says.
+
+Set one and Quartz asks
+`IAuthorizationService.AuthorizeAsync(user, new SchedulerResource(name), policy)` — ASP.NET Core's own
+resource-based authorization, so the application writes one
+`AuthorizationHandler<TRequirement, SchedulerResource>` and there is no Quartz callback type or claim-name
+convention to learn. The API answers `403` with problem details, decided before the scheduler is looked up
+so that a `404` only ever answers a name the caller was allowed to ask about, and filters
+`GET {ApiPath}/schedulers` to what the caller may act on. The dashboard filters its scheduler picker and
+its Schedulers page, renders a *not authorized* frame instead of a page for a scheduler the visitor fails
+for, and refuses the live-events hub group for it. Setting either option in a container with no
+authorization services is refused at startup.
+
+See [Authorizing a tenant on its own scheduler](multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler)
+for the handler and the registration.
+
 ## `CheckExists` is `Exists`
 
 Both overloads, on `IScheduler` and `IJobStore`:

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -440,7 +440,10 @@ anonymous caller gets whatever the policy says, which is a `403` when it refuses
 passes for; a page opened on one they do not renders a "not authorized" frame and reads nothing about that
 scheduler; and the live-events hub refuses to subscribe a connection to its group. It composes with what
 was already there: `AuthorizationPolicy` decides who reaches the dashboard at all, this decides which
-schedulers they see once they are in, and `ReadOnly` still decides what anyone may change.
+schedulers they see once they are in, and `ReadOnly` still decides what anyone may change. That frame is
+the dashboard's own layout, so read
+[Standalone hosting is where this applies today](packages/dashboard.md#one-scheduler-at-a-time) before
+relying on it in an application that hosts the components under a layout of its own.
 
 Null — the default — is the behaviour every earlier release had, so nothing changes for an application
 that does not set it. Setting it in a container with no authorization services fails at startup rather

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -376,6 +376,77 @@ builder.Services.AddQuartz("acme", q => q.AddQuartzHealthChecks(o => o.Tags.Add(
 
 Called on `IServiceCollection` instead, it checks the default scheduler only.
 
+### Authorizing a tenant on its own scheduler
+
+`QuartzHttpApiOptions.SchedulerAuthorizationPolicy` and `QuartzDashboardOptions.SchedulerAuthorizationPolicy`
+each name a policy that is evaluated once per request against the scheduler that request is for. Quartz
+supplies the resource — a `SchedulerResource` carrying the scheduler's name — and the application writes
+the handler. This is ASP.NET Core's own resource-based authorization rather than anything Quartz invented,
+so there is no callback type to implement and no claim name Quartz decides for you:
+
+<!-- snippet: sample_tenancy_scheduler_authorization_handler -->
+```csharp
+// What "may act on this scheduler" means is the application's to decide, so the requirement itself
+// says nothing and the handler says everything.
+public sealed class SchedulerOwnerRequirement : IAuthorizationRequirement;
+
+public sealed class SchedulerOwnerHandler : AuthorizationHandler<SchedulerOwnerRequirement, SchedulerResource>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        SchedulerOwnerRequirement requirement,
+        SchedulerResource resource)
+    {
+        string? tenant = context.User.FindFirst("tenant")?.Value;
+
+        // Scheduler names are compared ignoring case everywhere else in Quartz, so compare them that
+        // way here too - otherwise "Acme" and "acme" are the same scheduler and different tenants.
+        if (string.Equals(tenant, resource.SchedulerName, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+```
+<!-- endSnippet -->
+
+Register the policy, the handler, and the two options — one handler answers for both surfaces:
+
+<!-- snippet: sample_tenancy_scheduler_authorization -->
+```csharp
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("SchedulerOwner", policy => policy.AddRequirements(new SchedulerOwnerRequirement()));
+
+builder.Services.AddSingleton<IAuthorizationHandler, SchedulerOwnerHandler>();
+
+// One policy, one handler, both surfaces: the API answers 403 for a scheduler the caller fails
+// for, and the dashboard offers them only the schedulers they pass for.
+builder.Services.AddQuartzHttpApi(options => options.SchedulerAuthorizationPolicy = "SchedulerOwner");
+builder.Services.AddQuartzDashboard(options => options.SchedulerAuthorizationPolicy = "SchedulerOwner");
+```
+<!-- endSnippet -->
+
+**On the HTTP API**, every route that carries `{schedulerName}` is checked before the scheduler is looked
+up, so a caller who fails is answered `403` with problem details and cannot tell "not yours" from "no such
+scheduler": a `404` only ever answers a name the caller was allowed to ask about. `GET {ApiPath}/schedulers`
+names no scheduler, so it filters itself — a tenant is told about its own schedulers and learns nothing
+about the others, registrations included. The check is authorization and never authentication: an
+anonymous caller gets whatever the policy says, which is a `403` when it refuses, so keep
+`RequireAuthorization()` on the mapped group if anonymous callers should be challenged with a `401` first.
+
+**On the dashboard**, the scheduler picker and the Schedulers page offer only the schedulers the visitor
+passes for; a page opened on one they do not renders a "not authorized" frame and reads nothing about that
+scheduler; and the live-events hub refuses to subscribe a connection to its group. It composes with what
+was already there: `AuthorizationPolicy` decides who reaches the dashboard at all, this decides which
+schedulers they see once they are in, and `ReadOnly` still decides what anyone may change.
+
+Null — the default — is the behaviour every earlier release had, so nothing changes for an application
+that does not set it. Setting it in a container with no authorization services fails at startup rather
+than quietly enforcing nothing; a policy name no `IAuthorizationPolicyProvider` knows fails the way it
+does everywhere else in ASP.NET Core, at the first request that names it.
+
 ## Group per tenant
 
 One scheduler; the tenant is the group half of every key.
@@ -742,13 +813,14 @@ calls. It is worth asking whether concurrency is what you actually meant: "at mo
 jobs at once" is usually the real requirement behind "100 an hour", and it is the one Quartz can enforce
 honestly.
 
-**HTTP API and dashboard authorization is per process, all or nothing.** One `MapQuartzHttpApi` serves
-every scheduler in the container, with the scheduler named in the route
-(`{apiPath}/schedulers/{schedulerName}/…`), and `RequireAuthorization(...)` applies uniformly to all of
-it. The dashboard has a single `AuthorizationPolicy` and a single `ReadOnly` flag. There is no
-per-scheduler policy and no scheduler-name claim check. If tenants must reach their own scheduler and
-not each other's, enforce that **outside** Quartz — a process per tenant, or a proxy or middleware that
-authorizes on the `{schedulerName}` route segment.
+**Read-only is per process, and there is no per-operation policy.** A tenant *can* be held to its own
+scheduler on both surfaces — see
+[Authorizing a tenant on its own scheduler](#authorizing-a-tenant-on-its-own-scheduler) — but what a
+tenant may *do* to the scheduler it reaches is still one setting for the whole process: the dashboard's
+`ReadOnly` flag. "acme may look, globex may act" is not something either surface expresses, and neither
+is "this tenant may pause but not delete". The resource-based shape leaves room for it — the policy is
+evaluated against a `SchedulerResource`, and an operation requirement could join it later without another
+option — but that is not built.
 
 **Tenants cannot be onboarded at runtime *through the DI path*.** Schedulers are registered against
 `IServiceCollection`, which is closed once the container is built, and the hosted service enumerates

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -59,7 +59,7 @@ the dashboard needs it: the pages read the schedulers in this process directly.
 
 ## Options
 
-`AddQuartzDashboard(options => …)` takes five settings, and none of them points the dashboard at a
+`AddQuartzDashboard(options => …)` takes six settings, and none of them points the dashboard at a
 scheduler — **the dashboard renders the schedulers registered in its own application**, reading them
 through the `IQuartzApiClient` in the container rather than over a network.
 
@@ -67,6 +67,7 @@ through the `IQuartzApiClient` in the container rather than over a network.
 |---|---|---|
 | `DashboardPath` | `/quartz` | The base path the UI is served from — see [Hosting under a custom path](#hosting-under-a-custom-path) |
 | `AuthorizationPolicy` | none | The policy applied to the dashboard pages, hub, circuit and assets — see [Policy and role-based authorization](#policy-and-role-based-authorization) |
+| `SchedulerAuthorizationPolicy` | none | The policy each *scheduler* is held to, evaluated against that scheduler — see [One scheduler at a time](#one-scheduler-at-a-time) |
 | `ReadOnly` | `false` | Hides every mutating action: no pause, resume, trigger-now, reschedule, unschedule or delete |
 | `HistoryRetention` | 24 hours | How far back the dashboard's own history store keeps executions and misfires — see [Execution history and misfires](#execution-history-and-misfires) |
 | `HistoryMaxEntriesPerScheduler` | `2000` | How many executions and how many misfires it keeps per scheduler, oldest dropped first |
@@ -308,6 +309,28 @@ Assets served by the host's `app.MapStaticAssets()` (the .NET 9/10 default) and 
 
 With a custom `DashboardPath` this caveat does not apply to the dashboard itself: the framework script and the dashboard static assets are then served under the dashboard path by dashboard-owned endpoints that carry the dashboard's authorization metadata.
 :::
+
+### One scheduler at a time
+
+`AuthorizationPolicy` decides who reaches the dashboard; it says nothing about *which* of the schedulers
+in the process they then see, and by default they see all of them. Name a policy in
+`SchedulerAuthorizationPolicy` and each scheduler is authorized on its own, evaluated as
+`IAuthorizationService.AuthorizeAsync(user, new SchedulerResource(name), policy)`:
+
+- the scheduler picker and the **Schedulers** page offer only the schedulers the visitor passes for;
+- a page opened on one they do not renders a *not authorized* frame, and reads nothing about that
+  scheduler — the page is never created, so no `IQuartzApiClient` call is made on their behalf;
+- the live-events hub refuses a connection's request to join that scheduler's group.
+
+The three policies compose rather than replace one another: `AuthorizationPolicy` decides who is in,
+`SchedulerAuthorizationPolicy` decides which schedulers they see, and `ReadOnly` decides what anyone may
+change. `QuartzHttpApiOptions.SchedulerAuthorizationPolicy` takes the same policy against the same
+resource, so one `AuthorizationHandler<TRequirement, SchedulerResource>` answers for the dashboard and the
+HTTP API together. The worked example is in
+[Multi-tenancy](../multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler).
+
+Leaving it unset is the behaviour every earlier release had: whoever passes `AuthorizationPolicy` sees
+every scheduler in the process.
 
 ### API key or custom authorization checks
 

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -329,6 +329,17 @@ resource, so one `AuthorizationHandler<TRequirement, SchedulerResource>` answers
 HTTP API together. The worked example is in
 [Multi-tenancy](../multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler).
 
+::: warning Standalone hosting is where this applies today
+The *not authorized* frame is drawn by the dashboard's own layout, which is in the render tree only when
+the dashboard owns its Blazor root — the `MapQuartzDashboard()` overloads that take no components builder.
+Every scheduler listing the dashboard writes is filtered in both hosting modes, and so is the hub
+subscription, so nothing in the dashboard itself will ever point a visitor at a scheduler they fail the
+policy for. But when the components are hosted under an application's own layout
+([Integrating with an existing Blazor Server app](#integrating-with-an-existing-blazor-server-app)) the
+frame is not rendered, so an application that routes a visitor to a scheduler by its own means is
+responsible for not routing them to one they fail for.
+:::
+
 Leaving it unset is the behaviour every earlier release had: whoever passes `AuthorizationPolicy` sees
 every scheduler in the process.
 

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -453,13 +453,34 @@ a total outage.
 
 `QuartzHttpApiOptions` supports:
 
-- `ApiPath` (default: `/quartz-api`) - base path for all API endpoints
-- `IncludeStackTraceInProblemDetails` (default: `false`) - includes stack traces in RFC 7807 error payloads
+| Option | Default | What it does |
+|---|---|---|
+| `ApiPath` | `/quartz-api` | The base path every endpoint is served under — see [Where the API is served](#where-the-api-is-served) |
+| `IncludeStackTraceInProblemDetails` | `false` | Adds `Quartz-ExceptionStackTrace` to RFC 7807 error payloads |
+| `SchedulerAuthorizationPolicy` | none | The policy every route that names a scheduler is held to, evaluated against that scheduler — see [Authorizing per scheduler](#authorizing-per-scheduler) |
 
 There is one set of these per process, not one per scheduler: `ApiPath` describes the endpoints, and
 every scheduler is reached under it. Calling `services.AddQuartzHttpApi(configure)` twice therefore
 configures the same options twice, and the callback registered last wins for any setting both of them
 touch.
+
+### Authorizing per scheduler
+
+`RequireAuthorization(...)` on what `MapQuartzHttpApi()` returns covers the whole API uniformly, which is
+the right shape when everyone who reaches the API may reach every scheduler in the process. When they may
+not, name a policy in `SchedulerAuthorizationPolicy` and it is evaluated per request as
+`IAuthorizationService.AuthorizeAsync(user, new SchedulerResource(name), policy)`, against the
+`{schedulerName}` the route carries. A caller who fails gets `403` with problem details,
+decided **before** the scheduler is looked up — so a `404` only ever answers a name the caller was allowed
+to ask about — and `GET {ApiPath}/schedulers` is filtered to the schedulers they may act on. The
+application writes one `AuthorizationHandler<TRequirement, SchedulerResource>`; Quartz supplies the
+resource and asks. `QuartzDashboardOptions.SchedulerAuthorizationPolicy` takes the same policy against the
+same resource, so one handler answers for both. The worked example, with the handler, is in
+[Multi-tenancy](../multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler).
+
+Setting it in a container with no authorization services fails at startup. The check is authorization and
+never authentication: an anonymous caller gets whatever the policy says, which is a `403` when it refuses,
+so keep `RequireAuthorization()` on the mapped group if they should be challenged with a `401` first.
 
 ## Calling it from .NET
 

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -517,12 +517,17 @@ and resolves what it needs, by key if you like, inside `Execute` is the shape to
 Quartz.NET gives you partitioning, and isolation is your application's job — a tenant id read from
 the firing and threaded through every query, not a boundary the scheduler enforces.
 
-**Dashboard and HTTP API authorization is per process, all or nothing.** The dashboard has a single
-authorization policy and a single read-only flag on both versions, and 4.x's HTTP API serves every
-scheduler in the container behind one uniformly-applied policy, with the scheduler named in the route.
-There is no per-scheduler policy and no scheduler-name claim check. If tenants must reach their own
-scheduler and not each other's, enforce that outside Quartz.NET — a process per tenant, or middleware
-that authorizes on the scheduler-name route segment.
+**On 3.x, dashboard authorization is per process, all or nothing.** One policy, one read-only flag, no
+per-scheduler policy and no scheduler-name claim check. If 3.x tenants must reach their own scheduler and
+not each other's, enforce that outside Quartz.NET — a process per tenant, or middleware that authorizes on
+the scheduler-name route segment.
+
+4.x holds each caller to its own scheduler on both surfaces:
+`QuartzDashboardOptions.SchedulerAuthorizationPolicy` and `QuartzHttpApiOptions.SchedulerAuthorizationPolicy`
+name a policy evaluated per request against a `SchedulerResource` carrying the scheduler's name, so one
+`AuthorizationHandler<TRequirement, SchedulerResource>` covers every route and every page. What a caller
+may *do* to the scheduler it reaches is still process-wide — the dashboard's read-only flag — so
+"this tenant may look, that one may act" remains outside Quartz.NET on either version.
 
 **A shut-down scheduler cannot be restarted.** `Standby()` / `Start()` is the pause-and-resume pair.
 Shutdown is terminal: the scheduler refuses to start again and every other operation throws. You can

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 
 using Quartz.AspNetCore.HttpApi.Util;
 using Quartz.HttpApiContract;
@@ -59,29 +60,43 @@ internal static class SchedulerEndpoints
     /// Lists every scheduler the container knows about, ordered by name.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The registrations rather than the repository: a repository holds the schedulers something has
     /// already built, so a tenant nobody has asked for was invisible here — and the caller could not tell
     /// that from "no such tenant". Such an entry is listed with a null status, and asking for it does not
     /// build it. The repository is still read, for the instance id of the schedulers that do exist.
+    /// </para>
+    /// <para>
+    /// This route names no scheduler, so the endpoint filter has nothing to check and the listing filters
+    /// itself: with <see cref="QuartzHttpApiOptions.SchedulerAuthorizationPolicy" /> set, a caller is told
+    /// about the schedulers they may act on and no others.
+    /// </para>
     /// </remarks>
     [ProducesResponseType(typeof(SchedulerHeaderDto[]), StatusCodes.Status200OK)]
     private static async Task<IResult> GetAllSchedulers(
         EndpointHelper endpointHelper,
+        HttpContext httpContext,
+        IOptions<QuartzHttpApiOptions> apiOptions,
         ISchedulerRegistry schedulerRegistry,
         ISchedulerRepository schedulerRepository,
         CancellationToken cancellationToken = default)
     {
         List<SchedulerRegistration> registrations = await schedulerRegistry.QuerySchedulers(cancellationToken).ConfigureAwait(false);
+        string? policyName = apiOptions.Value.SchedulerAuthorizationPolicy;
 
-        SchedulerHeaderDto[] result = new SchedulerHeaderDto[registrations.Count];
-        for (int i = 0; i < registrations.Count; i++)
+        List<SchedulerHeaderDto> result = new(registrations.Count);
+        foreach (SchedulerRegistration registration in registrations)
         {
-            SchedulerRegistration registration = registrations[i];
+            if (!await SchedulerAuthorization.IsAuthorized(httpContext, policyName, registration.Name, cancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
             IScheduler? scheduler = registration.IsCreated ? schedulerRepository.Lookup(registration.Name) : null;
-            result[i] = SchedulerHeaderDto.Create(registration, scheduler);
+            result.Add(SchedulerHeaderDto.Create(registration, scheduler));
         }
 
-        return endpointHelper.JsonResponse(result);
+        return endpointHelper.JsonResponse(result.ToArray());
     }
 
     [ProducesResponseType(typeof(SchedulerDto), StatusCodes.Status200OK)]

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/QuartzHttpApiOptions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/QuartzHttpApiOptions.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Quartz;
@@ -52,6 +54,28 @@ public sealed class QuartzHttpApiOptions
     /// </summary>
     public bool IncludeStackTraceInProblemDetails { get; set; }
 
+    /// <summary>
+    /// The authorization policy every route that names a scheduler is held to, evaluated against a
+    /// <see cref="SchedulerResource" /> carrying that name. Null — the default — leaves the API as it was:
+    /// whatever <c>RequireAuthorization(…)</c> the application put on the mapped group, applied uniformly
+    /// to every scheduler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set it and each request is checked with
+    /// <c>IAuthorizationService.AuthorizeAsync(user, new SchedulerResource(name), policy)</c> before the
+    /// scheduler is looked up, so a caller who fails cannot tell "no such scheduler" from "not yours": a
+    /// refusal is <c>403</c> with problem details, and a <c>404</c> only ever answers a scheduler the
+    /// caller was allowed to ask about. The scheduler listing is filtered the same way.
+    /// </para>
+    /// <para>
+    /// The check is authorization, never authentication: an anonymous caller gets whatever the policy
+    /// says, which is a <c>403</c> when the policy refuses. Put <c>RequireAuthorization()</c> on the
+    /// mapped group as well to have an anonymous caller challenged with a <c>401</c> first.
+    /// </para>
+    /// </remarks>
+    public string? SchedulerAuthorizationPolicy { get; set; }
+
     internal string TrimmedApiPath => ApiPath.TrimEnd('/');
 
     /// <summary>
@@ -74,12 +98,35 @@ public sealed class QuartzHttpApiOptions
 /// </remarks>
 internal sealed class QuartzHttpApiOptionsValidator : IValidateOptions<QuartzHttpApiOptions>
 {
+    private readonly IServiceProviderIsService? registrations;
+
+    /// <param name="registrations">
+    /// What the container has, used to catch a per-scheduler policy with nothing to evaluate it. The
+    /// default DI container supplies this; a third-party one that does not leaves the check unmade, which
+    /// is why the parameter has a default rather than being required.
+    /// </param>
+    public QuartzHttpApiOptionsValidator(IServiceProviderIsService? registrations = null)
+    {
+        this.registrations = registrations;
+    }
+
     public ValidateOptionsResult Validate(string? name, QuartzHttpApiOptions options)
     {
         if (!QuartzHttpApiOptions.IsRoutableApiPath(options.ApiPath))
         {
             return ValidateOptionsResult.Fail(
                 $"{nameof(QuartzHttpApiOptions.ApiPath)} is required and must start with '/', was '{options.ApiPath}'.");
+        }
+
+        // A policy name with no IAuthorizationService behind it is a security setting that silently does
+        // nothing, which is worse than one that is missing: say so at startup rather than at the first
+        // request that would have been refused.
+        if (!string.IsNullOrWhiteSpace(options.SchedulerAuthorizationPolicy)
+            && registrations?.IsService(typeof(IAuthorizationService)) == false)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(QuartzHttpApiOptions.SchedulerAuthorizationPolicy)} is '{options.SchedulerAuthorizationPolicy}', "
+                + "but the container has no authorization services to evaluate it with - call services.AddAuthorization() and register that policy.");
         }
 
         return ValidateOptionsResult.Success;

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/SchedulerAuthorization.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/SchedulerAuthorization.cs
@@ -1,0 +1,130 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.AspNetCore.HttpApi.Util;
+
+/// <summary>
+/// Holds <see cref="QuartzHttpApiOptions.SchedulerAuthorizationPolicy" /> against the scheduler a request
+/// names.
+/// </summary>
+/// <remarks>
+/// The check is a filter over the whole route rather than a call inside each handler, so it runs before
+/// anything is read: before the scheduler is looked up, and before a request body is bound. That ordering
+/// is the point — a caller who fails the policy gets the same answer whether or not the scheduler exists,
+/// so a <c>404</c> only ever answers a name the caller was allowed to ask about.
+/// </remarks>
+internal static class SchedulerAuthorization
+{
+    /// <summary>
+    /// The route parameter every scheduler-scoped endpoint carries. A route without it — the scheduler
+    /// listing — is about no single scheduler and filters its own answer instead.
+    /// </summary>
+    internal const string SchedulerNameRouteValue = "schedulerName";
+
+    /// <summary>
+    /// Puts <paramref name="policyName" /> in front of the endpoint, when the endpoint names a scheduler.
+    /// </summary>
+    /// <remarks>
+    /// Whether it does is read from the route pattern rather than passed in, so an endpoint added later
+    /// is covered by carrying <c>{schedulerName}</c> like every other one and by nothing else.
+    /// </remarks>
+    public static void RequireSchedulerAuthorization(this RouteHandlerBuilder builder, string policyName)
+    {
+        builder.Add(endpointBuilder =>
+        {
+            if (endpointBuilder is not RouteEndpointBuilder routeEndpointBuilder || !NamesAScheduler(routeEndpointBuilder.RoutePattern))
+            {
+                return;
+            }
+
+            // Metadata rather than ProducesProblem(403) at the map site: the map site does not know
+            // whether the route names a scheduler, and this convention does.
+            endpointBuilder.Metadata.Add(new ProducesResponseTypeMetadata(
+                StatusCodes.Status403Forbidden,
+                typeof(ProblemDetails),
+                ["application/problem+json"]));
+
+            RequestDelegate next = endpointBuilder.RequestDelegate
+                ?? throw new InvalidOperationException($"Endpoint {endpointBuilder.DisplayName} has null RequestDelegate");
+
+            endpointBuilder.RequestDelegate = context => Authorize(context, policyName, next);
+        });
+    }
+
+    private static bool NamesAScheduler(RoutePattern pattern)
+    {
+        foreach (RoutePatternParameterPart parameter in pattern.Parameters)
+        {
+            if (string.Equals(parameter.Name, SchedulerNameRouteValue, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task Authorize(HttpContext context, string policyName, RequestDelegate next)
+    {
+        if (context.Request.RouteValues[SchedulerNameRouteValue] is string schedulerName
+            && !await IsAuthorized(context, policyName, schedulerName).ConfigureAwait(false))
+        {
+            await Forbidden(schedulerName).ExecuteAsync(context).ConfigureAwait(false);
+            return;
+        }
+
+        await next(context).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Whether the request's user may act on <paramref name="schedulerName" />. A null or blank policy is
+    /// the default configuration, where every caller who reached the endpoint may act on every scheduler.
+    /// </summary>
+    public static ValueTask<bool> IsAuthorized(
+        HttpContext context,
+        string? policyName,
+        string schedulerName,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(policyName))
+        {
+            return new ValueTask<bool>(true);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return Evaluate(context, policyName, schedulerName);
+
+        static async ValueTask<bool> Evaluate(HttpContext context, string policyName, string schedulerName)
+        {
+            // Resolved per request rather than injected: IAuthorizationService is transient, and an API
+            // with no policy configured must keep working in a container that has none registered.
+            IAuthorizationService authorizationService = context.RequestServices.GetRequiredService<IAuthorizationService>();
+            AuthorizationResult result = await authorizationService
+                .AuthorizeAsync(context.User, new SchedulerResource(schedulerName), policyName)
+                .ConfigureAwait(false);
+
+            return result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// The refusal, in the problem-details shape every other error the API produces takes.
+    /// </summary>
+    /// <remarks>
+    /// No <c>Quartz-ExceptionType</c>: that member names the exception a failure came from, and a policy
+    /// that said no is a decision rather than a failure. The detail names the scheduler the caller asked
+    /// for, which is the caller's own input, and says nothing about whether it exists.
+    /// </remarks>
+    private static IResult Forbidden(string schedulerName)
+    {
+        return Results.Problem(
+            detail: $"Not authorized for scheduler {schedulerName}",
+            statusCode: StatusCodes.Status403Forbidden);
+    }
+}

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/SchedulerAuthorization.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/SchedulerAuthorization.cs
@@ -59,21 +59,15 @@ internal static class SchedulerAuthorization
 
     private static bool NamesAScheduler(RoutePattern pattern)
     {
-        foreach (RoutePatternParameterPart parameter in pattern.Parameters)
-        {
-            if (string.Equals(parameter.Name, SchedulerNameRouteValue, StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return pattern.Parameters.Any(parameter => string.Equals(parameter.Name, SchedulerNameRouteValue, StringComparison.Ordinal));
     }
 
     private static async Task Authorize(HttpContext context, string policyName, RequestDelegate next)
     {
+        // The request's own token: a caller who has gone away is not one to evaluate a policy for, and
+        // every endpoint behind this filter already abandons its work the same way.
         if (context.Request.RouteValues[SchedulerNameRouteValue] is string schedulerName
-            && !await IsAuthorized(context, policyName, schedulerName).ConfigureAwait(false))
+            && !await IsAuthorized(context, policyName, schedulerName, context.RequestAborted).ConfigureAwait(false))
         {
             await Forbidden(schedulerName).ExecuteAsync(context).ConfigureAwait(false);
             return;

--- a/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
@@ -280,7 +280,20 @@ public static class QuartzAspNetCoreConfigurationExtensions
         var allEndpoints = calendarEndpoints
             .Union(jobEndpoints)
             .Union(schedulerEndpoints)
-            .Union(triggerEndpoints);
+            .Union(triggerEndpoints)
+            .ToArray();
+
+        if (!string.IsNullOrWhiteSpace(options.SchedulerAuthorizationPolicy))
+        {
+            // Applied after the endpoints are built, so that every route added by any of the four groups
+            // is covered by the one rule: a route that carries {schedulerName} is authorized against that
+            // scheduler. The convention reads the pattern, so nothing here has to list which routes those
+            // are. The scheduler listing carries no such parameter and filters its own answer instead.
+            foreach (RouteHandlerBuilder endpoint in allEndpoints)
+            {
+                endpoint.RequireSchedulerAuthorization(options.SchedulerAuthorizationPolicy);
+            }
+        }
 
         return new QuartzApiConventionBuilder(allEndpoints);
     }

--- a/src/Quartz.AspNetCore/SchedulerResource.cs
+++ b/src/Quartz.AspNetCore/SchedulerResource.cs
@@ -1,0 +1,36 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// The scheduler a per-scheduler authorization policy is evaluated against: the resource passed to
+/// <c>IAuthorizationService.AuthorizeAsync(user, resource, policyName)</c> by every HTTP API route and
+/// every dashboard page that names a scheduler.
+/// </summary>
+/// <remarks>
+/// Write an <c>AuthorizationHandler&lt;TRequirement, SchedulerResource&gt;</c> and the same decision
+/// covers both surfaces. <see cref="SchedulerName" /> is the name the caller asked for, spelled as they
+/// spelled it — scheduler lookups compare names ignoring case, so a handler that matches a claim against
+/// it should do the same.
+/// </remarks>
+/// <param name="SchedulerName">The scheduler the request is about.</param>
+public sealed record SchedulerResource(string SchedulerName);

--- a/src/Quartz.Dashboard/Components/Layout/DashboardLayout.razor
+++ b/src/Quartz.Dashboard/Components/Layout/DashboardLayout.razor
@@ -2,7 +2,9 @@
 @using Microsoft.JSInterop
 @using Quartz.Dashboard.Components.Shared
 @using Quartz.Dashboard.Services
+@implements IDisposable
 @inject Quartz.Dashboard.Services.SchedulerState SchedulerState
+@inject Quartz.Dashboard.Services.SchedulerAuthorization Authorization
 @inject Microsoft.JSInterop.IJSRuntime JsRuntime
 
 <HeadContent>
@@ -54,7 +56,21 @@
             </header>
 
             <main class="qz-content" role="main">
-                @Body
+                @* The page frame is where a per-scheduler refusal belongs: a page that is never rendered
+                   never runs its OnInitializedAsync, so nothing about a scheduler the visitor may not see
+                   is read on their behalf. The header above stays, so they can pick one they may. *@
+                @if (_access is SchedulerAccess.Granted)
+                {
+                    @Body
+                }
+                else if (_access is SchedulerAccess.Denied)
+                {
+                    <SchedulerNotAuthorized SchedulerName="@SchedulerState.ActiveSchedulerName" />
+                }
+                else
+                {
+                    <LoadingSpinner />
+                }
             </main>
         </div>
     </div>
@@ -65,11 +81,60 @@
     private const string themePreferenceKey = "qz_theme";
     private const string timeZonePreferenceKey = "qz_tz";
 
+    /// <summary>
+    /// What the frame knows about the visitor's right to the scheduler the dashboard is currently about.
+    /// </summary>
+    private enum SchedulerAccess
+    {
+        /// <summary>The policy has not answered yet, and until it does the page is not rendered.</summary>
+        Unknown,
+        Granted,
+        Denied
+    }
+
+    private SchedulerAccess _access = SchedulerAccess.Unknown;
+
     private readonly IReadOnlyList<TimeZoneInfo> _timeZones = TimeZoneInfo
         .GetSystemTimeZones()
         .OrderBy(static tz => tz.Id, StringComparer.Ordinal)
         .ToList();
     private bool _preferencesLoaded;
+
+    protected override async Task OnInitializedAsync()
+    {
+        SchedulerState.OnSchedulerChanged += OnSchedulerChanged;
+
+        // Awaited before the first render, so a dashboard with no per-scheduler policy — where this
+        // completes synchronously — renders its page exactly as it always did, with no intermediate frame.
+        await UpdateAccessAsync();
+    }
+
+    /// <summary>
+    /// Re-asks the policy about whatever the dashboard is now about. The previous answer stands while the
+    /// new one is being fetched: dropping back to <see cref="SchedulerAccess.Unknown" /> would tear the
+    /// page down and build it again on every switch between two schedulers the visitor may see.
+    /// </summary>
+    private async Task UpdateAccessAsync()
+    {
+        _access = await Authorization.IsAuthorized(SchedulerState.ActiveSchedulerName)
+            ? SchedulerAccess.Granted
+            : SchedulerAccess.Denied;
+    }
+
+    private async void OnSchedulerChanged(object? sender, EventArgs e)
+    {
+        SchedulerAccess previous = _access;
+        await UpdateAccessAsync();
+        if (previous != _access)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public void Dispose()
+    {
+        SchedulerState.OnSchedulerChanged -= OnSchedulerChanged;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
+++ b/src/Quartz.Dashboard/Components/Layout/SchedulerSelector.razor
@@ -1,6 +1,7 @@
 @using Quartz.Dashboard.Services
 @inject Quartz.Dashboard.Services.SchedulerState SchedulerState
 @inject Quartz.Dashboard.Services.IQuartzApiClient ApiClient
+@inject Quartz.Dashboard.Services.SchedulerAuthorization Authorization
 @implements IDisposable
 
 <div class="qz-scheduler-selector">
@@ -62,7 +63,9 @@
             System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto> schedulers =
                 await ApiClient.GetSchedulers();
 
-            SchedulerState.AvailableSchedulers = schedulers.AsReadOnly();
+            // Filtered before anything is offered: a name in this list is a name the visitor can select,
+            // and the one thing a per-scheduler policy has to prevent is reaching another tenant's.
+            SchedulerState.AvailableSchedulers = (await Authorization.Filter(schedulers)).AsReadOnly();
 
             if (SchedulerState.ActiveSchedulerName is null)
             {
@@ -100,6 +103,15 @@
         if (SchedulerState.Find(SchedulerState.ActiveSchedulerName) is { IsCreated: false })
         {
             _statusLabel = "Not created";
+            _schedulerStatus = null;
+            return;
+        }
+
+        // A scheduler the visitor may not see is not asked for its status either; the status read is the
+        // one call this component makes that is about a single scheduler rather than about the listing.
+        if (!await Authorization.IsAuthorized(SchedulerState.ActiveSchedulerName))
+        {
+            _statusLabel = "Not authorized";
             _schedulerStatus = null;
             return;
         }

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -7,6 +7,7 @@
 @implements IDisposable
 @inject IQuartzApiClient Api
 @inject SchedulerState Scheduler
+@inject SchedulerAuthorization Authorization
 @inject IOptions<QuartzDashboardOptions> Options
 @inject ToastService Toasts
 @inject DashboardActionLogService ActionLog
@@ -503,7 +504,12 @@
 
     private async Task RefreshSchedulersAsync(string? preferredSchedulerName)
     {
-        List<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
+        List<SchedulerHeaderDto> registered = await Api.GetSchedulers();
+
+        // Filtered like every other listing the dashboard writes into SchedulerState. This one decides
+        // which scheduler the page moves to next, so an unfiltered list here would hand a visitor a
+        // scheduler they may not see - and the read below would go straight to it.
+        List<SchedulerHeaderDto> schedulers = await Authorization.Filter(registered);
         Scheduler.AvailableSchedulers = schedulers.AsReadOnly();
 
         // The preferred scheduler has to still exist, not merely still be registered: shutting one down

--- a/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
@@ -5,6 +5,7 @@
 @using Quartz.Dashboard.Services
 @inject IQuartzApiClient Api
 @inject SchedulerState Scheduler
+@inject SchedulerAuthorization Authorization
 @inject IOptions<QuartzDashboardOptions> Options
 @inject NavigationManager Navigation
 
@@ -182,7 +183,10 @@
         {
             _rows.Clear();
 
-            List<SchedulerHeaderDto> schedulers = await Api.GetSchedulers();
+            // The fleet view is a listing like the picker's, and it is filtered like the picker's: a row
+            // here is a scheduler the visitor can click through to.
+            List<SchedulerHeaderDto> registered = await Api.GetSchedulers();
+            List<SchedulerHeaderDto> schedulers = await Authorization.Filter(registered);
             Scheduler.AvailableSchedulers = schedulers.AsReadOnly();
 
             foreach (SchedulerHeaderDto header in schedulers)

--- a/src/Quartz.Dashboard/Components/Shared/SchedulerNotAuthorized.razor
+++ b/src/Quartz.Dashboard/Components/Shared/SchedulerNotAuthorized.razor
@@ -1,0 +1,29 @@
+@* What a page frame renders instead of the page when the visitor may not see the scheduler it would be
+   about. Nothing is fetched to draw it, which is the point: the refusal happens before the page exists,
+   so no scheduler the visitor may not see is read on their behalf. *@
+
+<div class="qz-page">
+    <div class="qz-empty" role="alert">
+        <p class="qz-empty-title">Not authorized</p>
+        <p class="qz-empty-description">
+            @if (string.IsNullOrWhiteSpace(SchedulerName))
+            {
+                <text>You are not authorized to view this scheduler.</text>
+            }
+            else
+            {
+                <text>You are not authorized to view scheduler <strong>@SchedulerName</strong>.</text>
+            }
+            Pick another one from the scheduler list above.
+        </p>
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// The scheduler the visitor was pointed at, named so that someone who administers several knows
+    /// which one they were refused rather than only that they were.
+    /// </summary>
+    [Parameter]
+    public string? SchedulerName { get; set; }
+}

--- a/src/Quartz.Dashboard/Hubs/QuartzDashboardHub.cs
+++ b/src/Quartz.Dashboard/Hubs/QuartzDashboardHub.cs
@@ -17,19 +17,51 @@
  */
 #endregion
 
+using System.Security.Claims;
+
 using Microsoft.AspNetCore.SignalR;
+
+using Quartz.Dashboard.Services;
 
 namespace Quartz.Dashboard.Hubs;
 
 internal sealed class QuartzDashboardHub : Hub<IQuartzDashboardHubClient>
 {
-    public Task JoinScheduler(string schedulerName)
+    private readonly SchedulerAuthorization authorization;
+
+    public QuartzDashboardHub(SchedulerAuthorization authorization)
     {
-        return Groups.AddToGroupAsync(Context.ConnectionId, schedulerName);
+        this.authorization = authorization;
+    }
+
+    /// <summary>
+    /// Subscribes this connection to one scheduler's live events.
+    /// </summary>
+    /// <remarks>
+    /// The group name is the scheduler's name — it is what the live-events plugin broadcasts to — so
+    /// joining a group is reaching a scheduler, and it is checked as one. Refusing is a
+    /// <see cref="HubException" /> rather than a silent no-op: a subscription that never delivers and
+    /// never says why is indistinguishable from a scheduler that is idle.
+    /// </remarks>
+    public async Task JoinScheduler(string schedulerName)
+    {
+        ClaimsPrincipal user = Context.User ?? Anonymous;
+        if (!await authorization.IsAuthorized(user, schedulerName).ConfigureAwait(false))
+        {
+            throw new HubException($"Not authorized for scheduler {schedulerName}");
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, schedulerName).ConfigureAwait(false);
     }
 
     public Task LeaveScheduler(string schedulerName)
     {
         return Groups.RemoveFromGroupAsync(Context.ConnectionId, schedulerName);
     }
+
+    /// <summary>
+    /// What a connection that authenticated as nobody is: an empty principal, so the policy decides it
+    /// rather than the hub deciding for it.
+    /// </summary>
+    private static readonly ClaimsPrincipal Anonymous = new();
 }

--- a/src/Quartz.Dashboard/Hubs/QuartzDashboardHub.cs
+++ b/src/Quartz.Dashboard/Hubs/QuartzDashboardHub.cs
@@ -46,17 +46,17 @@ internal sealed class QuartzDashboardHub : Hub<IQuartzDashboardHubClient>
     public async Task JoinScheduler(string schedulerName)
     {
         ClaimsPrincipal user = Context.User ?? Anonymous;
-        if (!await authorization.IsAuthorized(user, schedulerName).ConfigureAwait(false))
+        if (!await authorization.IsAuthorized(user, schedulerName, Context.ConnectionAborted).ConfigureAwait(false))
         {
             throw new HubException($"Not authorized for scheduler {schedulerName}");
         }
 
-        await Groups.AddToGroupAsync(Context.ConnectionId, schedulerName).ConfigureAwait(false);
+        await Groups.AddToGroupAsync(Context.ConnectionId, schedulerName, Context.ConnectionAborted).ConfigureAwait(false);
     }
 
     public Task LeaveScheduler(string schedulerName)
     {
-        return Groups.RemoveFromGroupAsync(Context.ConnectionId, schedulerName);
+        return Groups.RemoveFromGroupAsync(Context.ConnectionId, schedulerName, Context.ConnectionAborted);
     }
 
     /// <summary>

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -44,6 +44,28 @@ public sealed class QuartzDashboardOptions
 
     public string? AuthorizationPolicy { get; set; }
 
+    /// <summary>
+    /// The authorization policy each scheduler is held to, evaluated against a
+    /// <see cref="SchedulerResource" /> carrying that scheduler's name. Null — the default — leaves the
+    /// dashboard as it was: whoever passes <see cref="AuthorizationPolicy" /> sees every scheduler in the
+    /// process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Set it and the scheduler picker offers only the schedulers the visitor passes for, a page opened on
+    /// one they do not says so without reading anything, and the live-events hub refuses to subscribe them
+    /// to it. The two policies compose: <see cref="AuthorizationPolicy" /> decides who reaches the
+    /// dashboard at all, this one decides which schedulers they see once they are in, and
+    /// <see cref="ReadOnly" /> still decides what anyone may change.
+    /// </para>
+    /// <para>
+    /// It is the same policy and the same resource the HTTP API's
+    /// <c>QuartzHttpApiOptions.SchedulerAuthorizationPolicy</c> evaluates, so one
+    /// <c>AuthorizationHandler&lt;TRequirement, SchedulerResource&gt;</c> answers for both surfaces.
+    /// </para>
+    /// </remarks>
+    public string? SchedulerAuthorizationPolicy { get; set; }
+
     public bool ReadOnly { get; set; }
 
     /// <summary>

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ public static class QuartzDashboardServiceCollectionExtensions
             provider.GetRequiredService<IOptions<QuartzDashboardOptions>>(),
             provider.GetRequiredService<IDashboardHistoryStore>()));
         services.TryAddScoped<SchedulerState>();
+        services.TryAddScoped<SchedulerAuthorization>();
         services.TryAddScoped<ToastService>();
         services.TryAddSingleton<IDashboardLiveConnectionFactory, SignalRDashboardLiveConnectionFactory>();
         // The store measures its retention window on the scheduler's clock, and falls back to the system

--- a/src/Quartz.Dashboard/Services/SchedulerAuthorization.cs
+++ b/src/Quartz.Dashboard/Services/SchedulerAuthorization.cs
@@ -1,0 +1,144 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Quartz.Dashboard.Services;
+
+/// <summary>
+/// Holds <see cref="QuartzDashboardOptions.SchedulerAuthorizationPolicy" /> against one scheduler, for
+/// the three places the dashboard is about a scheduler: the picker that lists them, the page frame that
+/// renders one, and the hub group that streams one's events.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The visitor comes from <see cref="AuthenticationStateProvider" /> rather than from an
+/// <c>HttpContext</c>, because a rendered dashboard is a circuit and its request is long gone. The hub
+/// has its own caller, so it passes one in.
+/// </para>
+/// <para>
+/// With no policy configured nothing here is asked anything: <see cref="IsEnabled" /> is false and every
+/// scheduler passes, which is what keeps a dashboard that never set the option exactly as it was.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerAuthorization
+{
+    private readonly IOptions<QuartzDashboardOptions> options;
+    private readonly IAuthorizationService authorizationService;
+    private readonly AuthenticationStateProvider authenticationStateProvider;
+
+    public SchedulerAuthorization(
+        IOptions<QuartzDashboardOptions> options,
+        IAuthorizationService authorizationService,
+        AuthenticationStateProvider authenticationStateProvider)
+    {
+        this.options = options;
+        this.authorizationService = authorizationService;
+        this.authenticationStateProvider = authenticationStateProvider;
+    }
+
+    /// <summary>
+    /// Whether a per-scheduler policy is configured at all. A component reads it to know whether it has
+    /// anything to wait for before it renders.
+    /// </summary>
+    public bool IsEnabled => !string.IsNullOrWhiteSpace(options.Value.SchedulerAuthorizationPolicy);
+
+    /// <summary>
+    /// Whether the visitor this circuit belongs to may see <paramref name="schedulerName" />. A blank name
+    /// is no scheduler at all — the dashboard before its first listing has answered — and passes.
+    /// </summary>
+    public ValueTask<bool> IsAuthorized(string? schedulerName, CancellationToken cancellationToken = default)
+    {
+        if (!IsEnabled || string.IsNullOrWhiteSpace(schedulerName))
+        {
+            return new ValueTask<bool>(true);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return Evaluate(schedulerName, cancellationToken);
+
+        async ValueTask<bool> Evaluate(string schedulerName, CancellationToken cancellationToken)
+        {
+            AuthenticationState state = await authenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(false);
+            return await IsAuthorized(state.User, schedulerName, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="user" /> may see <paramref name="schedulerName" />, for a caller that
+    /// already holds the principal — the hub, whose caller is a connection rather than a circuit.
+    /// </summary>
+    public ValueTask<bool> IsAuthorized(ClaimsPrincipal user, string? schedulerName, CancellationToken cancellationToken = default)
+    {
+        string? policyName = options.Value.SchedulerAuthorizationPolicy;
+        if (string.IsNullOrWhiteSpace(policyName) || string.IsNullOrWhiteSpace(schedulerName))
+        {
+            return new ValueTask<bool>(true);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return Evaluate(user, policyName, schedulerName);
+
+        async ValueTask<bool> Evaluate(ClaimsPrincipal user, string policyName, string schedulerName)
+        {
+            AuthorizationResult result = await authorizationService
+                .AuthorizeAsync(user, new SchedulerResource(schedulerName), policyName)
+                .ConfigureAwait(false);
+
+            return result.Succeeded;
+        }
+    }
+
+    /// <summary>
+    /// The schedulers of <paramref name="schedulers" /> the visitor may see, in the order they arrived.
+    /// </summary>
+    /// <remarks>
+    /// The listing is filtered rather than annotated, because a name in the picker is a name the visitor
+    /// can select — and the count of tenants in a process is itself something a tenant should not learn.
+    /// </remarks>
+    public async ValueTask<List<SchedulerHeaderDto>> Filter(
+        IReadOnlyList<SchedulerHeaderDto> schedulers,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(schedulers);
+
+        if (!IsEnabled)
+        {
+            return [.. schedulers];
+        }
+
+        AuthenticationState state = await authenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(false);
+
+        List<SchedulerHeaderDto> allowed = new(schedulers.Count);
+        foreach (SchedulerHeaderDto scheduler in schedulers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await IsAuthorized(state.User, scheduler.SchedulerName, cancellationToken).ConfigureAwait(false))
+            {
+                allowed.Add(scheduler);
+            }
+        }
+
+        return allowed;
+    }
+}

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -320,6 +321,51 @@ public static class MultiTenancySamples
 
         await tenantFactory.DisposeAsync();
         app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
+
+        #endregion
+    }
+
+    #region sample_tenancy_scheduler_authorization_handler
+
+    // What "may act on this scheduler" means is the application's to decide, so the requirement itself
+    // says nothing and the handler says everything.
+    public sealed class SchedulerOwnerRequirement : IAuthorizationRequirement;
+
+    public sealed class SchedulerOwnerHandler : AuthorizationHandler<SchedulerOwnerRequirement, SchedulerResource>
+    {
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            SchedulerOwnerRequirement requirement,
+            SchedulerResource resource)
+        {
+            string? tenant = context.User.FindFirst("tenant")?.Value;
+
+            // Scheduler names are compared ignoring case everywhere else in Quartz, so compare them that
+            // way here too - otherwise "Acme" and "acme" are the same scheduler and different tenants.
+            if (string.Equals(tenant, resource.SchedulerName, StringComparison.OrdinalIgnoreCase))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    #endregion
+
+    public static void SchedulerAuthorization(IHostApplicationBuilder builder)
+    {
+        #region sample_tenancy_scheduler_authorization
+
+        builder.Services.AddAuthorizationBuilder()
+            .AddPolicy("SchedulerOwner", policy => policy.AddRequirements(new SchedulerOwnerRequirement()));
+
+        builder.Services.AddSingleton<IAuthorizationHandler, SchedulerOwnerHandler>();
+
+        // One policy, one handler, both surfaces: the API answers 403 for a scheduler the caller fails
+        // for, and the dashboard offers them only the schedulers they pass for.
+        builder.Services.AddQuartzHttpApi(options => options.SchedulerAuthorizationPolicy = "SchedulerOwner");
+        builder.Services.AddQuartzDashboard(options => options.SchedulerAuthorizationPolicy = "SchedulerOwner");
 
         #endregion
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
@@ -2,12 +2,15 @@ using Bunit;
 
 using FakeItEasy;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Dashboard.Support;
 using Quartz.Tests.AspNetCore.Support;
 
 namespace Quartz.Tests.AspNetCore.Dashboard.Components;
@@ -42,11 +45,20 @@ internal sealed class DashboardComponentContext : BunitContext
         // every page that lists one for a call no test is about.
         JSInterop.Mode = JSRuntimeMode.Loose;
 
+        // Nothing is authorized against until a test sets QuartzDashboardOptions.SchedulerAuthorizationPolicy:
+        // with it unset, SchedulerAuthorization answers "yes" without asking either of these, which is what
+        // keeps every test that is about something else unaffected.
+        AuthorizationService = new TestSchedulerAuthorizationService();
+        AuthenticationState = new TestAuthenticationStateProvider();
+
         Services.AddSingleton(Api);
         Services.AddSingleton<IDashboardLiveConnectionFactory>(LiveConnections);
         Services.AddSingleton(Microsoft.Extensions.Options.Options.Create(Options));
         Services.AddSingleton(A.Fake<IHttpContextAccessor>());
+        Services.AddSingleton<IAuthorizationService>(AuthorizationService);
+        Services.AddSingleton<AuthenticationStateProvider>(AuthenticationState);
         Services.AddSingleton<SchedulerState>();
+        Services.AddSingleton<SchedulerAuthorization>();
         Services.AddSingleton<ToastService>();
         Services.AddSingleton<DashboardActionLogService>();
 
@@ -73,6 +85,10 @@ internal sealed class DashboardComponentContext : BunitContext
 
     public IQuartzApiClient Api { get; }
 
+    public TestSchedulerAuthorizationService AuthorizationService { get; }
+
+    public TestAuthenticationStateProvider AuthenticationState { get; }
+
     public FakeDashboardLiveConnectionFactory LiveConnections { get; }
 
     public QuartzDashboardOptions Options { get; }
@@ -98,6 +114,27 @@ internal sealed class DashboardComponentContext : BunitContext
     /// Where the browser is now, which is what a page writing its filters into the query string moves.
     /// </summary>
     public string CurrentUri => Services.GetRequiredService<NavigationManager>().Uri;
+
+    /// <summary>
+    /// Turns the per-scheduler policy on and says which schedulers the visitor passes for. Every other
+    /// scheduler is one they may not see.
+    /// </summary>
+    public DashboardComponentContext WithSchedulerPolicy(params string[] allowedSchedulers)
+    {
+        Options.SchedulerAuthorizationPolicy = SchedulerPolicyName;
+        foreach (string schedulerName in allowedSchedulers)
+        {
+            AuthorizationService.Allowed.Add(schedulerName);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// The policy name <see cref="WithSchedulerPolicy" /> configures, which is what the dashboard is
+    /// expected to pass to <c>IAuthorizationService</c>.
+    /// </summary>
+    public const string SchedulerPolicyName = "SchedulerOwner";
 
     /// <summary>
     /// Points the pages at a scheduler that exists and is running, which is what all but the

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
@@ -1,0 +1,192 @@
+using Bunit;
+
+using FakeItEasy;
+
+using Microsoft.AspNetCore.Components;
+
+using Quartz.Dashboard.Components.Layout;
+using Quartz.Dashboard.Components.Pages;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard.Components;
+
+/// <summary>
+/// What <see cref="QuartzDashboardOptions.SchedulerAuthorizationPolicy" /> does to the dashboard: which
+/// schedulers are offered, and what a page frame pointed at one the visitor may not see renders instead.
+/// </summary>
+public class SchedulerAuthorizationTest
+{
+    private DashboardComponentContext context = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        context = new DashboardComponentContext();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        context.Dispose();
+    }
+
+    /// <summary>
+    /// The picker offers what the visitor may reach and nothing else — a name it offered would be a name
+    /// they could select, and how many tenants a process runs is itself something a tenant should not
+    /// learn.
+    /// </summary>
+    [Test]
+    public void ThePickerOffersOnlyTheSchedulersTheVisitorPassesFor()
+    {
+        GivenSchedulers("acme", "globex", "initech");
+        context.WithSchedulerPolicy("acme");
+
+        IRenderedComponent<SchedulerSelector> selector = context.Render<SchedulerSelector>();
+
+        selector.TextOfAll("option").Should().Equal(["acme"],
+            "a scheduler the policy refuses is not in the picker at all");
+        context.SchedulerState.ActiveSchedulerName.Should().Be("acme",
+            "the dashboard opens on the first scheduler the visitor may see, which is now the first of the "
+            + "filtered listing rather than of the whole process");
+    }
+
+    /// <summary>
+    /// The policy is asked about each scheduler by name, through the resource the handler is written
+    /// against. This is the contract the sample's <c>AuthorizationHandler&lt;…, SchedulerResource&gt;</c>
+    /// relies on.
+    /// </summary>
+    [Test]
+    public void EachSchedulerIsAskedAboutByNameAgainstTheConfiguredPolicy()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+
+        context.Render<SchedulerSelector>();
+
+        context.AuthorizationService.Asked.Should().Contain(
+            (DashboardComponentContext.SchedulerPolicyName, new SchedulerResource("globex")),
+            "the refused scheduler is refused by the policy the options name, evaluated against the scheduler itself");
+    }
+
+    /// <summary>
+    /// With the option unset nothing is asked and nothing is filtered, which is what keeps every dashboard
+    /// that never configured a per-scheduler policy exactly as it was.
+    /// </summary>
+    [Test]
+    public void WithNoPolicyEverySchedulerIsOfferedAndNothingIsAsked()
+    {
+        GivenSchedulers("acme", "globex");
+
+        IRenderedComponent<SchedulerSelector> selector = context.Render<SchedulerSelector>();
+
+        selector.TextOfAll("option").Should().Equal(["acme", "globex"]);
+        context.AuthorizationService.Asked.Should().BeEmpty(
+            "an unset policy is not a policy that always succeeds - there is nothing to evaluate");
+    }
+
+    /// <summary>
+    /// The one read the picker makes about a single scheduler is its status, and it is not made for a
+    /// scheduler the visitor may not see.
+    /// </summary>
+    [Test]
+    public void ASchedulerTheVisitorMayNotSeeIsNotAskedForItsStatus()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+        context.SchedulerState.ActiveSchedulerName = "globex";
+
+        IRenderedComponent<SchedulerSelector> selector = context.Render<SchedulerSelector>();
+
+        selector.Markup.Should().Contain("Not authorized");
+        A.CallTo(() => context.Api.GetScheduler("globex", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The page frame pointed at a foreign scheduler renders the refusal instead of the page, so the page
+    /// is never created and nothing it would have read is read.
+    /// </summary>
+    [Test]
+    public void APageFrameOnAForeignSchedulerRendersTheRefusalAndCreatesNoPage()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+        context.SchedulerState.ActiveSchedulerName = "globex";
+
+        IRenderedComponent<DashboardLayout> layout = RenderLayoutAround<Jobs>();
+
+        layout.Markup.Should().Contain("Not authorized");
+        layout.Markup.Should().Contain("globex", "the refusal names the scheduler the visitor was pointed at");
+        layout.FindAll("h1").Should().NotContain(heading => heading.TextContent.Trim() == "Jobs",
+            "the page is not rendered at all, which is what guarantees it read nothing");
+
+        // The frame's own header still lists the schedulers the visitor may see — that listing is the
+        // filtered one. What must not have happened is any of the reads the page itself makes.
+        A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The same frame on a scheduler the visitor may see renders the page, and the page reads its data.
+    /// </summary>
+    [Test]
+    public void APageFrameOnTheVisitorsOwnSchedulerRendersThePage()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+        context.SchedulerState.ActiveSchedulerName = "acme";
+
+        IRenderedComponent<DashboardLayout> layout = RenderLayoutAround<Jobs>();
+
+        layout.Markup.Should().NotContain("Not authorized");
+        layout.FindAll("h1").Should().Contain(heading => heading.TextContent.Trim() == "Jobs");
+        A.CallTo(() => context.Api.GetJobs("acme", A<DashboardJobQuery>._, A<CancellationToken>._)).MustHaveHappened();
+    }
+
+    /// <summary>
+    /// The fleet view is a listing like the picker's, and is filtered like it.
+    /// </summary>
+    [Test]
+    public void TheSchedulersPageListsOnlyTheSchedulersTheVisitorPassesFor()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+
+        IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
+
+        page.Markup.Should().Contain("acme");
+        page.Markup.Should().NotContain("globex",
+            "the fleet view is where an operator counts tenants, so it must not count somebody else's");
+        A.CallTo(() => context.Api.GetScheduler("globex", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// Renders <typeparamref name="TPage" /> the way the dashboard does: inside the frame that decides
+    /// whether it is rendered at all.
+    /// </summary>
+    private IRenderedComponent<DashboardLayout> RenderLayoutAround<TPage>() where TPage : IComponent
+    {
+        RenderFragment page = builder =>
+        {
+            builder.OpenComponent<TPage>(0);
+            builder.CloseComponent();
+        };
+
+        return context.Render<DashboardLayout>(parameters => parameters.Add(layout => layout.Body, page));
+    }
+
+    private void GivenSchedulers(params string[] names)
+    {
+        List<SchedulerHeaderDto> headers = [];
+        foreach (string name in names)
+        {
+            headers.Add(TestData.Dashboard.SchedulerHeader(name));
+            A.CallTo(() => context.Api.GetScheduler(name, A<CancellationToken>._))
+                .Returns(TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, name));
+        }
+
+        A.CallTo(() => context.Api.GetSchedulers(A<CancellationToken>._)).Returns(headers);
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
@@ -9,6 +9,8 @@ using Quartz.Dashboard.Components.Pages;
 using Quartz.Dashboard.Services;
 using Quartz.Tests.AspNetCore.Support;
 
+using DashboardPage = Quartz.Dashboard.Components.Pages.Dashboard;
+
 namespace Quartz.Tests.AspNetCore.Dashboard.Components;
 
 /// <summary>
@@ -159,6 +161,43 @@ public class SchedulerAuthorizationTest
         page.Markup.Should().Contain("acme");
         page.Markup.Should().NotContain("globex",
             "the fleet view is where an operator counts tenants, so it must not count somebody else's");
+        A.CallTo(() => context.Api.GetScheduler("globex", A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The overview re-reads the scheduler listing after an action and moves to another scheduler when the
+    /// one it acted on is gone — a shutdown leaves its registration behind with nothing to read. The
+    /// scheduler it moves to has to be one the visitor may see.
+    /// </summary>
+    /// <remarks>
+    /// This listing is the third the dashboard writes into <c>SchedulerState</c>, and the only one that
+    /// then picks the active scheduler itself. Unfiltered it would hand a visitor somebody else's tenant
+    /// and read it on the next line, without the page frame ever getting a say.
+    /// </remarks>
+    [Test]
+    public void AnActionThatMovesTheOverviewOffItsSchedulerMovesItToOneTheVisitorMaySee()
+    {
+        GivenSchedulers("acme", "globex");
+        context.WithSchedulerPolicy("acme");
+        context.SchedulerState.ActiveSchedulerName = "acme";
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        // What the listing says once the action has been carried out: the scheduler it acted on is a
+        // registration with nothing behind it, and the only scheduler still running is the foreign one.
+        A.CallTo(() => context.Api.GetSchedulers(A<CancellationToken>._)).Returns(new List<SchedulerHeaderDto>
+        {
+            TestData.Dashboard.RegisteredSchedulerHeader("acme"),
+            TestData.Dashboard.SchedulerHeader("globex")
+        });
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Standby").Click();
+
+        context.SchedulerState.ActiveSchedulerName.Should().Be("acme",
+            "the visitor passes for no other scheduler, so there is nowhere else for the page to go");
+        context.SchedulerState.AvailableSchedulers.Select(scheduler => scheduler.SchedulerName).Should().Equal(["acme"],
+            "the refreshed listing is filtered like every other one, so the picker is not repopulated with "
+            + "schedulers the visitor may not see");
         A.CallTo(() => context.Api.GetScheduler("globex", A<CancellationToken>._)).MustNotHaveHappened();
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardHubAuthorizationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzDashboardHubAuthorizationTest.cs
@@ -1,0 +1,95 @@
+using System.Security.Claims;
+
+using FakeItEasy;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+using Quartz.Dashboard.Hubs;
+using Quartz.Dashboard.Services;
+using Quartz.Tests.AspNetCore.Dashboard.Support;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// The live-events hub's group join, which is the third way a dashboard reaches a scheduler: the plugin
+/// broadcasts to a group named after the scheduler, so joining that group is subscribing to it.
+/// </summary>
+/// <remarks>
+/// A connection is not a circuit — its caller is a <see cref="HubCallerContext" />, and the policy is
+/// evaluated against that caller's principal rather than against the rendered dashboard's.
+/// </remarks>
+public class QuartzDashboardHubAuthorizationTest
+{
+    private const string SchedulerPolicyName = "SchedulerOwner";
+
+    [Test]
+    public async Task AConnectionMayJoinTheGroupOfASchedulerItPassesFor()
+    {
+        (QuartzDashboardHub hub, IGroupManager groups, TestSchedulerAuthorizationService authorization) =
+            CreateHub(policyName: SchedulerPolicyName, allowed: "acme");
+
+        await hub.JoinScheduler("acme");
+
+        A.CallTo(() => groups.AddToGroupAsync("connection-1", "acme", A<CancellationToken>._)).MustHaveHappened();
+        authorization.Asked.Should().Equal([(SchedulerPolicyName, new SchedulerResource("acme"))],
+            "the hub asks the same policy about the same resource the pages and the API do");
+    }
+
+    [Test]
+    public async Task AConnectionIsRefusedTheGroupOfASchedulerItDoesNotPassFor()
+    {
+        (QuartzDashboardHub hub, IGroupManager groups, _) =
+            CreateHub(policyName: SchedulerPolicyName, allowed: "acme");
+
+        Func<Task> join = () => hub.JoinScheduler("globex");
+
+        await join.Should().ThrowAsync<HubException>()
+            .WithMessage("*globex*",
+                "a refusal that silently did not join would look exactly like a scheduler with nothing to report");
+
+        A.CallTo(() => groups.AddToGroupAsync(A<string>._, A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task WithNoPolicyEveryGroupIsJoinedAndNothingIsAsked()
+    {
+        (QuartzDashboardHub hub, IGroupManager groups, TestSchedulerAuthorizationService authorization) =
+            CreateHub(policyName: null, allowed: []);
+
+        await hub.JoinScheduler("globex");
+
+        A.CallTo(() => groups.AddToGroupAsync("connection-1", "globex", A<CancellationToken>._)).MustHaveHappened();
+        authorization.Asked.Should().BeEmpty("an unset policy leaves the hub exactly as it was");
+    }
+
+    private static (QuartzDashboardHub Hub, IGroupManager Groups, TestSchedulerAuthorizationService Authorization) CreateHub(
+        string? policyName,
+        params string[] allowed)
+    {
+        TestSchedulerAuthorizationService authorizationService = new();
+        foreach (string schedulerName in allowed)
+        {
+            authorizationService.Allowed.Add(schedulerName);
+        }
+
+        SchedulerAuthorization authorization = new(
+            Options.Create(new QuartzDashboardOptions { SchedulerAuthorizationPolicy = policyName }),
+            authorizationService,
+            new TestAuthenticationStateProvider());
+
+        HubCallerContext callerContext = A.Fake<HubCallerContext>();
+        A.CallTo(() => callerContext.ConnectionId).Returns("connection-1");
+        A.CallTo(() => callerContext.User).Returns(new ClaimsPrincipal(new ClaimsIdentity("test")));
+
+        IGroupManager groups = A.Fake<IGroupManager>();
+
+        QuartzDashboardHub hub = new(authorization)
+        {
+            Context = callerContext,
+            Groups = groups
+        };
+
+        return (hub, groups, authorizationService);
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Support/TestSchedulerAuthorization.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Support/TestSchedulerAuthorization.cs
@@ -1,0 +1,57 @@
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Quartz.Tests.AspNetCore.Dashboard.Support;
+
+/// <summary>
+/// An <see cref="IAuthorizationService" /> that answers for a fixed set of scheduler names, so a test can
+/// say which tenant the visitor is without writing a policy and a handler for it.
+/// </summary>
+/// <remarks>
+/// It records what it was asked, because the resource and the policy name are half of what the dashboard
+/// promises: one <c>AuthorizationHandler&lt;TRequirement, SchedulerResource&gt;</c> answers for every
+/// scheduler-scoped decision. The end-to-end shape — a real policy, a real handler — is exercised against
+/// the HTTP API, where the container is a real one.
+/// </remarks>
+internal sealed class TestSchedulerAuthorizationService : IAuthorizationService
+{
+    /// <summary>
+    /// The schedulers the visitor passes for. Compared ignoring case, the way every scheduler lookup in
+    /// Quartz is.
+    /// </summary>
+    public HashSet<string> Allowed { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Every (policy, resource) pair this service was asked about, in order.
+    /// </summary>
+    public List<(string PolicyName, object? Resource)> Asked { get; } = [];
+
+    public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+    {
+        throw new NotSupportedException("The dashboard evaluates a named policy, never a bare requirement set.");
+    }
+
+    public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, string policyName)
+    {
+        Asked.Add((policyName, resource));
+
+        bool succeeded = resource is SchedulerResource scheduler && Allowed.Contains(scheduler.SchedulerName);
+        return Task.FromResult(succeeded ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+    }
+}
+
+/// <summary>
+/// The visitor a rendered dashboard belongs to. The real one is the circuit's, seeded by the framework
+/// from the request that started it; bUnit renders no circuit, so a test supplies the principal itself.
+/// </summary>
+internal sealed class TestAuthenticationStateProvider : AuthenticationStateProvider
+{
+    public ClaimsPrincipal User { get; set; } = new(new ClaimsIdentity());
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+    {
+        return Task.FromResult(new AuthenticationState(User));
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerAuthorizationEndpointTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerAuthorizationEndpointTest.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions.Execution;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.HttpApiContract;
+using Quartz.Serialization.SystemTextJson;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// What <see cref="QuartzHttpApiOptions.SchedulerAuthorizationPolicy" /> does to the API: every route
+/// that names a scheduler is authorized against that scheduler, and the listing is filtered to the
+/// schedulers the caller may act on.
+/// </summary>
+/// <remarks>
+/// Two tenants in one process, reached over one set of endpoints — the arrangement the option exists for.
+/// The policy is a real one and the handler is a real
+/// <c>AuthorizationHandler&lt;SchedulerOwnerRequirement, SchedulerResource&gt;</c>, because the promise
+/// being tested is that an application writes one of those and Quartz does the rest.
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerAuthorizationEndpointTest
+{
+    private const string JobsRoute = "schedulers/globex/jobs";
+
+    private readonly List<WebApplicationFactory<Program>> factories = [];
+    private readonly List<IScheduler> schedulers = [];
+
+    private WebApplicationFactory<Program> application = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        application = CreateApplication(policyName: TenantAuthenticationExtensions.SchedulerOwnerPolicy);
+        await CreateSchedulers("acme", "globex");
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        foreach (IScheduler scheduler in schedulers)
+        {
+            await scheduler.Shutdown();
+        }
+
+        schedulers.Clear();
+
+        // Named as well as enumerated: it is in the list below, and disposing twice is a no-op, but the
+        // analyzer reads the field rather than the list.
+        await application.DisposeAsync();
+
+        foreach (WebApplicationFactory<Program> factory in factories)
+        {
+            await factory.DisposeAsync();
+        }
+
+        factories.Clear();
+    }
+
+    /// <summary>
+    /// One route from each endpoint group, read and written, for a scheduler that is not the caller's.
+    /// </summary>
+    /// <remarks>
+    /// Every one of them resolves its scheduler from the same <c>{schedulerName}</c> segment, so the check
+    /// belongs to the route rather than to any handler — and that is what this asserts by sampling all
+    /// four groups rather than testing one endpoint.
+    /// </remarks>
+    [Test]
+    public async Task EveryRouteOfAForeignSchedulerAnswersForbidden()
+    {
+        using HttpClient client = ClientFor("acme");
+
+        using (new AssertionScope())
+        {
+            await Row(client, HttpMethod.Get, "schedulers/globex", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, "schedulers/globex/context", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Post, "schedulers/globex/pause-all", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, JobsRoute, HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Post, "schedulers/globex/jobs/group/name/pause", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, "schedulers/globex/triggers", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Post, "schedulers/globex/triggers/group/name/pause", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, "schedulers/globex/calendars", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Delete, "schedulers/globex/calendars/holidays", HttpStatusCode.Forbidden);
+        }
+    }
+
+    /// <summary>
+    /// The same routes on the caller's own scheduler answer as they always did.
+    /// </summary>
+    [Test]
+    public async Task TheCallersOwnSchedulerAnswersAsItAlwaysDid()
+    {
+        using HttpClient client = ClientFor("acme");
+
+        using (new AssertionScope())
+        {
+            await Row(client, HttpMethod.Get, "schedulers/acme", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Get, "schedulers/acme/context", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Post, "schedulers/acme/pause-all", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Get, "schedulers/acme/jobs", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Post, "schedulers/acme/jobs/group/name/pause", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Get, "schedulers/acme/triggers", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Get, "schedulers/acme/calendars", HttpStatusCode.OK);
+        }
+    }
+
+    /// <summary>
+    /// A refusal comes before the scheduler is looked up, so a caller cannot use the difference between
+    /// <c>403</c> and <c>404</c> to discover which tenants exist. A <c>404</c> is only ever the answer to
+    /// a name the caller was allowed to ask about.
+    /// </summary>
+    [Test]
+    public async Task AnUnknownSchedulerIsForbiddenRatherThanNotFound()
+    {
+        using HttpClient client = ClientFor("acme");
+
+        using (new AssertionScope())
+        {
+            await Row(client, HttpMethod.Get, "schedulers/no-such-scheduler", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, "schedulers/globex", HttpStatusCode.Forbidden);
+            await Row(client, HttpMethod.Get, "schedulers/acme/jobs/group/no-such-job", HttpStatusCode.NotFound);
+        }
+    }
+
+    /// <summary>
+    /// The listing names no scheduler, so it filters its own answer: a tenant is told about its own
+    /// schedulers and learns nothing about the others, not even that they are there.
+    /// </summary>
+    [Test]
+    public async Task TheSchedulerListingCarriesOnlyTheCallersSchedulers()
+    {
+        using HttpClient acme = ClientFor("acme");
+        using HttpClient globex = ClientFor("globex");
+
+        SchedulerHeaderDto[] acmeSees = await ReadSchedulers(acme);
+        SchedulerHeaderDto[] globexSees = await ReadSchedulers(globex);
+
+        acmeSees.Select(x => x.Name).Should().Equal(["acme"],
+            "the default scheduler the test application also registers is not this tenant's either");
+        globexSees.Select(x => x.Name).Should().Equal(["globex"]);
+    }
+
+    /// <summary>
+    /// The refusal on the wire: RFC 7807 problem details, like every other error the API produces, and
+    /// without <c>Quartz-ExceptionType</c> — no exception was raised, a policy said no.
+    /// </summary>
+    [Test]
+    public async Task ForbiddenProblemDetailsBody()
+    {
+        using HttpClient client = ClientFor("acme");
+
+        using HttpResponseMessage response = await client.GetAsync(JobsRoute);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+
+        string body = await response.Content.ReadAsStringAsync();
+
+        await VerifyJson(body)
+            .UseStrictJson()
+            .UseDirectory("../Verify")
+            .UseFileName("SchedulerAuthorizationEndpointTest_ForbiddenProblemDetailsBody")
+            .DisableRequireUniquePrefix();
+    }
+
+    /// <summary>
+    /// Without the option the API is what it was: one policy for the whole surface, or none, and every
+    /// scheduler reachable by whoever got through it.
+    /// </summary>
+    [Test]
+    public async Task WithoutTheOptionEverySchedulerIsReachable()
+    {
+        WebApplicationFactory<Program> unauthorized = CreateApplication(policyName: null);
+        await CreateSchedulers(unauthorized, "zeta");
+
+        using HttpClient client = ClientFor(unauthorized, "acme");
+
+        using (new AssertionScope())
+        {
+            await Row(client, HttpMethod.Get, "schedulers/zeta", HttpStatusCode.OK);
+            await Row(client, HttpMethod.Get, "schedulers/zeta/jobs", HttpStatusCode.OK);
+        }
+
+        SchedulerHeaderDto[] listed = await ReadSchedulers(client);
+        listed.Select(x => x.Name).Should().Contain("zeta",
+            "with no per-scheduler policy the listing is unfiltered, whoever is asking");
+    }
+
+    private static async Task Row(HttpClient client, HttpMethod method, string url, HttpStatusCode expected)
+    {
+        using HttpRequestMessage request = new(method, url);
+        if (method == HttpMethod.Post)
+        {
+            request.Content = new StringContent("", Encoding.UTF8, "application/json");
+        }
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(expected, $"{method} {url} answers {expected:D}, body was {body}");
+    }
+
+    private HttpClient ClientFor(string tenant) => ClientFor(application, tenant);
+
+    private static HttpClient ClientFor(WebApplicationFactory<Program> factory, string tenant)
+    {
+        HttpClient client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TenantAuthenticationHandler.TenantHeaderName, tenant);
+        return client;
+    }
+
+    private static async Task<SchedulerHeaderDto[]> ReadSchedulers(HttpClient client)
+    {
+        JsonSerializerOptions serializerOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            .ConfigureWireFormat(new SystemTextJsonSerializerRegistry());
+
+        using HttpResponseMessage response = await client.GetAsync("schedulers");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<SchedulerHeaderDto[]>(body, serializerOptions)!;
+    }
+
+    private Task CreateSchedulers(params string[] names) => CreateSchedulers(application, names);
+
+    /// <summary>
+    /// Builds each tenant's scheduler, because a registration nothing has built answers <c>404</c> on
+    /// every route and the status codes are the whole subject here.
+    /// </summary>
+    private async Task CreateSchedulers(WebApplicationFactory<Program> factory, params string[] names)
+    {
+        foreach (string name in names)
+        {
+            IScheduler scheduler = await factory.Services
+                .GetRequiredKeyedService<ISchedulerFactory>(name)
+                .GetScheduler();
+
+            schedulers.Add(scheduler);
+        }
+    }
+
+    private WebApplicationFactory<Program> CreateApplication(string? policyName)
+    {
+        TestContentRoot.Apply();
+
+        WebApplicationFactory<Program> root = new();
+        factories.Add(root);
+
+        WebApplicationFactory<Program> configured = root.WithWebHostBuilder(builder => builder.ConfigureServices(services =>
+        {
+            services.AddTenantAuthorization();
+            services.AddQuartz("acme", q => q.UseInMemoryStore());
+            services.AddQuartz("globex", q => q.UseInMemoryStore());
+            services.AddQuartz("zeta", q => q.UseInMemoryStore());
+            services.AddQuartzHttpApi(options => options.SchedulerAuthorizationPolicy = policyName);
+        }));
+
+        factories.Add(configured);
+
+        return configured;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerAuthorizationOptionsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerAuthorizationOptionsTest.cs
@@ -1,0 +1,70 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// What the options validator says about a per-scheduler policy the container cannot evaluate.
+/// </summary>
+/// <remarks>
+/// A policy name nothing knows is ASP.NET Core's to complain about, and it does, at the first request
+/// that names it. A container with no authorization services at all is different: nothing would ever
+/// complain, and the setting would read as enforced while enforcing nothing.
+/// </remarks>
+public class SchedulerAuthorizationOptionsTest
+{
+    [Test]
+    public async Task APolicyWithNoAuthorizationServicesToEvaluateItIsRefusedAtStartup()
+    {
+        await using WebApplication app = CreateApp(authorization: false);
+
+        Action act = () => _ = app.Services.GetRequiredService<IOptions<QuartzHttpApiOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*AddAuthorization*",
+                "a security setting that silently does nothing is worse than one that is missing, so the "
+                + "message says what to call");
+    }
+
+    [Test]
+    public async Task APolicyIsAcceptedWhenTheContainerCanEvaluateIt()
+    {
+        await using WebApplication app = CreateApp(authorization: true);
+
+        QuartzHttpApiOptions options = app.Services.GetRequiredService<IOptions<QuartzHttpApiOptions>>().Value;
+
+        options.SchedulerAuthorizationPolicy.Should().Be(TenantAuthenticationExtensions.SchedulerOwnerPolicy);
+    }
+
+    [Test]
+    public async Task NoPolicyNeedsNoAuthorizationServices()
+    {
+        await using WebApplication app = CreateApp(authorization: false, policyName: null);
+
+        QuartzHttpApiOptions options = app.Services.GetRequiredService<IOptions<QuartzHttpApiOptions>>().Value;
+
+        options.SchedulerAuthorizationPolicy.Should().BeNull(
+            "an API that configured no per-scheduler policy asks nothing of the container");
+    }
+
+    private static WebApplication CreateApp(
+        bool authorization,
+        string? policyName = TenantAuthenticationExtensions.SchedulerOwnerPolicy)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddQuartz();
+
+        if (authorization)
+        {
+            builder.Services.AddTenantAuthorization();
+        }
+
+        builder.Services.AddQuartzHttpApi(options => options.SchedulerAuthorizationPolicy = policyName);
+        return builder.Build();
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Support/TenantAuthentication.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TenantAuthentication.cs
@@ -1,0 +1,95 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Quartz.Tests.AspNetCore.Support;
+
+/// <summary>
+/// Authenticates a request as the tenant named in its <c>X-Tenant</c> header, so one test can drive the
+/// API as two different tenants over two clients.
+/// </summary>
+/// <remarks>
+/// A header rather than a token because none of what is under test is authentication: the claim is the
+/// input to the policy, and how the caller came by it is the application's business.
+/// </remarks>
+public sealed class TenantAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "tenant";
+
+    public const string TenantHeaderName = "X-Tenant";
+
+    public const string TenantClaimType = "tenant";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(TenantHeaderName, out Microsoft.Extensions.Primitives.StringValues tenant)
+            || string.IsNullOrWhiteSpace(tenant))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        ClaimsIdentity identity = new(
+            [new Claim(ClaimTypes.Name, tenant.ToString()), new Claim(TenantClaimType, tenant.ToString())],
+            SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(
+            new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName)));
+    }
+}
+
+/// <summary>
+/// The requirement the per-scheduler policy carries. It says nothing itself — what "owning" a scheduler
+/// means is the handler's to decide — which is why it has no members.
+/// </summary>
+public sealed class SchedulerOwnerRequirement : IAuthorizationRequirement;
+
+/// <summary>
+/// Grants a scheduler to the tenant whose claim names it. The shape the documentation samples show, and
+/// the shape both surfaces evaluate: one handler over <see cref="SchedulerResource" />.
+/// </summary>
+public sealed class SchedulerOwnerHandler : AuthorizationHandler<SchedulerOwnerRequirement, SchedulerResource>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        SchedulerOwnerRequirement requirement,
+        SchedulerResource resource)
+    {
+        string? tenant = context.User.FindFirst(TenantAuthenticationHandler.TenantClaimType)?.Value;
+        if (string.Equals(tenant, resource.SchedulerName, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}
+
+public static class TenantAuthenticationExtensions
+{
+    public const string SchedulerOwnerPolicy = "SchedulerOwner";
+
+    /// <summary>
+    /// Registers the tenant scheme and the per-scheduler policy the tests configure Quartz with.
+    /// </summary>
+    public static IServiceCollection AddTenantAuthorization(this IServiceCollection services)
+    {
+        services
+            .AddAuthentication(TenantAuthenticationHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TenantAuthenticationHandler>(TenantAuthenticationHandler.SchemeName, _ => { });
+
+        services.AddAuthorizationBuilder()
+            .AddPolicy(SchedulerOwnerPolicy, policy => policy.AddRequirements(new SchedulerOwnerRequirement()));
+
+        services.AddSingleton<IAuthorizationHandler, SchedulerOwnerHandler>();
+
+        return services;
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.AspNetCore.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.AspNetCore.verified.txt
@@ -23,5 +23,11 @@ namespace Quartz
         public QuartzHttpApiOptions() { }
         public string ApiPath { get; set; }
         public bool IncludeStackTraceInProblemDetails { get; set; }
+        public string? SchedulerAuthorizationPolicy { get; set; }
+    }
+    public sealed class SchedulerResource : System.IEquatable<Quartz.SchedulerResource>
+    {
+        public SchedulerResource(string SchedulerName) { }
+        public string SchedulerName { get; init; }
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -390,6 +390,7 @@ namespace Quartz
         public int HistoryMaxEntriesPerScheduler { get; set; }
         public System.TimeSpan HistoryRetention { get; set; }
         public bool ReadOnly { get; set; }
+        public string? SchedulerAuthorizationPolicy { get; set; }
     }
     public static class QuartzDashboardServiceCollectionExtensions
     {

--- a/src/Quartz.Tests.AspNetCore/Verify/SchedulerAuthorizationEndpointTest_ForbiddenProblemDetailsBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/SchedulerAuthorizationEndpointTest_ForbiddenProblemDetailsBody.verified.json
@@ -1,0 +1,6 @@
+﻿{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.4",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Not authorized for scheduler globex"
+}


### PR DESCRIPTION
`QuartzDashboardOptions` had one `AuthorizationPolicy` and one `ReadOnly` flag, and `QuartzHttpApiOptions`
had no policy at all — `RequireAuthorization(...)` on the mapped group applies uniformly and the scheduler
is a route segment inside it. So a tenant who could reach one scheduler could reach every tenant's.

Both surfaces now take a `SchedulerAuthorizationPolicy` that is evaluated per request against the
scheduler the request is for. `null` — the default — is exactly today's behaviour on both, so nothing
changes for an application that does not set it.

## As built

**The shape is the framework's.** A new `public sealed record SchedulerResource(string SchedulerName)`
(namespace `Quartz`, in `Quartz.AspNetCore`, which the dashboard already references) is the resource
Quartz passes to `IAuthorizationService.AuthorizeAsync(user, resource, policyName)`. The application
writes one `AuthorizationHandler<TRequirement, SchedulerResource>` and it answers for every route and
every page. There is no delegate option and no claim convention.

**HTTP API.** `MapQuartzHttpApi` applies a convention to every endpoint it maps; the convention reads the
endpoint's own `RoutePattern` and wraps only the routes carrying `{schedulerName}`, so the rule belongs to
the route rather than to any handler and a route added later is covered by carrying the parameter like
every other one. The wrapper runs before the handler's arguments are bound and before `EndpointHelper`
looks the scheduler up, so a refusal is `403` whether or not the scheduler exists — a `404` only ever
answers a name the caller was allowed to ask about. `GET /schedulers` carries no `{schedulerName}`, so it
filters its own answer instead: registrations included, a tenant sees its own and learns nothing about the
others. The refusal body is RFC 7807 problem details with no `Quartz-ExceptionType` — that member names
the exception a failure came from, and a policy that said no is a decision, not a failure. The endpoints
that carry the check also gain `403` in their OpenAPI metadata.

**Dashboard.** Three places reach a scheduler and all three ask, through a scoped
`SchedulerAuthorization` service that reads the visitor from `AuthenticationStateProvider` (a rendered
dashboard is a circuit; its request is long gone):

- all three scheduler listings the dashboard writes into `SchedulerState` are filtered — the picker's, the
  **Schedulers** page's, and the overview's post-action refresh — so a name a visitor cannot use is never
  offered, and the count of tenants in the process is itself not something a tenant should learn;
- `DashboardLayout` renders `SchedulerNotAuthorized` in place of `@Body` for a scheduler the visitor fails
  for. The page component is never created, so its `OnInitializedAsync` never runs and no
  `IQuartzApiClient` member is called on their behalf. The header stays, so the visitor can switch to a
  scheduler they may see;
- `QuartzDashboardHub.JoinScheduler` refuses with a `HubException`. The live-events plugin broadcasts to a
  group named after the scheduler, so joining that group *is* reaching it; a silent no-op would look
  exactly like an idle scheduler. The hub has a caller of its own, so it passes `Context.User` in.

The three settings compose rather than replace: `AuthorizationPolicy` decides who is in,
`SchedulerAuthorizationPolicy` decides which schedulers they see, `ReadOnly` decides what anyone may
change.

**Validation.** `QuartzHttpApiOptionsValidator` refuses a policy name in a container with no
`IAuthorizationService` — a security setting that silently does nothing is worse than one that is missing.
A policy name no `IAuthorizationPolicyProvider` knows still fails at first use, the way ASP.NET Core makes
it fail everywhere else.

**Sample.** `MultiTenancySamples` compiles the handler (`tenant` claim equal to the scheduler name, matched
ignoring case as every scheduler lookup in Quartz is), the policy registration and both options.

## For a reviewer to decide

1. **A refusal is always `403`, never a `401` challenge.** The spec said "the policy decides… do not
   special-case", and the filter does not look at whether the caller is authenticated. It also does not
   call `ChallengeAsync` for an anonymous caller the way `AuthorizationMiddleware` would: with no default
   challenge scheme registered that throws, and an API is a machine interface that cannot be challenged
   interactively. The documented answer is to keep `RequireAuthorization()` on the mapped group, where the
   authorization middleware issues the `401`. Say if you want the challenge inside the filter instead.

2. **No dashboard-side validator.** The spec asked for an `IValidateOptions` refusal on both, but
   `AddQuartzDashboard` calls `AddSignalR()`, which calls `AddAuthorization()` internally (verified: after
   `AddSignalR()` the container already has `IAuthorizationService` and `IAuthorizationPolicyProvider`), so
   a dashboard-side check could never fail. It would be unreachable code, so it is not there. The HTTP API
   validator can and does fail, and is tested.

3. **The dashboard gate lives in `DashboardLayout`, not in each page.** One place, and it guarantees "no
   data fetched" by never creating the page — a per-page check would still let each page's own
   `OnInitializedAsync` run. The consequence: in *integrated* mode the host's router supplies its own
   `DefaultLayout`, so dashboard pages there are not wrapped by `DashboardLayout` and the frame does not
   run. That is now written down where a user reads it, in `packages/dashboard.md` under "One scheduler at
   a time", and linked from `multi-tenancy.md`: every listing the dashboard writes is filtered in both
   modes and so is the hub subscription, so nothing in the dashboard points a visitor at a scheduler they
   fail for — but an application that routes visitors under its own layout owns that part. If integrated
   mode ever grows its own chrome, the gate moves with it.

4. **A narrow fail-open window on the dashboard.** `_access` starts granted while
   `ActiveSchedulerName` is null, and a scheduler that becomes active is re-evaluated asynchronously. A
   foreign scheduler cannot become active through the UI — every listing that can set it is filtered — so
   this is defence-in-depth rather than the enforcement path. Closing it entirely would need a synchronous
   decision, which resource-based authorization does not offer.

## Found while verifying the integrated-mode claim

Checking whether a page could reach a foreign scheduler's data with the frame absent turned up a hole
that was not mode-specific, and it is fixed in `a6a35d2`. `Dashboard.RefreshSchedulersAsync` — the
overview's re-read after a start, standby, shutdown, pause-all or resume-all — was the third listing
written into `SchedulerState` and the only one that then picks the active scheduler itself, and it was
unfiltered. Shutting down the one scheduler a visitor was authorized for made
`SchedulerState.DefaultSchedulerName` fall through to a foreign one, repopulated the picker with every
name in the process, and `LoadDataAsync()` on the next line read that scheduler — all before the page
frame was consulted. `AnActionThatMovesTheOverviewOffItsSchedulerMovesItToOneTheVisitorMaySee` reproduces
it (it fails on the parent commit with `ActiveSchedulerName` `"globex"`, expected `"acme"`).

## Baselines

Re-accepted, with exactly this delta:

`PublicApiTest_Quartz.AspNetCore.verified.txt`

```diff
+        public string? SchedulerAuthorizationPolicy { get; set; }
+    }
+    public sealed class SchedulerResource : System.IEquatable<Quartz.SchedulerResource>
+    {
+        public SchedulerResource(string SchedulerName) { }
+        public string SchedulerName { get; init; }
```

`PublicApiTest_Quartz.Dashboard.verified.txt`

```diff
+        public string? SchedulerAuthorizationPolicy { get; set; }
```

One new wire snapshot, `SchedulerAuthorizationEndpointTest_ForbiddenProblemDetailsBody.verified.json`:

```json
{
  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.4",
  "title": "Forbidden",
  "status": 403,
  "detail": "Not authorized for scheduler globex"
}
```

`SchedulerNotAuthorized.razor` is a Blazor component, which `PublicApiTest` excludes by design.

## Docs

`multi-tenancy.md` loses the "enforce that outside Quartz" paragraph; the honest limit that remains is
stated for what it is (`ReadOnly` is still process-wide, and there is no per-operation policy), and the
feature is a section under **Scheduler per tenant** with the compiled sample.
`packages/http-api.md` gains an options table where its three settings were a bullet list, plus a section
on the option; `packages/dashboard.md` gains the row and a **One scheduler at a time** section, which
carries the standalone-versus-integrated caveat that `multi-tenancy.md` links to rather than repeats; the
migration guide records the two options and the record.

Two pages outside the brief said 4.x has no per-scheduler policy and now would have been wrong:
`best-practices.md` ("Do not let users choose the job type", which the task named) and
`tenancy-patterns.md` ("What Quartz.NET does not give you"), which the first links to. Both now say which
version has what. `docs/documentation/quartz-3.x/` is untouched.

## Verification

```
dotnet build Quartz.slnx                    Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit           Passed! Failed: 0, Passed: 3593, Skipped: 4, Total: 3597
dotnet test src/Quartz.Tests.AspNetCore     Passed! Failed: 0, Passed: 547, Skipped: 0, Total: 547
dotnet fallout VerifyDocsSnippets           Documentation snippets are up to date (93 markdown files checked)
npm run docs:check-links                    214 pages, 851 internal links, 502 fragments - no dead links or anchors
```

Rebased onto `843cd347` after #3482 made `EndpointHelper` an instance. The one conflict was
`GetAllSchedulers`'s last line, resolved to keep both sides: `endpointHelper.JsonResponse(result.ToArray())`,
the instance call over the filtered listing. `RequestDelegatesAreSourceGeneratedTest` still counts
`SchedulerEndpoints.cs = 13` — no route was added, and the generator still intercepts the listing after it
grew an `HttpContext` and an `IOptions<QuartzHttpApiOptions>` parameter, which is the thing that test
exists to catch.

`Quartz.Tests.Integration` references neither `Quartz.AspNetCore` nor `Quartz.Dashboard`, so nothing here
can reach it; Docker is available on this machine if you want it run anyway.

The analyzer findings on the first push are cleared in `5771e1e`: the route filter passes
`context.RequestAborted` and the hub passes `Context.ConnectionAborted` (S8949, MA0040), and the
route-pattern scan is an `Any` rather than a loop that returns out of itself (S3267). `LeaveScheduler`
takes the token too, so the two hub methods read alike — one line beyond what was reported, for
consistency within the class. The MA0003 "name the parameter" notes are on `new ValueTask<bool>(true)` and
on calls to local functions whose parameter names already match their arguments; naming them reads worse,
so they stand.

Closes #3423
