### PR TITLE
A data source takes the driver description that names no type

### DIFF
--- a/src/Quartz.Tests.Unit/Configuration/DataSourceMetadataResolutionTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/DataSourceMetadataResolutionTest.cs
@@ -1,0 +1,186 @@
+#nullable enable
+
+using System.Data.Common;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Tests.Unit.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Which half of a driver description each way of reaching a database asks for. A <see cref="DbDataSource"/>
+/// hands over the connections, so the description it needs names no type; only the connection string path,
+/// where Quartz constructs the driver's own objects, resolves the driver's types by name.
+/// </summary>
+/// <remarks>
+/// The difference is invisible until an application publishes trimmed, and the trimming canary cannot show
+/// it — <c>Microsoft.Data.Sqlite</c> ships no <see cref="DbDataSource"/> — so these tests are the guard.
+/// They ask the question from both sides: a recording description says which half was asked for, and a
+/// driver this test assembly does not reference says what asking for the wrong half costs.
+/// </remarks>
+public sealed class DataSourceMetadataResolutionTest
+{
+    private const string FakeProvider = "FakeDriver";
+
+    [Test]
+    public void ADataSourceFactory_ResolvesTheDescriptionWithoutTheDriversTypes()
+    {
+        RecordingDriverDescription driver = new();
+        using FakeDataSource source = new();
+        using ServiceProvider container = ContainerFor(driver, options => options.DataSourceFactory = _ => source);
+
+        AssertTheTypedHalfWasNeverAskedFor(container, driver);
+    }
+
+    [Test]
+    public void AKeyedDataSource_ResolvesTheDescriptionWithoutTheDriversTypes()
+    {
+        RecordingDriverDescription driver = new();
+        using ServiceProvider container = ContainerFor(
+            driver,
+            options => options.DataSourceServiceKey = "tenant-a",
+            services => services.AddKeyedSingleton<DbDataSource>("tenant-a", new FakeDataSource()));
+
+        AssertTheTypedHalfWasNeverAskedFor(container, driver);
+    }
+
+    [Test]
+    public void ARegisteredDataSource_ResolvesTheDescriptionWithoutTheDriversTypes()
+    {
+        RecordingDriverDescription driver = new();
+        using ServiceProvider container = ContainerFor(
+            driver,
+            options => options.UseRegisteredDataSource = true,
+            services => services.AddSingleton<DbDataSource>(new FakeDataSource()));
+
+        AssertTheTypedHalfWasNeverAskedFor(container, driver);
+    }
+
+    /// <summary>
+    /// The control for the three above: the distinction is between the two halves of a description, not
+    /// between asking for one and asking for nothing.
+    /// </summary>
+    [Test]
+    public void AConnectionString_StillResolvesTheDriversTypes()
+    {
+        RecordingDriverDescription driver = new();
+        using ServiceProvider container = ContainerFor(driver, options => options.ConnectionString = "irrelevant");
+
+        IDbProvider provider = container.GetRequiredService<IDbProvider>();
+
+        provider.Should().BeOfType<DbProvider>();
+        driver.TypedRequests.Should().Be(1,
+            "Quartz constructs the driver's connection and command itself when it holds the connection "
+            + "string, so this path cannot do without their types");
+        provider.Metadata.ConnectionType.Should().Be(typeof(FakeConnection));
+    }
+
+    /// <summary>
+    /// The same distinction told by a description Quartz ships, where the typed half is a
+    /// <see cref="Type.GetType(string)" /> per driver type. Firebird's driver is nowhere near this test
+    /// assembly, which is the position a trimmed application is in for a type the trimmer removed.
+    /// </summary>
+    [Test]
+    public void ADriverThisProcessCannotLoadIsStillReachableThroughADataSource()
+    {
+        using FakeDataSource source = new();
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+            store.UseFirebird(db => db.DataSourceFactory = _ => source)));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        container.GetRequiredService<IDbProvider>().Should().BeOfType<DataSourceDbProvider>(
+            "connections come from the data source, so whether the driver's assembly is loadable decides "
+            + "nothing here — and it is exactly what a trimmed application cannot promise");
+    }
+
+    [Test]
+    public void TheSameDriverOnTheConnectionStringPathStillNeedsItsAssembly()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseFirebird("irrelevant")));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        Action resolve = () => container.GetRequiredService<IDbProvider>();
+
+        resolve.Should().Throw<ArgumentException>().WithMessage("*'Firebird'*",
+            "the driver's types are what this path constructs from, so a driver that is not here is a "
+            + "configuration mistake rather than something to work around");
+    }
+
+    private static void AssertTheTypedHalfWasNeverAskedFor(ServiceProvider container, RecordingDriverDescription driver)
+    {
+        IDbProvider provider = container.GetRequiredService<IDbProvider>();
+
+        provider.Should().BeOfType<DataSourceDbProvider>();
+        driver.TypedRequests.Should().Be(0,
+            "the typed half resolves the driver's connection, command, parameter and exception types by "
+            + "name, and a provider built over a DbDataSource constructs none of them");
+        driver.TypeFreeRequests.Should().Be(1);
+        provider.Metadata.ConnectionType.Should().BeNull(
+            "the description that reached the provider is the one that names no type at all");
+    }
+
+    /// <summary>
+    /// Builds a container whose only description of <see cref="FakeProvider" /> is the one passed in, so
+    /// what the store asks of it is what the store asked of any driver description.
+    /// </summary>
+    private static ServiceProvider ContainerFor(
+        DbMetadataFactory driver,
+        Action<DataSourceOptions> configureDataSource,
+        Action<IServiceCollection>? register = null)
+    {
+        ServiceCollection services = new();
+        register?.Invoke(services);
+        services.AddSingleton(driver);
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+            store.UseGenericDatabase(FakeProvider, configureDataSource)));
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// A driver description that counts which of its two halves was asked for.
+    /// </summary>
+    /// <remarks>
+    /// The halves say the same things about the driver, and differ only in the types — which is the shape
+    /// <see cref="BuiltInDbMetadataFactory" /> has, and the only thing under test here.
+    /// </remarks>
+    private sealed class RecordingDriverDescription : DbMetadataFactory
+    {
+        public int TypedRequests { get; private set; }
+
+        public int TypeFreeRequests { get; private set; }
+
+        public override List<string> GetProviderNames() => [FakeProvider];
+
+        public override DbMetadata GetDbMetadata(string providerName)
+        {
+            TypedRequests++;
+            return facts with
+            {
+                ConnectionType = typeof(FakeConnection),
+                CommandType = typeof(FakeCommand),
+                ParameterType = typeof(FakeParameter),
+            };
+        }
+
+        public override DbMetadata GetTypeFreeDbMetadata(string providerName)
+        {
+            TypeFreeRequests++;
+            return facts;
+        }
+
+        private static readonly DbMetadata facts = new()
+        {
+            ProductName = "Fake",
+            ParameterNamePrefix = "@",
+            UseParameterNamePrefixInParameterCollection = true,
+            BindByName = true,
+        };
+    }
+}

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -64,25 +64,37 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
 
             // The driver description comes from the container, so a provider Quartz ships no description
             // for is usable as soon as the application registers one.
