### PR TITLE
The persistent store builder follows its own conventions

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -596,7 +596,7 @@ identically under `AddQuartz` and on a standalone `QuartzSchedulerBuilder`.
 | `UseTypeLoader<T>()` | how a type named by a string — a stored `JOB_CLASS_NAME`, a `.type` key — is resolved | resolution through the container's assemblies, with the 3.x namespace fallbacks |
 | `UseInstanceIdGenerator<T>()` | how `InstanceId` is derived when `GenerateInstanceId` is on | `SimpleInstanceIdGenerator`: host name plus a timestamp |
 | `UseJobStore<T>()`, `UseJobStore<T, TOptions>()` | the job store, for one that is neither of the two Quartz ships | the in-memory store |
-| `UseDriverDelegate<T>()` (on the persistent store builder) | the SQL dialect the ADO.NET store speaks | selected by the database method — `UseSqlServer` picks `SqlServerDelegate`, and so on |
+| `UseDriverDelegate<T>()`, `UseDriverDelegate(factory)` (on the persistent store builder) | the SQL dialect the ADO.NET store speaks | selected by the database method — `UseSqlServer` picks `SqlServerDelegate`, and so on |
 
 `UseTimeProvider` is the one to reach for in a test: a `FakeTimeProvider` makes `TriggerBuilder`,
 `GetFireTimeAfter` and misfire calculations see the time you set. It does not drive the scheduler's own

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -351,7 +351,7 @@ The same thing can be said as properties, which is the form 3.x used and which n
 
 A store's data source is named after the scheduler that owns it, or `quartz` for the default scheduler,
 so the name never has to be invented or kept in step by hand. Name one explicitly with
-`store.UseDataSourceName("reporting-db")` — before choosing the database, since the name is fixed once
+`store.UseDataSource("reporting-db")` — before choosing the database, since the name is fixed once
 the data source is configured — when two stores should read the same `Quartz:DataSource:<name>`
 settings, or when the settings live under a name of the application's choosing.
 
@@ -454,9 +454,10 @@ composite type registrations — is in play for Quartz's statements too.
 
 There are three entry points for a data source and they say different things.
 `UseDataSource(configure)` **defines** one — which driver, and how to reach the database — and the
-database methods above are shorthands for it. `UseDataSourceName(name)` **refers to** one by name,
-which is how a store picks up settings registered elsewhere, such as a `Quartz:DataSource:<name>`
-section. Where the connection itself comes from is `DataSourceOptions`' to say, not a fourth method's.
+database methods above are shorthands for it. `UseDataSource(name)` **refers to** one by name, which is
+how a store picks up settings registered elsewhere, such as a `Quartz:DataSource:<name>` section — one
+concept, so one name, told apart by whether it is handed a name or a callback. Where the connection
+itself comes from is `DataSourceOptions`' to say, not a fourth method's.
 
 #### Bringing your own connection provider
 

--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -201,6 +201,13 @@ the database method or it is silently ignored.
 The delegate is constructed with `ActivatorUtilities`, so **constructor dependencies work** — take an
 `ILogger<MyDatabaseDelegate>` or anything else in the container.
 
+For a delegate that needs more than the container can supply — a constructor argument only the caller
+has, or a property set before it is handed over — `UseDriverDelegate(factory)` takes the delegate you
+built. The factory is given a provider that resolves this scheduler's own parts, which is what
+registering `IDriverDelegate` against `Services` would not do: a named scheduler resolves its delegate
+under its own key and would never see an unkeyed registration. `UseSerializer`, `UseLockHandler`,
+`UseConnectionProvider` and `UseTriggerPersistenceDelegate` all take a factory the same way.
+
 The legacy `quartz.jobStore.driverDelegateType` key still selects a delegate by type name, and stands
 on its own: an application that has moved store selection into code can still name its delegate in a
 configuration file.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -307,9 +307,9 @@ spelling, and binds directly.
 ### A setting stops wearing a verb
 
 `IPersistentStoreBuilder.AcceptEnlistedTransactions()` was exactly
-`Configure(options => options.AcceptEnlistedTransactions = true)` — one assignment, no side effect —
+`ConfigureStore(options => options.AcceptEnlistedTransactions = true)` — one assignment, no side effect —
 while the other nineteen `AdoJobStoreOptions` settings, `UseDbLocks` and `StoreJobDataAsStrings` among them,
-are set through `Configure` like everything else. A reader of the interface reasonably concluded that
+are set through `ConfigureStore` like everything else. A reader of the interface reasonably concluded that
 the settings with verbs were the important ones.
 
 ```diff
@@ -317,7 +317,7 @@ the settings with verbs were the important ones.
   {
       store.UsePostgres(connectionString);
 -     store.AcceptEnlistedTransactions();
-+     store.Configure(options => options.AcceptEnlistedTransactions = true);
++     store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
   });
 ```
 
@@ -338,7 +338,7 @@ verb: it genuinely does more than one assignment, setting `Enabled` on `Clusteri
   {
       store.UseSqlServer(connectionString);
 -     store.Configure(options => options.UseProperties = true);
-+     store.Configure(options => options.StoreJobDataAsStrings = true);
++     store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
   });
 
 - Matchers.Group<JobKey>(@operator: StringOperator.StartsWith, compareTo: "reports");
@@ -349,6 +349,38 @@ The flat key is unchanged: `quartz.jobStore.useProperties` still sets `StoreJobD
 `appsettings.json` the section entry follows the option, so `JobStore:UseProperties` becomes
 `JobStore:StoreJobDataAsStrings` — the old spelling still works, because every section is also flattened
 onto its `quartz.*` key and read there.
+
+### The persistent store builder says which thing it configures
+
+Three members of `IPersistentStoreBuilder` did not follow the conventions the rest of it set.
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `store.Configure(options => …)` | `store.ConfigureStore(options => …)` |
+| `store.UseDataSourceName(name)` | `store.UseDataSource(name)` |
+| — | `store.UseDriverDelegate(factory)`, new |
+
+`Configure` was a bare verb inside a callback that already has `ConfigureScheduler` and
+`ConfigureOptions<TOptions>` in scope, so it said nothing about which of the things in reach it
+configured. `UseDataSourceName` and `UseDataSource` were two names for one concept, and naming a data
+source is the string overload of defining one. `UseDriverDelegate` was the only registration on the
+builder without a `Func<IServiceProvider, T>` overload — `UseConnectionProvider`, `UseSerializer`,
+`UseLockHandler` and `UseTriggerPersistenceDelegate` all had one — which made a dialect that needs
+anything from the container the one part of the store that could not be built from it.
+
+```diff
+  q.UsePersistentStore(store =>
+  {
+-     store.UseDataSourceName("reporting-db");
++     store.UseDataSource("reporting-db");
+      store.UseSqlServer(connectionString);
+-     store.Configure(options => options.TablePrefix = "RPT_QRTZ_");
++     store.ConfigureStore(options => options.TablePrefix = "RPT_QRTZ_");
+  });
+```
+
+No configuration key moved. `quartz.jobStore.*`, `Quartz:JobStore:*` and `quartz.jobStore.dataSource`
+all say what they said, so only code that calls these methods has anything to change.
 
 ### The hosted service's extension point is its four hooks
 
