### PR TITLE
The in-memory store notifies its listeners with the lock released

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreNotifiesAfterUnlockTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreNotifiesAfterUnlockTest.cs
@@ -1,0 +1,420 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Triggers;
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// The in-memory store raises its notifications with its lock released, so a listener may call back
+/// into the scheduler from inside one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A notification runs listener code on the calling thread, and a listener is entitled to do what any
+/// other caller does: pause a trigger, reschedule one, ask the store a question. That call goes back
+/// through the scheduler and into the store it came from, and the store's lock is a
+/// <see cref="SemaphoreSlim" /> — not re-entrant, so a notification raised from inside the critical
+/// section deadlocks the caller against itself. That is #3472; the misfire notification predated the
+/// rule the trigger-in-error notifications were written to.
+/// </para>
+/// <para>
+/// Each test drives the store directly rather than through a scheduler, because a scheduler adds
+/// nothing here: <c>SchedulerSignalerImpl</c> forwards to the listeners and the listener's call comes
+/// straight back to <see cref="RAMJobStore" />. Driving the store makes the re-entrant call the test
+/// writes the same call the listener would make, and makes the misfire happen at a decided moment
+/// rather than whenever a scheduler thread gets round to it.
+/// </para>
+/// </remarks>
+[TestFixture]
+public sealed class RAMJobStoreNotifiesAfterUnlockTest
+{
+    /// <summary>
+    /// How long a store operation gets before the test calls it deadlocked. Long enough that a loaded
+    /// build agent does not fail it, short enough that a deadlock is reported rather than hung on —
+    /// nothing here waits for time to pass, so a passing run never spends any of it.
+    /// </summary>
+    private static readonly TimeSpan DeadlockTimeout = TimeSpan.FromSeconds(30);
+
+    private static readonly DateTimeOffset Now = new DateTimeOffset(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly JobKey MisfiringJobKey = new JobKey("misfiring", "jobs");
+    private static readonly JobKey OtherJobKey = new JobKey("other", "jobs");
+    private static readonly TriggerKey OverdueKey = new TriggerKey("overdue", "triggers");
+    private static readonly TriggerKey OtherKey = new TriggerKey("other", "triggers");
+
+    private FakeTimeProvider clock;
+    private ReentrantSignaler signaler;
+    private RAMJobStore store;
+
+    [SetUp]
+    public async Task BuildStore()
+    {
+        clock = new FakeTimeProvider(Now);
+        signaler = new ReentrantSignaler();
+        store = TestJobStores.Ram(signaler, clock);
+        signaler.Store = store;
+
+        await store.Initialize(TestJobStores.Identity());
+    }
+
+    [TearDown]
+    public async Task ShutDownStore()
+    {
+        await store.Shutdown();
+    }
+
+    [Test]
+    public async Task AMisfireAppliedWhileAcquiringLetsTheListenerBackIntoTheStore()
+    {
+        await GivenAnOverdueTrigger();
+        await GivenATriggerToPauseFromTheListener();
+
+        signaler.OnMisfire = s => s.PauseTrigger(OtherKey);
+
+        Func<Task<List<IOperableTrigger>>> acquire = async () => await store.AcquireNextTriggers(Acquisition());
+
+        await acquire.Should().CompleteWithinAsync(DeadlockTimeout,
+            "a listener that pauses a trigger from inside TriggerMisfired is doing what any listener may "
+            + "do, and the store must not be holding the lock that call needs");
+
+        signaler.LockHeldWhenNotified.Should().NotContain(true,
+            "the store's critical section is over before a notification runs listener code");
+
+        (await store.GetTriggerState(OtherKey)).Should().Be(TriggerState.Paused,
+            "the listener's call reached the store and took effect, rather than being swallowed");
+    }
+
+    [Test]
+    public async Task AMisfireAppliedWhileResumingLetsTheListenerBackIntoTheStore()
+    {
+        await GivenAnOverdueTrigger();
+        await GivenATriggerToPauseFromTheListener();
+
+        await store.PauseTrigger(OverdueKey);
+
+        signaler.OnMisfire = s => s.PauseTrigger(OtherKey);
+
+        Func<Task<bool>> resume = async () => await store.ResumeTrigger(OverdueKey);
+
+        (await resume.Should().CompleteWithinAsync(DeadlockTimeout,
+            "resuming a trigger settles its misfire debt, and the notification that goes with it must "
+            + "not be raised from inside the lock"))
+            .Which.Should().BeTrue("the trigger was paused, so resuming it moves it");
+
+        signaler.Misfired.Should().ContainSingle(
+            "resuming an overdue trigger applies its misfire policy exactly once")
+            .Which.Key.Should().Be(OverdueKey);
+
+        (await store.GetTriggerState(OtherKey)).Should().Be(TriggerState.Paused);
+    }
+
+    [Test]
+    public async Task AMisfireAppliedWhileUnblockingLetsTheListenerBackIntoTheStore()
+    {
+        // The path #3463 added: a trigger blocked behind a [DisallowConcurrentExecution] job cannot be
+        // acquired and is not swept, so the completion that unblocks it is where its misfire policy
+        // runs — inside TriggeredJobComplete, and so inside the store's lock.
+        IJobDetail job = JobBuilder.Create()
+            .OfType<NonConcurrentJob>()
+            .WithIdentity(MisfiringJobKey)
+            .Build();
+
+        SimpleTriggerImpl running = Trigger("running", MisfiringJobKey, Now.AddSeconds(5));
+        await store.ScheduleJob(job, running);
+
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(Acquisition());
+        IOperableTrigger firing = acquired.Should().ContainSingle(
+            "the trigger that does the blocking has to be handed over before it can fire").Subject;
+
+        SimpleTriggerImpl blocked = Trigger(OverdueKey.Name, MisfiringJobKey, Now.AddHours(-1), OverdueKey.Group);
+        await store.AddTrigger(blocked, replace: false);
+
+        await store.TriggersFired([firing]);
+
+        (await store.GetTriggerState(OverdueKey)).Should().Be(TriggerState.Blocked,
+            "firing one trigger of a job that forbids concurrent execution blocks the rest of them");
+
+        await GivenATriggerToPauseFromTheListener();
+
+        signaler.OnMisfire = s => s.PauseTrigger(OtherKey);
+
+        Func<Task> complete = async () => await store.TriggeredJobComplete(firing, job, SchedulerInstruction.NoInstruction);
+
+        await complete.Should().CompleteWithinAsync(DeadlockTimeout,
+            "unblocking an overdue trigger applies its misfire policy, and the notification that goes "
+            + "with it must not be raised from inside the lock either");
+
+        signaler.Misfired.Should().ContainSingle(
+            "the one unblocked trigger was overdue, so one misfire is announced")
+            .Which.Key.Should().Be(OverdueKey);
+
+        signaler.LockHeldWhenNotified.Should().NotContain(true,
+            "the store's critical section is over before a notification runs listener code");
+
+        (await store.GetTriggerState(OtherKey)).Should().Be(TriggerState.Paused);
+    }
+
+    [Test]
+    public async Task AMisfireIsAnnouncedOnceAndBeforeTheAcquisitionHandsTheTriggerOver()
+    {
+        await GivenAnOverdueTrigger();
+
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(Acquisition());
+        signaler.Observed.Add("acquired");
+
+        acquired.Should().ContainSingle(
+            "FireNow reschedules the missed firing to now, so the same acquisition pass picks it up")
+            .Which.Key.Should().Be(OverdueKey);
+
+        signaler.Observed.Should().Equal(["misfired", "acquired"],
+            "the notification is raised before the batch is handed back, which is what keeps the "
+            + "announcement of a misfire ahead of the firing it rescheduled");
+
+        signaler.LockHeldWhenNotified.Should().NotContain(true,
+            "the announcement comes before the batch but after the lock, not before both");
+
+        signaler.Misfired.Should().ContainSingle("the policy ran once, so it is announced once")
+            .Which.NextFireTimeUtc.Should().Be(Now.AddHours(-1),
+            "the listener is told about the trigger as it was when it misfired, not as the policy left it");
+
+        await store.TriggersFired(acquired);
+
+        signaler.Misfired.Should().ContainSingle(
+            "firing the rescheduled trigger is not a second misfire");
+
+        (await store.AcquireNextTriggers(Acquisition())).Should().BeEmpty(
+            "the trigger had one firing in it, so there is nothing left to acquire");
+
+        signaler.Misfired.Should().ContainSingle(
+            "a later acquisition pass does not re-announce a misfire that has already been settled");
+    }
+
+    [Test]
+    public async Task ADeletedJobIsAnnouncedWithTheLockFree()
+    {
+        await GivenAnOverdueTrigger();
+
+        signaler.OnJobDeleted = s => s.PauseTrigger(OverdueKey);
+
+        SimpleTriggerImpl onlyTrigger = Trigger("only", OtherJobKey, Now.AddMinutes(5), "triggers");
+        await store.ScheduleJob(
+            JobBuilder.Create().OfType<NoOpJob>().WithIdentity(OtherJobKey).Build(),
+            onlyTrigger);
+
+        Func<Task<bool>> unschedule = async () => await store.DeleteTrigger(onlyTrigger.Key);
+
+        (await unschedule.Should().CompleteWithinAsync(DeadlockTimeout,
+            "removing the last trigger of a non-durable job deletes the job and announces it, and that "
+            + "announcement is listener code too"))
+            .Which.Should().BeTrue();
+
+        signaler.JobsDeleted.Should().Equal([OtherJobKey]);
+        signaler.LockHeldWhenNotified.Should().NotContain(true,
+            "the store's critical section is over before a notification runs listener code");
+
+        (await store.GetTriggerState(OverdueKey)).Should().Be(TriggerState.Paused,
+            "the listener's call reached the store");
+    }
+
+    [Test]
+    public async Task ATriggerParkedInErrorIsAnnouncedAfterTheChangeThatCausedIt()
+    {
+        IJobDetail job = JobBuilder.Create()
+            .OfType<NoOpJob>()
+            .WithIdentity(MisfiringJobKey)
+            .Build();
+
+        SimpleTriggerImpl trigger = Trigger("failing", MisfiringJobKey, Now.AddSeconds(5));
+        await store.ScheduleJob(job, trigger);
+
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(Acquisition());
+        await store.TriggersFired(acquired);
+
+        signaler.OnTriggerInError = s => s.GetTriggerState(trigger.Key).AsTask();
+
+        Func<Task> complete = async () => await store.TriggeredJobComplete(
+            acquired[0], job, SchedulerInstruction.SetTriggerError);
+
+        await complete.Should().CompleteWithinAsync(DeadlockTimeout,
+            "a listener told a trigger is in error may ask the store about it, which needs the lock");
+
+        signaler.Observed.Should().Equal(["scheduling-change", "trigger-in-error"],
+            "the scheduler thread is poked first and the listeners told after, which is the order the "
+            + "store raised them in when only the error notification was deferred");
+
+        signaler.TriggerStateSeenByListener.Should().Be(TriggerState.Error,
+            "the state the notification announces is already visible to anyone who asks");
+    }
+
+    private async Task GivenAnOverdueTrigger()
+    {
+        IJobDetail job = JobBuilder.Create()
+            .OfType<NoOpJob>()
+            .WithIdentity(MisfiringJobKey)
+            .StoreDurably()
+            .Build();
+
+        await store.AddJob(job, replace: false);
+        await store.AddTrigger(
+            Trigger(OverdueKey.Name, MisfiringJobKey, Now.AddHours(-1), OverdueKey.Group),
+            replace: false);
+    }
+
+    private async Task GivenATriggerToPauseFromTheListener()
+    {
+        IJobDetail job = JobBuilder.Create()
+            .OfType<NoOpJob>()
+            .WithIdentity(OtherJobKey)
+            .StoreDurably()
+            .Build();
+
+        await store.AddJob(job, replace: false);
+        await store.AddTrigger(
+            Trigger(OtherKey.Name, OtherJobKey, Now.AddHours(1), OtherKey.Group),
+            replace: false);
+    }
+
+    private SimpleTriggerImpl Trigger(string name, JobKey jobKey, DateTimeOffset startAt, string group = "triggers")
+    {
+        SimpleTriggerImpl trigger = new SimpleTriggerImpl(clock)
+        {
+            Key = new TriggerKey(name, group),
+            JobKey = jobKey,
+            StartTimeUtc = startAt,
+            RepeatCount = 0,
+            MisfireInstructionCode = MisfireInstruction.SimpleTrigger.FireNow,
+        };
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private static TriggerAcquisitionRequest Acquisition() => new TriggerAcquisitionRequest
+    {
+        NoLaterThan = Now.AddMinutes(1),
+        MaxCount = 5,
+        TimeWindow = TimeSpan.Zero,
+    };
+
+    [DisallowConcurrentExecution]
+    private sealed class NonConcurrentJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A signaler that does what a listener is entitled to do: call back into the store that is
+    /// notifying it, and record whether that store was still inside its critical section at the time.
+    /// </summary>
+    /// <remarks>
+    /// On a store that notifies from inside its lock the callback never returns, so a test that uses
+    /// one fails on its completion assertion rather than on anything it asserts afterwards.
+    /// </remarks>
+    private sealed class ReentrantSignaler : ISchedulerSignaler
+    {
+        public RAMJobStore Store { get; set; }
+
+        public Func<RAMJobStore, ValueTask<bool>> OnMisfire { get; set; }
+
+        public Func<RAMJobStore, ValueTask<bool>> OnJobDeleted { get; set; }
+
+        public Func<RAMJobStore, Task<TriggerState>> OnTriggerInError { get; set; }
+
+        /// <summary>Every notification, in the order it arrived.</summary>
+        public List<string> Observed { get; } = [];
+
+        public List<ITrigger> Misfired { get; } = [];
+
+        public List<JobKey> JobsDeleted { get; } = [];
+
+        public List<bool> LockHeldWhenNotified { get; } = [];
+
+        public TriggerState? TriggerStateSeenByListener { get; private set; }
+
+        public async ValueTask NotifyTriggerListenersMisfired(ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            Record("misfired");
+            Misfired.Add(trigger);
+
+            if (OnMisfire is not null)
+            {
+                await OnMisfire(Store);
+            }
+        }
+
+        public ValueTask NotifySchedulerListenersFinalized(ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            Record("finalized");
+            return default;
+        }
+
+        public async ValueTask NotifySchedulerListenersJobDeleted(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            Record("job-deleted");
+            JobsDeleted.Add(jobKey);
+
+            if (OnJobDeleted is not null)
+            {
+                await OnJobDeleted(Store);
+            }
+        }
+
+        public async ValueTask NotifySchedulerListenersTriggerInError(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+        {
+            Record("trigger-in-error");
+
+            if (OnTriggerInError is not null)
+            {
+                TriggerStateSeenByListener = await OnTriggerInError(Store);
+            }
+        }
+
+        public ValueTask NotifySchedulerListenersTriggersInError(JobKey jobKey, CancellationToken cancellationToken = default)
+        {
+            Record("triggers-in-error");
+            return default;
+        }
+
+        public ValueTask SignalSchedulingChange(DateTimeOffset? candidateNewNextFireTimeUtc, CancellationToken cancellationToken = default)
+        {
+            Record("scheduling-change");
+            return default;
+        }
+
+        public ValueTask NotifySchedulerListenersError(SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
+        {
+            Record("error");
+            return default;
+        }
+
+        private void Record(string notification)
+        {
+            Observed.Add(notification);
+            LockHeldWhenNotified.Add(Store.LockHeld);
+        }
+    }
+}

--- a/src/Quartz/Extensibility/ISchedulerSignaler.cs
+++ b/src/Quartz/Extensibility/ISchedulerSignaler.cs
@@ -25,6 +25,16 @@ namespace Quartz.Extensibility;
 /// An interface to be used by <see cref="IJobStore" /> instances in order to
 /// communicate signals back to the <see cref="QuartzScheduler" />.
 /// </summary>
+/// <remarks>
+/// Every member here runs scheduler and listener code on the calling thread, and a listener is
+/// entitled to do what any other caller does: pause a trigger, reschedule one, ask the store a
+/// question. That call comes straight back into the store that signalled. A store whose lock is not
+/// re-entrant therefore has to release it first, or the listener deadlocks against the caller it is
+/// running on: <see cref="Quartz.Impl.RAMJobStore" /> collects what it owes while it holds its
+/// semaphore and raises it once the lock is gone, in the order it recorded it. A store holding a
+/// database lock is re-entrant for its own connection by construction, but what it announces from
+/// inside a transaction may still roll back, so it too prefers to notify after the commit.
+/// </remarks>
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
 public interface ISchedulerSignaler

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -208,6 +208,8 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     public async ValueTask Clear(CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -217,7 +219,7 @@ public sealed class RAMJobStore : IJobStore
                 var keys = GetTriggerKeysNoLock(GroupMatcher<TriggerKey>.GroupEquals(group));
                 foreach (TriggerKey key in keys)
                 {
-                    await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+                    RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, ref pending);
                 }
             }
 
@@ -227,7 +229,7 @@ public sealed class RAMJobStore : IJobStore
                 var keys = GetJobKeysNoLock(GroupMatcher<JobKey>.GroupEquals(group));
                 foreach (JobKey key in keys)
                 {
-                    await RemoveJobNoLock(key, cancellationToken).ConfigureAwait(false);
+                    RemoveJobNoLock(key, ref pending);
                 }
             }
 
@@ -244,6 +246,8 @@ public sealed class RAMJobStore : IJobStore
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -322,24 +326,30 @@ public sealed class RAMJobStore : IJobStore
     /// </returns>
     public async ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        bool deleted;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await RemoveJobNoLock(jobKey, cancellationToken).ConfigureAwait(false);
+            deleted = RemoveJobNoLock(jobKey, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
     }
 
-    private async ValueTask<bool> RemoveJobNoLock(JobKey jobKey, CancellationToken cancellationToken)
+    private bool RemoveJobNoLock(JobKey jobKey, ref PendingSignals pending)
     {
         bool found = false;
         var triggersForJob = GetTriggerKeysForJobNoLock(jobKey);
         foreach (var key in triggersForJob)
         {
-            await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+            RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, ref pending);
             found = true;
         }
 
@@ -362,50 +372,58 @@ public sealed class RAMJobStore : IJobStore
 
     public async ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
             foreach (JobKey key in jobKeys)
             {
-                if (await RemoveJobNoLock(key, cancellationToken).ConfigureAwait(false))
+                if (RemoveJobNoLock(key, ref pending))
                 {
                     deleted.Add(key);
                 }
             }
-
-            return deleted;
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
     }
 
     public async ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
             foreach (TriggerKey key in triggerKeys)
             {
-                if (await RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false))
+                if (RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, ref pending))
                 {
                     deleted.Add(key);
                 }
             }
