### PR TITLE
RecurrenceTrigger is serialized under the same guarantees as the other four, and cron gets a differential

### DIFF
--- a/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/CalendarConverter.cs
@@ -10,62 +10,80 @@ internal sealed class CalendarConverter(NewtonsoftJsonSerializerRegistry registr
 {
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
-        if (value is not ICalendar calendar)
+        try
         {
-            throw new ArgumentException("The value must implement ICalendar", nameof(value));
+            if (value is not ICalendar calendar)
+            {
+                throw new ArgumentException("The value must implement ICalendar", nameof(value));
+            }
+
+            writer.WriteStartObject();
+            writer.WritePropertyName("$type");
+            var type = value!.GetType().AssemblyQualifiedNameWithoutVersion();
+            writer.WriteValue(type);
+
+            if (value is BaseCalendar baseCalendar)
+            {
+                // handle base properties
+                writer.WritePropertyName("Description");
+                writer.WriteValue(baseCalendar.Description);
+
+                writer.WritePropertyName("TimeZoneId");
+                writer.WriteValue(baseCalendar.TimeZone?.Id);
+
+                writer.WritePropertyName("BaseCalendar");
+                if (baseCalendar.CalendarBase is not null)
+                {
+                    serializer.Serialize(writer, baseCalendar.CalendarBase, baseCalendar.CalendarBase.GetType());
+                }
+                else
+                {
+                    writer.WriteNull();
+                }
+            }
+
+            registry.GetCalendarSerializer(type).SerializeFields(writer, calendar);
+
+            writer.WriteEndObject();
         }
-
-        writer.WriteStartObject();
-        writer.WritePropertyName("$type");
-        var type = value!.GetType().AssemblyQualifiedNameWithoutVersion();
-        writer.WriteValue(type);
-
-        if (value is BaseCalendar baseCalendar)
+        catch (Exception e)
         {
-            // handle base properties
-            writer.WritePropertyName("Description");
-            writer.WriteValue(baseCalendar.Description);
-
-            writer.WritePropertyName("TimeZoneId");
-            writer.WriteValue(baseCalendar.TimeZone?.Id);
-
-            writer.WritePropertyName("BaseCalendar");
-            if (baseCalendar.CalendarBase is not null)
-            {
-                serializer.Serialize(writer, baseCalendar.CalendarBase, baseCalendar.CalendarBase.GetType());
-            }
-            else
-            {
-                writer.WriteNull();
-            }
+            // Quartz's exception, deliberately qualified - see the note in TriggerConverter, which this
+            // mirrors. Without it a calendar naming a serializer the registry lacks came out as the raw
+            // ArgumentException the registry throws, past every catch that handles a store read.
+            throw new Quartz.JsonSerializationException("Failed to serialize ICalendar to json", e);
         }
-
-        registry.GetCalendarSerializer(type).SerializeFields(writer, calendar);
-
-        writer.WriteEndObject();
     }
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
-        JObject jObject = JObject.Load(reader);
-        string type = jObject["$type"]!.Value<string>()!;
-
-        var calendarConverter = registry.GetCalendarSerializer(type);
-        ICalendar calendar = calendarConverter.Create(jObject);
-        if (calendar is BaseCalendar target)
+        try
         {
-            target.Description = jObject["Description"]!.Value<string>();
-            target.TimeZone = TimeZones.FindById(jObject["TimeZoneId"]!.Value<string>()!);
-            var baseCalendar = jObject["BaseCalendar"]!.Value<JObject>();
-            if (baseCalendar is not null)
+            JObject jObject = JObject.Load(reader);
+            string type = jObject["$type"]!.Value<string>()!;
+
+            var calendarConverter = registry.GetCalendarSerializer(type);
+            ICalendar calendar = calendarConverter.Create(jObject);
+            if (calendar is BaseCalendar target)
             {
-                var baseCalendarType = Type.GetType(baseCalendar["$type"]!.Value<string>()!, true);
-                var o = baseCalendar.ToObject(baseCalendarType!, serializer);
-                target.CalendarBase = (ICalendar?) o;
+                target.Description = jObject["Description"]!.Value<string>();
+                target.TimeZone = TimeZones.FindById(jObject["TimeZoneId"]!.Value<string>()!);
+                var baseCalendar = jObject["BaseCalendar"]!.Value<JObject>();
+                if (baseCalendar is not null)
+                {
+                    var baseCalendarType = Type.GetType(baseCalendar["$type"]!.Value<string>()!, true);
+                    var o = baseCalendar.ToObject(baseCalendarType!, serializer);
+                    target.CalendarBase = (ICalendar?) o;
+                }
             }
+            calendarConverter.DeserializeFields(calendar, jObject);
+            return calendar;
         }
-        calendarConverter.DeserializeFields(calendar, jObject);
-        return calendar;
+        catch (Exception e)
+        {
+            // Quartz's exception, deliberately qualified - see the note on the serialize side above.
+            throw new Quartz.JsonSerializationException("Failed to parse ICalendar from json", e);
+        }
     }
 
     public override bool CanConvert(Type objectType)

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -247,6 +247,247 @@ public class CronExpressionBuilderTest
         }
     }
 