@@ -374,7 +406,7 @@ assignable on a live instance with nothing saying which wins or when. The compon
 | Component | Configure through |
 |---|---|
 | `RAMJobStore.MisfireThreshold` | `UseInMemoryStore(o => o.MisfireThreshold = …)` |
-| `AdoJobStoreBase.MisfireThreshold` | `UsePersistentStore(store => store.Configure(o => o.MisfireThreshold = …))` |
+| `AdoJobStoreBase.MisfireThreshold` | `UsePersistentStore(store => store.ConfigureStore(o => o.MisfireThreshold = …))` |
 | `TaskSchedulingThreadPool.MaxConcurrency`, `.Scheduler` | `UseDefaultThreadPool(maxConcurrency: …)`; both setters are `protected internal`, so a pool of your own can still set them |
 | `RedisSemaphore.RedisConfiguration`, `.KeyPrefix`, `.LockTimeToLive`, `.LockRetryInterval` | `UseRedisLockHandler(o => …)` |
 | The history plugins' message templates | `UseJobHistoryLogging(o => …)`, `UseTriggerHistoryLogging(o => …)`, and now `UseStructuredJobLogging(o => …)` / `UseStructuredTriggerLogging(o => …)` |
@@ -498,7 +530,7 @@ A scheduler has one job store and therefore one database, so there is no name to
 -     store.UseSqlServer("sql-server-01", connectionString);
 +     store.UseSqlServer(connectionString);
       store.UseSystemTextJsonSerializer();
-+     store.Configure(options => options.StoreJobDataAsStrings = true);
++     store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
   });
 ```
 
@@ -3619,7 +3651,7 @@ already have them.
 * **`JobInstantiationException`** — a job that could not be built names the trigger, the job and the fire instance instead of only interpolating the job key into a message (see [Instantiation failures name the trigger](#instantiation-failures-name-the-trigger))
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
 * **Every listener callback names its scheduler** — one listener can serve several schedulers in one host and still say which of them paused a trigger or failed, and `SchedulerError` carries the trigger, job and firing it was raised for. A listener still carrying a signature from 3.x or from alpha.1 is refused when it is registered, with a message naming the member, rather than being attached and never called (see [Listeners are told which scheduler is calling](#listeners-are-told-which-scheduler-is-calling))
-* **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.Configure(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
+* **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.ConfigureStore(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
 * **Pause, resume and reset a set of keys in one call** — `PauseTriggers`, `ResumeTriggers`, `PauseJobs`, `ResumeJobs` and `ResetTriggersFromErrorState` take a key collection, do the whole set in one lock and one transaction, and answer with the keys they applied to (see [A set of keys pauses, resumes or resets in one call](#a-set-of-keys-pauses-resumes-or-resets-in-one-call))
@@ -4645,7 +4677,7 @@ guarantee the write landed before `Initialize` ran:
 ```diff
 - ((ExternalTransactionJobStore) store).OpenConnection = true;
 + services.AddQuartz(q => q.UsePersistentStore<ExternalTransactionJobStore>(store =>
-+     store.Configure(options => options.OpenConnection = true)));
++     store.ConfigureStore(options => options.OpenConnection = true)));
 ```
 
 ## Nine `Execute…Lock` overloads became four members
@@ -4716,7 +4748,7 @@ configuring goes where it always did in 4.0:
 
 ```diff
 - var store = new JobStoreTX(...) { Clustered = true, MaxTransientRetries = 5 };