-
-            return deleted;
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
     }
 
     public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -437,7 +455,7 @@ public sealed class RAMJobStore : IJobStore
                 AddJobNoLock(triggersByJob.Key, replace: true);
                 foreach (IOperableTrigger trigger in triggersByJob.Value)
                 {
-                    await AddTriggerNoLock(trigger, replace: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    AddTriggerNoLock(trigger, replace: true, ref pending);
                 }
             }
         }
@@ -445,6 +463,8 @@ public sealed class RAMJobStore : IJobStore
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -470,18 +490,22 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public async ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            await AddTriggerNoLock(trigger, replace, cancellationToken).ConfigureAwait(false);
+            AddTriggerNoLock(trigger, replace, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task AddTriggerNoLock(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken)
+    private void AddTriggerNoLock(IOperableTrigger trigger, bool replace, ref PendingSignals pending)
     {
         TriggerWrapper tw = new((IOperableTrigger) trigger.Clone());
         if (triggersByKey.ContainsKey(tw.TriggerKey))
@@ -492,7 +516,7 @@ public sealed class RAMJobStore : IJobStore
             }
 
             // don't delete orphaned job, this trigger has the job anyways
-            await RemoveTriggerNoLock(tw.TriggerKey, removeOrphanedJob: false, keepExecutions: true, cancellationToken).ConfigureAwait(false);
+            RemoveTriggerNoLock(tw.TriggerKey, removeOrphanedJob: false, keepExecutions: true, ref pending);
         }
 
         if (!jobsByKey.ContainsKey(tw.JobKey))