+    /// <summary>
+    /// The round trip that matters: what the builder was asked for is what the parser resolves the
+    /// built expression to. Everything above is a worked example checking the text the builder renders;
+    /// this checks that the text means what the call meant, over randomly drawn values in every field
+    /// and every shape - a single value, a list, a range that may run backwards, and a step.
+    /// </summary>
+    /// <remarks>
+    /// A builder that renders a token the parser reads as something else passes every ToString
+    /// assertion in this file and still schedules the wrong days. The expected sets here are this
+    /// test's own arithmetic rather than anything read back out of <see cref="CronExpression" />.
+    /// </remarks>
+    /// <param name="seed">Fixed, and named in the case, so a failure is reproducible.</param>
+    [TestCase(11)]
+    [TestCase(22)]
+    [TestCase(33)]
+    [TestCase(44)]
+    public void TestBuiltExpressionParsesBackToTheValuesTheBuilderWasGiven(int seed)
+    {
+        Random random = new Random(seed);
+
+        for (int iteration = 0; iteration < 100; iteration++)
+        {
+            CronExpressionBuilder builder = CronExpressionBuilder.Create();
+
+            HashSet<int> seconds = ConfigureField(random, 0, 59,
+                value => builder.WithSecond(value),
+                values => builder.WithSeconds(values),
+                (from, to) => builder.WithSecondRange(from, to),
+                (from, increment) => builder.WithSecondIncrements(from, increment));
+
+            HashSet<int> minutes = ConfigureField(random, 0, 59,
+                value => builder.WithMinute(value),
+                values => builder.WithMinutes(values),
+                (from, to) => builder.WithMinuteRange(from, to),
+                (from, increment) => builder.WithMinuteIncrements(from, increment));
+
+            HashSet<int> hours = ConfigureField(random, 0, 23,
+                value => builder.WithHour(value),
+                values => builder.WithHours(values),
+                (from, to) => builder.WithHourRange(from, to),
+                (from, increment) => builder.WithHourIncrements(from, increment));
+
+            HashSet<int> months = ConfigureField(random, 1, 12,
+                value => builder.WithMonth(value),
+                values => builder.WithMonths(values),
+                (from, to) => builder.WithMonthRange(from, to),
+                (from, increment) => builder.WithMonthIncrements(from, increment));
+
+            // The builder refuses to configure both day fields, exactly as the parser refuses to read both.
+            bool useDayOfWeek = random.Next(2) == 0;
+            HashSet<int> daysOfMonth = [];
+            HashSet<int> daysOfWeek = [];
+
+            if (useDayOfWeek)
+            {
+                daysOfWeek = ConfigureField(random, 1, 7,
+                    value => builder.WithDaysOfWeek(ToDayOfWeek(value)),
+                    values => builder.WithDaysOfWeek(values.Select(ToDayOfWeek).ToArray()),
+                    (from, to) => builder.WithDayOfWeekRange(ToDayOfWeek(from), ToDayOfWeek(to)),
+                    (from, increment) => builder.WithDayOfWeekIncrements(ToDayOfWeek(from), increment));
+            }
+            else
+            {
+                daysOfMonth = ConfigureField(random, 1, 31,
+                    value => builder.WithDayOfMonth(value),
+                    values => builder.WithDaysOfMonth(values),
+                    (from, to) => builder.WithDayOfMonthRange(from, to),
+                    (from, increment) => builder.WithDayOfMonthIncrements(from, increment));
+            }
+
+            int firstYear = random.Next(2030, 2041);
+            int lastYear = firstYear + random.Next(0, 6);
+            builder.WithYearRange(firstYear, lastYear);
+            HashSet<int> years = [];
+            for (int year = firstYear; year <= lastYear; year++)
+            {
+                years.Add(year);
+            }
+
+            string text = builder.ToString();
+
+            builder.Build().CronExpressionString.Should().Be(text,
+                "Build and ToString have to render the same expression, or one of them is a lie");
+
+            CronExpression parsed = new CronExpression(text);
+
+            parsed.GetSet(CronExpressionConstants.Second).Should().BeEquivalentTo(seconds, "expression '{0}'", text);
+            parsed.GetSet(CronExpressionConstants.Minute).Should().BeEquivalentTo(minutes, "expression '{0}'", text);
+            parsed.GetSet(CronExpressionConstants.Hour).Should().BeEquivalentTo(hours, "expression '{0}'", text);
+            parsed.GetSet(CronExpressionConstants.Month).Should().BeEquivalentTo(months, "expression '{0}'", text);
+            parsed.GetSet(CronExpressionConstants.Year).Should().BeEquivalentTo(years, "expression '{0}'", text);
+
+            if (useDayOfWeek)
+            {
+                parsed.GetSet(CronExpressionConstants.DayOfWeek).Should().BeEquivalentTo(daysOfWeek, "expression '{0}'", text);
+                parsed.GetSet(CronExpressionConstants.DayOfMonth).Should().Equal([CronExpressionConstants.NoSpec], "expression '{0}'", text);
+            }
+            else
+            {
+                parsed.GetSet(CronExpressionConstants.DayOfMonth).Should().BeEquivalentTo(daysOfMonth, "expression '{0}'", text);
+                parsed.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal([CronExpressionConstants.NoSpec], "expression '{0}'", text);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The special day forms have no value set to compare, so the round trip for them is the day they
+    /// pick out of a month.
+    /// </summary>
+    [Test]
+    public void TestSpecialDayFormsParseBackToTheDayTheyName()
+    {
+        // March 2024: 31 days, the 31st is a Sunday, and the last Thursday is the 28th.
+        DateTimeOffset march = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnLastDayOfMonth(), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 31, 12, 0, 0, TimeSpan.Zero));
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnNearestWeekdayOfMonth(16), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 15, 12, 0, 0, TimeSpan.Zero), "the 16th is a Saturday, so the nearest weekday is the Friday before it");
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 15, 12, 0, 0, TimeSpan.Zero));
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnLastDayOfWeekOfMonth(DayOfWeek.Thursday), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 28, 12, 0, 0, TimeSpan.Zero));
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnLastDayOfWeek(), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 2, 12, 0, 0, TimeSpan.Zero), "'L' alone in the day-of-week field is Saturday");
+
+        FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnWeekdays(), march)
+            .Should().Be(new DateTimeOffset(2024, 3, 1, 12, 0, 0, TimeSpan.Zero), "the 1st is a Friday");
+    }
+
+    /// <summary>
+    /// <c>MON/2</c> is a Quartz extension meaning every second week, and it is why
+    /// <see cref="CronExpressionBuilder.WithDayOfWeekIncrements" /> renders an explicit list instead of
+    /// the token its name suggests: the numeric <c>2/2</c> the builder means and the textual
+    /// <c>MON/2</c> the reader would guess are two different schedules.
+    /// </summary>
+    [Test]
+    public void TestTheBuilderNeverRendersTheTextualEveryNthWeekExtension()
+    {
+        CronExpressionBuilder builder = CronExpressionBuilder.Create()
+            .WithSecond(0).WithMinute(0).WithHour(12)
+            .WithDayOfWeekIncrements(DayOfWeek.Monday, 2);
+
+        builder.ToString().Should().NotContain("/", "a textual day-of-week step is read as every-second-week, not as a step through the week");
+
+        CronExpression everySecondWeek = new CronExpression("0 0 12 ? * MON/2", TimeZoneInfo.Utc);
+        CronExpression everySecondDayOfWeek = new CronExpression(builder.ToString(), TimeZoneInfo.Utc);
+
+        DateTimeOffset start = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
+
+        DateTimeOffset firstMonday = new DateTimeOffset(2024, 3, 11, 12, 0, 0, TimeSpan.Zero);
+        everySecondWeek.GetNextValidTimeAfter(start).Should().Be(firstMonday,
+            "the extension counts whole weeks from where the search starts, so it skips the Monday two days later");
+        everySecondWeek.GetNextValidTimeAfter(firstMonday).Should().Be(new DateTimeOffset(2024, 3, 25, 12, 0, 0, TimeSpan.Zero),
+            "and then a fortnight at a time");
+
+        everySecondDayOfWeek.GetNextValidTimeAfter(start).Should().Be(new DateTimeOffset(2024, 3, 1, 12, 0, 0, TimeSpan.Zero),
+            "what the builder means is MON,WED,FRI, which includes the Friday the window opens on");
+    }
+
+    private static DateTimeOffset? FirstFireAfter(CronExpressionBuilder builder, DateTimeOffset after)
+    {
+        return new CronExpression(builder.ToString(), TimeZoneInfo.Utc).GetNextValidTimeAfter(after);
+    }
+
+    private static DayOfWeek ToDayOfWeek(int quartzDayOfWeek) => (DayOfWeek) (quartzDayOfWeek - 1);
+
+    /// <summary>
+    /// Draws one of the four shapes a value field can take, configures the builder with it, and returns
+    /// the values it stands for.
+    /// </summary>
+    private static HashSet<int> ConfigureField(
+        Random random,
+        int min,
+        int max,
+        Action<int> single,
+        Action<int[]> list,
+        Action<int, int> range,
+        Action<int, int> increments)
+    {
+        int span = max - min + 1;
+
+        switch (random.Next(4))
+        {
+            case 0:
+            {
+                int value = random.Next(min, max + 1);
+                single(value);
+                return [value];
+            }
+
+            case 1:
+            {
+                HashSet<int> values = [];
+                int count = random.Next(1, 5);
+                for (int i = 0; i < count; i++)
+                {
+                    values.Add(random.Next(min, max + 1));
+                }
+
+                list(values.ToArray());
+                return values;
+            }
+
+            case 2:
+            {
+                int from = random.Next(min, max + 1);
+                int to = random.Next(min, max + 1);
+                range(from, to);
+
+                // A range that runs backwards wraps through the top of the field and carries on from its bottom.
+                HashSet<int> values = [];
+                for (int value = from; value <= (from <= to ? to : to + span); value++)
+                {
+                    values.Add(value > max ? value - span : value);
+                }
+
+                return values;
+            }
+
+            default:
+            {
+                int from = random.Next(min, max + 1);
+                int increment = random.Next(1, span);
+                increments(from, increment);
+
+                HashSet<int> values = [];
+                for (int value = from; value <= max; value += increment)
+                {
+                    values.Add(value);
+                }
+
+                return values;
+            }
+        }
+    }
+
     private static Action Invoking(Action<CronExpressionBuilder> action)
     {
         return () => action(CronExpressionBuilder.Create());

--- a/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
@@ -24,12 +24,25 @@ using Quartz.Util;
 namespace Quartz.Tests.Unit;
 
 /// <summary>
-/// Differential / property tests for the bitmask fast path added to
-/// <see cref="CronExpression" />. These guard against the bitmask diverging
-/// from the original SortedSet-based behaviour, including the De Bruijn
-/// trailing-zero fallback used on frameworks without
-/// <c>System.Numerics.BitOperations</c> (net462/net472/netstandard2.0).
+/// Differential / property tests for <see cref="CronExpression" />: every expectation here is
+/// computed by this file rather than borrowed from the class under test, so a parse that disagrees
+/// with its own evaluation has somewhere to surface.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The first group guards the bitmask fast path against diverging from the original SortedSet-based
+/// behaviour, including the De Bruijn trailing-zero fallback used on frameworks without
+/// <c>System.Numerics.BitOperations</c> (net462/net472/netstandard2.0).
+/// </para>
+/// <para>
+/// The last one is wider and works on whole expressions rather than one field's mechanics: a random
+/// expression is walked minute by minute over a bounded window and the minutes it matches are
+/// compared with the sequence <c>GetNextValidTimeAfter</c> chains out of it. That is a genuine
+/// difference of method even though both ends are Quartz — the walk only ever asks the search to step
+/// one minute, while the chain asks it to jump a gap, and it is jumping that has to work out which
+/// day, month or year to land in. A disagreement is a fire time one of the two invented or lost.
+/// </para>
+/// </remarks>
 /// <author>Marko Lahma (.NET)</author>
 public class CronExpressionDifferentialTest
 {
@@ -281,6 +294,305 @@ public class CronExpressionDifferentialTest
 
             expected.Should().NotBeNull("expression {0} fires within a year", expr);
             actual.Should().Be(expected, "expression {0}, start {1:O}", expr, start);
+        }
+    }
+
+    /// <summary>The window every generated expression is walked over — long enough to cross a month boundary.</summary>
+    private const int WindowDays = 45;
+
+    /// <summary>
+    /// How many fire times are compared per expression. A dense expression fires every minute, and
+    /// chaining through all sixty-four thousand of them would dominate the run for no extra reach: a
+    /// chain that skips or invents a fire disagrees at that index, whatever comes after it. The day
+    /// fields, which are the ones that make the search jump, get the whole window instead — see the
+    /// once-a-day comparison in the test.
+    /// </summary>
+    private const int FiresPerExpression = 300;
+
+    /// <summary>How many minutes per expression are put to <c>IsSatisfiedBy</c> as well as to the walk.</summary>
+    private const int SampledMinutes = 120;
+
+    private const int ExpressionsPerSeed = 120;
+
+    /// <summary>
+    /// Expression-level property: the minutes a random expression matches, found by walking the window
+    /// a minute at a time, are exactly the fire times <see cref="CronExpression.GetNextValidTimeAfter" />
+    /// chains out of the same window — and <see cref="CronExpression.IsSatisfiedBy" /> agrees with both
+    /// on a sample of the minutes in between.
+    /// </summary>
+    /// <remarks>
+    /// The membership rule is this file's own arithmetic, so a field parsed into the wrong set is caught
+    /// as well as a search that lands in the wrong place. The generated grammar is deliberately the part
+    /// the worked examples cover thinnest: wrapping ranges in every field, step values, and the
+    /// day-of-week forms — a plain set, <c>d#n</c> and <c>dL</c>. The day-of-month special forms are left
+    /// out because <see cref="GetNextValidTimeAfter_MatchesBruteForce_LastDayAndWeekday" /> already walks
+    /// those against a reference of their own.
+    /// </remarks>
+    /// <param name="seed">
+    /// Fixed, and part of the case name: a fuzz that draws from the clock reports a failure nobody can
+    /// reproduce.
+    /// </param>
+    [TestCase(101)]
+    [TestCase(202)]
+    [TestCase(303)]
+    [TestCase(404)]
+    [TestCase(505)]
+    [TestCase(606)]
+    public void MinuteWalkAndGetNextValidTimeAfterAgreeOnRandomExpressions(int seed)
+    {
+        Random random = new Random(seed);
+        DateTimeOffset windowStart = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset windowEnd = windowStart.AddDays(WindowDays);
+
+        int expressionsThatFired = 0;
+
+        for (int iteration = 0; iteration < ExpressionsPerSeed; iteration++)
+        {
+            GeneratedExpression generated = NextExpression(random);
+            CronExpression cron = new CronExpression(generated.Text, TimeZoneInfo.Utc);
+
+            // The walk: every minute in the window, tested against this file's own membership rule.
+            List<DateTimeOffset> expected = [];
+            for (DateTimeOffset minute = windowStart.AddMinutes(1); minute <= windowEnd && expected.Count < FiresPerExpression; minute = minute.AddMinutes(1))
+            {
+                if (generated.Matches(minute))
+                {
+                    expected.Add(minute);
+                }
+            }
+
+            // The chain: each fire time asked for from the one before it, so every step is a jump.
+            List<DateTimeOffset> actual = [];
+            DateTimeOffset cursor = windowStart;
+            while (actual.Count < FiresPerExpression)
+            {
+                DateTimeOffset? next = cron.GetNextValidTimeAfter(cursor);
+                if (next is null || next > windowEnd)
+                {
+                    break;
+                }
+
+                actual.Add(next.Value);
+                cursor = next.Value;
+            }
+
+            actual.Should().Equal(expected, "expression '{0}' (seed {1}, expression {2})", generated.Text, seed, iteration);
+
+            if (expected.Count > 0)
+            {
+                expressionsThatFired++;
+            }
+
+            // The same day and month fields at a fixed time of day. This fires at most once a day, so the
+            // comparison reaches the end of the window however dense the minute and hour fields were - and
+            // it is the day fields that make the search jump a gap, so a jump landing in the wrong week or
+            // the wrong month has nowhere else to show up.
+            CronExpression daily = new CronExpression(generated.DailyText, TimeZoneInfo.Utc);
+
+            DateTimeOffset noonOnTheFirstDay = new DateTimeOffset(windowStart.Year, windowStart.Month, windowStart.Day, 12, 0, 0, TimeSpan.Zero);
+
+            List<DateTimeOffset> expectedDays = [];
+            for (int day = 0; day <= WindowDays; day++)
+            {
+                DateTimeOffset candidate = noonOnTheFirstDay.AddDays(day);
+                if (candidate > windowStart && candidate <= windowEnd && generated.MatchesDay(candidate))
+                {
+                    expectedDays.Add(candidate);
+                }
+            }
+
+            List<DateTimeOffset> actualDays = [];
+            cursor = windowStart;
+            while (true)
+            {
+                DateTimeOffset? next = daily.GetNextValidTimeAfter(cursor);
+                if (next is null || next > windowEnd)
+                {
+                    break;
+                }
+
+                actualDays.Add(next.Value);
+                cursor = next.Value;
+            }
+
+            actualDays.Should().Equal(expectedDays, "expression '{0}' (seed {1}, expression {2})", generated.DailyText, seed, iteration);
+
+            for (int sample = 0; sample < SampledMinutes; sample++)
+            {
+                DateTimeOffset minute = windowStart.AddMinutes(random.Next(0, WindowDays * 24 * 60));
+
+                cron.IsSatisfiedBy(minute).Should().Be(
+                    generated.Matches(minute),
+                    "expression '{0}' at {1:O} (seed {2}, expression {3})", generated.Text, minute, seed, iteration);
+            }
+        }
+
+        // Around half of the draws pick a month the window does not contain, and those still assert
+        // something worth having - that the chain finds nothing either. The floor is here for the case
+        // where a change to the generator makes every expression fire on nothing.
+        expressionsThatFired.Should().BeGreaterThan(
+            ExpressionsPerSeed / 3,
+            "a generator that stopped producing expressions which fire inside the window would leave this test asserting nothing");
+    }
+
+    /// <summary>
+    /// A random expression together with the membership rule this file derived it from. The two are
+    /// built side by side so the rule can never be read back out of <see cref="CronExpression" />.
+    /// </summary>
+    private sealed class GeneratedExpression
+    {
+        public required string Text { get; init; }
+
+        /// <summary>The same day and month fields, fixed at noon.</summary>
+        public required string DailyText { get; init; }
+
+        public required HashSet<int> Minutes { get; init; }
+
+        public required HashSet<int> Hours { get; init; }
+
+        public required HashSet<int> Months { get; init; }
+
+        public required Func<DateTimeOffset, bool> DayMatches { get; init; }
+
+        public bool Matches(DateTimeOffset moment)
+        {
+            return moment.Second == 0
+                   && moment.Millisecond == 0
+                   && MatchesDay(moment)
+                   && Hours.Contains(moment.Hour)
+                   && Minutes.Contains(moment.Minute);
+        }
+
+        public bool MatchesDay(DateTimeOffset moment)
+        {
+            return Months.Contains(moment.Month) && DayMatches(moment);
+        }
+    }
+
+    private static GeneratedExpression NextExpression(Random random)
+    {
+        (string minuteToken, HashSet<int> minutes) = NextField(random, 0, 59);
+        (string hourToken, HashSet<int> hours) = NextField(random, 0, 23);
+        (string monthToken, HashSet<int> months) = NextField(random, 1, 12);
+
+        string dayOfMonthToken;
+        string dayOfWeekToken;
+        Func<DateTimeOffset, bool> dayMatches;
+
+        // Exactly one of the two day fields carries a value and the other a '?', which is the only
+        // combination Quartz reads without complaint.
+        if (random.Next(2) == 0)
+        {
+            (dayOfWeekToken, dayMatches) = NextDayOfWeek(random);
+            dayOfMonthToken = "?";
+        }
+        else
+        {
+            (dayOfMonthToken, HashSet<int> daysOfMonth) = NextField(random, 1, 31);
+            dayMatches = moment => daysOfMonth.Contains(moment.Day);
+            dayOfWeekToken = "?";
+        }
+
+        return new GeneratedExpression
+        {
+            Text = $"0 {minuteToken} {hourToken} {dayOfMonthToken} {monthToken} {dayOfWeekToken}",
+            DailyText = $"0 0 12 {dayOfMonthToken} {monthToken} {dayOfWeekToken}",
+            Minutes = minutes,
+            Hours = hours,
+            Months = months,
+            DayMatches = dayMatches
+        };
+    }
+
+    private static (string Token, Func<DateTimeOffset, bool> Matches) NextDayOfWeek(Random random)
+    {
+        int shape = random.Next(5);
+
+        // Quartz numbers the week 1 = Sunday through 7 = Saturday.
+        if (shape == 3)
+        {
+            int day = random.Next(1, 8);
+            int nth = random.Next(1, 6);
+
+            // The nth such weekday in the month, and no fallback when the month has fewer than n of them.
+            return ($"{day}#{nth}", moment => QuartzDayOfWeek(moment) == day && (moment.Day - 1) / 7 + 1 == nth);
+        }
+
+        if (shape == 4)
+        {
+            int day = random.Next(1, 8);
+
+            return ($"{day}L", moment => QuartzDayOfWeek(moment) == day && moment.Day + 7 > DateTime.DaysInMonth(moment.Year, moment.Month));
+        }
+
+        (string token, HashSet<int> values) = NextField(random, 1, 7);
+        return (token, moment => values.Contains(QuartzDayOfWeek(moment)));
+    }
+
+    private static int QuartzDayOfWeek(DateTimeOffset moment) => (int) moment.DayOfWeek + 1;
+
+    /// <summary>
+    /// One field, as a token and as the set of values that token means. Four shapes: the wildcard, a
+    /// list, a range that may run backwards through the top of the field, and a step.
+    /// </summary>
+    private static (string Token, HashSet<int> Values) NextField(Random random, int min, int max)
+    {
+        int span = max - min + 1;
+
+        switch (random.Next(4))
+        {
+            case 0:
+            {
+                HashSet<int> all = [];
+                for (int value = min; value <= max; value++)
+                {
+                    all.Add(value);
+                }
+
+                return ("*", all);
+            }
+
+            case 1:
+            {
+                HashSet<int> values = [];
+                int count = random.Next(1, 5);
+                for (int i = 0; i < count; i++)
+                {
+                    values.Add(random.Next(min, max + 1));
+                }
+
+                return (string.Join(",", values.OrderBy(value => value)), values);
+            }
+
+            case 2:
+            {
+                int from = random.Next(min, max + 1);
+                int to = random.Next(min, max + 1);
+
+                HashSet<int> values = [];
+                for (int value = from; value <= (from <= to ? to : to + span); value++)
+                {
+                    values.Add(value > max ? value - span : value);
+                }
+
+                return ($"{from}-{to}", values);
+            }
+
+            default:
+            {
+                int from = random.Next(min, max + 1);
+
+                // Quartz rejects an increment that reaches the top of the field, so the draw stops short of it.
+                int increment = random.Next(1, span);
+
+                HashSet<int> values = [];
+                for (int value = from; value <= max; value += increment)
+                {
+                    values.Add(value);
+                }
+
+                return ($"{from}/{increment}", values);
+            }
         }
     }
 

