### PR TITLE
A registered job cannot take a scheduler's parts by constructor, and startup says so

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1334,13 +1334,26 @@ A job type that is an interface or an abstract class is not registered, since th
 construct it. Jobs named by an XML or JSON schedule are not registered either — nothing describes them
 to the container — so those still fail at fire time if their dependencies are missing.
 
-One case changes shape rather than merely failing earlier. A job that injects one of a *named*
-scheduler's own parts — `ISchedulerFactory`, `IJobStore`, `IThreadPool` — used to be activated through
-that scheduler's view of the container and was handed its parts. It is now resolved from the container
-like any other service, which resolves those unkeyed: with a default scheduler present it gets the
-default scheduler's, and with only named schedulers it fails validation. Take the scheduler from
-`IJobExecutionContext.Scheduler`, which is the scheduler that is actually running the job, or register
-the job with `AddJobType<T>(factory)` — below — and resolve what it needs by key inside the factory.
+**A registered job may not take a scheduler's own parts by constructor.** `IScheduler`,
+`ISchedulerFactory`, `IJobStore`, `IThreadPool` and `IOptions<QuartzSchedulerOptions>` belong to one
+scheduler. A job that injected one of them used to be activated through its scheduler's view of the
+container and was handed that scheduler's; a registered job is now resolved from the container like any
+other service, which resolves them unkeyed — the default scheduler's, or nothing at all in a container
+holding only named schedulers. Rather than leave a job silently holding another scheduler's
+collaborators, the constructor is refused when the host starts, with a message naming the job and the
+parameter:
+
+```text
+Job type ArchiveJob is registered on scheduler 'acme', and its constructor takes ISchedulerFactory
+schedulerFactory — a part that belongs to one scheduler. …
+```
+
+Take the scheduler from `IJobExecutionContext.Scheduler`, which is the scheduler actually running the
+job; take `IJobExecutionContextAccessor` in code the context is not handed to; or, where the job really
+has to be *constructed* with something of its scheduler's, register it with `AddJobType<T>(factory)` —
+below — and resolve that part by key inside the factory, which is not examined. A job type the container
+does not hold is unaffected: it is still activated by the job factory and still receives its own
+scheduler's parts.
 
 ### `AddJobType` gives one scheduler its own build of a job type
 