@@ -553,21 +577,27 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="cancellationToken"></param>
     private async ValueTask<bool> DeleteTrigger(TriggerKey key, bool removeOrphanedJob, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        bool deleted;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await RemoveTriggerNoLock(key, removeOrphanedJob, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+            deleted = RemoveTriggerNoLock(key, removeOrphanedJob, keepExecutions: false, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
     }
 
     // keepExecutions: whether executions already started under this key survive. Only a trigger being
     // replaced in place keeps them, matching the ADO store, where updating a trigger leaves its
     // fired-trigger rows alone but deleting one removes them. There is no default: every caller says which.
-    private async Task<bool> RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, bool keepExecutions, CancellationToken cancellationToken)
+    private bool RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, bool keepExecutions, ref PendingSignals pending)
     {
         if (!keepExecutions)
         {
@@ -602,9 +632,9 @@ public sealed class RAMJobStore : IJobStore
             {
                 JobWrapper jw = jobsByKey[tw.JobKey];
                 var triggerKeys = GetTriggerKeysForJobNoLock(tw.JobKey);
-                if (triggerKeys.Length == 0 && !jw.JobDetail.Durable && await RemoveJobNoLock(jw.Key, cancellationToken).ConfigureAwait(false))
+                if (triggerKeys.Length == 0 && !jw.JobDetail.Durable && RemoveJobNoLock(jw.Key, ref pending))
                 {
-                    await signaler.NotifySchedulerListenersJobDeleted(jw.Key, cancellationToken).ConfigureAwait(false);
+                    pending.RecordJobDeleted(jw.Key);
                 }
             }
         }
@@ -620,6 +650,7 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public async ValueTask<bool> ReplaceTrigger(TriggerKey triggerKey, IOperableTrigger trigger, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
         bool found;
 
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -643,16 +674,16 @@ public sealed class RAMJobStore : IJobStore
                 // The old trigger is deleted rather than updated, so its executions go with it, as they do
                 // in the ADO store where ReplaceTrigger deletes the fired-trigger rows. Removing through
                 // the shared path means anything kept per trigger is cleaned up here too.
-                await RemoveTriggerNoLock(triggerKey, removeOrphanedJob: false, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+                RemoveTriggerNoLock(triggerKey, removeOrphanedJob: false, keepExecutions: false, ref pending);
 
                 try
                 {
-                    await AddTriggerNoLock(trigger, replace: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    AddTriggerNoLock(trigger, replace: false, ref pending);
                 }
                 catch (JobPersistenceException)
                 {
                     // put previous trigger back...
-                    await AddTriggerNoLock(tw.Trigger, replace: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    AddTriggerNoLock(tw.Trigger, replace: false, ref pending);
 
                     // ...along with the executions it never stopped running.
                     if (fireInstances is not null)
@@ -668,6 +699,8 @@ public sealed class RAMJobStore : IJobStore
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
         return found;
     }
 
@@ -2084,15 +2117,21 @@ public sealed class RAMJobStore : IJobStore
     /// </remarks>
     public async ValueTask<bool> ResumeTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        bool resumed;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await ResumeTriggerNoLock(triggerKey).ConfigureAwait(false);
+            resumed = ResumeTriggerNoLock(triggerKey, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumed;
     }
 
     /// <summary>
@@ -2102,27 +2141,30 @@ public sealed class RAMJobStore : IJobStore
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        List<TriggerKey> resumed = new List<TriggerKey>(triggerKeys.Count);
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            List<TriggerKey> resumed = new List<TriggerKey>(triggerKeys.Count);
             foreach (TriggerKey triggerKey in triggerKeys)
             {
-                if (await ResumeTriggerNoLock(triggerKey).ConfigureAwait(false))
+                if (ResumeTriggerNoLock(triggerKey, ref pending))
                 {
                     resumed.Add(triggerKey);
                 }
             }
-
-            return resumed;
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumed;
     }
 
-    private async ValueTask<bool> ResumeTriggerNoLock(TriggerKey triggerKey)
+    private bool ResumeTriggerNoLock(TriggerKey triggerKey, ref PendingSignals pending)
     {
         // does the trigger exist?
         if (!triggersByKey.TryGetValue(triggerKey, out var tw))
@@ -2146,7 +2188,7 @@ public sealed class RAMJobStore : IJobStore
             tw.state = StoredTriggerState.Waiting;
         }
 
-        await ApplyMisfireNoLock(tw).ConfigureAwait(false);
+        ApplyMisfireNoLock(tw, ref pending);
 
         if (tw.state == StoredTriggerState.Waiting)
         {
@@ -2166,18 +2208,24 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     public async ValueTask<List<string>> ResumeTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        List<string> resumedGroups;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await ResumeTriggersNoLock(matcher).ConfigureAwait(false);
+            resumedGroups = ResumeTriggersNoLock(matcher, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumedGroups;
     }
 
-    private async ValueTask<List<string>> ResumeTriggersNoLock(GroupMatcher<TriggerKey> matcher)
+    private List<string> ResumeTriggersNoLock(GroupMatcher<TriggerKey> matcher, ref PendingSignals pending)
     {
         var groups = new HashSet<string>();
         var keys = GetTriggerKeysNoLock(matcher);
@@ -2194,7 +2242,7 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
 
-            await ResumeTriggerNoLock(triggerKey).ConfigureAwait(false);
+            ResumeTriggerNoLock(triggerKey, ref pending);
         }
 
         // Forget the pause of every group the matcher selects, whichever operator it carries — the
@@ -2225,15 +2273,21 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     public async ValueTask<bool> ResumeJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        bool resumed;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            return await ResumeJobNoLock(jobKey).ConfigureAwait(false);
+            resumed = ResumeJobNoLock(jobKey, ref pending);
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumed;
     }
 
     /// <summary>
@@ -2243,27 +2297,30 @@ public sealed class RAMJobStore : IJobStore
         IReadOnlyCollection<JobKey> jobKeys,
         CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        List<JobKey> resumed = new List<JobKey>(jobKeys.Count);
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            List<JobKey> resumed = new List<JobKey>(jobKeys.Count);
             foreach (JobKey jobKey in jobKeys)
             {
-                if (await ResumeJobNoLock(jobKey).ConfigureAwait(false))
+                if (ResumeJobNoLock(jobKey, ref pending))
                 {
                     resumed.Add(jobKey);
                 }
             }
-
-            return resumed;
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumed;
     }
 
-    private async ValueTask<bool> ResumeJobNoLock(JobKey jobKey)
+    private bool ResumeJobNoLock(JobKey jobKey, ref PendingSignals pending)
     {
         if (!jobsByKey.ContainsKey(jobKey))
         {
@@ -2278,7 +2335,7 @@ public sealed class RAMJobStore : IJobStore
         var triggerKeysForJob = GetTriggerKeysForJobNoLock(jobKey);
         foreach (TriggerKey key in triggerKeysForJob)
         {
-            await ResumeTriggerNoLock(key).ConfigureAwait(false);
+            ResumeTriggerNoLock(key, ref pending);
         }
 
         return true;
@@ -2295,10 +2352,12 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     public async ValueTask<List<string>> ResumeJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+        var resumedGroups = new List<string>();
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var resumedGroups = new List<string>();
             var keys = GetJobKeysNoLock(matcher);
 
             foreach (string pausedJobGroup in pausedJobGroups)
@@ -2320,15 +2379,17 @@ public sealed class RAMJobStore : IJobStore
                 var triggerKeys = GetTriggerKeysForJobNoLock(key);
                 foreach (TriggerKey triggerKey in triggerKeys)
                 {
-                    await ResumeTriggerNoLock(triggerKey).ConfigureAwait(false);
+                    ResumeTriggerNoLock(triggerKey, ref pending);
                 }
             }
-            return resumedGroups;
         }
         finally
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return resumedGroups;
     }
 
     /// <summary>
@@ -2367,6 +2428,8 @@ public sealed class RAMJobStore : IJobStore
     /// <seealso cref="PauseAll(CancellationToken)" />
     public async ValueTask ResumeAll(CancellationToken cancellationToken = default)
     {
+        PendingSignals pending = default;
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
@@ -2376,7 +2439,7 @@ public sealed class RAMJobStore : IJobStore
 
             foreach (string groupName in triggersByGroup.Keys)
             {
-                await ResumeTriggersNoLock(GroupMatcher<TriggerKey>.GroupEquals(groupName)).ConfigureAwait(false);
+                ResumeTriggersNoLock(GroupMatcher<TriggerKey>.GroupEquals(groupName), ref pending);
             }
 
             // make sure we don't have anything left in groups
@@ -2386,18 +2449,24 @@ public sealed class RAMJobStore : IJobStore
         {
             lockObject.Release();
         }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Applies the misfire.
     /// </summary>
     /// <param name="tw">The trigger wrapper.</param>
+    /// <param name="pending">
+    /// Collects the misfire notification, and the finalization that may follow it, for the caller to
+    /// raise once the store's lock is released.
+    /// </param>
     /// <returns>
     /// <see langword="true"/> if the next fire time of the trigger was updated from either
     /// one value to another, or from a given value to <see langword="null"/>; otherwise,
     /// <see langword="false"/>.
     /// </returns>
-    private async ValueTask<bool> ApplyMisfireNoLock(TriggerWrapper tw)
+    private bool ApplyMisfireNoLock(TriggerWrapper tw, ref PendingSignals pending)
     {
         if (tw.Trigger.MisfireInstructionCode == MisfireInstruction.IgnoreMisfirePolicy)
         {
@@ -2422,7 +2491,10 @@ public sealed class RAMJobStore : IJobStore
             calendarsByName.TryGetValue(tw.Trigger.CalendarName, out calendar);
         }
 
-        await signaler.NotifyTriggerListenersMisfired(tw.Trigger.Clone()).ConfigureAwait(false);
+        // Cloned here rather than at the point the notification is raised: the listener is told about
+        // the trigger as it was when it misfired, which is what it saw before this method deferred the
+        // notification, and UpdateAfterMisfire is about to move the trigger on.
+        pending.RecordMisfire(tw.Trigger.Clone());
 
         // Save the original scheduled fire time before misfire handling changes it.
         var originalFireTime = tnft;
@@ -2446,7 +2518,7 @@ public sealed class RAMJobStore : IJobStore
         if (!updatedTnft.HasValue)
         {
             tw.state = StoredTriggerState.Complete;
-            await signaler.NotifySchedulerListenersFinalized(tw.Trigger).ConfigureAwait(false);
+            pending.RecordFinalized(tw.Trigger);
 
             // We do not remove the trigger that we applied the misfire for (since its next fire time has been
             // updated). Instead we remove a trigger with the same trigger key, but with no next fire time set.
@@ -2472,16 +2544,18 @@ public sealed class RAMJobStore : IJobStore
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        PendingSignals pending = default;
+        List<IOperableTrigger> result = [];
+
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            // return empty list if store has no triggers.
+            // return empty list if store has no triggers. Returning from inside the lock skips the
+            // notification flush below, which is only safe because nothing has been recorded yet.
             if (timeTriggers.Count == 0)
             {
-                return [];
+                return result;
             }
-
-            List<IOperableTrigger> result = [];
 
             // Both sets stay null until something needs them. Only a job that disallows concurrent
             // execution fills the first, and only a trigger that is turned away fills the second, so on
@@ -2524,7 +2598,7 @@ public sealed class RAMJobStore : IJobStore
                     continue;
                 }
 
-                if (await ApplyMisfireNoLock(tw).ConfigureAwait(false))
+                if (ApplyMisfireNoLock(tw, ref pending))
                 {
                     // If - after applying the misfire policy - the trigger is still scheduled to fire, we'll
                     // add it back to the set of triggers. We cannot use the "cached" next fire time here as
@@ -2635,13 +2709,16 @@ public sealed class RAMJobStore : IJobStore
                     timeTriggers.Add(excludedTrigger);
                 }
             }
-
-            return result;
         }
         finally
         {
             lockObject.Release();
         }
+
+        // Before the batch is handed back, so that every misfire this pass applied has been announced
+        // by the time the caller can fire anything it acquired.
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return result;
     }
 
     /// <summary>
@@ -2835,10 +2912,7 @@ public sealed class RAMJobStore : IJobStore
     /// </summary>
     public async ValueTask TriggeredJobComplete(IOperableTrigger trigger, IJobDetail jobDetail, SchedulerInstruction triggerInstructionCode, CancellationToken cancellationToken = default)
     {
-        // Which error notification the state changes below earned, raised once the lock is gone.
-        // Listener code runs on this thread and may well call back into the store, which would
-        // deadlock on the semaphore we are holding.
-        ErrorNotification errorNotification = ErrorNotification.None;
+        PendingSignals pending = default;
 
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -2889,7 +2963,7 @@ public sealed class RAMJobStore : IJobStore
                             // with a past-due fire time still on it until then. The ADO store applies
                             // the policy as it unblocks (RecoverUnblockedMisfires, in the same
                             // transaction), and this is the same moment.
-                            await ApplyMisfireNoLock(ttw).ConfigureAwait(false);
+                            ApplyMisfireNoLock(ttw, ref pending);
 
                             if (ttw.state == StoredTriggerState.Waiting)
                             {
@@ -2915,11 +2989,11 @@ public sealed class RAMJobStore : IJobStore
                     {
                         foreach (TriggerKey finalizedKey in finalized)
                         {
-                            await RemoveTriggerNoLock(finalizedKey, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+                            RemoveTriggerNoLock(finalizedKey, removeOrphanedJob: true, keepExecutions: false, ref pending);
                         }
                     }
 
-                    await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                    pending.RecordSchedulingChange();
                 }
             }
             else
@@ -2946,7 +3020,7 @@ public sealed class RAMJobStore : IJobStore
                         d = tw.Trigger.NextFireTimeUtc;
                         if (!d.HasValue)
                         {
-                            await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
+                            RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, ref pending);
                         }
                         else
                         {
@@ -2955,34 +3029,34 @@ public sealed class RAMJobStore : IJobStore
                     }
                     else
                     {
-                        await RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, cancellationToken).ConfigureAwait(false);
-                        await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                        RemoveTriggerNoLock(trigger.Key, removeOrphanedJob: true, keepExecutions: false, ref pending);
+                        pending.RecordSchedulingChange();
                     }
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetTriggerComplete)
                 {
                     tw.state = StoredTriggerState.Complete;
                     timeTriggers.Remove(tw);
-                    await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                    pending.RecordSchedulingChange();
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetTriggerError)
                 {
                     logger.TriggerSetToError(trigger.Key);
                     tw.state = StoredTriggerState.Error;
-                    errorNotification = ErrorNotification.Trigger;
-                    await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                    pending.RecordSchedulingChange();
+                    pending.RecordTriggerInError(trigger.Key);
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersError)
                 {
                     logger.JobTriggersSetToError(trigger.JobKey);
                     SetAllTriggersOfJobToState(trigger.JobKey, StoredTriggerState.Error);
-                    errorNotification = ErrorNotification.JobTriggers;
-                    await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                    pending.RecordSchedulingChange();
+                    pending.RecordTriggersInError(trigger.JobKey);
                 }
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersComplete)
                 {
                     SetAllTriggersOfJobToState(trigger.JobKey, StoredTriggerState.Complete);
-                    await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                    pending.RecordSchedulingChange();
                 }
             }
         }
