### PR TITLE
The trimming and native AOT story is a how-to, not a csproj comment

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -144,6 +144,7 @@ export const sidebarEn: SidebarConfig = [
               "/documentation/quartz-4.x/how-tos/multiple-triggers",
               "/documentation/quartz-4.x/how-tos/job-template",
               "/documentation/quartz-4.x/how-tos/aspire",
+              "/documentation/quartz-4.x/how-tos/trimming-and-native-aot",
               "/documentation/quartz-4.x/how-tos/custom-job-store",
               "/documentation/quartz-4.x/how-tos/dialect-delegate",
               "/documentation/quartz-4.x/how-tos/trigger-persistence-delegate",

--- a/docs/documentation/quartz-4.x/how-tos/README.md
+++ b/docs/documentation/quartz-4.x/how-tos/README.md
@@ -15,6 +15,7 @@ Short, task-shaped recipes. Each page answers one question; the
 * [Multiple Triggers](multiple-triggers.md) — drive one job from several triggers, and give each its own data
 * [Job Template](job-template.md) — the recommended skeleton for a job class
 * [Running Quartz under Aspire](aspire.md) — telemetry, health and the database, wired to an AppHost
+* [Publishing Trimmed and Native AOT](trimming-and-native-aot.md) — what each package claims, what still warns, and what to do about it
 
 Extending Quartz — the four seams the `Quartz.Impl.AdoJobStore` types exist for:
 

--- a/docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md
+++ b/docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md
@@ -1,0 +1,405 @@
+---
+title: 'Publishing Trimmed and Native AOT'
+---
+
+# Publishing Trimmed and Native AOT
+
+A trimmed publish removes the code an application does not reach. A native AOT publish is a trimmed
+publish with an ahead-of-time compiler behind it, producing an executable that starts without a runtime
+installed. Both ask a library the same question, and it is an awkward one for a scheduler: everything
+you will use at run time has to be visible to a tool reading IL before the program has started.
+
+Quartz answers it in three parts. The `Quartz` package declares `IsAotCompatible`; eight other packages
+say yes or no to trimming and mean it; and the places that genuinely cannot answer — a job type that
+arrives as a string — are written down rather than suppressed, so your publish tells you about them.
+
+Start at [what is claimed](#what-quartz-claims) if you are deciding whether to try, and at
+[the recipe](#the-recipe) if you have already decided.
+
+## What Quartz claims
+
+`<IsTrimmable>true</IsTrimmable>` is not a promise that nothing in the assembly reflects, and it is not
+what decides whether Quartz gets cut into. Under `TrimMode=full` — the default for console applications
+since .NET 7 and for the Web SDK since .NET 8 — every assembly is trimmed member by member whether it
+is marked or not. The mark matters under `TrimMode=partial`, where an unmarked assembly is copied
+whole; and it matters, everywhere, for what you are *told*.
+
+That second half is the part worth knowing, because it is easy to misread a quiet build as a safe one.
+A trimmer collapses the warnings it finds inside a `PackageReference` assembly into a single
+`IL2104: Assembly 'X' produced trim warnings` — the `TrimmerSingleWarn` property, which defaults to
+true. The exception is `IL2026`, the warning for calling an API that says `[RequiresUnreferencedCode]`:
+it is *not* collapsed for an assembly marked `IsTrimmable`, on the reasoning that a library that went
+to the trouble of marking itself meant those messages to reach you.
+
+So an application referencing the Quartz package sees every deliberate "this API needs reflection"
+message, and one line standing in for everything else. To see everything else as well:
+
+```xml
+<TrimmerSingleWarn>false</TrimmerSingleWarn>
+```
+
+`<IsAotCompatible>true</IsAotCompatible>` is a narrower claim layered on top: that nothing the package
+does needs code to be *generated* at run time, so it produces no `IL3050`. Setting it turns on
+`IsTrimmable` and the trim, AOT and single-file analyzers together. It is **not** a claim that no
+`IL2xxx` remains — trimming and dynamic code are different questions, and Quartz answers only the second
+one with a clean yes.
+
+Quartz declares it; no other package does yet. If you want to be told which of your own dependencies
+have not made the claim, .NET has an opt-in for it:
+
+```xml
+<VerifyReferenceAotCompatibility>true</VerifyReferenceAotCompatibility>
+```
+
+That reports `IL3058` for every referenced assembly carrying no `IsAotCompatible` metadata. It is
+opt-in because plenty of libraries are compatible without having said so, and because the metadata
+itself only arrived in .NET 10 — so expect noise, and read it as a list of things to check rather than
+a list of things that are broken.
+
+### Which packages say whether they can be trimmed
+
+Every shipped package answers, because silence is worse than a "no".
+
+| Package | Trimmable | What a trimmed publish reports against it |
+|---|---|---|
+| `Quartz` | yes, and `IsAotCompatible` | the string-named paths in the next section |
+| `Quartz.Jobs` | yes | one: `DirectoryScanJob` finds the listener named in its job data by walking the loaded assemblies for a type of that name |
+| `Quartz.Plugins` | yes | two: the XML and JSON schedule-file plugins name each job's type as text, which is what the file format is for |
+| `Quartz.HttpClient` | yes | one: a job read back over HTTP carries its type as a name |
+| `Quartz.AspNetCore` | yes | one: a job posted to the HTTP API names its type as a string |
+| `Quartz.Extensions.Redis` | yes | nothing |
+| `Quartz.Plugins.TimeZoneConverter` | yes | nothing |
+| `Quartz.Serialization.Newtonsoft` | **no** | Json.NET decides what a type looks like by reflecting over it, and has no source-generated form to move to |
+| `Quartz.Dashboard` | **no** | Blazor Server sets a component's `[Parameter]` properties by name and finds page components by type; that is the framework's model, not something the package can resolve |
+
+Every one of the side packages' remaining warnings is an `IL2026`, which is exactly the kind that is not
+collapsed — so those five lines are ones you will actually see, without setting anything.
+
+The seven that say yes build with the trim, AOT and single-file analyzers on and warnings as errors,
+and each that has anything left to record keeps it in a `TrimAnalysisBaseline.cs` beside its csproj.
+Redis and TimeZoneConverter have no such file because they have nothing to put in one. Those files do
+not ship, and nothing is suppressed in the shipped assemblies — deliberately, because an
+`UnconditionalSuppressMessage` in a library hides a real risk from the application that inherited it.
+
+### What still warns, and what to do about each
+
+Nearly all of it is one habit: a type or a member named by a string. Each row is either an API that says
+`[RequiresUnreferencedCode]` out loud — so avoiding it is a decision you make at compile time — or a
+path that only one configuration style reaches.
+
+| What names a type as text | Where you meet it | What to do |
+|---|---|---|
+| A job's type, spelled as a string | `JobType(string)`, `OfType(string)`, the `string` → `JobType` cast | use the typed forms; they carry `[DynamicallyAccessedMembers]` and warn about nothing |
+| The persisted `JOB_CLASS_NAME` column | any ADO.NET job store, when it reads a job back | register the job type with `AddJob<TJob>()` or `AddJobType<TJob>()` — that call is what the trimmer follows |
+| A schedule file | `job_scheduling_data` XML and its JSON twin, from `Quartz.Plugins` | the same: register the types the file names, or root them |
+| Jobs declared in configuration | the `Quartz:Schedule` section, and the type loader named by `quartz.scheduler.typeLoaderType` | the same again |
+| A job type in a request body | the HTTP API, and `Quartz.HttpClient` reading a job back | register the types a caller may name |
+| `DirectoryScanJob`'s listener | `Quartz.Jobs`, named in the job data map | register the listener in the container, or name it in a trimmer root descriptor |
+| A driver, chosen by name | `UseSqlServer(connectionString)` and its siblings | [hand over the driver's factory](#register-the-store-with-the-driver-s-factory) instead |
+| The flat `quartz.*` keys | `AddQuartz(NameValueCollection)`, `quartz.plugin.*`, `quartz.*.listener.*`, `quartz.dbprovider.*` | configure in code or from `appsettings.json`; neither reaches these |
+
+Two entries are not about a type name and are worth separating out, because neither has an action.
+
+`Quartz.Util.ValueConverter` reports `IL2026` and `IL2067` where a `JobDataMap` value is coerced onto a
+job's property of a different type: the conversion goes through `TypeDescriptor`, which finds a
+converter by reflecting over the target type, and a `PropertyInfo.PropertyType` is not something the BCL
+lets anyone annotate. Keep job data to the types the map has accessors for and the converter is never
+reached.
+
+`TransientErrorDetector` reports `IL2070` reading `SQLSTATE` and `Errors[n].Number` off driver exception
+types Quartz deliberately does not reference. It asks `DbException.SqlState` first, which needs no
+reflection and is what most drivers answer with, and the reflective lookups behind it are null-tolerant
+— so a property the trimmer removed makes an error classify as *not* transient rather than throwing.
+You lose a retry, not a scheduler.
+
+Registering job types is the only item on either list that is really work, and it is work you were
+probably doing anyway: `AddJob<TJob>()` in the container is both the registration and the thing the
+trimmer follows.
+
+## The recipe
+
+### Register the store with the driver's factory
+
+Naming a database — `UseSqlite(connectionString)` — makes Quartz resolve the driver's connection,
+command and parameter types from strings, because Quartz references no driver package. A trimmer does
+not follow a string, so it removes what the name pointed at, and the registration fails while the
+container is still being built with `Cannot instantiate type which has no empty constructor`. That is
+not a warning to weigh up; it is a program that does not start.
+
+Every `Use<Db>` therefore also takes the `DbProviderFactory` the driver ships, and that overload names
+nothing:
+
+<!-- snippet: sample_trimming_provider_factory -->
+```csharp
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    // The driver's own factory, rather than its name. Nothing is resolved from a string, so
+    // there is nothing for the trimmer to have removed.
+    store.UseSqlite(SqliteFactory.Instance, connectionString);
+}));
+```
+<!-- endSnippet -->
+
+The factory hands back an instance of every type the store uses — a connection, and the connection
+makes the command, and the command makes its parameters. `SqlClientFactory.Instance`,
+`NpgsqlFactory.Instance`, `MySqlConnectorFactory.Instance` and the rest work exactly the same way; the
+[configuration reference](../configuration/reference.md#naming-a-driver-or-handing-over-its-factory)
+lists them, and covers Oracle, which needs two settings a factory cannot carry.
+
+::: warning The factory overload is the one to use, not merely one of two
+A `DbDataSource` registered in the container is a good way to run a store for other reasons — pooling,
+type mappers, logging, an Aspire-supplied connection — but it is not an equivalent answer to this
+question. The overload that reaches it, `UseSqlite(db => db.UseRegisteredDataSource = true)`, carries
+`[RequiresUnreferencedCode]`, because the same overload also lets you name a connection string and
+nothing tells the two apart at compile time. Behind it, the data-source path still resolves the driver's
+description the type-loading way, where the factory path alone skips that. In practice it works,
+because an application holding a `DbDataSource` references the driver and roots its types — but it is
+not the guarantee the factory overload gives, and the warning it reports is a real one.
+:::
+
+### Name job types as types
+
+A job type survives trimming only if something the trimmer can see points at it. The generic
+registrations do that, and they also declare what Quartz reflects over on a job — its public
+constructors, its public properties, and the interfaces it implements:
+
+<!-- snippet: sample_trimming_job_types -->
+```csharp
+services.AddQuartz(q =>
+{
+    // AddJob<T> declares what Quartz reflects over on a job — its public constructors, its
+    // public properties and the interfaces it implements — so the trimmer keeps exactly those,
+    // and the store finds the type when it reads JOB_CLASS_NAME back as a string.
+    q.AddJob<ReportingJob>(job => job.WithIdentity("reporting").StoreDurably());
+
+    q.AddTrigger(trigger => trigger
+        .ForJob("reporting")
+        .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
+});
+```
+<!-- endSnippet -->
+
+`JobBuilder.Create<TJob>()`, `OfType<TJob>()`, `AddJob<TJob>()`, `AddJobType<TJob>()`,
+`ScheduleJob<TJob>` and `TriggerBuilder.Create<TJob>()` all carry the annotation. Their string-taking
+counterparts carry `[RequiresUnreferencedCode]` instead, so the choice shows up in your build rather
+than at three in the morning.
+
+If you wrap one of these in a generic method of your own and build with the trim analyzer on, the
+forwarding type parameter needs the same annotation — the requirement travels, and the analyzer says
+where it stopped.
+
+### Declare your own job-data value types
+
+`PublishTrimmed` sets the `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` feature switch
+to false, and `PublishAot` implies `PublishTrimmed`. An application that keeps its schedule in memory
+never notices. One with a **persistent job store** writes every trigger, calendar and `JobDataMap`
+through `IObjectSerializer`, and so depends on what System.Text.Json can resolve without reflecting.
+
+Almost all of it is already answered. The default serializer carries a source-generated contract for
+everything Quartz itself writes: every trigger type, every calendar type, `CronExpression`, the
+`NameValueCollection` written under `useProperties`, and a `JobDataMap` holding any of the types
+`DataMapExtensions` declares an accessor for — `string`, `bool`, `char`, `int`, `long`, `float`,
+`double`, `decimal`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `Dictionary<string, string>`. A
+custom trigger or calendar type of your own is answered too, because `AddTriggerSerializer<TTrigger>`
+and `AddCalendarSerializer<TCalendar>` know the type statically.
+
+What is left open is a job-data value of a type only your application knows — an enum, or anything else
+you put in the map. With reflection off there is no metadata for it, and the write fails with a
+`NotSupportedException` naming it. Generate the metadata:
+
+<!-- snippet: sample_trimming_job_data_context -->
+```csharp
+// A job data value type of this application's own, which no contract of Quartz's can name.
+public enum ReportFormat
+{
+    Csv,
+    Pdf
+}
+
+// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
+// on, the resolver chain still ends in reflection and this changes nothing.
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ReportFormat))]
+internal sealed partial class ReportJobDataContext : JsonSerializerContext;
+```
+<!-- endSnippet -->
+
+and hand it to the registry:
+
+<!-- snippet: sample_trimming_job_data_resolver -->
+```csharp
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlite(SqliteFactory.Instance, connectionString);
+    store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
+}));
+```
+<!-- endSnippet -->
+
+`AddTypeInfoResolver` may be called more than once. Resolvers are asked in the order they were added,
+behind Quartz's own contract and in front of reflection, and one that does not know a type returns
+nothing so the next is asked. With reflection on it changes nothing, so it is safe to configure
+unconditionally rather than behind a build flag.
+
+::: warning Turning reflection back on is not a way round this
+`<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` looks
+like an escape hatch and is not one: the trimmer has already removed what reflection would have needed,
+so the failure moves rather than going away. In one console application the same write came back as
+`FileNotFoundException: Could not load file or assembly 'System.Private.Uri'`, under `TrimMode=partial`
+as much as `full`; a larger application keeps more and fails somewhere else. The .NET documentation
+lists reflection-based serializers among the known trimming incompatibilities and says the answer is to
+move to source generation, which is what the paragraphs above are.
+:::
+
+### Configuration binds as it is
+
+Nothing is asked of you here, but it is worth knowing why. The `Quartz` section of `appsettings.json`
+reaches `QuartzSchedulerOptions` and its siblings through a binder the compiler wrote, not through
+`ConfigurationBinder`'s reflection, so an application configured from a file is as
+ahead-of-time-safe as one configured in code.
+
+That was the last `IL3050` in the package, and it was more than a warning. Built against the reflection
+binder, the repository's own canary publishes natively, comes up, and reports `MaxBatchSize`,
+`ShutdownJobInterruption` and the whole scheduler context sitting at their defaults — no exception, no
+log line, just configuration that was read and then not used.
+
+The flat `quartz.*` keys are the exception, and the table above says so: they name components and set
+their properties by string, and no generator can help with that. They still work; they warn.
+
+## The worked example
+
+`src/Quartz.Trimming.Canary` in the repository is a complete application that publishes both ways and
+runs. It is worth reading before you publish your own, because it is the shape of the thing that has
+been proven rather than argued.
+
+It does three checks, in order:
+
+- **The serializer.** It asserts `JsonSerializer.IsReflectionEnabledByDefault` is false — so a green run
+  cannot be one that happened to keep reflection — then round-trips every blob a job store writes
+  through the ordinary `SystemTextJsonObjectSerializer`: all five trigger types, all seven calendar
+  types plus a chained one, a `JobDataMap`, a `NameValueCollection` and a `CronExpression`. Each is
+  serialized, read back under the very type `StdAdoDelegate` asks for, and serialized again, with the
+  two payloads compared byte for byte.
+- **The store.** It creates a SQLite file from the schema Quartz ships, registers it as
+  `UseSqlite(SqliteFactory.Instance, …)` with `PerformSchemaValidation` on, schedules a job, waits for
+  the job itself to signal that it fired, and reads the job and the trigger back through `IScheduler`.
+  The firing is the point: that is where the job's type comes back out of `JOB_CLASS_NAME` as a string.
+- **The binding.** It builds a whole scheduler from an in-memory `IConfiguration` and reads ten values
+  back off the components that use them — the scheduler's own name, its thread pool's size, the
+  scheduler context a job would read, and the rest from the container's options.
+
+Its csproj is short, and every line of it is a decision:
+
+```xml
+<PublishTrimmed>true</PublishTrimmed>
+<TrimMode>full</TrimMode>
+<ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
+<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+```
+
+There is deliberately **no** `TrimmerRootAssembly` and no suppressions file, because the point is an
+application trimmed down to what it actually reaches — which is the shape in which a missing
+`JsonTypeInfo` or a removed constructor shows up. The two `TreatWarningsAsErrors` are off for the same
+reason: the canary reaches the recorded reflection, and a publish that stops at the first line of it is
+a canary that never runs. The build target reads the warnings afterwards and checks them against
+`src/Quartz/ILLink.Suppressions.xml` instead, failing on any Quartz warning that file does not record.
+
+That check exists in that shape because ILCompiler has no `--link-attributes` option, so a suppressions
+file cannot be handed to a native publish at all. One baseline, applied the one way that works for both
+tools. Both legs publish the canary for the runner's own RID and then *start* it, on Windows, Linux and
+macOS, on every pull request that touches code.
+
+To run it yourself:
+
+```shell
+dotnet fallout PublishTrimmed
+dotnet fallout PublishAot
+```
+
+### Reading the warnings your own publish reports
+
+Publishing the canary trimmed reports about thirty warnings against Quartz, in five groups. Yours will
+be a subset, because it depends on what your application reaches — and, from a `PackageReference`,
+mostly the `IL2026` rows unless you have set `TrimmerSingleWarn` to false.
+
+| Group | Codes | Reached by |
+|---|---|---|
+| `QuartzPropertyBridge`, `SchedulerPluginFactory`, `PropertyListenerFactory` | `IL2026`, `IL2067`, `IL2072`, `IL2075` | configuring with flat `quartz.*` keys |
+| `SimpleTypeLoader`, `JobType` | `IL2057` | a job type named as a string, anywhere |
+| `StdAdoDelegate.CreateJobType` | `IL2057`, `IL2072` | reading a job back out of an ADO.NET store |
+| `BuiltInDbMetadataFactory`, `ConfigurationBasedDbMetadataFactory` | `IL2026`, `IL2057` | the ADO.NET store being in the closure at all |
+| `ValueConverter`, `TransientErrorDetector`, `JsonSchedulingHelper` | `IL2026`, `IL2067`, `IL2070`, `IL2072` | job data coerced onto job properties, retry classification, jobs declared in configuration |
+
+Two things are easy to misread here.
+
+**A warning is about reachability, not about your configuration.** The canary registers its store with a
+`DbProviderFactory` and never names a driver, and `BuiltInDbMetadataFactory`'s `IL2057` is reported all
+the same — because the code that *would* resolve a driver by name is still in the closure. Seeing a
+warning does not mean the path is one your application takes.
+
+**A warning is not an error, and an error is not a warning.** The `IL2xxx` above are reports. What
+actually breaks a trimmed application is quieter: a type the trimmer removed, discovered when something
+asks for it. That is why the canary runs rather than only compiling — both of the real bugs this track
+found were invisible to a publish that merely succeeded, and one of them broke every persistent store in
+every trimmed application while producing no new warning at all.
+
+What you should **not** see is any `IL3050` naming a Quartz member: `Quartz` produces none, and one
+appearing would mean the claim had broken. Nor should you see a warning in a Quartz type that its
+package's `TrimAnalysisBaseline.cs` does not list. Either of those is worth reporting — those files are
+the whole record, and they are checked on every pull request.
+
+## The two packages that are not trimmable
+
+`Quartz.Serialization.Newtonsoft` and `Quartz.Dashboard` declare `IsTrimmable=false`, in their csproj
+and on their nuget.org page, so it reads as a decision rather than an oversight.
+
+Json.NET decides what a type looks like by reflecting over it — a contract resolver reads the members of
+whatever it is handed — and there is no source-generated form of that to move to. Marking it trimmable
+would tell the trimmer it may remove members that a job data map is about to be deserialized into, and
+the failure would arrive when a job fires. Publish with the System.Text.Json serializer instead: it is
+built into `Quartz`, it is the default, and the section above is all it asks of you.
+
+Blazor Server is reflective by design: a component's `[Parameter]` properties are set by name from the
+render tree, the router finds page components by type, and the Blazor packages themselves are not marked
+trimmable either. An application that publishes trimmed does so without the dashboard, and drives its
+schedulers over the [HTTP API](../packages/http-api.md) instead — both `Quartz.AspNetCore` and
+`Quartz.HttpClient` are trimmable.
+
+## How this compares
+
+A scheduler declaring `IsAotCompatible` is unusual for the category, though no longer unique, and the
+reason is structural rather than a matter of effort.
+
+[Hangfire](https://github.com/HangfireIO/Hangfire) declares neither property, and
+[#2478](https://github.com/HangfireIO/Hangfire/issues/2478) — opened by a user who hit exactly the
+`IL2104: Assembly 'Hangfire.NetCore' produced trim warnings` described above — is open, with the
+maintainer answering that support "requires a huge amount of work" and will take "considerable amount of
+time". Its storage keeps a job's type as an assembly-qualified string and resolves it with
+`Type.GetType`, which is structurally the same problem as Quartz's `JOB_CLASS_NAME` column.
+[MassTransit](https://github.com/MassTransit/MassTransit/discussions/4772) is blunter: "There are no
+plans in the near future, MassTransit is rich with reflection and it's almost an entire underlying
+rewrite to eliminate it." [Rebus](https://github.com/rebus-org/Rebus/issues/1095) has an open issue and
+a maintainer who would like to but has not tried. Coravel, NCronJob, FluentScheduler and Silverback do
+not mention it.
+
+Two do declare it, and both bought it the same way.
+[TickerQ](https://github.com/Arcenox-co/TickerQ) resolves the string it stores against a
+`FrozenDictionary` its source generator filled at compile time, rather than against the type system, and
+[Wolverine 6](https://wolverinefx.io/guide/aot) requires handler code to be generated ahead of time and
+loaded with `TypeLoadMode.Static`. That is the axis: the claim is cheap when the stored name is symbolic
+and resolved against a compile-time table, and expensive when the stored name is a *type* name that
+something has to turn back into a `Type`.
+
+Quartz is in the second group and stays there, because `JOB_CLASS_NAME` is a persisted contract that
+predates all of this and cannot be redefined without breaking every existing database. So the claim it
+makes is the honest one for that position: no runtime code generation at all, every reflective call site
+reported individually rather than hidden, and a canary that runs a real store out of a native executable
+on every pull request. What it does not claim is that the string-named paths went away.
+
+The two packages that say **no** have good company in how they say it: Json.NET upstream runs the trim
+and AOT analyzers without setting either flag, precisely so that no `IsTrimmable` metadata reaches
+consumers who publish with `TrimMode=partial`. The reasoning is the same one this page opened with —
+the mark is a statement to the person publishing, and making it falsely is worse than not making it.
+
+Quartz 3.x makes no statement at all: `EnableTrimAnalyzer` is in its csproj, commented out. The
+[migration guide](../migration-guide.md#trimming-annotations) covers what changed.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1406,8 +1406,8 @@ same of *your* code, which is the annotation doing its job:
 build, because a type resolved from a string cannot be proven reachable. So does the
 `job_scheduling_data` XML loader. Prefer the typed spelling, or root the type yourself with a
 [trimmer root descriptor](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors).
-See [Trimming](tutorial/more-about-jobs.md#trimming) in the tutorial for what a trimmed application has
-to do.
+See [Publishing Trimmed and Native AOT](how-tos/trimming-and-native-aot.md) for what a trimmed
+application has to do.
 
 `DbMetadata.ConnectionType`, `.CommandType` and `.ParameterType` carry annotations too, saying what
 `DbProvider` does with each: constructs connections and commands, and reads the properties the metadata
@@ -3815,7 +3815,7 @@ driver without naming one — `UseSqlServer(SqlClientFactory.Instance, connectio
 blob a store writes, and a custom trigger or calendar type is answered by the registry it was registered
 with. The one thing left open is a job-data value of a type of your own, which the registry is handed
 metadata for through `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — see
-[Trimming](tutorial/more-about-jobs.md#trimming) for the shape of that.
+[Publishing Trimmed and Native AOT](how-tos/trimming-and-native-aot.md) for the shape of that.
 
 `Quartz` also declares **`IsAotCompatible`** on 4.0, which 3.x does not. What it claims is narrow and
 checkable: nothing Quartz does needs code generated at run time, so a native AOT publish reports no
@@ -3836,7 +3836,7 @@ member of any of them gained `[RequiresUnreferencedCode]` or `[DynamicallyAccess
 you call changes shape. `Quartz.Serialization.Newtonsoft` and `Quartz.Dashboard` say the opposite
 deliberately, in their csproj and in their nuget.org readme: Json.NET's contract is reflection, and
 Blazor Server binds components and their parameters by name. The table is in
-[Which packages say whether they can be trimmed](tutorial/more-about-jobs.md#which-packages-say-whether-they-can-be-trimmed).
+[Which packages say whether they can be trimmed](how-tos/trimming-and-native-aot.md#which-packages-say-whether-they-can-be-trimmed).
 
 ## Executing is a trigger state
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3798,10 +3798,13 @@ needs the same annotation:
       => q.ScheduleJob<TJob>(t => t.StartNow());
 ```
 
-`Quartz` is also marked `IsTrimmable` now, which changes what a trimmed publish tells you about it. On
-3.x the assembly is not marked, so ILLink collapses everything it finds in Quartz into one
-`IL2104: Assembly 'Quartz' produced trim warnings`. On 4.0 you get the individual warnings instead —
-around fifty of them, at the reflective call sites listed in `src/Quartz/TrimAnalysisBaseline.cs`.
+`Quartz` is also marked `IsTrimmable` now, which changes what a trimmed publish tells you about it.
+Under `TrimMode=full` the assembly is member-trimmed either way; what the mark changes is the reporting.
+With `TrimmerSingleWarn` on, which is the default, an assembly's trim-analysis warnings collapse into one
+`IL2104: Assembly 'Quartz' produced trim warnings`, and `IsTrimmable` exempts exactly its `IL2026`s from
+that collapse. So on 4.0 you see every `[RequiresUnreferencedCode]` call site individually, and
+`<TrimmerSingleWarn>false</TrimmerSingleWarn>` shows the rest — around fifty in all, at the reflective
+call sites listed in `src/Quartz/TrimAnalysisBaseline.cs`.
 
 That is not a regression: the same reflection was there before and the same code could break under
 trimming; you can now see which parts. None of those warnings is suppressed in the shipped assembly,
@@ -3831,7 +3834,8 @@ of the track is [#3341](https://github.com/quartznet/quartznet/issues/3341).
 application that adds any plugin to a trimmed publish gets one `IL2104` per unmarked assembly and no
 detail; on 4.0, `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.HttpClient`, `Quartz.AspNetCore`,
 `Quartz.Extensions.Redis` and `Quartz.Plugins.TimeZoneConverter` are marked trimmable and report their
-individual call sites — between none and two each, all of them a job type spelled as a string. No public
+individual call sites — between none and two each, all of them a job type spelled as a string, and all of
+them an `IL2026`, which is the code `IsTrimmable` exempts from the collapse. No public
 member of any of them gained `[RequiresUnreferencedCode]` or `[DynamicallyAccessedMembers]`, so nothing
 you call changes shape. `Quartz.Serialization.Newtonsoft` and `Quartz.Dashboard` say the opposite
 deliberately, in their csproj and in their nuget.org readme: Json.NET's contract is reflection, and

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -412,208 +412,22 @@ vary the data of a detail of your own, and `Clone()` to copy one.
 
 ## Trimming
 
-The `Quartz` package is marked trimmable, so an application published with `PublishTrimmed` can cut
-away what it does not use. A job type is only kept if something the trimmer can see points at it, and
-that is the one thing an application has to get right.
+The `Quartz` package is marked `IsTrimmable` and declares `IsAotCompatible`, so an application can
+publish with `PublishTrimmed` or `PublishAot` and get an executable that starts without a runtime
+installed. A scheduler over the in-memory store needs nothing from you to do it, and a scheduler over a
+__persistent__ store needs two things: the database registered by handing over the driver's
+`DbProviderFactory` rather than naming it, and job-data value types of your own declared to the
+serializer. The repository publishes a scheduler both ways and runs it — over a real SQLite store — on
+Windows, Linux and macOS on every pull request.
 
-**Name job types as types.** `JobBuilder.Create<TJob>()`, `OfType<TJob>()`, `AddJob<TJob>()` and
-`AddJobType<TJob>()` all declare what Quartz reflects over on a job — its public constructors, its
-public properties and the interfaces it implements — so the trimmer keeps exactly those:
-
-```csharp
-builder.AddJob<SendEmailJob>(j => j.WithIdentity("send-email"));
-```
-
-**An API that takes a type name says so.** The ones that accept a name instead of a type carry
-`[RequiresUnreferencedCode]`, so publishing trimmed reports them:
-
-```csharp
-// IL2026: a type named only by a string is not guaranteed to survive trimming
-IJobDetail detail = JobBuilder.Create().OfType("Acme.Jobs.SendEmailJob, Acme.Jobs").Build();
-```
-
-That is `JobBuilder<TJob>.OfType(string)`, the `JobType(string)` constructor and the explicit cast from
-`string`. Prefer the typed spelling; where you cannot, tell the trimmer to keep the type anyway with a
-[trimmer root descriptor](https://learn.microsoft.com/dotnet/core/deploying/trimming/trimming-options#root-descriptors).
-
-**Three places name job types by string whatever you do**, and each needs the job type registered or
-rooted:
-
-- an ADO.NET job store, because a stored job's type is the `JOB_CLASS_NAME` column;
-- `job_scheduling_data` XML, whose loader is `[RequiresUnreferencedCode]` for that reason;
-- the flat `quartz.*` configuration keys, which name plugins, listeners and job stores by string, and
-  set their properties by name.
-
-Registering every job type with `AddJob<TJob>()` or `AddJobType<TJob>()` covers the first of those:
-those calls are what the trimmer follows, and the store then finds the type it needs.
-
-### A persistent store under trimming
-
-`PublishTrimmed` sets `System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault` to false. An
-application that keeps its schedule in memory never notices; one with a **persistent job store** writes
-every trigger, calendar and `JobDataMap` through `IObjectSerializer`, and so depends on what
-`System.Text.Json` can still resolve.
-
-The default System.Text.Json serializer carries a source-generated contract for everything Quartz
-itself writes, so **the built-in shapes need nothing from you**: every trigger type, every calendar
-type, `CronExpression`, the `NameValueCollection` written under `useProperties`, and a `JobDataMap`
-holding a `string`, `bool`, `char`, `int`, `long`, `float`, `double`, `decimal`, `DateTime`,
-`DateTimeOffset`, `TimeSpan`, `Guid` or a `Dictionary<string, string>` — which is to say every type
-`DataMapExtensions` declares an accessor for. A **custom trigger or calendar type** needs nothing
-either: `AddTriggerSerializer<TTrigger>` and `AddCalendarSerializer<TCalendar>` know the type, so the
-registry answers for it.
-
-What is left open is a job-data value of a type of your own — an enum, or anything else you put in the
-map. With reflection off there is no metadata for it, and the write fails naming it. Hand the registry
-your own generated context:
-
-<!-- snippet: sample_more_about_jobs_trimmed_job_data_context -->
-```csharp
-// A job data value type of this application's own, which no contract of Quartz's can name.
-public enum ReportFormat
-{
-    Csv,
-    Pdf
-}
-
-// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
-// on, the resolver chain still ends in reflection and this changes nothing.
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
-[JsonSerializable(typeof(ReportFormat))]
-internal sealed partial class ReportJobDataContext : JsonSerializerContext;
-```
-<!-- endSnippet -->
-
-<!-- snippet: sample_more_about_jobs_trimmed_job_data_metadata -->
-```csharp
-services.AddQuartz(q => q.UsePersistentStore(store =>
-{
-    store.UseSqlServer(connectionString);
-    store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
-}));
-```
-<!-- endSnippet -->
-
-`AddTypeInfoResolver` can be called more than once, and resolvers are asked in the order they were
-added, behind Quartz's own contract and in front of reflection. With reflection on it changes nothing,
-so it is safe to configure unconditionally.
-
-**Hand the store the driver's factory rather than its name.** Naming a database —
-`UseSqlite(connectionString)` — resolves the driver's connection, command and parameter types from
-strings, and the trimmer does not follow a string: published `TrimMode=full`, that registration used to
-fail while the container was still being built, with `Cannot instantiate type which has no empty
-constructor`. Every `Use<Db>` therefore takes the `DbProviderFactory` the driver ships instead, and that
-overload names nothing:
-
-```csharp
-services.AddQuartz(q => q.UsePersistentStore(store =>
-{
-    store.UseSqlite(SqliteFactory.Instance, connectionString);
-}));
-```
-
-The factory hands back an instance of every type the store uses — a connection, and the connection
-makes the command, and the command makes its parameters. Registering a `DbDataSource` in the container
-does the same job and is just as safe; the overloads that take a name carry `[RequiresUnreferencedCode]`
-so that a trimmed publish tells you which registration you are on. Neither a `TrimmerRootAssembly` nor
-any other rooting is needed for either.
-
-::: warning Turning reflection back on is not a way round anything
-`<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` looks
-like an escape hatch and is not one: the trimmer has already removed what reflection would have needed,
-and what remains fails later and less clearly. In one console application the same write came back as
-`FileNotFoundException: Could not load file or assembly 'System.Private.Uri'`, under `TrimMode=partial`
-as much as `full`; a larger application keeps more and fails elsewhere. Reflection over a trimmed
-assembly is unsupported, not merely unreliable.
-
-The `Quartz.Serialization.Newtonsoft` serializer is reflection by nature and has no source-generated
-form to fall back on, so an application that publishes trimmed uses the System.Text.Json one.
-:::
-
-## Native AOT
-
-Everything above applies to `PublishAot` as well — it is a trimmed publish with an ahead-of-time
-compiler behind it — and native AOT adds one question of its own: what needs code to be *generated* at
-run time, which an AOT application has no way to do. Quartz builds with the AOT analyzer on, so those
-call sites are known rather than guessed at.
-
-**A scheduler over the in-memory store runs.** The worker example publishes and runs as a single native
-executable, with no runtime installed:
-
-```shell
-dotnet publish src/Quartz.Examples.Worker -c Release -r linux-x64 -p:PublishAot=true
-```
-
-It starts, initialises `RAMJobStore`, fires both its simple and its daily-time-interval trigger,
-executes and disposes job instances, applies flat `quartz.*` keys from `appsettings.json`, and shuts
-down cleanly on Ctrl+C with `WaitForJobsToComplete` honoured. Job types named as types, listeners and
-the DI graph all survive.
-
-**A persistent store runs too, natively.** A native AOT publish is a trimmed publish, so it switches the
-same reflection off, and the source-generated contract described above is what answers instead. The
-repository's `Quartz.Trimming.Canary` round-trips every blob a job store writes — every trigger, every
-calendar including a chained one, a `JobDataMap`, a `NameValueCollection` and a `CronExpression` — and
-then does it against a real database: it creates a SQLite file from the schema Quartz ships, registers
-it as `UseSqlite(SqliteFactory.Instance, …)`, schedules a job, waits for the job itself to report that
-it fired, and reads the job and the trigger back through `IScheduler`. That runs on every build, out of
-a fully trimmed publish and out of a native one, on Windows, Linux and macOS.
-
-**Configuration binds without reflecting over anything.** The `Quartz` section reaches
-`QuartzSchedulerOptions` and its siblings through a binder the compiler wrote, not through
-`ConfigurationBinder`'s reflection, so an application configured from `appsettings.json` is as
-ahead-of-time-safe as one configured in code. That is what closed the last `IL3050` in the package —
-and it was more than a warning: built against the reflection binder, the repository's canary publishes
-natively and comes up with `MaxBatchSize`, `ShutdownJobInterruption` and the whole scheduler context at
-their defaults, silently. Nothing is asked of you to get the generated binder; it is how the package
-was built.
-
-**The `Quartz` package declares `IsAotCompatible`.** What that claims is that nothing Quartz does needs
-code generated at run time, which the build checks rather than asserts: `Quartz` compiles with the
-trim, AOT and single-file analyzers on and warnings as errors, and the canary is published by
-ILCompiler and run on every pull request.
-
-What it does not claim is that no `IL2xxx` remains. Publishing your application AOT still reports the
-string-named paths described above against Quartz — a job type named as text, the `JOB_CLASS_NAME`
-column an ADO.NET store reads back, the `quartz.plugin.*` and `quartz.*.listener.*` keys, and the
-provider error codes `TransientErrorDetector` reads off exception types Quartz does not reference. Each
-is either an API that says `[RequiresUnreferencedCode]`, so avoiding it is a compile-time decision, or
-a path only a configuration style reaches. Quartz records them in the repository rather than in the
-shipped assembly, so an `UnconditionalSuppressMessage` never hides them from you — you see what your
-own application's closure reaches, and none of it stops a scheduler from starting, firing and shutting
-down out of a native executable.
-
-### Which packages say whether they can be trimmed
-
-Every shipped package answers the question, because an unmarked assembly is not a "no" — it is silence.
-A trimmer keeps an unmarked assembly whole and collapses everything it cannot reason about into a single
-`IL2104: Assembly 'X' produced trim warnings`, which tells you nothing about what is at risk.
-
-| Package | Trimmable | What a trimmed publish reports against it |
-|---|---|---|
-| `Quartz` | yes, and `IsAotCompatible` | the string-named paths described above |
-| `Quartz.Jobs` | yes | one: `DirectoryScanJob` finds the listener named in its job data by walking the loaded assemblies for a type of that name |
-| `Quartz.Plugins` | yes | two: the XML and JSON schedule-file plugins name each job's type as text, which is what the file format is for |
-| `Quartz.HttpClient` | yes | one: a job read back over HTTP carries its type as a name |
-| `Quartz.AspNetCore` | yes | one: a job posted to the HTTP API names its type as a string |
-| `Quartz.Extensions.Redis` | yes | nothing |
-| `Quartz.Plugins.TimeZoneConverter` | yes | nothing |
-| `Quartz.Serialization.Newtonsoft` | **no** | Json.NET decides what a type looks like by reflecting over it, and has no source-generated form to move to |
-| `Quartz.Dashboard` | **no** | Blazor Server sets a component's `[Parameter]` properties by name and finds page components by type; that is the framework's model, not something the package can resolve |
-
-None of the trimmable ones needs anything of your application beyond what the sections above ask for:
-name job types as types, and register a job whose type a store or a request will later name as a string.
-Each records its remaining warnings in a `TrimAnalysisBaseline.cs` in the repository rather than in the
-shipped assembly, so you still see every one of them against your own build.
-
-The two that say **no** say it in their csproj and in their nuget.org readme, so it reads as a decision
-rather than an oversight. An application that publishes trimmed uses the System.Text.Json serializer
-built into `Quartz`, and drives its schedulers through the HTTP API rather than the dashboard — both of
-which are trimmable.
-
-`IsAotCompatible` is declared by `Quartz` alone for now, and it is a narrower claim than trimmability:
-that nothing needs code generated at run time. None of the other packages reports an `IL3050` either,
-so the claim would hold for the trimmable ones as well; making it is tracked on
-[#3341](https://github.com/quartznet/quartznet/issues/3341) rather than assumed here.
+What the claim does not cover is the one thing a scheduler cannot give up: a job type that arrives as a
+string. The `JOB_CLASS_NAME` column an ADO.NET store reads back, a schedule file, an HTTP request body
+and the flat `quartz.*` keys all name types as text, and a trimmer cannot follow a string. Each of them
+is either an API that says `[RequiresUnreferencedCode]` or a path only one configuration style reaches,
+none of them is suppressed in the shipped assembly, and registering your job types with `AddJob<TJob>()`
+answers the common case. __[Publishing Trimmed and Native AOT](../how-tos/trimming-and-native-aot.md)__
+is the how-to: what each package claims, what a publish still reports and how to read it, and the
+recipe in full.
 
 ## JobExecutionException
 

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -24,9 +24,10 @@
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       116 warnings when the analyzers were first turned on here, one now. The generator above took 114;
       the last two were the API writing a response through JsonSerializerOptions alone, and the wire

--- a/src/Quartz.Documentation.Samples/HowTos/TrimmingSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/TrimmingSamples.cs
@@ -1,0 +1,80 @@
+using System.Text.Json.Serialization;
+
+using Microsoft.Data.Sqlite;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md.
+/// </summary>
+/// <remarks>
+/// SQLite is the driver these show because it is the one this repository already references — the
+/// canary runs on it. Every other driver's factory is named the same way.
+/// </remarks>
+public static class TrimmingSamples
+{
+    public static void RegisterTheStoreWithTheDriversFactory(IServiceCollection services, string connectionString)
+    {
+        #region sample_trimming_provider_factory
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            // The driver's own factory, rather than its name. Nothing is resolved from a string, so
+            // there is nothing for the trimmer to have removed.
+            store.UseSqlite(SqliteFactory.Instance, connectionString);
+        }));
+
+        #endregion
+    }
+
+    public static void NameJobTypesAsTypes(IServiceCollection services)
+    {
+        #region sample_trimming_job_types
+
+        services.AddQuartz(q =>
+        {
+            // AddJob<T> declares what Quartz reflects over on a job — its public constructors, its
+            // public properties and the interfaces it implements — so the trimmer keeps exactly those,
+            // and the store finds the type when it reads JOB_CLASS_NAME back as a string.
+            q.AddJob<ReportingJob>(job => job.WithIdentity("reporting").StoreDurably());
+
+            q.AddTrigger(trigger => trigger
+                .ForJob("reporting")
+                .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
+        });
+
+        #endregion
+    }
+
+    public static void JobDataMetadataForATrimmedPublish(IServiceCollection services, string connectionString)
+    {
+        #region sample_trimming_job_data_resolver
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlite(SqliteFactory.Instance, connectionString);
+            store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
+        }));
+
+        #endregion
+    }
+}
+
+#region sample_trimming_job_data_context
+
+// A job data value type of this application's own, which no contract of Quartz's can name.
+public enum ReportFormat
+{
+    Csv,
+    Pdf
+}
+
+// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
+// on, the resolver chain still ends in reflection and this changes nothing.
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ReportFormat))]
+internal sealed partial class ReportJobDataContext : JsonSerializerContext;
+
+#endregion

--- a/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
+++ b/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
@@ -58,6 +58,14 @@
     -->
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+
+    <!--
+      One ADO.NET driver, so that the trimming page can show the registration it is about with a real
+      factory — `UseSqlite(SqliteFactory.Instance, …)` rather than a `DbProviderFactory` parameter that
+      teaches nobody which one to pass. SQLite is the driver the repository already carries, for the
+      trim canary. Every other driver's factory is named exactly the same way.
+    -->
+    <PackageReference Include="Microsoft.Data.SQLite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/MoreAboutJobsSamples.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Quartz.Documentation.Samples.Tutorial;
@@ -217,36 +215,7 @@ public static class MoreAboutJobsSamples
         #endregion
     }
 
-    public static void JobDataMetadataForATrimmedPublish(IServiceCollection services, string connectionString)
-    {
-        #region sample_more_about_jobs_trimmed_job_data_metadata
-
-        services.AddQuartz(q => q.UsePersistentStore(store =>
-        {
-            store.UseSqlServer(connectionString);
-            store.UseSystemTextJsonSerializer(registry => registry.AddTypeInfoResolver(ReportJobDataContext.Default));
-        }));
-
-        #endregion
-    }
 }
-
-#region sample_more_about_jobs_trimmed_job_data_context
-
-// A job data value type of this application's own, which no contract of Quartz's can name.
-public enum ReportFormat
-{
-    Csv,
-    Pdf
-}
-
-// The metadata the registry is handed. Only a trimmed or native AOT publish needs it: with reflection
-// on, the resolver chain still ends in reflection and this changes nothing.
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
-[JsonSerializable(typeof(ReportFormat))]
-internal sealed partial class ReportJobDataContext : JsonSerializerContext;
-
-#endregion
 
 #region sample_more_about_jobs_custom_job_detail
 

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -9,9 +9,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       There are none, and there were none the first time the analyzers were pointed at this package: the
       lock handler talks to Redis over StackExchange.Redis with a Lua script and a connection string, and

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -8,9 +8,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       Ten warnings when the analyzers were first turned on here, two now. Eight of them were the client
       serializing and deserializing the wire contract through JsonSerializerOptions alone; the contract

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -8,9 +8,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       One is left, and it is the directory scan job's listener lookup - recorded in TrimAnalysisBaseline.cs
       beside this file, which says why. Nothing else here reflects: the jobs are ordinary types the

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -10,9 +10,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       There are none, and there were none the first time the analyzers were pointed at this package: the
       plugin registers one resolver with TimeZones and that resolver asks TZConvert for a TimeZoneInfo by

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -8,9 +8,10 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).
-      Without IsTrimmable a trimmer keeps this assembly whole and collapses whatever it cannot follow into
-      one IL2104, so an application publishing trimmed learned nothing about the package; with it, the
-      warning is the reflective call site.
+      Under TrimMode=full every assembly is member-trimmed whether it is marked or not; what the mark
+      changes is what a publish reports. With TrimmerSingleWarn on, which is the default, an assembly's
+      trim-analysis warnings collapse into one IL2104, and IsTrimmable exempts exactly its IL2026s from
+      that collapse - which is what lets this package report its own reflective call site.
 
       Four warnings when the analyzers were first turned on here, two now, and neither of the two is a
       new one: the schedule-file plugins hand a job type spelled as text to the scheduler, which is what

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -60,7 +60,7 @@
       counts the interceptions in the built assembly as well, because that is the only place the fact is
       recorded, and Quartz.Trimming.Canary binds a scheduler out of an IConfiguration and reads every
       value back — the reflection binder passes that check trimmed and fails it natively, dropping three
-      of its eight values without a word.
+      of its ten values without a word.
     -->
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
   </PropertyGroup>

--- a/src/Quartz/README.md
+++ b/src/Quartz/README.md
@@ -70,4 +70,5 @@ await scheduler.Start();
 - [Quick start](https://www.quartz-scheduler.net/documentation/quartz-4.x/quick-start.html)
 - [Tutorial](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/)
 - [Configuration reference](https://www.quartz-scheduler.net/documentation/quartz-4.x/configuration/reference.html)
+- [Publishing trimmed and native AOT](https://www.quartz-scheduler.net/documentation/quartz-4.x/how-tos/trimming-and-native-aot.html)
 - [Migrating from Quartz 3](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html)


### PR DESCRIPTION
Closes #3447.

What Quartz claims about trimming lived in a 20-line comment in `src/Quartz/Quartz.csproj` and in the
remarks on two build targets. Now that #3470, #3476 and #3482 have landed there is something to
describe, so this is the page.

## The page

`docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md`, registered in
`docs/.vuepress/configs/sidebar/en.ts` and in the how-tos index:

1. **What Quartz claims** — what `IsTrimmable` and `IsAotCompatible` each mean and, more usefully, what
   neither means; the packages table; and a table of the string-named contracts with an action for each
   row. Two entries that are *not* type names — `ValueConverter`'s `TypeDescriptor` coercion and
   `TransientErrorDetector`'s provider error codes — are separated out, because neither has an action
   and only one of them can cost you anything (a retry, not a scheduler).
2. **The recipe** — the store registered with a `DbProviderFactory`, job types named as types, job-data
   value types declared through `AddTypeInfoResolver`, and configuration binding, which asks nothing of
   the reader.
3. **The worked example** — what `Quartz.Trimming.Canary` actually checks, the csproj properties it
   publishes with and why each is there, and a section on reading the warnings your own publish
   reports, grouped by area, with the two ways they are commonly misread.
4. **The two packages that are deliberately not trimmable** and what to use instead.
5. **How this compares** — where the rest of the category stands.

Four C# blocks, all `#region sample_*` in `src/Quartz.Documentation.Samples/HowTos/TrimmingSamples.cs`.
The samples project gains one `Microsoft.Data.SQLite` reference (already in `Directory.Packages.props`,
already used by the canary) so the central sample can be `UseSqlite(SqliteFactory.Instance, …)` rather
than a `DbProviderFactory` parameter that teaches nobody which one to pass.

## What moved out of the tutorial

`more-about-jobs.md` had `## Trimming`, `### A persistent store under trimming`, `## Native AOT` and
`### Which packages say whether they can be trimmed` — 204 lines. They are now two paragraphs under the
same `## Trimming` heading, so the anchor still resolves, ending in a link here. The packages table
**moved**; there is no second copy. The two snippet regions moved with it and were renamed, and the
metadata sample now registers its store the way the surrounding prose says to — it was calling
`UseSqlServer(connectionString)`, the `[RequiresUnreferencedCode]` overload, in a sample about trimming.

The migration guide keeps both its sections. Its three links into the tutorial now point here, including
the one to the packages table.

`src/Quartz/README.md` had no trimming sentence, so it gains one line in its documentation list, with an
absolute URL.

## Where the seed and the tree disagreed

The code and the ILLink/ILC sources won in each case; none of these is repeated on the new page.

- **`IL2104` is not what an unmarked assembly gets.** Several csproj comments, the tutorial and the
  migration guide say that without `IsTrimmable` a trimmer "keeps this assembly whole and collapses
  whatever it cannot follow into a single `IL2104`". Under `TrimMode=full` — the default for console
  apps since .NET 7 — every assembly is trimmed member by member, marked or not
  ([breaking change](https://learn.microsoft.com/dotnet/core/compatibility/deployment/7.0/trim-all-assemblies)).
  The collapse is `TrimmerSingleWarn`, which keys on `PackageReference`, not on the mark
  (`ILLink.targets`, `LinkContext.IsSingleWarn`). What `IsTrimmable` actually buys is one exemption:
  `IL2026` is not collapsed for a marked assembly (`MessageContainer.TryLogSingleWarning`). That
  happens to be enough for Quartz — every side package's remaining entry is an `IL2026` — but the
  general statement is wrong, so the page says the specific thing instead and tells the reader about
  `<TrimmerSingleWarn>false</TrimmerSingleWarn>`.
- **A registered `DbDataSource` is not an equally name-free registration.** The overload that reaches
  it is `Use<Db>(Action<DataSourceOptions>)`, which carries `[RequiresUnreferencedCode]`; and
  `PersistentStoreBuilder.cs:67` calls `DbMetadataResolver.Resolve` — the type-loading one — before it
  branches into the three `DbDataSource` cases, where the factory overload alone uses
  `ResolveWithoutTypes` (`PersistentStoreBuilderExtensions.cs:472`). The tutorial's "just as safe" and
  `configuration/reference.md`'s "Equally free of type names" both overstate it, and four code comments
  say the data-source path never asks for the typed half. **This looks like a real bug worth its own
  issue** — the resolve call is probably on the wrong side of the branch — and I have not touched the
  reference page, since the fix belongs in code. The how-to states the verified position in a warning
  box and recommends the factory overload without contradicting the reference page.
- **The native leg runs on three OSes, not two.** `Build.CI.GitHubActions.cs` and `pr-tests-unit.yml`
  put `PublishTrimmed` *and* `PublishAot` on windows, ubuntu and macOS.

Three smaller ones, noted but not fixed here: `Quartz.csproj` says the canary reads "eight values" where
`BindingCheck` asserts ten; the tutorial's `dotnet publish src/Quartz.Examples.Worker -p:PublishAot=true`
is not a command CI runs and would report the whole baseline as errors (that worker is the ILLink
canary, and it roots Quartz) — I dropped the command rather than reproducing it; and "records its
warnings in a `TrimAnalysisBaseline.cs`" is true of five packages, not seven, since Redis and
TimeZoneConverter deliberately have none.

## Prior art

Read, not recalled. Official framing: the
[prepare-libraries-for-trimming](https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming)
and [native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) pages,
[IL2104](https://learn.microsoft.com/dotnet/core/deploying/trimming/trim-warnings/il2104), the
[PublishTrimmed/System.Text.Json breaking change](https://learn.microsoft.com/dotnet/core/compatibility/serialization/8.0/publishtrimmed),
and dotnet/runtime's own `ILLink.targets`, `LinkContext.cs`, `MessageContainer.cs`, `Logger.cs` and
`ILCompilerRootCommand.cs` — the last of which confirms ILC has no `--link-attributes`, which is why
`build/Build.cs` applies the baseline by reading ILC's report.

Category: Hangfire ([#2478](https://github.com/HangfireIO/Hangfire/issues/2478), open, maintainer says
it "requires a huge amount of work"), MassTransit
([#4772](https://github.com/MassTransit/MassTransit/discussions/4772), "no plans in the near future"),
Rebus ([#1095](https://github.com/rebus-org/Rebus/issues/1095), open), and Coravel, NCronJob,
FluentScheduler and Silverback silent. TickerQ (since v10.3.0) and Wolverine 6 declare
`IsAotCompatible`, both by resolving a symbolic name against a compile-time table rather than turning a
type name back into a `Type` — which is the axis the page names, and the reason Quartz's position is
what it is.

## Where the helpers disagreed

The docs-survey and the source-audit helpers collided on `IL2104`: the audit reported the tutorial's
claim CONFIRMED, the survey reported it CONTRADICTED. They were checking different things — the audit
verified that the message text exists in `build/Build.cs`, the survey verified the trigger condition in
ILLink's own source. The survey was right about the mechanism, so the minority view is what the page
says. The `DbDataSource` finding came from the audit alone and I confirmed it first-hand before writing
the warning box.

## Could not verify

The `System.Private.Uri` failure in the "turning reflection back on" box is one probe's observation from
a commit message, not reproducible from source; it was already hedged as "in one console application"
and stays that way. The "about thirty warnings" count is from my own `TrimMode=full` publish of the
canary on win-x64 and will differ by RID and by what an application reaches, which the page says.

## Verification

- `dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors.
- `dotnet fallout DocsSnippets` then `dotnet fallout VerifyDocsSnippets` — "Documentation snippets are
  up to date (92 markdown files checked)", no unreferenced samples.
- `npm run docs:check-links` — 214 pages, 838 internal links, 489 fragments, no dead links or anchors.
- `dotnet test src/Quartz.Tests.Unit --filter "FullyQualifiedName~PackageReadmeTest|FullyQualifiedName~SourceEncodingTest"`
  — 46 passed.
- `markdownlint-cli2` on the new page, the tutorial and the how-tos index — clean; the tutorial had
  eight pre-existing MD050 errors in the replaced section and now has none. The migration guide's MD004
  errors are pre-existing and nowhere near the three link edits.
- `dotnet publish src/Quartz.Trimming.Canary -r win-x64` — the source for the warning table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