-+ services.AddQuartz(q => q.UsePersistentStore(store => store.Configure(options =>
++ services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
 + {
 +     options.Clustered = true;
 +     options.MaxTransientRetries = 5;
@@ -4725,7 +4757,7 @@ configuring goes where it always did in 4.0:
 
 `MisfireThreshold` keeps a **public getter** on both `AdoJobStoreBase` and `RAMJobStore` — it is read on
 every misfire pass rather than only at startup, so a store that wraps one needs to see it — but its setter
-is `internal` like the rest. Set it on the options type: `UsePersistentStore(store => store.Configure(o =>
+is `internal` like the rest. Set it on the options type: `UsePersistentStore(store => store.ConfigureStore(o =>
 o.MisfireThreshold = …))`, or `UseInMemoryStore(o => o.MisfireThreshold = …)`.
 
 Two properties that nothing read are gone rather than made read-only: `DriverDelegateType` (the delegate is
@@ -5139,7 +5171,7 @@ wants, and which reads without blocking writers — was not expressible at all, 
 
 ```diff
 - store.Configure(options => options.TxIsolationLevelSerializable = true);
-+ store.Configure(options => options.TransactionIsolationLevel = IsolationLevel.Serializable);
++ store.ConfigureStore(options => options.TransactionIsolationLevel = IsolationLevel.Serializable);
 ```
 
 `quartz.jobStore.txIsolationLevelSerializable` is still read: `true` becomes `Serializable`, and `false`
@@ -7841,7 +7873,7 @@ Parameters and behavior are unchanged:
 | The vetoed-fire span is `Quartz.Job.Veto` | `OperationName.Job.Veto` read `"Quartz.Job.Vetoed"` — the constant's name and its value disagreed. `Quartz.Job.Execute` and the `Quartz.JobStore.*` span names are unchanged |
 | `XmlSchedulingOptions` and `JsonSchedulingOptions` merged | They were byte-for-byte identical and are now one type |
 | Constructing a scheduler no longer starts a thread | `QuartzScheduler` starts its scheduler thread from `Start()` rather than its constructor, so resolving the service graph, running a `ValidateOnBuild` pass or asserting on registrations no longer spins one up. The thread always started paused, so this changes when the thread exists, not when jobs run |
-| `IPersistentStoreBuilder.AcceptEnlistedTransactions()` | Never shipped; the setting is `Configure(o => o.AcceptEnlistedTransactions = true)`, like the other nineteen `AdoJobStoreOptions` settings — see [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction) |
+| `IPersistentStoreBuilder.AcceptEnlistedTransactions()` | Never shipped; the setting is `ConfigureStore(o => o.AcceptEnlistedTransactions = true)`, like the other nineteen `AdoJobStoreOptions` settings — see [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction) |
 | Group matchers translate to SQL correctly | `SelectTriggerGroups`, `DeletePausedTriggerGroup` and both `UpdateTriggerGroupStateFromOtherState(s)` members always built a `LIKE`, even for an equality matcher; they take the `=` path now, which is exact and index-friendly. `LIKE` patterns escape `%`, `_` and the escape character in the matcher's own text with an explicit `ESCAPE` clause, so a group literally named `50%` matches itself. The escape character is `!` rather than a backslash, because MySQL applies C-style escaping inside string literals and `ESCAPE '\'` is a syntax error there |
 | `StdAdoConstants` group and fired-trigger statements were split | `SqlDeletePausedTriggerGroup`, `SqlSelectTriggerGroupsFiltered`, `SqlUpdateTriggerGroupStateFromState` and `SqlUpdateTriggerGroupStateFromStates` are `…Equals` / `…Like` pairs, and the FIRED_TRIGGERS statements are one `SqlSelectFiredTriggers` / `SqlDeleteFiredTriggers` base plus `SqlFiredTrigger*Predicate` fragments. The type is internal |
 | `IDashboardAuthorizationFilter` and `QuartzDashboardOptions.AuthorizationFilter` removed | Nothing ever invoked the filter, so setting it bought a false sense of security. Use `AuthorizationPolicy`, which is enforced |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1230,7 +1230,7 @@ What is left says four different things:
 | Member | Role |
 |---|---|
 | `UseDataSource(configure)` | **defines** a data source — which driver, and how to reach the database. The database methods such as `UseSqlServer` are shorthands for it |
-| `UseDataSourceName(name)` | **refers to** a data source by name, picking up settings registered elsewhere, such as a `Quartz:DataSource:<name>` section |
+| `UseDataSource(name)` | **refers to** a data source by name, picking up settings registered elsewhere, such as a `Quartz:DataSource:<name>` section |
 | `DataSourceOptions.UseRegisteredDataSource` | takes connections from the container's unkeyed `DbDataSource`, instead of from a connection string |
 | `DataSourceOptions.DataSourceServiceKey` / `.DataSourceFactory` | the same, for a `DbDataSource` registered under a key of its own or built by the caller. Set from code — neither a service key nor a delegate is something a configuration binder can produce |
 | `UseConnectionProvider<T>()` / `UseConnectionProvider(factory)` | **replaces** the connection provider outright, for connections Quartz cannot describe. The code spelling of `quartz.dataSource.<name>.connectionProvider.type` |

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -495,7 +495,7 @@ option, so two tenants can have entirely separate table *sets* in one database:
 builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
 {
     s.UseSqlServer(sharedConnectionString);
-    s.Configure(o => o.TablePrefix = "ACME_QRTZ_");
+    s.ConfigureStore(o => o.TablePrefix = "ACME_QRTZ_");
 }));
 ```
 <!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -536,7 +536,7 @@ q.UsePersistentStore(store =>
     store.UseSystemTextJsonSerializer();
     store.UseClustering();
 
-    store.Configure(options =>
+    store.ConfigureStore(options =>
     {
         // Every statement the store issues, the lock handler's included. Left unset it is
         // whatever the provider gives a new command, usually 30 seconds.

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -39,7 +39,7 @@ builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
 
     // it's generally recommended to stick with
     // string property keys and values when serializing
-    store.Configure(options => options.StoreJobDataAsStrings = true);
+    store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 
     store.UseNewtonsoftJsonSerializer();
 }));
@@ -54,7 +54,7 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
     .UsePersistentStore(store =>
     {
         store.UseGenericDatabase("MyProvider", "my connection string");
-        store.Configure(options => options.StoreJobDataAsStrings = true);
+        store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
         store.UseNewtonsoftJsonSerializer();
     })
     .Build();

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -180,7 +180,7 @@ builder.Services.AddQuartz(q =>
         store.UseSqlServer(connectionString);
         store.UseSystemTextJsonSerializer();
 
-        store.Configure(options =>
+        store.ConfigureStore(options =>
         {
             options.TablePrefix = "QRTZ_";        // the default
             options.StoreJobDataAsStrings = true; // preferred, but not the default
@@ -197,7 +197,7 @@ builder.Services.AddQuartz(q =>
 ```
 <!-- endSnippet -->
 
-Settings of the store itself go through `store.Configure(...)`, which configures `AdoJobStoreOptions`; the
+Settings of the store itself go through `store.ConfigureStore(...)`, which configures `AdoJobStoreOptions`; the
 database call and the clustering call are the ones that hang off the builder. How duplicate scheduling data is
 treated is a setting of its own:
 

--- a/docs/documentation/quartz-4.x/packages/system-text-json.md
+++ b/docs/documentation/quartz-4.x/packages/system-text-json.md
@@ -26,7 +26,7 @@ services.AddQuartz(q =>
 
         // it's generally recommended to stick with
         // string property keys and values when serializing
-        store.Configure(options => options.StoreJobDataAsStrings = true);
+        store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 
         store.UseSystemTextJsonSerializer();
     });

--- a/docs/documentation/quartz-4.x/quick-start.md
+++ b/docs/documentation/quartz-4.x/quick-start.md
@@ -56,7 +56,7 @@ builder.AddQuartz(q =>
         // System.Text.Json is built in; the Newtonsoft one is a package away
         store.UseSystemTextJsonSerializer();
 
-        store.Configure(options =>
+        store.ConfigureStore(options =>
         {
             // store job data as strings, which avoids surprises when a serialized
             // type changes shape later

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -176,7 +176,7 @@ a serialized blob:
 q.UsePersistentStore(s =>
 {
     s.UseSqlServer(connectionString);
-    s.Configure(o => o.StoreJobDataAsStrings = true);
+    s.ConfigureStore(o => o.StoreJobDataAsStrings = true);
 });
 ```
 <!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -75,7 +75,7 @@ builder.Services.AddQuartz(q =>
         store.UseSqlServer("Server=localhost;Database=quartz;Trusted_Connection=True;Encrypt=False");
         store.UseSystemTextJsonSerializer();
 
-        store.Configure(options =>
+        store.ConfigureStore(options =>
         {
             options.TablePrefix = "QRTZ_";
             options.StoreJobDataAsStrings = true;
@@ -117,7 +117,7 @@ If your scheduler is very busy — nearly always executing as many jobs as the t
 maximum pool size of the data source to around `ThreadPool:MaxConcurrency` plus one. That is a setting of the
 ADO.NET connection string, not of Quartz.
 
-Every setting of the store is on `AdoJobStoreOptions`, reached through `store.Configure(...)` or bound from the
+Every setting of the store is on `AdoJobStoreOptions`, reached through `store.ConfigureStore(...)` or bound from the
 `Quartz:JobStore` configuration section; they are all tabulated in the
 [configuration reference](../configuration/reference.md#persistent-job-store).
 
@@ -134,7 +134,7 @@ This is the recommended configuration, because it greatly decreases the possibil
 
 <!-- snippet: sample_job_stores_store_job_data_as_strings -->
 ```csharp
-store.Configure(options => options.StoreJobDataAsStrings = true);
+store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 ```
 <!-- endSnippet -->
 
@@ -177,7 +177,7 @@ builder.Services.AddQuartz(q =>
     q.UsePersistentStore(store =>
     {
         store.UsePostgres(connectionString);
-        store.Configure(options => options.AcceptEnlistedTransactions = true);
+        store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
     });
 });
 ```

--- a/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
+++ b/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
@@ -234,7 +234,7 @@ await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder.Create()
     {
         s.UseSqlServer(connectionString);
         s.UseClustering(c => c.CheckinInterval = TimeSpan.FromSeconds(10));
-        s.Configure(o => o.TablePrefix = "QRTZ_");
+        s.ConfigureStore(o => o.TablePrefix = "QRTZ_");
     })
     .Build();
 ```

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -133,7 +133,7 @@ q.UsePersistentStore(s =>
     s.UseSystemTextJsonSerializer();
     s.UseSqlServer(connectionString);
 
-    s.Configure(options =>
+    s.ConfigureStore(options =>
     {
         // A pass handles at most this many triggers, then commits. Lower it when the
         // sweep is timing out; the loop comes straight back for the rest.

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -218,7 +218,7 @@ public static class MultiTenancySamples
         builder.Services.AddQuartz("acme", q => q.UsePersistentStore(s =>
         {
             s.UseSqlServer(sharedConnectionString);
-            s.Configure(o => o.TablePrefix = "ACME_QRTZ_");
+            s.ConfigureStore(o => o.TablePrefix = "ACME_QRTZ_");
         }));
 
         #endregion

--- a/src/Quartz.Documentation.Samples/OperationsSamples.cs
+++ b/src/Quartz.Documentation.Samples/OperationsSamples.cs
@@ -99,7 +99,7 @@ public static class OperationsSamples
                 store.UseSystemTextJsonSerializer();
                 store.UseClustering();
 
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     // Every statement the store issues, the lock handler's included. Left unset it is
                     // whatever the provider gives a new command, usually 30 seconds.

--- a/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
+++ b/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
@@ -196,7 +196,7 @@ public static class PackageReadmeSamples
             builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
             {
                 store.UseSqlServer(connectionString);
-                store.Configure(options => options.StoreJobDataAsStrings = true);
+                store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
                 store.UseNewtonsoftJsonSerializer();
             }));
 

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -100,7 +100,7 @@ public static class MicrosoftDiIntegrationSamples
                 store.UseSqlServer(connectionString);
                 store.UseSystemTextJsonSerializer();
 
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     options.TablePrefix = "QRTZ_";        // the default
                     options.StoreJobDataAsStrings = true; // preferred, but not the default

--- a/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
@@ -33,7 +33,7 @@ public static class NewtonsoftJsonSamples
 
             // it's generally recommended to stick with
             // string property keys and values when serializing
-            store.Configure(options => options.StoreJobDataAsStrings = true);
+            store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 
             store.UseNewtonsoftJsonSerializer();
         }));
@@ -49,7 +49,7 @@ public static class NewtonsoftJsonSamples
             .UsePersistentStore(store =>
             {
                 store.UseGenericDatabase("MyProvider", "my connection string");
-                store.Configure(options => options.StoreJobDataAsStrings = true);
+                store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
                 store.UseNewtonsoftJsonSerializer();
             })
             .Build();

--- a/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/SystemTextJsonSamples.cs
@@ -26,7 +26,7 @@ public static class SystemTextJsonSamples
 
                 // it's generally recommended to stick with
                 // string property keys and values when serializing
-                store.Configure(options => options.StoreJobDataAsStrings = true);
+                store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 
                 store.UseSystemTextJsonSerializer();
             });

--- a/src/Quartz.Documentation.Samples/QuickStartSamples.cs
+++ b/src/Quartz.Documentation.Samples/QuickStartSamples.cs
@@ -33,7 +33,7 @@ public static class QuickStartSamples
                 // System.Text.Json is built in; the Newtonsoft one is a package away
                 store.UseSystemTextJsonSerializer();
 
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     // store job data as strings, which avoids surprises when a serialized
                     // type changes shape later

--- a/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
@@ -110,7 +110,7 @@ public static class JobDataMapSamples
             q.UsePersistentStore(s =>
             {
                 s.UseSqlServer(connectionString);
-                s.Configure(o => o.StoreJobDataAsStrings = true);
+                s.ConfigureStore(o => o.StoreJobDataAsStrings = true);
             });
 
             #endregion

--- a/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
@@ -36,7 +36,7 @@ public static class JobStoresSamples
                 store.UseSqlServer("Server=localhost;Database=quartz;Trusted_Connection=True;Encrypt=False");
                 store.UseSystemTextJsonSerializer();
 
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     options.TablePrefix = "QRTZ_";
                     options.StoreJobDataAsStrings = true;
@@ -51,7 +51,7 @@ public static class JobStoresSamples
     {
         #region sample_job_stores_store_job_data_as_strings
 
-        store.Configure(options => options.StoreJobDataAsStrings = true);
+        store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
 
         #endregion
     }
@@ -65,7 +65,7 @@ public static class JobStoresSamples
             q.UsePersistentStore(store =>
             {
                 store.UsePostgres(connectionString);
-                store.Configure(options => options.AcceptEnlistedTransactions = true);
+                store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
             });
         });
 

--- a/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/StandaloneSchedulerSamples.cs
@@ -163,7 +163,7 @@ public static class StandaloneSchedulerSamples
             {
                 s.UseSqlServer(connectionString);
                 s.UseClustering(c => c.CheckinInterval = TimeSpan.FromSeconds(10));
-                s.Configure(o => o.TablePrefix = "QRTZ_");
+                s.ConfigureStore(o => o.TablePrefix = "QRTZ_");
             })
             .Build();
 

--- a/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
+++ b/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
@@ -93,7 +93,7 @@ public static class VersionNeutralPageSamples
                 s.UseSystemTextJsonSerializer();
                 s.UseSqlServer(connectionString);
 
-                s.Configure(options =>
+                s.ConfigureStore(options =>
                 {
                     // A pass handles at most this many triggers, then commits. Lower it when the
                     // sweep is timing out; the loop comes straight back for the rest.

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -261,7 +261,7 @@ public class Startup
                     // if needed, a custom strategy for handling connections is registered as
                     // IDbProvider in the container, the way CustomSqlServerConnectionProvider is above
                 });
-                s.Configure(options =>
+                s.ConfigureStore(options =>
                 {
                     options.PerformSchemaValidation = true; // default
                     options.UseProperties = true; // preferred, but not default

--- a/src/Quartz.Examples/13_ClusteringJobsExecution/ClusteringJobsExecutionExample.cs
+++ b/src/Quartz.Examples/13_ClusteringJobsExecution/ClusteringJobsExecutionExample.cs
@@ -87,7 +87,7 @@ public class ClusteringJobsExecutionExample : IExample
                 // plus CheckinMisfireThreshold, 7.5 seconds each by default and both settable here
                 store.UseClustering();
                 store.UseSystemTextJsonSerializer();
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     options.StoreJobDataAsStrings = true;
                     options.MisfireThreshold = TimeSpan.FromSeconds(60);

--- a/src/Quartz.Serialization.Newtonsoft/README.md
+++ b/src/Quartz.Serialization.Newtonsoft/README.md
@@ -22,7 +22,7 @@ dotnet add package Quartz.Serialization.Newtonsoft
 builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
 {
     store.UseSqlServer(connectionString);
-    store.Configure(options => options.StoreJobDataAsStrings = true);
+    store.ConfigureStore(options => options.StoreJobDataAsStrings = true);
     store.UseNewtonsoftJsonSerializer();
 }));
 ```

--- a/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
@@ -366,7 +366,7 @@ public sealed class SchedulerAcrossDstTransitionTest
             builder.UsePersistentStore(persistent =>
             {
                 persistent.UseSqlite(ConnectionString);
-                persistent.Configure(options =>
+                persistent.ConfigureStore(options =>
                 {
                     options.TablePrefix = TablePrefix;
                     options.MisfireThreshold = MisfireThreshold;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
@@ -164,7 +164,7 @@ public class AdoJobStorePagingTest
 
         config.UsePersistentStore(store =>
         {
-            store.Configure(o =>
+            store.ConfigureStore(o =>
             {
                 o.StoreJobDataAsStrings = false;
                 o.PerformSchemaValidation = true;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -277,7 +277,7 @@ public class AdoJobStoreSmokeTest
 
         config.UsePersistentStore(store =>
         {
-            store.Configure(o =>
+            store.ConfigureStore(o =>
             {
                 o.StoreJobDataAsStrings = false;
                 o.PerformSchemaValidation = true;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigratedSchemaWorkload.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigratedSchemaWorkload.cs
@@ -251,7 +251,7 @@ internal static class MigratedSchemaWorkload
 
         builder.UsePersistentStore(store =>
         {
-            store.Configure(o =>
+            store.ConfigureStore(o =>
             {
                 o.TablePrefix = tablePrefix;
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancyTestBase.cs
@@ -154,7 +154,7 @@ public abstract class SharedDatabaseTenancyTestBase
             UseDatabase(store);
             // The same prefix on both, which is the supported arrangement: SCHED_NAME is what separates
             // the tenants, and a prefix is for separate table sets rather than for isolation.
-            store.Configure(options => options.TablePrefix = "QRTZ_");
+            store.ConfigureStore(options => options.TablePrefix = "QRTZ_");
         });
     }
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/TriggerInErrorNotificationAdoTest.cs
@@ -51,7 +51,7 @@ public sealed class TriggerInErrorNotificationAdoTest
         {
             store.UsePostgres(TestConstants.PostgresConnectionString);
             store.UseNewtonsoftJsonSerializer();
-            store.Configure(options => options.TablePrefix = SchedulerHelper.TablePrefix);
+            store.ConfigureStore(options => options.TablePrefix = SchedulerHelper.TablePrefix);
         });
 
         IScheduler scheduler = await builder.BuildScheduler();

--- a/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
+++ b/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
@@ -37,7 +37,7 @@ public class SchedulerHelper
         {
             UseDatabase(store, provider);
             store.UseNewtonsoftJsonSerializer();
-            store.Configure(options =>
+            store.ConfigureStore(options =>
             {
                 options.TablePrefix = TablePrefix;
                 configureStore?.Invoke(options);

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -45,7 +45,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
     {
         q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             RegisterStubProvider(store.Services, q.SchedulerName);
         });
     }
@@ -206,7 +206,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         {
             q.UsePersistentStore(store =>
             {
-                store.Configure(options =>
+                store.ConfigureStore(options =>
                 {
                     options.DataSource = "test";
                     options.TablePrefix = "REPORT_";
@@ -228,7 +228,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz(q => q.UsePersistentStore(store =>
         {
-            store.Configure(options =>
+            store.ConfigureStore(options =>
             {
                 options.DataSource = "test";
                 options.UseDbLocks = true;
@@ -252,7 +252,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz(q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseLockHandler<SimpleSemaphore>();
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
@@ -269,7 +269,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             // Takes an IDbProvider, which for a named scheduler exists only under that scheduler's key.
             store.UseLockHandler<SelectForUpdateSemaphore>();
             RegisterStubProvider(store.Services, q.SchedulerName);
@@ -370,7 +370,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseTriggerPersistenceDelegate<MarkedTriggerPersistenceDelegate>();
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
@@ -392,12 +392,12 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz("a", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
         services.AddQuartz("b", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseSerializer<CountingObjectSerializer>();
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
@@ -415,13 +415,13 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var services = new ServiceCollection();
         services.AddQuartz("a", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<TriggerKnownToA>(new TriggerKnownToASerializer()));
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
         services.AddQuartz("b", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseSystemTextJsonSerializer(json => json.AddTriggerSerializer<TriggerKnownToB>(new TriggerKnownToBSerializer()));
             RegisterStubProvider(store.Services, q.SchedulerName);
         }));
@@ -723,7 +723,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
                 ["quartz.jobStore.dataSource"] = "test",
                 ["quartz.dataSource.test.connectionProvider.type"] = typeof(CountingDbProvider).AssemblyQualifiedName,
             },
-            q => q.UsePersistentStore(store => store.Configure(options => options.DataSource = "test")));
+            q => q.UsePersistentStore(store => store.ConfigureStore(options => options.DataSource = "test")));
 
         using var provider = services.BuildServiceProvider();
 
@@ -740,7 +740,7 @@ public class ConfigurationIsNeverSilentlyDroppedTest
             new NameValueCollection { ["quartz.jobStore.clusterCheckinInterval"] = "20000" },
             q => q.UsePersistentStore(store =>
             {
-                store.Configure(options => options.DataSource = "test");
+                store.ConfigureStore(options => options.DataSource = "test");
                 store.UseClustering();
                 RegisterStubProvider(store.Services, q.SchedulerName);
             }));

--- a/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
@@ -103,7 +103,7 @@ public class OptionsValidationTest
     public void AMissingDataSourceOnAPersistentStoreFailsAtStartup()
     {
         var services = new ServiceCollection();
-        services.AddQuartz(q => q.UsePersistentStore(store => store.Configure(options => options.DataSource = "")));
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options => options.DataSource = "")));
 
         using var provider = services.BuildServiceProvider();
 
@@ -122,7 +122,7 @@ public class OptionsValidationTest
     public void ACommandTimeoutThatIsNotPositiveIsAConfigurationError(int seconds)
     {
         var services = new ServiceCollection();
-        services.AddQuartz(q => q.UsePersistentStore(store => store.Configure(options =>
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
         {
             options.DataSource = "test";
             options.CommandTimeout = TimeSpan.FromSeconds(seconds);
@@ -139,7 +139,7 @@ public class OptionsValidationTest
     public void ACommandTimeoutLeftUnsetIsFine()
     {
         var services = new ServiceCollection();
-        services.AddQuartz(q => q.UsePersistentStore(store => store.Configure(options => options.DataSource = "test")));
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options => options.DataSource = "test")));
 
         using var provider = services.BuildServiceProvider();
 
@@ -159,7 +159,7 @@ public class OptionsValidationTest
         var services = new ServiceCollection();
         services.AddQuartz(q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseClustering(clustering => clustering.Enabled = false);
         }));
 
@@ -176,7 +176,7 @@ public class OptionsValidationTest
         var services = new ServiceCollection();
         services.AddQuartz(q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseClustering(clustering => clustering.CheckinInterval = TimeSpan.FromSeconds(20));
         }));
 
@@ -196,11 +196,11 @@ public class OptionsValidationTest
         var services = new ServiceCollection();
         services.AddQuartz("clustered", q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = "test");
+            store.ConfigureStore(options => options.DataSource = "test");
             store.UseClustering();
         }));
         services.AddQuartz("solo", q => q.UsePersistentStore(store =>
-            store.Configure(options => options.DataSource = "test")));
+            store.ConfigureStore(options => options.DataSource = "test")));
 
         using var provider = services.BuildServiceProvider();
 

--- a/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Quartz.Configuration;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
 
 namespace Quartz.Tests.Unit.Configuration;
 
@@ -14,6 +16,7 @@ namespace Quartz.Tests.Unit.Configuration;
 public sealed class PersistentStoreBuilderTest
 {
     private const string ConnectionString = "Server=nowhere;Database=quartz;";
+    private const string ReportingConnectionString = "Server=nowhere;Database=reporting;";
 
     [Test]
     public void UseDataSource_WithAName_IsWhatTheStoreReadsItsConnectionUnder()
@@ -77,5 +80,59 @@ public sealed class PersistentStoreBuilderTest
         provider.GetRequiredService<IOptionsMonitor<DataSourceOptions>>().Get("quartz")
             .Provider.Should().Be("SqlServer",
                 "the two overloads are told apart by what they are handed, so neither may shadow the other");
+    }
+
+    [Test]
+    public void UseDriverDelegate_WithAFactory_RunsTheFactory()
+    {
+        var built = new CountingDriverDelegate();
+
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseDriverDelegate(_ => built);
+            store.UseSqlServer(ConnectionString);
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IDriverDelegate>().Should().BeSameAs(built,
+            "a dialect that needs building is the case the type-argument overload cannot serve");
+    }
+
+    [Test]
+    public void UseDriverDelegate_WithAFactory_IsGivenTheSchedulersOwnProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
+        {
+            store.UseDriverDelegate(scoped => new CountingDriverDelegate
+            {
+                Provider = scoped.GetRequiredService<IDbProvider>(),
+            });
+            store.UseSqlServer(ReportingConnectionString);
+        }));
+
+        using var container = services.BuildServiceProvider();
+
+        container.GetRequiredKeyedService<IDriverDelegate>("reporting").Should().BeOfType<CountingDriverDelegate>()
+            .Which.Provider!.ConnectionString.Should().Be(ReportingConnectionString,
+                "the factory runs against a provider keyed to this scheduler, so a named scheduler's "
+                + "delegate is handed its own database rather than the default scheduler's");
+    }
+
+    [Test]
+    public void UseDriverDelegate_WithAFactory_RefusesNull()
+    {
+        var services = new ServiceCollection();
+        var act = () => services.AddQuartz(q => q.UsePersistentStore(store => store.UseDriverDelegate(factory: null!)));
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    private sealed class CountingDriverDelegate : StdAdoDelegate
+    {
+        public IDbProvider? Provider { get; init; }
     }
 }

--- a/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
@@ -1,0 +1,81 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// The persistent store builder's own conventions: one name per concept, and a factory overload
+/// wherever a component can be registered by type.
+/// </summary>
+public sealed class PersistentStoreBuilderTest
+{
+    private const string ConnectionString = "Server=nowhere;Database=quartz;";
+
+    [Test]
+    public void UseDataSource_WithAName_IsWhatTheStoreReadsItsConnectionUnder()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseDataSource("reporting-db");
+            store.UseSqlServer(ConnectionString);
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetSchedulerOptions<AdoJobStoreOptions>(null).DataSource.Should().Be("reporting-db",
+            "naming a data source and defining one are the same concept, so the name overload has to "
+            + "reach the same setting the callback overload does");
+        provider.GetRequiredService<IOptionsMonitor<DataSourceOptions>>().Get("reporting-db")
+            .ConnectionString.Should().Be(ConnectionString,
+                "the database method configures DataSourceOptions under whatever name was chosen");
+    }
+
+    [Test]
+    public void UseDataSource_WithNoName_FallsBackToTheSchedulersOwnName()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetSchedulerOptions<AdoJobStoreOptions>("reporting").DataSource.Should().Be("reporting",
+            "a name that never has to be invented is the reason naming one is optional");
+    }
+
+    [Test]
+    public void UseDataSource_WithANameAfterTheDatabaseChoice_SaysSo()
+    {
+        var services = new ServiceCollection();
+        var act = () => services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ConnectionString);
+            store.UseDataSource("reporting-db");
+        }));
+
+        act.Should().Throw<SchedulerConfigException>().WithMessage("*already been configured*",
+            "the name is what the connection provider is registered under, so renaming afterwards would "
+            + "leave the store looking for settings nobody wrote");
+    }
+
+    [Test]
+    public void UseDataSource_WithACallback_StillDefinesTheDataSource()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseDataSource(options =>
+        {
+            options.Provider = "SqlServer";
+            options.ConnectionString = ConnectionString;
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptionsMonitor<DataSourceOptions>>().Get("quartz")
+            .Provider.Should().Be("SqlServer",
+                "the two overloads are told apart by what they are handed, so neither may shadow the other");
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
@@ -195,7 +195,7 @@ public sealed class SharedDatabaseValidatorTest
     {
         builder.UsePersistentStore(store =>
         {
-            store.Configure(options =>
+            store.ConfigureStore(options =>
             {
                 options.DataSource = "tenants";
                 options.TablePrefix = tablePrefix;

--- a/src/Quartz.Tests.Unit/Impl/SchedulerRepositoryIsolationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/SchedulerRepositoryIsolationTest.cs
@@ -153,7 +153,7 @@ public sealed class SchedulerRepositoryIsolationTest
         services.AddLogging();
         services.AddQuartz(instanceName, q => q.UsePersistentStore(store =>
         {
-            store.Configure(options => options.DataSource = instanceName);
+            store.ConfigureStore(options => options.DataSource = instanceName);
             store.Services.AddKeyedSingleton<IDbProvider>(instanceName, new StubDbProvider());
         }));
         return services.BuildServiceProvider();

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -573,7 +573,7 @@ namespace Quartz
         Quartz.IPersistentStoreBuilder UseConnectionProvider<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
             where T :  class, Quartz.Impl.AdoJobStore.Common.IDbProvider;
         Quartz.IPersistentStoreBuilder UseDataSource(System.Action<Quartz.DataSourceOptions> configure);
-        Quartz.IPersistentStoreBuilder UseDataSourceName(string name);
+        Quartz.IPersistentStoreBuilder UseDataSource(string name);
         Quartz.IPersistentStoreBuilder UseDriverDelegate<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
             where T :  class, Quartz.Impl.AdoJobStore.IDriverDelegate;
         Quartz.IPersistentStoreBuilder UseLockHandler(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.ISemaphore> factory);

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -574,6 +574,7 @@ namespace Quartz
             where T :  class, Quartz.Impl.AdoJobStore.Common.IDbProvider;
         Quartz.IPersistentStoreBuilder UseDataSource(System.Action<Quartz.DataSourceOptions> configure);
         Quartz.IPersistentStoreBuilder UseDataSource(string name);
+        Quartz.IPersistentStoreBuilder UseDriverDelegate(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.IDriverDelegate> factory);
         Quartz.IPersistentStoreBuilder UseDriverDelegate<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
             where T :  class, Quartz.Impl.AdoJobStore.IDriverDelegate;
         Quartz.IPersistentStoreBuilder UseLockHandler(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.ISemaphore> factory);

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -567,7 +567,7 @@ namespace Quartz
     {
         string SchedulerName { get; }
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
-        Quartz.IPersistentStoreBuilder Configure(System.Action<Quartz.AdoJobStoreOptions> configure);
+        Quartz.IPersistentStoreBuilder ConfigureStore(System.Action<Quartz.AdoJobStoreOptions> configure);
         Quartz.IPersistentStoreBuilder UseClustering(System.Action<Quartz.ClusteringOptions>? configure = null);
         Quartz.IPersistentStoreBuilder UseConnectionProvider(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.Common.IDbProvider> factory);
         Quartz.IPersistentStoreBuilder UseConnectionProvider<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()

--- a/src/Quartz.Trimming.Canary/StoreCheck.cs
+++ b/src/Quartz.Trimming.Canary/StoreCheck.cs
@@ -79,7 +79,7 @@ internal static class StoreCheck
                     // The registration this whole check exists for: the driver's own factory, so nothing
                     // is resolved from a type name and nothing is constructed by reflection.
                     store.UseSqlite(SqliteFactory.Instance, connectionString);
-                    store.Configure(options => options.PerformSchemaValidation = true);
+                    store.ConfigureStore(options => options.PerformSchemaValidation = true);
                 });
             });
 

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -127,6 +127,15 @@ public interface IPersistentStoreBuilder
         where T : class, IDriverDelegate;
 
     /// <summary>
+    /// Uses a driver delegate the caller builds, for cases where it needs configuring first.
+    /// </summary>
+    /// <remarks>
+    /// As with <see cref="UseSerializer(Func{IServiceProvider, IObjectSerializer})"/>, this registers
+    /// under the scheduler's own key, which registering against <see cref="Services"/> would not.
+    /// </remarks>
+    IPersistentStoreBuilder UseDriverDelegate(Func<IServiceProvider, IDriverDelegate> factory);
+
+    /// <summary>
     /// Takes part in a cluster with every other scheduler sharing this database.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -35,13 +35,14 @@ public interface IPersistentStoreBuilder
     string SchedulerName { get; }
 
     /// <summary>
-    /// Configures the job store.
+    /// Configures the job store itself.
     /// </summary>
     /// <remarks>
     /// These are the same settings, under the same names, as the <c>Quartz:JobStore</c> configuration
-    /// section.
+    /// section. The name says which of the several things in scope here is being configured — the store,
+    /// rather than the scheduler around it or the data source under it.
     /// </remarks>
-    IPersistentStoreBuilder Configure(Action<AdoJobStoreOptions> configure);
+    IPersistentStoreBuilder ConfigureStore(Action<AdoJobStoreOptions> configure);
 
     /// <summary>
     /// Says which data source this store reads and writes through, by name.

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -51,9 +51,10 @@ public interface IPersistentStoreBuilder
     /// <para>
     /// This <em>refers to</em> a data source rather than defining one:
     /// <see cref="UseDataSource(Action{DataSourceOptions})"/> defines it, and the two are told apart by
-    /// that. The settings it names are the <see cref="DataSourceOptions"/> registered under this name —
-    /// from a <c>Quartz:DataSource:&lt;name&gt;</c> configuration section, say, or from another
-    /// scheduler that already configured it.
+    /// what they are given rather than by carrying different names. The settings it names are the
+    /// <see cref="DataSourceOptions"/> registered under this name — from a
+    /// <c>Quartz:DataSource:&lt;name&gt;</c> configuration section, say, or from another scheduler that
+    /// already configured it.
     /// </para>
     /// <para>
     /// The name defaults to the scheduler's name, or <c>quartz</c> for the default scheduler, so it never
@@ -66,7 +67,7 @@ public interface IPersistentStoreBuilder
     /// configured.
     /// </para>
     /// </remarks>
-    IPersistentStoreBuilder UseDataSourceName(string name);
+    IPersistentStoreBuilder UseDataSource(string name);
 
     /// <summary>
     /// Defines this store's data source: which ADO.NET driver, and how to reach the database.

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -209,6 +209,13 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         return this;
     }
 
+    public IPersistentStoreBuilder UseDriverDelegate(Func<IServiceProvider, IDriverDelegate> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        RegisterScoped(factory);
+        return this;
+    }
+
     public IPersistentStoreBuilder UseClustering(Action<ClusteringOptions>? configure = null)
     {
         // Configured rather than assigned from a copy, so UseClustering() with no arguments turns

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -187,7 +187,7 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
     private string? dataSourceName;
     private bool dataSourceConfigured;
 
-    public IPersistentStoreBuilder UseDataSourceName(string name)
+    public IPersistentStoreBuilder UseDataSource(string name)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -39,7 +39,7 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
 
     private string OptionsName => schedulerKey ?? Microsoft.Extensions.Options.Options.DefaultName;
 
-    public IPersistentStoreBuilder Configure(Action<AdoJobStoreOptions> configure)
+    public IPersistentStoreBuilder ConfigureStore(Action<AdoJobStoreOptions> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);
         Services.Configure(OptionsName, configure);
@@ -55,7 +55,7 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         dataSourceConfigured = true;
         Services.Configure(DataSourceName, configure);
         Services.ValidateOnStart<DataSourceOptions>(DataSourceName);
-        Configure(options => options.DataSource = DataSourceName);
+        ConfigureStore(options => options.DataSource = DataSourceName);
 
         var name = DataSourceName;
         RegisterProvider(provider =>
@@ -145,7 +145,7 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         // The provider carries everything needed to reach the database, but the store still refuses to
         // start without a data source name. Name it after the scheduler, exactly as UseDataSource would,
         // so UseConnectionProvider on its own is a complete configuration.
-        return Configure(options => options.DataSource = DataSourceName);
+        return ConfigureStore(options => options.DataSource = DataSourceName);
     }
 
     /// <summary>
@@ -226,7 +226,7 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
 
         // Clustering has never worked without database locking, so enabling one enables the other
         // rather than leaving a configuration nobody meant to write.
-        return Configure(options => options.UseDbLocks = true);
+        return ConfigureStore(options => options.UseDbLocks = true);
     }
 
     public IPersistentStoreBuilder UseSerializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()


### PR DESCRIPTION
Three members of `IPersistentStoreBuilder` did not follow the conventions the rest of the builder sets.
Each is visible only next to its own siblings, and each is fixed here.

## What changed

| Before | After |
|---|---|
| `store.Configure(options => …)` | `store.ConfigureStore(options => …)` |
| `store.UseDataSourceName(name)` | `store.UseDataSource(name)` |
| — | `store.UseDriverDelegate(Func<IServiceProvider, IDriverDelegate> factory)`, new |

**`Configure` → `ConfigureStore`.** A bare verb inside a callback that already has `ConfigureScheduler`
and `ConfigureOptions<TOptions>` in scope, so the one name that had to say *which* of the things in
reach it configured was the one that said nothing.

**`UseDataSourceName(name)` → `UseDataSource(name)`.** Naming a data source and defining one are the
same concept; they are now one name, told apart by whether they are handed a string or a callback. The
behaviour is unchanged — the name still defaults to the scheduler's own, and naming one after the
database has been chosen is still refused, because the name is what the connection provider is
registered under.

**`UseDriverDelegate(factory)`, new.** It was the only registration on this builder without a
`Func<IServiceProvider, T>` overload. `UseConnectionProvider`, `UseSerializer`, `UseLockHandler` and
`UseTriggerPersistenceDelegate` all have one, so a dialect that needs a constructor argument only the
caller has was the single part of the store that could not be handed over ready-made. It follows the
siblings' shape exactly: `ArgumentNullException.ThrowIfNull`, then `RegisterScoped`, so the factory runs
against a provider keyed to this scheduler and a named scheduler's delegate sees its own connection
provider rather than the default scheduler's.

No configuration key moved. `quartz.jobStore.*`, `Quartz:JobStore:*` and `quartz.jobStore.dataSource`
say what they said, and `QuartzPropertyBridge` never called either renamed member, so `LegacyPropertyKeys`
needed no change.

## Premises corrected

None. The issue was written against alpha.2 (`6f1117583`); all three bullets were re-verified against
`1aa346eb4` after #3470 (the `DbProviderFactory` overloads) and #3480 (`ObjectUtils`) landed, and all
three still held:

- `UseDataSourceName(string)` still sat beside `UseDataSource(Action<DataSourceOptions>)`.
- `UseDriverDelegate<T>()` was still the only registration on the builder with no factory overload —
  #3470 added `DbProviderFactory` overloads to the `Use<Db>` *extension* methods, which is a different
  axis and left the interface untouched.
- `Configure(Action<AdoJobStoreOptions>)` was still the odd one out beside `IQuartzBuilder`'s
  `ConfigureScheduler` and `ConfigureOptions<TOptions>`.

## For a reviewer to decide

`UseDataSource(string)` means *a data source name*, while a bare string on every `Use<Db>` method means
*a connection string*. The two are different methods and the parameter is named `name`, but it is worth
a look, since the issue's fix for one inconsistency creates a reading of the builder where a bare string
does not always mean the same thing.

Two files outside the issue's stated surface changed, mechanically and one line each, because the rename
would otherwise not compile: `src/Quartz.Examples/13_ClusteringJobsExecution/ClusteringJobsExecutionExample.cs`
and `src/Quartz.Examples.AspNetCore/Startup.cs`.

## Verification

```
dotnet build Quartz.slnx                       Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit              Passed! Failed: 0, Passed: 3515, Skipped: 4, Total: 3519
dotnet test src/Quartz.Tests.AspNetCore        Passed! Failed: 0, Passed: 523, Skipped: 0, Total: 523
integration, 'basic' leg (Docker running)      Passed! Failed: 0, Passed: 329, Skipped: 0, Total: 329
dotnet fallout VerifyDocsSnippets              Documentation snippets are up to date (91 markdown files checked)
npm run docs:check-links                       213 pages, 825 internal links, 481 fragments; no dead links or anchors
```

The public API baseline was re-approved through the Verify workflow — three deltas: `Configure` →
`ConfigureStore`, `UseDataSourceName` → `UseDataSource`, and the added `UseDriverDelegate` overload. The
same deltas are carried into `docs/documentation/quartz-4.x/migration-guide.md` under "The persistent
store builder says which thing it configures". `docs/documentation/quartz-3.x/` is untouched.

Closes #3441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