@@ -2991,24 +3065,7 @@ public sealed class RAMJobStore : IJobStore
             lockObject.Release();
         }
 
-        if (errorNotification == ErrorNotification.Trigger)
-        {
-            await signaler.NotifySchedulerListenersTriggerInError(trigger.Key, cancellationToken).ConfigureAwait(false);
-        }
-        else if (errorNotification == ErrorNotification.JobTriggers)
-        {
-            await signaler.NotifySchedulerListenersTriggersInError(trigger.JobKey, cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// Which error notification a completed firing earned, deferred until the store's lock is released.
-    /// </summary>
-    private enum ErrorNotification
-    {
-        None,
-        Trigger,
-        JobTriggers
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
     public TimeSpan EstimatedTimeToReleaseAndAcquireTrigger => TimeSpan.FromMilliseconds(5);
@@ -3070,5 +3127,106 @@ public sealed class RAMJobStore : IJobStore
         }
 
         return str.ToString();
+    }
+
+    /// <summary>
+    /// Whether some caller is currently inside the store's critical section. For tests that assert
+    /// where a notification is raised from; nothing in the store's own logic asks.
+    /// </summary>
+    internal bool LockHeld => lockObject.CurrentCount == 0;
+
+    /// <summary>
+    /// The notifications a locked section owes the signaler, raised once the lock is released.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every notification this store raises runs listener code on the calling thread, and a listener is
+    /// entitled to call back into the scheduler, which calls straight back into this store. The store's
+    /// lock is a <see cref="SemaphoreSlim" /> and is not re-entrant, so a notification raised from
+    /// inside it deadlocks the caller against itself. The sites that would notify therefore record
+    /// instead, and each public entry point raises what it collected after releasing the lock, in the
+    /// order it was recorded.
+    /// </para>
+    /// <para>
+    /// A <see langword="default" /> value is an empty collector that has allocated nothing, which is
+    /// what the operations that dominate a running scheduler leave behind; it is passed by reference so
+    /// that the first recorded signal reaches the entry point that will raise it.
+    /// </para>
+    /// </remarks>
+    private struct PendingSignals
+    {
+        private List<PendingSignal>? signals;
+
+        /// <summary>Records the misfire of <paramref name="trigger" />, as it was when it misfired.</summary>
+        public void RecordMisfire(ITrigger trigger) => Record(PendingSignalKind.Misfired, trigger);
+
+        /// <summary>Records that <paramref name="trigger" /> has no fire time left.</summary>
+        public void RecordFinalized(ITrigger trigger) => Record(PendingSignalKind.Finalized, trigger);
+
+        /// <summary>Records that the job <paramref name="jobKey" /> named was deleted.</summary>
+        public void RecordJobDeleted(JobKey jobKey) => Record(PendingSignalKind.JobDeleted, jobKey);
+
+        /// <summary>Records that the trigger <paramref name="triggerKey" /> named is now in error.</summary>
+        public void RecordTriggerInError(TriggerKey triggerKey) => Record(PendingSignalKind.TriggerInError, triggerKey);
+
+        /// <summary>Records that every trigger of the job <paramref name="jobKey" /> named is now in error.</summary>
+        public void RecordTriggersInError(JobKey jobKey) => Record(PendingSignalKind.TriggersInError, jobKey);
+
+        /// <summary>Records that there is something new for the scheduler thread to look at.</summary>
+        public void RecordSchedulingChange() => Record(PendingSignalKind.SchedulingChange, payload: null);
+
+        private void Record(PendingSignalKind kind, object? payload) => (signals ??= []).Add(new PendingSignal(kind, payload));
+
+        /// <summary>
+        /// Raises what was collected, in the order it was collected. Call only once the store's lock
+        /// has been released.
+        /// </summary>
+        public readonly ValueTask Raise(ISchedulerSignaler signaler, CancellationToken cancellationToken)
+        {
+            return signals is null ? default : RaiseAll(signaler, signals, cancellationToken);
+        }
+
+        private static async ValueTask RaiseAll(
+            ISchedulerSignaler signaler,
+            List<PendingSignal> signals,
+            CancellationToken cancellationToken)
+        {
+            foreach (PendingSignal signal in signals)
+            {
+                switch (signal.Kind)
+                {
+                    case PendingSignalKind.Misfired:
+                        await signaler.NotifyTriggerListenersMisfired((ITrigger) signal.Payload!, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case PendingSignalKind.Finalized:
+                        await signaler.NotifySchedulerListenersFinalized((ITrigger) signal.Payload!, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case PendingSignalKind.JobDeleted:
+                        await signaler.NotifySchedulerListenersJobDeleted((JobKey) signal.Payload!, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case PendingSignalKind.TriggerInError:
+                        await signaler.NotifySchedulerListenersTriggerInError((TriggerKey) signal.Payload!, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case PendingSignalKind.TriggersInError:
+                        await signaler.NotifySchedulerListenersTriggersInError((JobKey) signal.Payload!, cancellationToken).ConfigureAwait(false);
+                        break;
+                    case PendingSignalKind.SchedulingChange:
+                        await signaler.SignalSchedulingChange(candidateNewNextFireTimeUtc: null, cancellationToken).ConfigureAwait(false);
+                        break;
+                }
+            }
+        }
+
+        private readonly record struct PendingSignal(PendingSignalKind Kind, object? Payload);
+
+        private enum PendingSignalKind
+        {
+            Misfired,
+            Finalized,
+            JobDeleted,
+            TriggerInError,
+            TriggersInError,
+            SchedulingChange
+        }
     }
 }


### PR DESCRIPTION
`RAMJobStore` raised listener notifications from inside its own critical section. The lock is a
`SemaphoreSlim` and is not re-entrant, so a listener doing what any listener may do — pausing a
trigger, rescheduling one, asking the store a question — deadlocked against the caller it was
running on. #3211 settled the rule ("never notify under the store lock") for the notifications added
then; the misfire notification predated it, and #3463 gave it a third caller.

## Where the store signalled, before this change

| Call | Site | Reached from | Under the lock before? |
|---|---|---|---|
| `NotifyTriggerListenersMisfired` | `ApplyMisfireNoLock` | `AcquireNextTriggers`; `ResumeTrigger`/`ResumeTriggers`/`ResumeJob`/`ResumeJobs`/`ResumeAll`; `TriggeredJobComplete` unblocking a `[DisallowConcurrentExecution]` job's other triggers (#3463) | **yes** |
| `NotifySchedulerListenersFinalized` | `ApplyMisfireNoLock`, when the policy leaves no fire time | the same three paths | **yes** |
| `NotifySchedulerListenersJobDeleted` | `RemoveTriggerNoLock`, when the last trigger of a non-durable job goes | `Clear`, `DeleteJob(s)`, `DeleteTrigger(s)`, `AddTrigger`/`ScheduleJobs` replacing a trigger, `ReplaceTrigger`, `TriggeredJobComplete` | **yes** |
| `SignalSchedulingChange` | `TriggeredJobComplete` × 6 — the unblock fan-out and each of `DeleteTrigger`, `SetTriggerComplete`, `SetTriggerError`, `SetAllJobTriggersError`, `SetAllJobTriggersComplete` | `TriggeredJobComplete` | **yes** |
| `NotifySchedulerListenersTriggerInError` | `TriggeredJobComplete`, `SetTriggerError` | `TriggeredJobComplete` | no — already deferred by #3217 |
| `NotifySchedulerListenersTriggersInError` | `TriggeredJobComplete`, `SetAllJobTriggersError` | `TriggeredJobComplete` | no — already deferred by #3217 |

`NotifySchedulerListenersError` is never called by this store.

## The pattern

One shape for every site, not a per-site special case — the shape the ADO store already uses when it
notifies after the commit, and the shape #3217 gave the two error notifications here.

`PendingSignals` is a `default`-constructible collector passed by `ref` through the `*NoLock`
helpers. A site that would notify records instead; each public entry point raises what it collected
after `lockObject.Release()`, in the order it was recorded. Nothing is allocated on a pass that
signals nothing, which is what a running scheduler's acquisitions mostly are.

Taking the notifications out from under the lock removes the only `await`s in the helpers, so
`ApplyMisfireNoLock`, `RemoveTriggerNoLock`, `AddTriggerNoLock`, `RemoveJobNoLock`,
`ResumeTriggerNoLock`, `ResumeTriggersNoLock` and `ResumeJobNoLock` become plain synchronous methods
and lose the `CancellationToken` they only carried to hand to the signaler.

## Orderings kept, and stated

* **A misfire is announced before the firing it rescheduled.** The trigger passed to
  `TriggerMisfired` is still cloned at the moment of the misfire, before `UpdateAfterMisfire`, so the
  listener sees the trigger as it was when it missed its firing rather than as the policy left it.
  And the flush happens before the operation returns: `AcquireNextTriggers` announces every misfire
  of a pass before it hands the batch back, so nothing it acquired can have fired yet.
* **Within one operation the recorded order is the raised order.** `TriggeredJobComplete` still
  raises `SignalSchedulingChange` before `TriggerInError`/`TriggersInError`, which is the order it
  had when only the error notifications were deferred.
* **`SignalSchedulingChange` is raised after the state that caused it is visible.** It moves from
  inside the lock to after it, which can only help: the scheduler thread it wakes used to block on
  the semaphore the store was still holding.
* **A call that throws does not flush.** The notifications are raised after the `try`/`finally`, so
  an operation that failed part-way announces nothing — matching the ADO store, which notifies
  "deliberately after the transaction, and only if it committed". No path in this store records a
  signal and then throws.

A listener that does nothing observes no difference.

## What a reviewer may want to decide

* `internal bool RAMJobStore.LockHeld => lockObject.CurrentCount == 0` is new, and exists only so a
  test can assert *where* a notification was raised from instead of sleeping. It is internal, not in
  the public API baseline, and nothing in the store's own logic reads it.
* The `ISchedulerSignaler` doc comment now says when a store may call these. It stops short of "never
  from inside your lock", because the ADO store's acquisition-time notifications legitimately run
  inline — a database lock is re-entrant for its own connection — and #3472 says to leave that shape
  alone.
* The ADO store is untouched, as the issue asks.

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed! - Failed: 0, Passed: 3529, Skipped: 4, Total: 3533, Duration: 52 s

dotnet test src/Quartz.Tests.Integration  (the basic leg: every db-* category negated)
  Passed! - Failed: 0, Passed: 329, Skipped: 0, Total: 329, Duration: 2 m 38 s

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed! - Failed: 0, Passed: 527, Skipped: 0, Total: 527, Duration: 5 s

dotnet fallout VerifyDocsSnippets
  Documentation snippets are up to date (91 markdown files checked)
```

The `basic` leg runs `RAMJobStoreContractTest`, so #3471's misfire-parity cases
(`UnblockingAnOverdueTriggerAppliesItsMisfirePolicy`,
`UnblockingATriggerWithNothingLeftToFireRemovesIt`) and `MisfireWhilePausedOrBlockedTest` are green
on the in-memory store. Integration legs that need Docker were not run.

## Non-vacuity

`RAMJobStoreNotifiesAfterUnlockTest` has six cases. With the flush moved back inside the lock in
`AcquireNextTriggers`, `ResumeTrigger`, `DeleteTrigger` and `TriggeredJobComplete`, five of the six
fail (`Failed: 5, Passed: 1` — the survivor is the "announced exactly once, and before the batch is
handed over" case, whose ordering claim holds either way; it now also asserts the lock was free).

Closes #3472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