-            var metadata = provider.GetRequiredService<DbMetadataResolver>().Resolve(options.Provider);
+            DbMetadataResolver resolver = provider.GetRequiredService<DbMetadataResolver>();
 
             // Where the connection comes from is the data source's own setting, decided here rather than
             // by a second entry point that had to be called in the right order to take effect. Most
             // specific first: a data source the caller builds, then one registered under a key of its
             // own, then the container's single unkeyed one.
+            //
+            // Each of those three takes the half of the description that names no type, which is why the
+            // resolution happens inside the branch rather than above it: a data source hands over the
+            // connection, so there is nothing here to construct, and asking for the driver's own types
+            // resolves each of them by name — the Type.GetType a trimmed application cannot rely on, for
+            // an assembly it may well not carry.
             if (options.DataSourceFactory is { } dataSourceFactory)
             {
-                return new DataSourceDbProvider(metadata, dataSourceFactory(provider));
+                return new DataSourceDbProvider(
+                    resolver.ResolveWithoutTypes(options.Provider),
+                    dataSourceFactory(provider));
             }
 
             if (options.DataSourceServiceKey is { } dataSourceKey)
             {
-                return new DataSourceDbProvider(metadata, provider.GetRequiredKeyedService<DbDataSource>(dataSourceKey));
+                return new DataSourceDbProvider(
+                    resolver.ResolveWithoutTypes(options.Provider),
+                    provider.GetRequiredKeyedService<DbDataSource>(dataSourceKey));
             }
 
             if (options.UseRegisteredDataSource)
             {
-                return new DataSourceDbProvider(metadata, provider.GetRequiredService<DbDataSource>());
+                return new DataSourceDbProvider(
+                    resolver.ResolveWithoutTypes(options.Provider),
+                    provider.GetRequiredService<DbDataSource>());
             }
 
             var connectionString = options.ConnectionString;