@@ -7920,6 +7933,7 @@ Parameters and behavior are unchanged:
 | `Quartz.Impl.DelegatingJobStore` added | Forwards every `IJobStore` member to a wrapped store, each one `virtual`, so a decorating store overrides only what it changes — see [`DelegatingJobStore` decorates a store](#delegatingjobstore-decorates-a-store) |
 | `HostnameInstanceIdGenerator` is `HostNameInstanceIdGenerator` | Casing matched to `HostNameBasedIdGenerator`. The type is internal; a `quartz.scheduler.instanceIdGenerator.type` still naming the old spelling resolves, with a warning |
 | `AddJob<T>` and `ScheduleJob<T>` register the job type | Scoped, with `TryAdd`, so an unresolvable job fails `ValidateOnBuild` instead of at fire time — see [`AddJob` registers the job with the container](#addjob-registers-the-job-with-the-container) |
+| A registered job's constructor may not take a scheduler's parts | `IScheduler`, `ISchedulerFactory`, `IJobStore`, `IThreadPool` and `IOptions<QuartzSchedulerOptions>` belong to one scheduler, and the container resolves them unkeyed, so a registered job taking one is refused when the host starts rather than handed the default scheduler's. Read the scheduler from `IJobExecutionContext.Scheduler`, or register the job with `AddJobType<T>(factory)` and resolve the part by key there — see [`AddJob` registers the job with the container](#addjob-registers-the-job-with-the-container) |
 | The `JobKey`-taking `AddJob` overloads removed | Identity is set inside the configurator with `WithIdentity` — see [One shape per registration method](#one-shape-per-registration-method) |
 | `IServiceCollectionQuartzConfigurator` is `IQuartzBuilder` | And the `AddQuartz` overloads taking an `(configurator, IServiceProvider)` callback are gone; use the `(IServiceProvider, configurator)` shape of `AddJob` / `AddTrigger` / `ScheduleJob` |
 | DI `AddCalendar` takes `AddCalendarOptions` | The two adjacent bools are gone, and `calendarName` is `name` |

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -591,24 +591,43 @@ when it is constructed, `IJobExecutionContextAccessor` below is neither.
 
 ### Which scheduler's parts a job is built from
 
-Two jobs on the same named scheduler can be handed different collaborators, and which one you get turns
-on whether the *container* knows the job type.
+A **registered** job is built by the *container*, and the container resolves constructor parameters
+**unkeyed** — it knows nothing about which scheduler is firing the job. A job on scheduler `acme` taking
+`IScheduler`, `ISchedulerFactory`, `IJobStore`, `IThreadPool` or `IOptions<QuartzSchedulerOptions>`
+would therefore be handed the *default* scheduler's, and in a container holding only named schedulers
+there would be no unkeyed registration to hand it at all.
 
-- **A job type the container holds is built by the container.** `AddJob<T>` registers the type with
-  `TryAddScoped`, so the job is resolved as an ordinary scoped service and its constructor dependencies
-  are resolved **unkeyed**. A job on scheduler `acme` that injects `ISchedulerFactory`, `IJobStore`,
-  `IThreadPool` or `IOptions<QuartzSchedulerOptions>` therefore gets the *default* scheduler's — and in
-  a container holding only named schedulers there is no unkeyed registration to get, so the job cannot
-  be constructed at all: reported when the container is validated, or at the first fire in a container
-  that does not validate.
-- **A job type the container does not hold is activated by the job factory**, through the
-  scheduler-scoped provider, and its dependencies resolve to *its own* scheduler's parts. That is any
-  job the container was never told about: one scheduled at runtime with `ScheduleJob(jobDetail, …)`,
-  and one named only by an XML or JSON schedule, which nothing describes to the container.
+So **a registered job may not take a scheduler's parts by constructor, and startup says so.**
+`AddJob<T>`, `AddJob(type, …)`, `ScheduleJob<T>` and `AddJobType<T>` each record the job type against
+the scheduler they were called on, and validating that scheduler's options walks the public
+constructors of the type the container would build:
 
-That the two differ is the point worth carrying away, because nothing about the job says which path it
-is on. **Do not inject a scheduler's own parts into a job.** A job that needs the scheduler running it
-takes `IJobExecutionContext.Scheduler`, which is that scheduler under either path:
+```text
+Job type ArchiveJob is registered on scheduler 'acme', and its constructor takes ISchedulerFactory
+schedulerFactory — a part that belongs to one scheduler. A registered job type is built by the
+container, which resolves constructor parameters without a scheduler's service key: what the job is
+handed is the unkeyed registration — the default scheduler's — whichever scheduler the job belongs to,
+and in a container holding only named schedulers there is no unkeyed registration to hand it. Read the
+scheduler running the job from IJobExecutionContext.Scheduler, take IJobExecutionContextAccessor for
+the firing it is part of, or register the job with AddJobType<ArchiveJob>(provider => ...) and resolve
+the part by key inside that factory.
+```
+
+Every public constructor is examined, not the one the container would pick: which one that is depends on
+what else the container holds — a constructor is only chosen when every parameter of it can be
+resolved — so a job whose clean constructor is picked today is picked differently the moment an
+unrelated registration appears. `TimeProvider` is the deliberate exception to the list: a scheduler
+given no clock of its own inherits the container's, and injecting a clock is what the rest of Quartz
+asks you to do.
+
+**A job type the container does not hold is unaffected**, and is not examined. It is activated by the
+job factory, through the scheduler-scoped provider, and its dependencies resolve to *its own*
+scheduler's parts — that is any job the container was never told about: one scheduled at runtime with
+`ScheduleJob(jobDetail, …)`, and one named only by an XML or JSON schedule.
+
+There are three ways to write the job instead, and the first covers nearly every case. **The scheduler
+running the fire is `IJobExecutionContext.Scheduler`**, which is that scheduler whichever path built the
+job:
 
 <!-- snippet: sample_tenancy_job_reads_its_scheduler -->
 ```csharp
@@ -628,9 +647,27 @@ public sealed class RotateTenantKeysJob : IJob
 ```
 <!-- endSnippet -->
 
-and a service the job calls into reads the firing from [`IJobExecutionContextAccessor`](#reading-the-firing-from-anywhere-in-it).
-Where the job genuinely has to be *constructed* with something of its scheduler's, register it with
-`AddJobType<T>(factory)` and resolve that by key inside the factory.
+**Code the context is not handed** — a scoped service, a repository three calls below `Execute` — reads
+the firing from [`IJobExecutionContextAccessor`](#reading-the-firing-from-anywhere-in-it).
+
+**A job that genuinely has to be *constructed* with something of its scheduler's** is registered with a
+factory of its own, which resolves that part by key. A registration built by a factory is not examined,
+because the factory is where the key goes:
+
+<!-- snippet: sample_tenancy_job_built_by_its_scheduler -->
+```csharp
+builder.Services.AddQuartz("acme", q =>
+{
+    // A job the container builds may not take a scheduler's parts by constructor - startup
+    // refuses one that does. The job that genuinely has to be given them is built here instead,
+    // where the scheduler's key is known.
+    q.AddJobType<ArchiveJob>(provider =>
+        new ArchiveJob(provider.GetRequiredKeyedService<ISchedulerFactory>("acme")));
+
+    q.AddJob<ArchiveJob>(j => j.WithIdentity("archive"));
+});
+```
+<!-- endSnippet -->
 
 ### Reading the firing from anywhere in it
 

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -105,6 +105,17 @@ A singleton job serves every fire from one instance, so it must be thread-safe a
 scoped dependencies. Prefer scoped, which is what `AddJob` registers.
 :::
 
+::: warning A registered job may not take a scheduler's parts by constructor
+`IScheduler`, `ISchedulerFactory`, `IJobStore`, `IThreadPool` and `IOptions<QuartzSchedulerOptions>`
+belong to one scheduler, and the container that builds the job resolves them unkeyed — it knows nothing
+about which scheduler is firing it. Startup therefore refuses such a constructor, naming the job and the
+parameter. The scheduler running the fire is `IJobExecutionContext.Scheduler`; code the context is not
+handed to reads the firing from `IJobExecutionContextAccessor`; and a job that really has to be
+*constructed* with something of its scheduler's is registered with `AddJobType<T>(provider => …)`, which
+resolves that part by key and is not examined. See
+[which scheduler's parts a job is built from](../multi-tenancy.md#which-scheduler-s-parts-a-job-is-built-from).
+:::
+
 To add to the scope the factory opens rather than to replace the factory — to seed an ambient tenant, say —
 use `q.ConfigureJobScope((scope, bundle, scheduler) => …)`.
 

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -60,6 +60,12 @@ inside a scope of its own, so the job can take its dependencies through its cons
 application does. A ramification that does still hold is that it makes no sense to keep state in fields on the job
 class — the instance is gone when the fire ends, so nothing in it is preserved between executions.
 
+One thing a registered job may *not* take by constructor is a part that belongs to one scheduler —
+`IScheduler`, `ISchedulerFactory`, `IJobStore`, `IThreadPool` or `IOptions<QuartzSchedulerOptions>`. The
+container builds the job and knows nothing about which scheduler is firing it, so startup refuses such a
+constructor. The scheduler running the fire is `context.Scheduler`; see
+[which scheduler's parts a job is built from](../multi-tenancy.md#which-scheduler-s-parts-a-job-is-built-from).
+
 You may now be wanting to ask "how can I provide properties/configuration for a Job instance?" and "how can I
 keep track of a job's state between executions?" The answer to these questions are the same: the key is the `JobDataMap`,
 which is part of the JobDetail object.

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -117,6 +117,24 @@ public static class MultiTenancySamples
 
     #endregion
 
+    public static void JobConstructedWithItsSchedulersParts(IHostApplicationBuilder builder)
+    {
+        #region sample_tenancy_job_built_by_its_scheduler
+
+        builder.Services.AddQuartz("acme", q =>
+        {
+            // A job the container builds may not take a scheduler's parts by constructor - startup
+            // refuses one that does. The job that genuinely has to be given them is built here instead,
+            // where the scheduler's key is known.
+            q.AddJobType<ArchiveJob>(provider =>
+                new ArchiveJob(provider.GetRequiredKeyedService<ISchedulerFactory>("acme")));
+
+            q.AddJob<ArchiveJob>(j => j.WithIdentity("archive"));
+        });
+
+        #endregion
+    }
+
     public static void PluginNamedByProperties(IHostApplicationBuilder builder)
     {
         #region sample_tenancy_plugin_by_properties
@@ -335,6 +353,12 @@ public interface IExportSink;
 
 /// <inheritdoc cref="NightlyReportJob" />
 public sealed class ExportJob(IExportSink sink) : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}
+
+/// <inheritdoc cref="NightlyReportJob" />
+public sealed class ArchiveJob(ISchedulerFactory schedulerFactory) : IJob
 {
     public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 }

--- a/src/Quartz.Tests.Unit/Configuration/RegisteredJobConstructorTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/RegisteredJobConstructorTest.cs
@@ -1,0 +1,342 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// A registered job is built by the container, which resolves constructor parameters without a
+/// scheduler's service key — so a job type the container holds and one it does not were handed
+/// different collaborators, and nothing about the job said which of the two it was (#3388). A registered
+/// job may therefore not take a scheduler's own parts by constructor, and startup says so.
+/// </summary>
+/// <remarks>
+/// <see cref="IStartupValidator"/> is what a host resolves and runs at the end of <c>Build()</c>, so
+/// resolving it here is the same check an application gets — without needing a host.
+/// </remarks>
+public sealed class RegisteredJobConstructorTest
+{
+    [Test]
+    public void AJobRegisteredWithAddJobCannotTakeItsSchedulerByConstructor()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.AddJob<SchedulerJob>(job => job.WithIdentity("rotate")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*SchedulerJob*IScheduler scheduler*IJobExecutionContext.Scheduler*",
+                "the report has to name the job, the parameter and what to do instead, or it only says "
+                + "that something is wrong");
+    }
+
+    /// <summary>
+    /// Every type <c>SchedulerScopedServiceProvider</c> answers per scheduler, in the shapes a job would
+    /// plausibly ask for one.
+    /// </summary>
+    [TestCase(typeof(SchedulerJob), "IScheduler scheduler")]
+    [TestCase(typeof(SchedulerFactoryJob), "ISchedulerFactory schedulerFactory")]
+    [TestCase(typeof(JobStoreJob), "IJobStore jobStore")]
+    [TestCase(typeof(ThreadPoolJob), "IThreadPool threadPool")]
+    [TestCase(typeof(SchedulerOptionsJob), "IOptions<QuartzSchedulerOptions> options")]
+    public void EveryPartThatBelongsToOneSchedulerIsRefused(Type jobType, string parameter)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.AddJob(jobType, job => job.WithIdentity("rotate")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage($"*{parameter}*");
+    }
+
+    /// <summary>
+    /// The keyed registration <c>AddJobType</c> makes is the case that half-works today: it is this
+    /// scheduler's own registration, and the container still builds it unkeyed.
+    /// </summary>
+    [Test]
+    public void AJobTypeRegisteredForANamedSchedulerIsRefusedTheSameWay()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("acme", q => q.AddJobType<TenantJob, SchedulerTenantJob>());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*TenantJob, built as SchedulerTenantJob, is registered on scheduler 'acme'*",
+                "the job type named on the job detail and the type actually constructed can differ, and "
+                + "the constructor that matters is the one being constructed");
+    }
+
+    /// <summary>
+    /// One instance serving two schedulers is the worst of the cases: whichever scheduler's parts it was
+    /// built with, the other one's fires are run by a job holding the wrong collaborators for the whole
+    /// life of the container.
+    /// </summary>
+    [Test]
+    public void ASingletonJobTypeIsRefusedToo()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("acme", q => q.AddJobType<TenantJob, SchedulerTenantJob>(ServiceLifetime.Singleton));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*SchedulerTenantJob*IScheduler scheduler*");
+    }
+
+    /// <summary>
+    /// The approximation this check makes: every public constructor is examined, not the one the
+    /// container would pick.
+    /// </summary>
+    /// <remarks>
+    /// Which constructor that is depends on what else the container holds — one is only chosen when
+    /// every parameter of it can be resolved — so a job whose clean constructor is picked today is
+    /// picked differently the moment an unrelated registration appears, and the trap would be back
+    /// without the job having changed.
+    /// </remarks>
+    [Test]
+    public void AJobWithACleanConstructorBesideAnOffendingOneIsStillRefused()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.AddJob<TwoConstructorJob>(job => job.WithIdentity("rotate")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*TwoConstructorJob*ISchedulerFactory schedulerFactory*",
+                "which constructor the container picks is a property of the container's contents rather "
+                + "than of the job, so a job that must not be built with a scheduler's parts does not "
+                + "declare a constructor that takes them");
+    }
+
+    /// <summary>
+    /// What a job is supposed to take: the firing it is part of, the clock, and services of the
+    /// application's own.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TimeProvider"/> is the deliberate exclusion. A scheduler given no clock of its own
+    /// inherits the container's, and injecting one is what the rest of the repository asks code to do
+    /// rather than reading a clock statically.
+    /// </remarks>
+    [Test]
+    public void AJobTakingTheFiringOrAnApplicationServiceIsFine()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<TenantDirectory>();
+        services.AddQuartz(q => q.AddJob<WellBehavedJob>(job => job.WithIdentity("rotate")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// The escape hatch the documentation points at: a job that genuinely has to be <em>constructed</em>
+    /// with something of its scheduler's is registered with a factory, and resolves the part by key
+    /// inside it.
+    /// </summary>
+    [Test]
+    public void AJobBuiltByAFactoryOfItsOwnIsNotRefused()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("acme", q =>
+        {
+            q.AddJob<SchedulerJob>(job => job.WithIdentity("rotate"));
+            q.AddJobType<SchedulerJob>(provider =>
+                new SchedulerJob(provider.GetRequiredKeyedService<IScheduler>("acme")));
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow(
+            "the scheduler's own registration is what the job factory resolves first, and a factory "
+            + "constructs the job itself — there is no constructor for the container to fill in");
+    }
+
+    /// <summary>
+    /// A job type the container does not hold is activated by the job factory through the
+    /// scheduler-scoped provider, which hands it its own scheduler's parts. That path is unchanged, so
+    /// there is nothing to refuse.
+    /// </summary>
+    [Test]
+    public void AJobTypeTheContainerDoesNotHoldIsNotInspected()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("acme", q => q.AddTrigger<SchedulerJob>(
+            trigger => trigger.WithIdentity("rotate-trigger").ForJob("rotate", "tenancy")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetService<SchedulerJob>().Should().BeNull(
+            "naming a job type on a trigger does not register it, which is the premise of this test");
+
+        Action act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow(
+            "a job the container was never told about is activated by the job factory, which builds it "
+            + "from its own scheduler's parts");
+    }
+
+    /// <summary>
+    /// A job belongs to the scheduler it was added to, and so does the failure.
+    /// </summary>
+    [Test]
+    public void OnlyTheSchedulerThatWasGivenTheJobIsRefused()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("acme", q => q.AddJobType<TenantJob, SchedulerTenantJob>());
+        services.AddQuartz("initech", q => q.AddJobType<TenantJob, PlainTenantJob>());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        IOptionsMonitor<QuartzSchedulerOptions> options =
+            provider.GetRequiredService<IOptionsMonitor<QuartzSchedulerOptions>>();
+
+        Action initech = () => options.Get("initech");
+        initech.Should().NotThrow("initech builds the job type its own way, and its way is clean");
+
+        Action acme = () => options.Get("acme");
+        acme.Should().Throw<OptionsValidationException>().WithMessage("*scheduler 'acme'*");
+    }
+
+    public sealed class SchedulerJob : IJob
+    {
+        public SchedulerJob(IScheduler scheduler)
+        {
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class SchedulerFactoryJob : IJob
+    {
+        public SchedulerFactoryJob(ISchedulerFactory schedulerFactory)
+        {
+            SchedulerFactory = schedulerFactory;
+        }
+
+        public ISchedulerFactory SchedulerFactory { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class JobStoreJob : IJob
+    {
+        public JobStoreJob(IJobStore jobStore)
+        {
+            JobStore = jobStore;
+        }
+
+        public IJobStore JobStore { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class ThreadPoolJob : IJob
+    {
+        public ThreadPoolJob(IThreadPool threadPool)
+        {
+            ThreadPool = threadPool;
+        }
+
+        public IThreadPool ThreadPool { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class SchedulerOptionsJob : IJob
+    {
+        public SchedulerOptionsJob(IOptions<QuartzSchedulerOptions> options)
+        {
+            Options = options;
+        }
+
+        public IOptions<QuartzSchedulerOptions> Options { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class TwoConstructorJob : IJob
+    {
+        public TwoConstructorJob(TenantDirectory directory)
+        {
+            Directory = directory;
+        }
+
+        public TwoConstructorJob(TenantDirectory directory, ISchedulerFactory schedulerFactory)
+        {
+            Directory = directory;
+            SchedulerFactory = schedulerFactory;
+        }
+
+        public TenantDirectory Directory { get; }
+
+        public ISchedulerFactory? SchedulerFactory { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class WellBehavedJob : IJob
+    {
+        public WellBehavedJob(IJobExecutionContextAccessor accessor, TimeProvider clock, TenantDirectory directory)
+        {
+            Accessor = accessor;
+            Clock = clock;
+            Directory = directory;
+        }
+
+        public IJobExecutionContextAccessor Accessor { get; }
+
+        public TimeProvider Clock { get; }
+
+        public TenantDirectory Directory { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public abstract class TenantJob : IJob
+    {
+        public abstract ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default);
+    }
+
+    public sealed class SchedulerTenantJob : TenantJob
+    {
+        public SchedulerTenantJob(IScheduler scheduler)
+        {
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        public override ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    public sealed class PlainTenantJob : TenantJob
+    {
+        public override ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A service of the application's own, which a job is welcome to take.
+    /// </summary>
+    public sealed class TenantDirectory;
+}

--- a/src/Quartz/Configuration/QuartzBuilderExtensions.cs
+++ b/src/Quartz/Configuration/QuartzBuilderExtensions.cs
@@ -100,7 +100,7 @@ public static class QuartzBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
-        TryRegisterJobType(builder.Services, typeof(T));
+        TryRegisterJobType(builder, typeof(T));
 
         SchedulerContent.Register(builder.Services, builder.SchedulerName, serviceProvider =>
             new SchedulerContent().Add(
@@ -145,7 +145,7 @@ public static class QuartzBuilderExtensions
             Throw.ArgumentException("jobType must implement the IJob interface", nameof(jobType));
         }
 
-        TryRegisterJobType(builder.Services, jobType);
+        TryRegisterJobType(builder, jobType);
 
         SchedulerContent.Register(builder.Services, builder.SchedulerName, serviceProvider =>
             new SchedulerContent().Add(
@@ -261,7 +261,7 @@ public static class QuartzBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(trigger);
 
-        TryRegisterJobType(builder.Services, typeof(T));
+        TryRegisterJobType(builder, typeof(T));
 
         // One registration carrying both, because the job's key may be derived from the trigger's: built
         // as two independent registrations they could not agree on it.
@@ -398,6 +398,7 @@ public static class QuartzBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.Services.Add(Describe(builder, typeof(TJob), lifetime, implementationType: typeof(TImplementation)));
+        RegisteredJobTypes.For(builder.Services).Add(builder.SchedulerName, typeof(TJob));
         return builder;
     }
 
@@ -431,7 +432,11 @@ public static class QuartzBuilderExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(implementationFactory);
 
+        // Recorded like any other job-type registration even though a job built by a factory has no
+        // constructor to check: what it says is that this scheduler builds TJob its own way, which is
+        // what makes an AddJob<TJob> registration of the same type stop being the one that would be used.
         builder.Services.Add(Describe(builder, typeof(TJob), lifetime, factory: provider => implementationFactory(provider)));
+        RegisteredJobTypes.For(builder.Services).Add(builder.SchedulerName, typeof(TJob));
         return builder;
     }
 
@@ -496,9 +501,15 @@ public static class QuartzBuilderExtensions
     /// It is a <c>TryAdd</c>, so a registration the application made itself — with its own lifetime,
     /// factory or implementation type — is kept, and adding the same job twice is harmless.
     /// </para>
+    /// <para>
+    /// Being registered is also what makes the job the container's to build rather than the job
+    /// factory's to activate, so the scheduler is recorded as having been given it and
+    /// <see cref="RegisteredJobConstructorValidator"/> checks at startup that its constructor asks for
+    /// nothing that belongs to one scheduler.
+    /// </para>
     /// </remarks>
     private static void TryRegisterJobType(
-        IServiceCollection services,
+        IQuartzBuilder builder,
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type jobType)
     {
         // A job named by an interface or an abstract type is one the container could not construct
@@ -509,7 +520,8 @@ public static class QuartzBuilderExtensions
             return;
         }
 
-        services.TryAddScoped(jobType);
+        builder.Services.TryAddScoped(jobType);
+        RegisteredJobTypes.For(builder.Services).Add(builder.SchedulerName, jobType);
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/QuartzOptionsValidators.cs
+++ b/src/Quartz/Configuration/QuartzOptionsValidators.cs
@@ -1,3 +1,7 @@
+using System.Collections.Frozen;
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace Quartz.Configuration;
@@ -115,6 +119,203 @@ internal sealed class DefaultSchedulerNameValidator : IValidateOptions<QuartzSch
             + "is also registered, and two schedulers cannot share a name — the repository indexes them by "
             + "name, ignoring case. Give the default scheduler a different InstanceName, or move what "
             + "AddQuartz() configures onto the named scheduler and register only that one.");
+    }
+}
+
+/// <summary>
+/// Refuses a registered job type whose constructor takes one of a scheduler's own parts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A job type the container holds is built by the <em>container</em>, which resolves constructor
+/// parameters without a service key — so a job on scheduler <c>acme</c> taking an
+/// <see cref="ISchedulerFactory"/> is handed the default scheduler's, and in a container holding only
+/// named schedulers cannot be built at all. A job type the container does not hold is activated by the
+/// job factory through <see cref="SchedulerScopedServiceProvider"/> and is handed its own scheduler's
+/// parts. Registering a job — the documented, recommended thing to do — therefore changed which
+/// scheduler's collaborators it saw, and nothing about the job said which path it was on.
+/// </para>
+/// <para>
+/// The rule this enforces is the one the documentation already gives: a registered job does not take a
+/// scheduler's parts by constructor. It reads the scheduler running it from
+/// <see cref="IJobExecutionContext.Scheduler"/>, the firing from
+/// <see cref="IJobExecutionContextAccessor"/>, and where it genuinely has to be <em>constructed</em>
+/// with something of its scheduler's it is registered with <c>AddJobType&lt;T&gt;(factory)</c> and
+/// resolves that part by key inside the factory — which is why a registration that builds the job with
+/// a factory, or hands one over ready made, is not examined here.
+/// </para>
+/// <para>
+/// Every public constructor is examined rather than the one the container would pick. Which one that is
+/// depends on what else the container holds, since a constructor is only chosen when every parameter of
+/// it can be resolved: a job whose clean constructor is chosen today is chosen differently the moment an
+/// unrelated registration appears, and the trap would be back without the job having changed. A job that
+/// must not be built with a scheduler's parts therefore does not declare a constructor taking them.
+/// </para>
+/// <para>
+/// It runs wherever <see cref="QuartzSchedulerOptions"/> are created for a scheduler, which on a host is
+/// <c>ValidateOnStart</c> and in a container built by <see cref="QuartzSchedulerBuilder"/> — where
+/// nothing runs the startup validation — is when the scheduler is first built.
+/// </para>
+/// </remarks>
+internal sealed class RegisteredJobConstructorValidator : IValidateOptions<QuartzSchedulerOptions>
+{
+    /// <summary>
+    /// The service types belonging to one scheduler rather than to the container.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="SchedulerScopedServiceProvider"/>'s own list, so the two cannot drift apart, plus
+    /// <see cref="IScheduler"/> — registered per scheduler but resolved by key rather than through that
+    /// wrapper — plus every shape of the options types a scheduler owns, whose unnamed members read the
+    /// default scheduler's instance.
+    /// </para>
+    /// <para>
+    /// <see cref="TimeProvider"/> is deliberately absent although the wrapper routes it too: a scheduler
+    /// given no clock of its own inherits the container's, injecting one is what the rest of this
+    /// repository asks code to do rather than reading a clock statically, and refusing it would cost far
+    /// more than the case it would catch.
+    /// </para>
+    /// </remarks>
+    private static readonly FrozenSet<Type> schedulerParts = SchedulerParts();
+
+    private readonly RegisteredJobTypes jobTypes;
+    private readonly IEnumerable<SchedulerNamedOptions> pluginOptions;
+    private HashSet<Type>? declaredPluginOptions;
+
+    public RegisteredJobConstructorValidator(
+        RegisteredJobTypes jobTypes,
+        IEnumerable<SchedulerNamedOptions> pluginOptions)
+    {
+        this.jobTypes = jobTypes;
+        this.pluginOptions = pluginOptions;
+    }
+
+    public ValidateOptionsResult Validate(string? name, QuartzSchedulerOptions options)
+    {
+        List<string>? failures = null;
+        string schedulerName = name ?? Options.DefaultName;
+
+        foreach (ServiceDescriptor registration in jobTypes.Registrations(schedulerName))
+        {
+            Type? implementationType = RegisteredJobTypes.ImplementationType(registration);
+            if (implementationType is null)
+            {
+                continue;
+            }
+
+            foreach (ConstructorInfo constructor in implementationType.GetConstructors())
+            {
+                foreach (ParameterInfo parameter in constructor.GetParameters())
+                {
+                    if (!IsSchedulerPart(parameter.ParameterType))
+                    {
+                        continue;
+                    }
+
+                    string failure = Failure(schedulerName, registration.ServiceType, implementationType, parameter);
+
+                    // Two constructors can take the same part under the same name, and the report names
+                    // the job and the parameter rather than which constructor it was found on.
+                    failures ??= [];
+                    if (!failures.Contains(failure))
+                    {
+                        failures.Add(failure);
+                    }
+                }
+            }
+        }
+
+        return QuartzSchedulerOptionsValidator.Result(failures);
+    }
+
+    private static FrozenSet<Type> SchedulerParts()
+    {
+        HashSet<Type> parts = [.. SchedulerScopedServiceProvider.SchedulerScopedServiceTypes, typeof(IScheduler)];
+
+        foreach (Type optionsService in SchedulerScopedServiceProvider.DeclareQuartzOptions().Keys)
+        {
+            parts.Add(optionsService);
+        }
+
+        return FrozenSet.ToFrozenSet(parts);
+    }
+
+    private bool IsSchedulerPart(Type parameterType)
+    {
+        return schedulerParts.Contains(parameterType) || IsPluginOptions(parameterType);
+    }
+
+    /// <summary>
+    /// Whether the parameter is one shape of an options type a plugin declared as its scheduler's.
+    /// </summary>
+    /// <remarks>
+    /// The static set cannot list these: the type comes from the plugin rather than from Quartz.
+    /// <c>AddPlugin&lt;T, TOptions&gt;</c> registers a declaration instead, and a declaration names the
+    /// same three closed generic services <see cref="SchedulerScopedServiceProvider"/> answers.
+    /// </remarks>
+    private bool IsPluginOptions(Type parameterType)
+    {
+        // Every options service is a closed generic over IOptions<>, IOptionsMonitor<> or
+        // IOptionsSnapshot<>, so anything else is turned away before the declarations are read.
+        if (!parameterType.IsConstructedGenericType)
+        {
+            return false;
+        }
+
+        return (declaredPluginOptions ??= DeclarePluginOptions()).Contains(parameterType);
+    }
+
+    private HashSet<Type> DeclarePluginOptions()
+    {
+        Dictionary<Type, Func<IServiceProvider, string, object>> declared = [];
+
+        foreach (SchedulerNamedOptions options in pluginOptions)
+        {
+            options.DeclareInto(declared);
+        }
+
+        return [.. declared.Keys];
+    }
+
+    private static string Failure(
+        string schedulerName,
+        Type jobType,
+        Type implementationType,
+        ParameterInfo parameter)
+    {
+        string scheduler = string.IsNullOrEmpty(schedulerName)
+            ? "the default scheduler"
+            : $"scheduler '{schedulerName}'";
+
+        string built = implementationType == jobType ? "" : $", built as {TypeName(implementationType)},";
+
+        return $"Job type {TypeName(jobType)}{built} is registered on {scheduler}, and its constructor takes "
+            + $"{TypeName(parameter.ParameterType)} {parameter.Name} — a part that belongs to one scheduler. "
+            + "A registered job type is built by the container, which resolves constructor parameters without "
+            + "a scheduler's service key: what the job is handed is the unkeyed registration — the default "
+            + "scheduler's — whichever scheduler the job belongs to, and in a container holding only named "
+            + "schedulers there is no unkeyed registration to hand it. Read the scheduler running the job from "
+            + "IJobExecutionContext.Scheduler, take IJobExecutionContextAccessor for the firing it is part of, "
+            + $"or register the job with AddJobType<{TypeName(jobType)}>(provider => ...) and resolve the part "
+            + "by key inside that factory.";
+    }
+
+    /// <summary>
+    /// A type as it is spelled in source, one level of generic arguments deep — which is as deep as
+    /// <c>IOptions&lt;QuartzSchedulerOptions&gt;</c>, the only generic shape that reaches here, goes.
+    /// </summary>
+    private static string TypeName(Type type)
+    {
+        if (!type.IsConstructedGenericType)
+        {
+            return type.Name;
+        }
+
+        string name = type.Name;
+        int arity = name.IndexOf('`', StringComparison.Ordinal);
+        string[] arguments = Array.ConvertAll(type.GetGenericArguments(), static argument => argument.Name);
+
+        return $"{(arity < 0 ? name : name[..arity])}<{string.Join(", ", arguments)}>";
     }
 }
 

--- a/src/Quartz/Configuration/RegisteredJobTypes.cs
+++ b/src/Quartz/Configuration/RegisteredJobTypes.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// The job types a container has been told to carry, and the scheduler each was named for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A job type the container holds is built by the <em>container</em> rather than activated by the job
+/// factory, which is the difference <see cref="RegisteredJobConstructorValidator"/> exists to police.
+/// Only what Quartz was told about is recorded: a type an application registered for reasons of its own
+/// is its own business, even when it happens to implement <see cref="IJob"/>.
+/// </para>
+/// <para>
+/// It keeps the service collection rather than a copy of what was registered, because how a job type is
+/// built is only settled once registration is over. <c>AddJob</c> registers with <c>TryAdd</c> and loses
+/// to a registration the application made itself, <c>AddJobType</c> replaces what came before it, and a
+/// job built by a factory has no constructor for anything here to read — which is exactly the shape the
+/// documentation recommends for a job that must be constructed with something of its scheduler's. Read
+/// at registration time, each of those three would be read wrong.
+/// </para>
+/// </remarks>
+internal sealed class RegisteredJobTypes
+{
+    private readonly IServiceCollection services;
+
+    /// <summary>
+    /// Which scheduler was told to carry which job type. A set, because the same job type can be named
+    /// twice for one scheduler — <c>AddQuartz()</c> is additive, and container-wide configuration
+    /// reaches every scheduler — and saying it twice is not two jobs.
+    /// </summary>
+    private readonly HashSet<(string SchedulerName, Type JobType)> registered = [];
+
+    private RegisteredJobTypes(IServiceCollection services)
+    {
+        this.services = services;
+    }
+
+    /// <summary>
+    /// Returns the record belonging to a service collection, registering one — and the validator that
+    /// reads it — on first use.
+    /// </summary>
+    /// <remarks>
+    /// Held as a registered instance for the reason <see cref="SchedulerNameRegistry"/> is: it is written
+    /// while registration is still going on. The validator is registered here rather than beside the
+    /// other options validators so that it exists only in a container that was actually given a job to
+    /// carry, and so that it can require this record rather than do without it.
+    /// </remarks>
+    public static RegisteredJobTypes For(IServiceCollection services)
+    {
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(RegisteredJobTypes)
+                && descriptor.ImplementationInstance is RegisteredJobTypes existing)
+            {
+                return existing;
+            }
+        }
+
+        RegisteredJobTypes registrations = new(services);
+        services.AddSingleton(registrations);
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<
+            IValidateOptions<QuartzSchedulerOptions>,
+            RegisteredJobConstructorValidator>());
+
+        return registrations;
+    }
+
+    /// <summary>
+    /// Records that a scheduler was given a job of this type.
+    /// </summary>
+    /// <param name="schedulerName">
+    /// The scheduler the job was added to, empty or <see langword="null"/> for the default one.
+    /// </param>
+    /// <param name="jobType">The job type, as the container knows it.</param>
+    public void Add(string? schedulerName, Type jobType)
+    {
+        registered.Add((schedulerName ?? Options.DefaultName, jobType));
+    }
+
+    /// <summary>
+    /// The registrations one scheduler's job types would be built from, in no particular order.
+    /// </summary>
+    public List<ServiceDescriptor> Registrations(string schedulerName)
+    {
+        List<ServiceDescriptor> found = [];
+
+        // The default scheduler's registrations are the unkeyed ones; a key of "" is not the same as no
+        // key to a container.
+        object? key = string.IsNullOrEmpty(schedulerName) ? null : schedulerName;
+
+        foreach ((string name, Type jobType) in registered)
+        {
+            if (!string.Equals(name, schedulerName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (Winner(jobType, key) is { } descriptor)
+            {
+                found.Add(descriptor);
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// The registration the job factory's resolution lands on: this scheduler's own, then the container's
+    /// unkeyed one, the last registration winning in each case — which is how the container resolves.
+    /// </summary>
+    private ServiceDescriptor? Winner(Type jobType, object? key)
+    {
+        return Last(jobType, key) ?? (key is null ? null : Last(jobType, serviceKey: null));
+    }
+
+    private ServiceDescriptor? Last(Type jobType, object? serviceKey)
+    {
+        ServiceDescriptor? found = null;
+
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (descriptor.ServiceType == jobType && Equals(descriptor.ServiceKey, serviceKey))
+            {
+                found = descriptor;
+            }
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// The type the container would construct for a registration, or <see langword="null"/> when it
+    /// constructs nothing — a factory of the application's own, or an instance it handed over ready
+    /// made.
+    /// </summary>
+    /// <remarks>
+    /// The keyed and unkeyed properties are separate members of <see cref="ServiceDescriptor"/>, and
+    /// reading the wrong one throws rather than returning <see langword="null"/>. Both carry the
+    /// annotation that makes reading the type's constructors trimmable, which is why the type is taken
+    /// from here rather than from what was recorded above.
+    /// </remarks>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+    public static Type? ImplementationType(ServiceDescriptor descriptor)
+    {
+        return descriptor.IsKeyedService ? descriptor.KeyedImplementationType : descriptor.ImplementationType;
+    }
+}


### PR DESCRIPTION
A job type the container holds is built by the **container**, which resolves constructor parameters
without a scheduler's service key. A job on scheduler `acme` taking `IScheduler`, `ISchedulerFactory`,
`IJobStore`, `IThreadPool` or `IOptions<QuartzSchedulerOptions>` was therefore handed the *default*
scheduler's — or could not be built at all in a container holding only named schedulers. A job type the
container does *not* hold is activated by the job factory through `SchedulerScopedServiceProvider` and
is handed its own scheduler's parts. Registering a job, the documented and recommended thing to do,
changed which scheduler's collaborators it saw, and nothing about the job said which path it was on.

This is option 1 from #3388: refuse the ambiguity at startup rather than add a mechanism.

## The rule

**A registered job may not take a scheduler's parts by constructor.** `AddJob<T>`, `AddJob(type, …)`,
`ScheduleJob<T>` and `AddJobType<T>` record the job type against the scheduler they were called on;
`RegisteredJobConstructorValidator`, an `IValidateOptions<QuartzSchedulerOptions>`, walks the public
constructors of the type the container would build and fails validation with a message naming the job,
the parameter and the fix:

```text
Job type ArchiveJob is registered on scheduler 'acme', and its constructor takes ISchedulerFactory
schedulerFactory — a part that belongs to one scheduler. A registered job type is built by the
container, which resolves constructor parameters without a scheduler's service key: what the job is
handed is the unkeyed registration — the default scheduler's — whichever scheduler the job belongs to,
and in a container holding only named schedulers there is no unkeyed registration to hand it. Read the
scheduler running the job from IJobExecutionContext.Scheduler, take IJobExecutionContextAccessor for
the firing it is part of, or register the job with AddJobType<ArchiveJob>(provider => ...) and resolve
the part by key inside that factory.
```

It runs wherever `QuartzSchedulerOptions` are created for a scheduler — `ValidateOnStart` on a host,
and when the scheduler is first built in a container `QuartzSchedulerBuilder` made, where nothing runs
the startup validation. A singleton `AddJobType<TJob, TImpl>(ServiceLifetime.Singleton)` is refused the
same way; it is the worst of the cases rather than a different one.

The parts are `SchedulerScopedServiceProvider`'s own list — read from it, so the two cannot drift —
plus `IScheduler`, plus all three shapes of every options type a scheduler owns, a plugin's included.
`TimeProvider` is the deliberate exclusion although the wrapper routes it: a scheduler given no clock
of its own inherits the container's, injecting a clock is what the rest of the repository asks for, and
refusing it would cost far more than the case it catches. `IServiceProvider` is excluded for the same
kind of reason — `DirectoryScanJob` takes one.

## Two decisions a reviewer should weigh

**Every public constructor is examined, not the one the container would pick.** Which one that is
depends on what else the container holds, since MEDI only chooses a constructor whose every parameter
can be resolved: a job whose clean constructor is picked today is picked differently the moment an
unrelated registration appears, and the trap would be back without the job having changed. Modelling
MEDI's selection would also mean re-implementing it, and being subtly wrong there means *missing* a
trap silently. The cost is that a job with a clean constructor beside an offending one is refused —
`AJobWithACleanConstructorBesideAnOffendingOneIsStillRefused` pins that, and the docs say it.

**Which registration a job type would be built from is read from the service collection at validation
time**, not recorded as the calls are made. `AddJob` registers with `TryAdd` and loses to a
registration the application made itself, `AddJobType` replaces what came before it, and a job built by
a factory has no constructor to read — and that last one matters, because `AddJob<T>` plus
`AddJobType<T>(factory)` *is* the documented escape hatch for a job that must be constructed with
something of its scheduler's. Recorded at registration time, the escape hatch would be refused.
`RegisteredJobTypes` therefore holds the `IServiceCollection`, the way `SchedulerNameRegistry` holds
the names, and it is created only from `AddJob`/`AddJobType` — so it and the validator exist only in a
container that was given a job to carry.

Only job types Quartz was told about are examined. A type an application registered for reasons of its
own is its own business, even when it implements `IJob`.

## Trimming

No new reflection to record: `ServiceDescriptor.ImplementationType` / `KeyedImplementationType` carry
`[DynamicallyAccessedMembers(PublicConstructors)]`, so `GetConstructors()` reads an annotated type and
`TrimAnalysisBaseline.cs` is untouched. No public API change; the baselines did not move.

## Documentation

- `multi-tenancy.md` — "Which scheduler's parts a job is built from" rewritten: what is refused, the
  message, the constructor approximation, `TimeProvider`, and the three ways to write the job instead,
  the last with a new compiled sample of the factory registration.
- `tutorial/more-about-jobs.md` and `packages/microsoft-di-integration.md` — the one-sentence rule
  beside where job registration is taught, pointing at `IJobExecutionContext.Scheduler`.
- `migration-guide.md` — the paragraph that said this case "changes shape rather than merely failing
  earlier" now says the constructor is refused when the host starts, and the appendix gains a row.

## Verification

```
dotnet build Quartz.slnx                     0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit            3509 passed, 4 skipped, 0 failed
dotnet test src/Quartz.Tests.AspNetCore      523 passed, 0 failed
integration 'basic' leg (Docker up)          329 passed, 0 failed
dotnet fallout VerifyDocsSnippets            up to date, 91 markdown files checked
dotnet fallout PublishTrimmed                trim canary published and ran clean
npm run docs:check-links                     no dead links or anchors
```

Closes #3388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