--- a/src/Quartz.Tests.Unit/CronExpressionWrappingRangeTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionWrappingRangeTest.cs
@@ -1,0 +1,147 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// An overflowing range — a larger value on the left of the dash than on the right — is a documented
+/// <see cref="CronExpression" /> feature, and the three shapes below are the ones its own remarks use
+/// as examples: <c>22-2</c> for ten at night through two in the morning, <c>NOV-FEB</c> for a winter,
+/// <c>FRI-MON</c> for a long weekend.
+/// </summary>
+/// <remarks>
+/// What was already tested is that such an expression parses to a field that is not empty. That is a
+/// weak guard: a wrap silently read as the plain forward range, or as the whole field, passes it and
+/// then fires on something nobody asked for. So each case here says which values the field resolves
+/// to and when the expression actually fires.
+/// </remarks>
+/// <author>Marko Lahma (.NET)</author>
+public class CronExpressionWrappingRangeTest
+{
+    [Test]
+    public void AnHourRangeWrapsThroughMidnight()
+    {
+        CronExpression cron = new CronExpression("0 0 22-2 * * ?", TimeZoneInfo.Utc);
+
+        cron.GetSet(CronExpressionConstants.Hour).Should().Equal([0, 1, 2, 22, 23],
+            "22-2 is the five hours from ten at night to two in the morning, not the twenty-one hours between 2 and 22");
+
+        FireTimes(cron, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 7).Should().Equal(
+        [
+            new DateTimeOffset(2024, 1, 1, 1, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 2, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 22, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 23, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 2, 1, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 2, 2, 0, 0, TimeSpan.Zero)
+        ]);
+
+        cron.IsSatisfiedBy(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero)).Should().BeFalse(
+            "midday is on the far side of the wrap");
+    }
+
+    [Test]
+    public void ADayOfWeekRangeWrapsThroughSunday()
+    {
+        CronExpression cron = new CronExpression("0 0 12 ? * FRI-MON", TimeZoneInfo.Utc);
+
+        cron.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal([1, 2, 6, 7],
+            "the wrap runs FRI, SAT, SUN, MON, and Quartz numbers the week 1 = SUN through 7 = SAT");
+
+        // 2024-01-01 is a Monday, so the long weekend it belongs to has already begun.
+        FireTimes(cron, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 6).Should().Equal(
+        [
+            new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero),  // Monday
+            new DateTimeOffset(2024, 1, 5, 12, 0, 0, TimeSpan.Zero),  // Friday
+            new DateTimeOffset(2024, 1, 6, 12, 0, 0, TimeSpan.Zero),  // Saturday
+            new DateTimeOffset(2024, 1, 7, 12, 0, 0, TimeSpan.Zero),  // Sunday
+            new DateTimeOffset(2024, 1, 8, 12, 0, 0, TimeSpan.Zero),  // Monday
+            new DateTimeOffset(2024, 1, 12, 12, 0, 0, TimeSpan.Zero)  // Friday
+        ]);
+
+        cron.IsSatisfiedBy(new DateTimeOffset(2024, 1, 3, 12, 0, 0, TimeSpan.Zero)).Should().BeFalse(
+            "Wednesday is midweek, which is exactly what the wrap excludes");
+    }
+
+    [Test]
+    public void AMonthRangeWrapsThroughNewYear()
+    {
+        CronExpression cron = new CronExpression("0 0 12 1 NOV-FEB ?", TimeZoneInfo.Utc);
+
+        cron.GetSet(CronExpressionConstants.Month).Should().Equal([1, 2, 11, 12],
+            "the wrap runs November through February, and Quartz numbers the months 1 = January");
+
+        FireTimes(cron, new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero), 5).Should().Equal(
+        [
+            new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 2, 1, 12, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 11, 1, 12, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 12, 1, 12, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero)
+        ]);
+
+        cron.IsSatisfiedBy(new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero)).Should().BeFalse(
+            "June is summer, on the far side of the wrap");
+    }
+
+    /// <summary>
+    /// A wrap is written the same way in seconds and minutes, and the two are read by the same code as
+    /// the hour field, so one case covers both rather than repeating the hour test twice.
+    /// </summary>
+    [Test]
+    public void SecondAndMinuteRangesWrapThroughTheTopOfTheirField()
+    {
+        CronExpression cron = new CronExpression("58-1 59-0 12 * * ?", TimeZoneInfo.Utc);
+
+        cron.GetSet(CronExpressionConstants.Second).Should().Equal([0, 1, 58, 59]);
+        cron.GetSet(CronExpressionConstants.Minute).Should().Equal([0, 59]);
+
+        FireTimes(cron, new DateTimeOffset(2024, 1, 1, 11, 0, 0, TimeSpan.Zero), 5).Should().Equal(
+        [
+            new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 12, 0, 1, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 12, 0, 58, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 12, 0, 59, TimeSpan.Zero),
+            new DateTimeOffset(2024, 1, 1, 12, 59, 0, TimeSpan.Zero)
+        ]);
+    }
+
+    private static List<DateTimeOffset> FireTimes(CronExpression cron, DateTimeOffset after, int count)
+    {
+        List<DateTimeOffset> result = [];
+        DateTimeOffset cursor = after;
+
+        for (int i = 0; i < count; i++)
+        {
+            DateTimeOffset? next = cron.GetNextValidTimeAfter(cursor);
+            if (next is null)
+            {
+                break;
+            }
+
+            result.Add(next.Value);
+            cursor = next.Value;
+        }
+
+        return result;
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -1,0 +1,147 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A job data blob written by one serializer has to be readable by the other. Both are documented
+/// store formats and an application is free to switch between them, so the column contents outlive
+/// the choice that wrote them — and a value that survives its own author but not the other reader is
+/// a one-way door nobody is warned about.
+/// </summary>
+/// <remarks>
+/// The set covered here is the set <see cref="DataMapExtensions" /> declares an accessor for: those
+/// are the types Quartz teaches an application to store, and so the ones the store format owes an
+/// answer for. Everything past them is the application's own choice — see
+/// <c>QuartzStoreJsonContext</c>, whose remarks spell the closed read side out.
+/// </remarks>
+public class JobDataMapPortabilityTest
+{
+    private IObjectSerializer newtonsoftSerializer;
+    private IObjectSerializer systemTextJsonSerializer;
+
+    [SetUp]
+    public void SetUp()
+    {
+        newtonsoftSerializer = new NewtonsoftJsonObjectSerializer();
+        systemTextJsonSerializer = new SystemTextJsonObjectSerializer();
+    }
+
+    /// <summary>
+    /// The name is what a failure reports, so each value is its own case rather than a loop.
+    /// </summary>
+    private static IEnumerable<TestCaseData> PortableValues()
+    {
+        yield return Case("string", "value", map => map.GetString("string").Should().Be("value"));
+        yield return Case("bool", true, map => map.GetBoolean("bool").Should().BeTrue());
+        yield return Case("char", 'x', map => map.GetChar("char").Should().Be('x'));
+        yield return Case("int", 123, map => map.GetInt("int").Should().Be(123));
+        yield return Case("long", 9_000_000_000L, map => map.GetLong("long").Should().Be(9_000_000_000L));
+        yield return Case("float", 1.5f, map => map.GetFloat("float").Should().Be(1.5f));
+        yield return Case("double", 12.34, map => map.GetDouble("double").Should().Be(12.34));
+        yield return Case("decimal", 1.5m, map => map.GetDecimal("decimal").Should().Be(1.5m));
+        yield return Case("dateTime", new DateTime(1982, 6, 28, 1, 1, 1, DateTimeKind.Unspecified), map => map.GetDateTime("dateTime").Should().Be(new DateTime(1982, 6, 28, 1, 1, 1, DateTimeKind.Unspecified)));
+        yield return Case("dateTimeOffset", new DateTimeOffset(1982, 6, 28, 1, 1, 1, TimeSpan.FromHours(3)), map => map.GetDateTimeOffset("dateTimeOffset").Should().Be(new DateTimeOffset(1982, 6, 28, 1, 1, 1, TimeSpan.FromHours(3))));
+        yield return Case("timeSpan", TimeSpan.FromMinutes(90), map => map.GetTimeSpan("timeSpan").Should().Be(TimeSpan.FromMinutes(90)));
+        yield return Case("guid", Guid.Parse("11111111-2222-3333-4444-555555555555"), map => map.GetGuid("guid").Should().Be(Guid.Parse("11111111-2222-3333-4444-555555555555")));
+        yield return Case("dateOnly", new DateOnly(1982, 6, 28), map => map.GetDateOnly("dateOnly").Should().Be(new DateOnly(1982, 6, 28)));
+        yield return Case("timeOnly", new TimeOnly(1, 2, 3), map => map.GetTimeOnly("timeOnly").Should().Be(new TimeOnly(1, 2, 3)));
+        yield return Case("enum", IntervalUnit.Hour, map => map.GetEnum<IntervalUnit>("enum").Should().Be(IntervalUnit.Hour));
+        yield return Case("null", null, map => map["null"].Should().BeNull());
+    }
+
+    private static TestCaseData Case(string key, object value, Action<JobDataMap> assert)
+    {
+        return new TestCaseData(key, value, assert).SetName("{m}(" + key + ")");
+    }
+
+    [TestCaseSource(nameof(PortableValues))]
+    public void AValueTheAccessorsCoverReadsBackWhicheverSerializerWroteIt(string key, object value, Action<JobDataMap> assert)
+    {
+        JobDataMap original = new JobDataMap { { key, value } };
+
+        foreach ((string label, IObjectSerializer writer, IObjectSerializer reader) in Pairings())
+        {
+            JobDataMap restored = reader.Deserialize<JobDataMap>(writer.Serialize(original))!;
+
+            restored.Should().ContainKey(key, "{0}: the key must survive the crossing", label);
+
+            try
+            {
+                assert(restored);
+            }
+            catch (Exception e) when (e is not AssertionException)
+            {
+                throw new AssertionException($"{label}: reading '{key}' back threw {e.GetType().Name}: {e.Message}", e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The dirty flag says "changed since it was written", so a map that has only just been read is
+    /// clean — otherwise every load would schedule a needless write back.
+    /// </summary>
+    [Test]
+    public void AMapJustReadIsNotDirtyWhicheverSerializerWroteIt()
+    {
+        JobDataMap original = new JobDataMap { { "key", "value" } };
+
+        foreach ((string label, IObjectSerializer writer, IObjectSerializer reader) in Pairings())
+        {
+            JobDataMap restored = reader.Deserialize<JobDataMap>(writer.Serialize(original))!;
+
+            restored.Dirty.Should().BeFalse("{0}: a map loaded from the store has not been modified since it was written", label);
+        }
+    }
+
+    /// <summary>
+    /// Nesting is where the two formats stop agreeing, so this is the guarantee an application gets:
+    /// none. A nested map never comes back as the <see cref="JobDataMap" /> it went in as, and the two
+    /// serializers do not agree on what it does come back as — System.Text.Json's read side is closed
+    /// over the primitives plus <c>Dictionary&lt;string, string&gt;</c>, while Newtonsoft hands back
+    /// its own <c>JObject</c>. Job code that needs structure has to serialize the structure itself and
+    /// store the result as a string.
+    /// </summary>
+    [Test]
+    public void ANestedMapIsNotPartOfThePortableFormat()
+    {
+        JobDataMap original = new JobDataMap { { "nested", new JobDataMap { { "inner", "value" } } } };
+
+        foreach ((string label, IObjectSerializer writer, IObjectSerializer reader) in Pairings())
+        {
+            JobDataMap restored = reader.Deserialize<JobDataMap>(writer.Serialize(original))!;
+
+            restored["nested"].Should().NotBeOfType<JobDataMap>(
+                "{0}: neither format carries a nested map's identity, so job code must not expect one back", label);
+        }
+    }
+
+    private IEnumerable<(string Label, IObjectSerializer Writer, IObjectSerializer Reader)> Pairings()
+    {
+        yield return ("newtonsoft -> newtonsoft", newtonsoftSerializer, newtonsoftSerializer);
+        yield return ("newtonsoft -> system.text.json", newtonsoftSerializer, systemTextJsonSerializer);
+        yield return ("system.text.json -> newtonsoft", systemTextJsonSerializer, newtonsoftSerializer);
+        yield return ("system.text.json -> system.text.json", systemTextJsonSerializer, systemTextJsonSerializer);
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
@@ -118,8 +118,9 @@ public class NewtonsoftJsonDeserializationFailureTest
     {
         NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
 
-        // The calendar converter has no catch of its own, so Newtonsoft's reader exception travels
-        // all the way out to the serializer - the exact path the shadowed catch used to miss.
+        // Newtonsoft's reader exception is raised under the calendar converter, which wraps it, and the
+        // serializer wraps that again to attach the payload - the exact path the shadowed catch used to
+        // miss. What matters either way is that Newtonsoft's own type is the cause and never the escapee.
         const string Truncated = """{"$type": "Quartz.Impl.Calendar.AnnualCalendar, Quartz", "Description": "x""";
 
         Action act = () => serializer.Deserialize<AnnualCalendar>(Encoding.UTF8.GetBytes(Truncated));
@@ -127,7 +128,7 @@ public class NewtonsoftJsonDeserializationFailureTest
         Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
 
         thrown.Message.Should().Contain(Truncated);
-        thrown.InnerException.Should().BeOfType<global::Newtonsoft.Json.JsonReaderException>();
+        thrown.GetBaseException().Should().BeOfType<global::Newtonsoft.Json.JsonReaderException>();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -411,6 +411,59 @@ public class JsonObjectSerializerTest
         await VerifyCreatedJson(trigger);
     }
 
+    /// <summary>
+    /// The RRULE trigger goes through the same four writer/reader pairings as the other four, so a
+    /// blob one serializer wrote is proved readable by the other rather than only by its own author.
+    /// </summary>
+    [Test]
+    public async Task SerializeRecurrenceTrigger()
+    {
+        var timeProvider = CreateFakeTimeProvider();
+
+        var trigger = (IOperableTrigger) TriggerBuilder.Create(timeProvider)
+            .WithRecurrenceSchedule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR", builder => builder
+                .InTimeZone(TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time"))
+                .WithMisfireInstruction(RecurrenceTriggerMisfireInstruction.DoNothing)
+            )
+            .WithIdentity("RecurrenceTriggerKey", "RecurrenceTriggerGroup")
+            .ForJob("RecurrenceJobKey", "RecurrenceJobGroup")
+            .WithDescription("RecurrenceTrigger description")
+            .WithCalendarName("SomeCalendar")
+            .UsingJobData("TestKey", "TestValue")
+            .StartAt(timeProvider.GetUtcNow())
+            .EndAt(timeProvider.GetUtcNow().AddDays(30))
+            .WithPriority(TriggerConstants.DefaultPriority + 3)
+            .Build();
+
+        SetTimeProvider(timeProvider, trigger);
+
+        trigger.Triggered(new BaseCalendar());
+        trigger.Triggered(new BaseCalendar());
+        trigger.Triggered(new BaseCalendar());
+        trigger.Triggered(new BaseCalendar());
+
+        CompareSerialization(
+            trigger,
+            (deserialized, original) =>
+            {
+                using (new AssertionScope())
+                {
+                    original.NextFireTimeUtc.Should().Be(deserialized.NextFireTimeUtc);
+                    original.PreviousFireTimeUtc.Should().Be(deserialized.PreviousFireTimeUtc);
+
+                    var restored = (RecurrenceTriggerImpl) deserialized;
+                    restored.RecurrenceRule.Should().Be(((RecurrenceTriggerImpl) original).RecurrenceRule,
+                        "the rule is the whole schedule - a trigger that loses it fires on nothing");
+                    restored.TimeZone.Should().Be(((RecurrenceTriggerImpl) original).TimeZone,
+                        "the rule is evaluated in this zone, so a lost zone silently reschedules the job");
+                    restored.TimesTriggered.Should().Be(((RecurrenceTriggerImpl) original).TimesTriggered);
+                }
+            }
+        );
+
+        await VerifyCreatedJson(trigger);
+    }
+
     [Test]
     public async Task SerializeSimpleTrigger()
     {
@@ -658,11 +711,17 @@ public class JsonSerializationTestCalendar : BaseCalendar
 
 public class JsonSerializationTestTrigger : SimpleTriggerImpl
 {
+    /// <summary>
+    /// The name this trigger's payloads carry, which is what a reader without its serializer looks up
+    /// and fails to find.
+    /// </summary>
+    public const string Discriminator = "TestTrigger";
+
     public int CustomProperty { get; set; }
 
     public sealed class SystemTextJsonSerializer : Serialization.SystemTextJson.Triggers.TriggerSerializer<JsonSerializationTestTrigger>
     {
-        public override string TriggerTypeName => "TestTrigger";
+        public override string TriggerTypeName => Discriminator;
 
         public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, StjJsonSerializerOptions options)
         {
@@ -701,7 +760,7 @@ public class JsonSerializationTestTrigger : SimpleTriggerImpl
 
     public sealed class NewtonsoftSerializer : Serialization.Newtonsoft.Triggers.TriggerSerializer<JsonSerializationTestTrigger>
     {
-        public override string TriggerTypeName => "TestTrigger";
+        public override string TriggerTypeName => Discriminator;
 
         public override IScheduleBuilder CreateScheduleBuilder(JObject jsonElement)
         {

--- a/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/LegacyJsonPayloadTest.cs
@@ -314,6 +314,30 @@ public class LegacyJsonPayloadTest
         }
         """;
 
+    private const string LegacyRecurrenceTrigger =
+        """
+        {
+          "TriggerType": "RecurrenceTrigger",
+          "Key": {
+            "Name": "RecurrenceTriggerKey",
+            "Group": "RecurrenceTriggerGroup"
+          },
+          "JobKey": null,
+          "Description": "RecurrenceTrigger description",
+          "CalendarName": null,
+          "JobDataMap": {},
+          "MisfireInstruction": 2,
+          "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+          "EndTimeUtc": null,
+          "Priority": 5,
+          "NextFireTimeUtc": "2024-07-15T09:00:00+09:00",
+          "PreviousFireTimeUtc": "2024-07-01T09:00:00+09:00",
+          "RecurrenceRule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+          "TimeZone": "Tokyo Standard Time",
+          "TimesTriggered": 6
+        }
+        """;
+
     [Test]
     public void AnnualCalendarReadsTheTimestampArrayItUsedToBeWrittenWith()
     {
@@ -456,6 +480,25 @@ public class LegacyJsonPayloadTest
         daily.TimesTriggered.Should().Be(4);
     }
 
+    /// <summary>
+    /// The RRULE trigger has been written with these field names since 3.x added it, so its blobs are
+    /// as much in the wild as the other four's.
+    /// </summary>
+    [Test]
+    public void RecurrenceTriggerStillReadsItsUnchangedPayload()
+    {
+        var trigger = Deserialize<IOperableTrigger>(LegacyRecurrenceTrigger);
+
+        var recurrence = trigger.Should().BeOfType<RecurrenceTriggerImpl>().Subject;
+        recurrence.Key.Should().Be(new TriggerKey("RecurrenceTriggerKey", "RecurrenceTriggerGroup"));
+        recurrence.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR");
+        recurrence.TimeZone.Should().Be(TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time"),
+            "the rule is evaluated in the stored zone, so reading it back as the machine's local zone would silently reschedule the job");
+        recurrence.TimesTriggered.Should().Be(6);
+        recurrence.MisfireInstructionCode.Should().Be(MisfireInstruction.RecurrenceTrigger.DoNothing);
+        recurrence.NextFireTimeUtc.Should().Be(new DateTimeOffset(2024, 7, 15, 9, 0, 0, TimeSpan.FromHours(9)));
+    }
+
     [Test]
     public void TriggerPayloadsWrittenBeforePinningReadBackUnpinned()
     {
@@ -464,7 +507,8 @@ public class LegacyJsonPayloadTest
             LegacySimpleTrigger,
             LegacyCronTrigger,
             LegacyCalendarIntervalTrigger,
-            LegacyDailyTimeIntervalTrigger
+            LegacyDailyTimeIntervalTrigger,
+            LegacyRecurrenceTrigger
         ];
 
         foreach (string payload in payloads)

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
@@ -30,7 +30,7 @@ namespace Quartz.Tests.Unit.Simpl;
 /// <see cref="NewtonsoftJsonObjectSerializer.RegisterTriggerConverters" /> is on, and reads it back
 /// by constructing the concrete type reflectively. That path needs a genuinely parameterless
 /// constructor on every trigger implementation - a constructor whose only parameter has a default
-/// value does not count as one - so each of the four gets a round trip here.
+/// value does not count as one - so each of the five gets a round trip here.
 /// </summary>
 [TestFixture]
 public class NewtonsoftTriggerRoundTripTest
@@ -127,6 +127,26 @@ public class NewtonsoftTriggerRoundTripTest
         restored.StartTimeOfDay.Should().Be(new TimeOnly(3, 30));
         restored.EndTimeOfDay.Should().Be(new TimeOnly(4, 40));
         restored.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday });
+    }
+
+    [Test]
+    public void RecurrenceTriggerSurvivesTheRoundTrip()
+    {
+        RecurrenceTriggerImpl trigger = new RecurrenceTriggerImpl
+        {
+            Key = new TriggerKey("recurrence", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            RecurrenceRule = "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+            TimesTriggered = 3,
+            StartTimeUtc = startTime,
+            EndTimeUtc = startTime.AddDays(30)
+        };
+
+        RecurrenceTriggerImpl restored = RoundTrip(trigger);
+
+        restored.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+            "the rule is the whole schedule, so a trigger that loses it fires on nothing");
+        restored.TimesTriggered.Should().Be(3);
     }
 
     private T RoundTrip<T>(T trigger) where T : class, IOperableTrigger

--- a/src/Quartz.Tests.Unit/Simpl/UnregisteredCustomSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/UnregisteredCustomSerializerTest.cs
@@ -1,0 +1,155 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Serialization.Newtonsoft;
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A registry is per scheduler, so a blob can outlive the registration that wrote it: a node started
+/// without the <c>AddTriggerSerializer</c> call its neighbour has, or a store carried to an
+/// application that dropped the custom type. What that node reads is a payload naming a serializer it
+/// does not have, and it has to say so — as <see cref="Quartz.JsonSerializationException" />, the
+/// exception the HTTP API's handler maps and the dashboard special-cases, with the discriminator it
+/// could not resolve in the message. Anything else surfaces as an unhandled failure from inside a
+/// converter, which says nothing about which registration is missing.
+/// </summary>
+[TestFixture]
+public class UnregisteredCustomSerializerTest
+{
+    private static IEnumerable<TestCaseData> Serializers()
+    {
+        yield return new TestCaseData(SerializerKind.Newtonsoft).SetName("{m}(newtonsoft)");
+        yield return new TestCaseData(SerializerKind.SystemTextJson).SetName("{m}(system.text.json)");
+    }
+
+    public enum SerializerKind
+    {
+        Newtonsoft,
+        SystemTextJson
+    }
+
+    [TestCaseSource(nameof(Serializers))]
+    public void ACustomTriggerReadWithoutItsSerializerNamesTheDiscriminator(SerializerKind kind)
+    {
+        (IObjectSerializer writer, IObjectSerializer reader) = Pair(kind);
+
+        JsonSerializationTestTrigger trigger = new JsonSerializationTestTrigger
+        {
+            Key = new TriggerKey("custom", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            RepeatInterval = TimeSpan.FromMinutes(5),
+            RepeatCount = 3,
+            StartTimeUtc = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero),
+            CustomProperty = 42
+        };
+
+        byte[] blob = writer.Serialize<IOperableTrigger>(trigger);
+
+        Action act = () => reader.Deserialize<IOperableTrigger>(blob);
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a missing registration is a store read failure like any other, not a leak from inside a converter")
+            .Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.GetBaseException().Message.Should().Contain(
+            JsonSerializationTestTrigger.Discriminator,
+            "the discriminator is the only thing that says which AddTriggerSerializer call is missing");
+    }
+
+    [TestCaseSource(nameof(Serializers))]
+    public void ACustomCalendarReadWithoutItsSerializerNamesTheDiscriminator(SerializerKind kind)
+    {
+        (IObjectSerializer writer, IObjectSerializer reader) = Pair(kind);
+
+        JsonSerializationTestCalendar calendar = new JsonSerializationTestCalendar
+        {
+            Description = "Custom calendar",
+            CustomProperty = 42,
+            TimeZone = TimeZoneInfo.Utc
+        };
+
+        byte[] blob = writer.Serialize<ICalendar>(calendar);
+
+        Action act = () => reader.Deserialize<ICalendar>(blob);
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "both serializers write a calendar under its assembly-qualified name, and both have to fail the same way when nothing answers to it")
+            .Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.GetBaseException().Message.Should().Contain(
+            nameof(JsonSerializationTestCalendar),
+            "the discriminator is the only thing that says which AddCalendarSerializer call is missing");
+    }
+
+    /// <summary>
+    /// The write side has the same hole, and it is the one a node hits first: a scheduler that stores
+    /// a calendar it has no serializer for should say which one, not fail from inside a converter.
+    /// </summary>
+    [TestCaseSource(nameof(Serializers))]
+    public void ACustomCalendarWrittenWithoutItsSerializerNamesTheDiscriminator(SerializerKind kind)
+    {
+        (_, IObjectSerializer writerWithoutTheCustomTypes) = Pair(kind);
+
+        JsonSerializationTestCalendar calendar = new JsonSerializationTestCalendar
+        {
+            Description = "Custom calendar",
+            CustomProperty = 42,
+            TimeZone = TimeZoneInfo.Utc
+        };
+
+        Action act = () => writerWithoutTheCustomTypes.Serialize<ICalendar>(calendar);
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.GetBaseException().Message.Should().Contain(nameof(JsonSerializationTestCalendar));
+    }
+
+    /// <summary>
+    /// A writer that knows the custom types, and a reader that knows only the built-ins.
+    /// </summary>
+    private static (IObjectSerializer Writer, IObjectSerializer Reader) Pair(SerializerKind kind)
+    {
+        if (kind == SerializerKind.Newtonsoft)
+        {
+            NewtonsoftJsonSerializerRegistry registry = new NewtonsoftJsonSerializerRegistry()
+                .AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.NewtonsoftSerializer())
+                .AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.NewtonsoftSerializer());
+
+            return (
+                new NewtonsoftJsonObjectSerializer(registry) { RegisterTriggerConverters = true },
+                new NewtonsoftJsonObjectSerializer(new NewtonsoftJsonSerializerRegistry()) { RegisterTriggerConverters = true });
+        }
+
+        SystemTextJsonSerializerRegistry systemTextJsonRegistry = new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<JsonSerializationTestTrigger>(new JsonSerializationTestTrigger.SystemTextJsonSerializer())
+            .AddCalendarSerializer<JsonSerializationTestCalendar>(new JsonSerializationTestCalendar.SystemTextJsonSerializer());
+
+        return (
+            new SystemTextJsonObjectSerializer(systemTextJsonRegistry),
+            new SystemTextJsonObjectSerializer(new SystemTextJsonSerializerRegistry()));
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeRecurrenceTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeRecurrenceTrigger.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  "TriggerType": "RecurrenceTrigger",
+  "Key": {
+    "Name": "RecurrenceTriggerKey",
+    "Group": "RecurrenceTriggerGroup"
+  },
+  "JobKey": {
+    "Name": "RecurrenceJobKey",
+    "Group": "RecurrenceJobGroup"
+  },
+  "Description": "RecurrenceTrigger description",
+  "CalendarName": "SomeCalendar",
+  "JobDataMap": {
+    "TestKey": "TestValue"
+  },
+  "MisfireInstruction": 2,
+  "StartTimeUtc": "2024-07-01T00:00:00.5+00:00",
+  "EndTimeUtc": "2024-07-31T00:00:01+00:00",
+  "Priority": 8,
+  "NextFireTimeUtc": "2024-07-17T09:00:00+09:00",
+  "PreviousFireTimeUtc": "2024-07-15T09:00:00+09:00",
+  "ExecutionGroup": null,
+  "PreferredNode": null,
+  "PreferredNodeAuto": false,
+  "RecurrenceRule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+  "TimeZone": "Tokyo Standard Time",
+  "TimesTriggered": 4
+}


### PR DESCRIPTION
`RecurrenceTrigger` was the one trigger type neither JSON suite covered, and every cron test in the
suite was a worked example. This closes both gaps, and fixes the one defect the new tests exposed.

## What each fixture proves

**`JsonObjectSerializerTest.SerializeRecurrenceTrigger`** — the RRULE trigger through the same
`CompareSerialization` matrix as the other four (all four writer/reader pairings, so a blob one
serializer wrote is proved readable by the other) plus a Verify snapshot, which also pins that both
serializers write byte-identical JSON for it. The asserter names the rule, the time zone and
`TimesTriggered` explicitly, because those are what a lost field costs: a trigger firing on nothing,
or on the wrong clock.

**`NewtonsoftTriggerRoundTripTest.RecurrenceTriggerSurvivesTheRoundTrip`** — the Newtonsoft
plain-object-graph path, which is what that fixture exists for: it needs a genuinely parameterless
constructor on the concrete type. Five trigger types now, not four.

**`LegacyJsonPayloadTest.RecurrenceTriggerStillReadsItsUnchangedPayload`** — a stored-payload literal,
and the type is added to `TriggerPayloadsWrittenBeforePinningReadBackUnpinned`.

**`JobDataMapPortabilityTest`** (new) — every type `DataMapExtensions` declares an accessor for, read
back through that accessor, across all four writer/reader pairings: string, bool, char, int, long,
float, double, decimal, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `DateOnly`, `TimeOnly`, an
enum, and null. Each is its own case so a failure names the type. Plus the dirty flag (a map just read
is not dirty) and the one thing nesting guarantees: nothing.

**`UnregisteredCustomSerializerTest`** (new) — a custom trigger and a custom calendar written by a
registry that has their serializers and read by one that does not, for both serializers. The
registration is per scheduler, so this is a node started without the `AddCalendarSerializer` call its
neighbour has, and the discriminator in the message is the only thing that says which call is missing.

**`CronExpressionWrappingRangeTest`** (new) — `22-2`, `FRI-MON` and `NOV-FEB`, the three examples
`CronExpression`'s own remarks use, each saying which values the field resolves to *and* when the
expression fires. Plus a seconds/minutes case, since those wrap through the top of their field the
same way.

**`CronExpressionDifferentialTest.MinuteWalkAndGetNextValidTimeAfterAgreeOnRandomExpressions`** — a
random expression and the membership rule for it are generated side by side, the rule being the test's
own arithmetic and never read back out of `CronExpression`. The window is walked a minute at a time
and the matched minutes compared with the sequence `GetNextValidTimeAfter` chains out of it; a
once-a-day variant of the same day and month fields is compared over the whole window, since the day
fields are the ones that make the search jump; and `IsSatisfiedBy` is put to a sample of the minutes in
between. Six fixed seeds, named in the case. The generated grammar is what the worked examples cover
thinnest: wrapping ranges in every field, steps, and the day-of-week forms including `d#n` and `dL`.

**`CronExpressionBuilderTest.TestBuiltExpressionParsesBackToTheValuesTheBuilderWasGiven`** — the round
trip as a property over four seeds × 100 builders: draw values for every field in every shape the
builder offers, build, parse, compare the parsed fields with sets the test computed itself. Beside it,
the special day forms (whose round trip is the day they pick out of a month) and `MON/2` — the
every-second-week extension, and the reason `WithDayOfWeekIncrements` renders an explicit list rather
than the token its name suggests.

Both property tests were checked against a deliberate one-line break in the code they cover, to
confirm they can fail: narrowing an hour field's stop from 23 to 22 breaks all six fuzz seeds, and
rendering an hour range with a slash instead of a dash breaks all four builder seeds. The whole cron
suite — 439 tests — runs in 4 s.

## Defect found and fixed

`Quartz.Serialization.Newtonsoft`'s `CalendarConverter` was the only one of the four converters with no
catch of its own, so a payload naming a calendar its registry lacks came out as the raw
`ArgumentException` the registry throws — past the serializer's catch, which names three exception
types and not that one, and so past every handler that treats a store read failure as a store read
failure. The System.Text.Json converter has always wrapped. This wraps the Newtonsoft one the same way
on both directions, so the outer `Quartz.JsonSerializationException` carries the payload and the
discriminator survives as the base exception's message. `NewtonsoftJsonDeserializationFailureTest`
moved from `InnerException` to `GetBaseException()`, because the reader exception is now one level
deeper — the outer contract is unchanged.

## Premises corrected

The issue was written against alpha.2 and four of its claims did not survive checking:

1. **"no cross-read parity test between `SystemTextJsonObjectSerializer` and the Newtonsoft
   serializer"** — `JsonObjectSerializerTest.CompareSerialization` already runs every subject through
   all four writer/reader pairings, so every trigger, every calendar, `JobDataMap`, `CronExpression`
   and `NameValueCollection` in that fixture has had cross-read parity all along. What was thin was the
   *breadth* of the `JobDataMap` value set — seven values — which is what `JobDataMapPortabilityTest`
   fills.
2. **"4.0's own new trigger type"** — `RecurrenceTrigger` landed on `3.x` in #2990, with an identical
   field shape. That is why the legacy-payload literal is a real cross-version guarantee rather than a
   snapshot of ourselves.
3. **"a `KeyNotFoundException` from somewhere inside"** — the *trigger* path was already correct on
   both serializers: `ArgumentException("Don't know how to handle <discriminator>")` inside
   `JsonSerializationException("Failed to parse ITrigger from json")` inside the payload-carrying outer
   one. The hole was the calendar path on Newtonsoft, fixed above.
4. **Wrapping ranges are not rejected.** They are a documented `CronExpression` feature and all three
   named shapes parse to the right sets. There is no 4.1 question here; the tests state the semantics
   rather than a rejection message.

Two more, on the shape of the work rather than the issue:

5. `CronExpressionDifferentialTest` already existed, with brute-force oracles for three expression
   shapes (time-of-day, day-of-month, and the `L`/`W` family). The new test is beside them, not instead
   of them, and covers what they do not: day-of-week, steps, wrapping, and month/year jumping.
6. `IsSatisfiedBy` is implemented as `GetTimeAfter(t - 1s) == t`, so comparing the two directly is
   close to a tautology. The difference the test actually exploits is stepping versus jumping — the
   walk only ever asks the search to advance one minute, the chain asks it to cross a gap — which is
   where the parse-versus-evaluate disagreements the issue is after would live.

## Found and deliberately left alone

**A trigger's `TimeZone` is lost on the Newtonsoft plain-object-graph path.** With
`registerTriggerConverters: false` — the documented default of `UseNewtonsoftJsonSerializer`, on this
branch and on `3.x` — `TimeZoneInfo` is written as a whole object graph (`Id`, `DisplayName`,
`BaseUtcOffset`, …) and read back as nothing at all, so the getter falls through to
`TimeZoneInfo.Local`. A trigger stored in `Tokyo Standard Time` comes back on the reader's machine
clock, silently. It affects `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and
`RecurrenceTriggerImpl`; `CronTriggerImpl` escapes because its zone rides on the `CronExpression`,
which has a converter. The private `timeZoneInfoId` helper properties on the first two exist for
exactly this and are dead — `DefaultContractResolver` does not serialize private members. The fix is a
`TimeZoneInfo` converter plus a tolerant read of the old object form, which changes what is written on
a persistence path, and the issue puts the wire format out of scope. **This wants a decision, not a
drive-by.** The new round-trip test asserts the rule and `TimesTriggered`, matching what the existing
four assert, and does not assert the zone.

**System.Text.Json writes job data it cannot read.** A `JobDataMap` holding a `List<string>` or a
`Dictionary<string, object>` serializes without complaint and then fails deserialization with
`JsonSerializationException` — the blob is in the database and unreadable. The read side is closed by
design and documented in `QuartzStoreJsonContext`'s remarks; the write side is not closed to match.
Newtonsoft carries both, via `$type`, which is the other half of why nesting is not portable: a nested
map comes back as `Dictionary<string, string>` from one reader and a `JObject` from the other, and a
Newtonsoft-written nested map read by System.Text.Json picks the `$type` marker up as a data entry.
`JobDataMapPortabilityTest.ANestedMapIsNotPartOfThePortableFormat` states the guarantee that exists;
closing the write side is a separate call.

Closes #3438