@@ -97,7 +109,9 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
                 }
             }
 
-            return new DbProvider(metadata, connectionString!);
+            // Quartz holds the connection string here, so it constructs the driver's connection and
+            // command itself — and this is the one path that needs their types named.
+            return new DbProvider(resolver.Resolve(options.Provider), connectionString!);
         });
 
         return this;


### PR DESCRIPTION
`PersistentStoreBuilder.UseDataSource(Action<DataSourceOptions>)` resolved the driver description before
it looked at where connections come from, so every path through its `IDbProvider` factory took
`DbMetadataResolver.Resolve` — the half of a shipped description that loads the driver's connection,
command, parameter, parameter-type and exception types by name. A `DbDataSource` needs none of them: it
hands the connection over, and `DataSourceDbProvider` works the connection type out by asking the source
for one. Under a `TrimMode=full` publish the data-source path still walked the type names, and whether it
survived depended on which of the driver's types the trimmer happened to keep — while the factory
overloads beside it, which the trimming documentation presents as the equal alternative, name nothing.

## Before / after

The resolution moves below the branch, which is the whole of the fix:

```csharp
// before — one resolution, above the branch, for all four paths
var metadata = provider.GetRequiredService<DbMetadataResolver>().Resolve(options.Provider);

// after
DbMetadataResolver resolver = provider.GetRequiredService<DbMetadataResolver>();
...
return new DataSourceDbProvider(resolver.ResolveWithoutTypes(options.Provider), …);   // × 3
...
return new DbProvider(resolver.Resolve(options.Provider), connectionString!);         // the fallback
```

The connection-string fallback keeps `Resolve`, because that is the path that constructs the driver's
own objects and so is the one that cannot do without their types.

Nothing else moves. No public API changes, and the four comments in the tree that already describe the
data-source path as name-free — `BuiltInDbMetadataFactory`, `DbMetadataFactory.GetTypeFreeDbMetadata`,
`DataSourceDbProvider`, `DbMetadata` — become true rather than needing an edit, as does the "Equally free
of type names" row in `docs/documentation/quartz-4.x/configuration/reference.md`. The #3447 how-to needs
no change.

## What the test proves

`src/Quartz.Tests.Unit/Configuration/DataSourceMetadataResolutionTest.cs` asks the question from both
sides, and needed no new seam — `DbMetadataFactory` is already the container's extension point, so a
fake registered beside the built-in one is all it takes.

- A driver description that counts which of its two halves was asked for, registered as the container's
  only description of its provider name. For each of the three ways of naming a source
  (`DataSourceFactory`, `DataSourceServiceKey`, `UseRegisteredDataSource`) the store builds its
  `IDbProvider` with the typed half never asked for, and the description that reaches the provider names
  no type.
- The control: the same description over a connection string still resolves the types, so the test says
  which half was asked for rather than that nothing was.
- The same distinction told by a description Quartz ships, where the typed half really is a
  `Type.GetType` per driver type: Firebird — whose driver this test assembly does not reference — is
  reachable through a data source, and its connection-string sibling still fails naming the provider.
  That pair is the trimmed application's position, stated with production code.

Four of the six fail on `main`; the two controls pass either way.

The trimming canary cannot cover any of this, because `Microsoft.Data.Sqlite` ships no `DbDataSource` —
the unit test is the guard, as the issue says.

## Verification

- `dotnet build Quartz.slnx` — build succeeded, 0 warnings, 0 errors.
- `dotnet test src/Quartz.Tests.Unit` — Failed: 0, Passed: 3549, Skipped: 4.
- `dotnet test src/Quartz.Tests.AspNetCore` — Failed: 0, Passed: 527.
- Integration, `basic` leg (every `db-*` category negated) — Failed: 0, Passed: 329.
- Integration, `sqlite` leg — Failed: 0, Passed: 12. No integration fixture uses a `DbDataSource`
  anywhere in the repository, so no leg exercises the changed branch; these are regression cover for the
  connection-string path. Docker was available (29.5.3).
- `dotnet fallout PublishTrimmed` — succeeded; the canary still reports its store, binding and
  round-trip passes.

Closes #3490

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
