### PR TITLE
The benchmarks are run, not only compiled

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -25,6 +25,7 @@
       "type": "string",
       "enum": [
         "ApiDoc",
+        "BenchmarkSmoke",
         "Clean",
         "Compile",
         "DocsBuild",

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -48,8 +48,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -62,8 +62,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
@@ -76,5 +76,5 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, Compile, UnitTest, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations Compile UnitTest PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,66 +6,45 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/Quartz.Examples/bin/Debug/netcoreapp1.0/Quartz.Examples.dll",
+            "program": "${workspaceFolder}/artifacts/bin/Quartz.Examples/debug/Quartz.Examples.dll",
             "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
-        },
-         {
-            "name": "Unit Tests",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/Quartz.Tests.Unit/bin/Debug/netcoreapp1.0/Quartz.Tests.Unit.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "stopAtEntry": false
         },
         {
-            "name": "Integration Tests",
+            "name": "Worker example",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/Quartz.Tests.Integration/bin/Debug/netcoreapp1.0/Quartz.Tests.Integration.dll",
+            "program": "${workspaceFolder}/artifacts/bin/Quartz.Examples.Worker/debug/Quartz.Examples.Worker.dll",
             "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processName": "<example>"
-        },
-        {
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/Quartz.Web/bin/Debug/netcoreapp2.0/Quartz.Web.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}/src/Quartz.Web",
+            "cwd": "${workspaceFolder}/src/Quartz.Examples.Worker",
             "stopAtEntry": false,
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
+            "env": {
+                "DOTNET_ENVIRONMENT": "Development"
+            }
+        },
+        {
+            "name": "ASP.NET Core example",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/artifacts/bin/Quartz.Examples.AspNetCore/debug/Quartz.Examples.AspNetCore.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/Quartz.Examples.AspNetCore",
+            "stopAtEntry": false,
             "env": {
                 "ASPNETCORE_ENVIRONMENT": "Development"
             },
-            "sourceFileMap": {
-                "/Views": "${workspaceRoot}/Views"
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
             }
+        },
+        {
+            "name": "Attach",
+            "type": "coreclr",
+            "request": "attach"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,35 +2,33 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "command": "dotnet",
     "tasks": [
         {
             "label": "build",
-            "type": "shell",
+            "type": "process",
             "command": "dotnet",
             "args": [
                 "build",
-                "Quartz.sln"
+                "Quartz.slnx"
             ],
             "problemMatcher": "$msCompile",
             "group": {
-                "_id": "build",
-                "isDefault": false
+                "kind": "build",
+                "isDefault": true
             }
         },
         {
             "label": "test",
-            "type": "shell",
+            "type": "process",
             "command": "dotnet",
             "args": [
                 "test",
-                "src/Quartz.Tests.Unit/project.json",
-                "src/Quartz.Tests.Integration/project.json"
+                "src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj"
             ],
-            "problemMatcher": [],
+            "problemMatcher": "$msCompile",
             "group": {
-                "_id": "test",
-                "isDefault": false
+                "kind": "test",
+                "isDefault": true
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/Quartz)](#)
-[![Build status](https://ci.appveyor.com/api/projects/status/d9ahvu9u77qjhx9r/branch/master?svg=true)](https://ci.appveyor.com/project/lahma/quartznet-6fcn8/branch/master)
+[![Build status](https://github.com/quartznet/quartznet/actions/workflows/build.yml/badge.svg)](https://github.com/quartznet/quartznet/actions/workflows/build.yml)
 [![NuGet](http://img.shields.io/nuget/v/Quartz.svg)](https://www.nuget.org/packages/Quartz/)
 [![NuGet pre-release](http://img.shields.io/nuget/vpre/Quartz.svg)](https://www.nuget.org/packages/Quartz/)
-[![MyGet pre-release](https://img.shields.io/myget/quartznet/vpre/Quartz)](#)
 [![Join the chat at https://gitter.im/quartznet/quartznet](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/quartznet/quartznet?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Quartz.NET - Enterprise Job Scheduler
@@ -11,7 +10,9 @@ Please visit [https://www.quartz-scheduler.net/](https://www.quartz-scheduler.ne
 
 ## Compatibility
 
-Quartz.NET supports .NET Core/netstandard 2.0 and .NET Framework 4.6.2 and later.
+Quartz.NET 4 targets .NET 10, and nothing else. Quartz.NET 3.x, maintained on the
+[`3.x` branch](https://github.com/quartznet/quartznet/tree/3.x), supports .NET Standard 2.0 and
+.NET Framework 4.6.2 and later.
 
 ## Installation
 
@@ -20,8 +21,13 @@ Quartz.NET supports .NET Core/netstandard 2.0 and .NET Framework 4.6.2 and later
 
 ## Building
 
-* You can build the code by running `build.cmd` (Windows) or `build.sh` (*nix platform)
-* You need MSBuild 17 and .NET Core SDK 6.0 to build
+* You need the .NET 10 SDK. `global.json` asks for 10.0.100 and rolls forward to the latest 10.0.x you
+  have installed.
+* Build the code by running `build.cmd` (Windows) or `./build.sh` (Linux, macOS). The scripts restore the
+  [Fallout](https://fallout.build/) CLI from `.config/dotnet-tools.json` and hand it the arguments, so
+  there is nothing to install globally.
+* `build.cmd Compile UnitTest` compiles and runs the unit tests. The integration tests need a running
+  Docker daemon; [CONTRIBUTING.md](CONTRIBUTING.md) has the rest.
 
 ## License
 

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -20,7 +20,11 @@ using Quartz.Build;
     // workflow covers. macOS is included rather than assumed: the runner image ships the Xcode command
     // line tools ILCompiler links with, so there is nothing to install, and if that stops being true the
     // leg says so out loud rather than the claim going unchecked on a third platform.
-    InvokedTargets = [nameof(VerifyMigrations), nameof(ICompile.Compile), nameof(UnitTest), nameof(PublishTrimmed), nameof(PublishAot)],
+    //
+    // BenchmarkSmoke is on this workflow alone. Every change reaches main through a pull request, so
+    // this is where a broken benchmark is caught while somebody is still looking; the push and release
+    // legs have ten-minute budgets and nothing to do with the benchmarks.
+    InvokedTargets = [nameof(VerifyMigrations), nameof(ICompile.Compile), nameof(UnitTest), nameof(BenchmarkSmoke), nameof(PublishTrimmed), nameof(PublishAot)],
     CacheKeyFiles = [],
     // Generating native code is minutes rather than seconds, and it happens after everything else here.
     TimeoutMinutes = 20,

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -403,6 +403,45 @@ partial class Build : FalloutBuild, ICompile, IPack
             });
         });
 
+    /// <summary>
+    /// Executes every benchmark once and fails the leg when one of them does not run to completion.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Quartz.Benchmark</c> is in the solution, so <c>Compile</c> has always caught a benchmark that
+    /// stopped compiling; nothing caught one that compiled and threw. Issue #3439 is that gap, and the
+    /// first run of this target found it: every case in <c>SchedulerBenchmark</c> had been failing on a
+    /// scheduler it could no longer configure. This is a liveness check on the harness — nothing is
+    /// measured, published or compared, and no build fails over a number.
+    /// </para>
+    /// <para>
+    /// What the run covers, and the two categories it leaves out, is decided in the benchmark project
+    /// behind <c>--smoke</c> rather than by a list of names here: a benchmark written later is in it
+    /// without anybody remembering to add it, which is the property that makes this worth running.
+    /// <c>src/Quartz.Benchmark/Program.cs</c> and <c>BenchmarkCategories</c> say the rest.
+    /// </para>
+    /// <para>
+    /// Release whatever the rest of the build is configured as, because BenchmarkDotNet refuses a
+    /// non-optimized assembly and a smoke run of one would prove nothing. It runs after the unit tests
+    /// rather than beside them: both want the machine, and the tests are the ones whose failure is worth
+    /// reading first.
+    /// </para>
+    /// </remarks>
+    Target BenchmarkSmoke => _ => _
+        .DependsOn<ICompile>()
+        .After(UnitTest)
+        .Before<IPack>()
+        .Executes(() =>
+        {
+            var solution = ((IHasSolution) this).Solution;
+
+            DotNetRun(s => s
+                .SetProjectFile(solution.AllProjects.First(x => x.Name == "Quartz.Benchmark"))
+                .SetConfiguration(Configuration.Release)
+                .SetApplicationArguments("--smoke")
+            );
+        });
+
     static readonly string[] DatabaseCategories =
         ["db-postgres", "db-sqlserver", "db-mysql", "db-oracle", "db-firebird", "db-sqlite", "db-redis"];
 

--- a/src/Quartz.Benchmark/BenchmarkCategories.cs
+++ b/src/Quartz.Benchmark/BenchmarkCategories.cs
@@ -1,0 +1,33 @@
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The categories the <c>BenchmarkSmoke</c> build target excludes from its dry run, and the only reasons
+/// a benchmark is allowed to sit outside it.
+/// </summary>
+/// <remarks>
+/// The smoke run executes every benchmark in this assembly once — see <c>build/Build.cs</c> — so a
+/// benchmark that stops working is caught by the same pull request that broke it. A benchmark carrying
+/// one of these categories is not covered by that, and rots unnoticed until somebody runs it; add one
+/// only when the benchmark genuinely cannot be executed unattended in a couple of seconds, and say why
+/// on the benchmark itself.
+/// </remarks>
+internal static class BenchmarkCategories
+{
+    /// <summary>
+    /// What <c>--smoke</c> leaves out. Everything else in the assembly is in the smoke run, including
+    /// whatever is written next.
+    /// </summary>
+    public static readonly string[] ExcludedFromSmokeRun = [RequiresDatabase, LongRunning];
+
+    /// <summary>
+    /// Measures against a database that has to be running and pointed at by an environment variable.
+    /// BenchmarkDotNet runs a process per benchmark case, so the benchmark cannot own a container.
+    /// </summary>
+    public const string RequiresDatabase = "RequiresDatabase";
+
+    /// <summary>
+    /// One iteration is hundreds of thousands of operations, so a single dry run of the benchmark is
+    /// minutes rather than seconds — measured on purpose, and too much for a smoke run to carry.
+    /// </summary>
+    public const string LongRunning = "LongRunning";
+}

--- a/src/Quartz.Benchmark/ExecutionCeilingBenchmark.cs
+++ b/src/Quartz.Benchmark/ExecutionCeilingBenchmark.cs
@@ -73,6 +73,7 @@ namespace Quartz.Benchmark;
 /// </remarks>
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
+[BenchmarkCategory(BenchmarkCategories.RequiresDatabase)]
 public class ExecutionCeilingBenchmark
 {
     private const string SchedulerName = "BenchmarkScheduler";

--- a/src/Quartz.Benchmark/KeyBenchmark.cs
+++ b/src/Quartz.Benchmark/KeyBenchmark.cs
@@ -4,7 +4,6 @@ using Quartz.Util;
 namespace Quartz.Benchmark;
 
 [MemoryDiagnoser]
-[DisassemblyDiagnoser]
 public class KeyBenchmark
 {
     private const string KeyNameA = "KeyNameA";

--- a/src/Quartz.Benchmark/Program.cs
+++ b/src/Quartz.Benchmark/Program.cs
@@ -1,18 +1,154 @@
 using System.Runtime.CompilerServices;
 
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
 namespace Quartz.Benchmark;
 
 internal static class Program
 {
-    private static void Main(string[] args)
-    {
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+    /// <summary>
+    /// The smoke run: every benchmark in the assembly executed once, in this process, with nothing
+    /// measured. It is what the <c>BenchmarkSmoke</c> build target runs on every pull request, and what
+    /// to run by hand before changing a benchmark. See <see cref="SmokeConfig" /> for what it does and
+    /// why it is a switch of ours rather than a line of BenchmarkDotNet options.
+    /// </summary>
+    private const string SmokeOption = "--smoke";
 
-        //DispatchBenchmark();
+    /// <summary>
+    /// The switcher options that print something and run nothing, so that an empty run is only a
+    /// failure when the caller asked for benchmarks to be executed.
+    /// </summary>
+    private static readonly string[] printOnlyOptions = ["--help", "--version", "--list", "--info"];
+
+    private static int Main(string[] args)
+    {
+        bool smoke = args.Contains(SmokeOption, StringComparer.OrdinalIgnoreCase);
+        if (smoke && args.Length > 1)
+        {
+            Console.Error.WriteLine($"{SmokeOption} takes no other arguments: it is a whole run, not a modifier on one.");
+            return 1;
+        }
+
+        // The filter is passed even in smoke mode, because a switcher given no selection at all asks the
+        // console which benchmark to run, and CI has nobody to ask.
+        string[] switcherArguments = smoke ? ["--filter", "*"] : args;
+
+        List<Summary> summaries;
+        try
+        {
+            summaries =
+            [
+                .. BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(switcherArguments, smoke ? SmokeConfig() : null)
+            ];
+        }
+        catch (Exception exception)
+        {
+            // A benchmark that throws while running in this process takes the run down with it: the
+            // exception comes back out through the switcher instead of being recorded as a failed case,
+            // and the cases queued behind it never run. Reported here rather than left to become an
+            // unhandled exception, whose exit code reads as a crash in the runtime. The benchmark that
+            // threw is the last one the log names above this.
+            Console.Error.WriteLine("The run stopped on an exception, so the benchmarks after it did not run:");
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+
+        return Report(summaries, args);
     }
 
+    /// <summary>
+    /// A dry run of everything that can run unattended, arranged to be worth having on every pull
+    /// request rather than to measure anything.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is a configuration rather than a line of switcher options because none of what it decides can
+    /// be spelled on BenchmarkDotNet's command line. The switcher selects categories —
+    /// <c>--anyCategories</c>, <c>--allCategories</c> — but cannot reject one, and this run is defined by
+    /// what it leaves out: a benchmark written tomorrow is in it without anybody remembering to add it,
+    /// which a list of names on a command line could never promise.
+    /// </para>
+    /// <para>
+    /// The rest is what makes a couple of hundred cases affordable on every pull request. Running in
+    /// this process skips a build and a process launch per case, and
+    /// <see cref="InProcessNoEmitToolchain" /> is the half of that pair <c>--inProcess</c> cannot ask
+    /// for — it binds delegates where the other emits an assembly per case. Not enforcing a power plan
+    /// is the large one on Windows, where BenchmarkDotNet otherwise switches the machine to High
+    /// Performance and back around every case: 249 cases took 81 seconds with that and 20 without it,
+    /// and a smoke run has no business touching the machine's power settings for measurements it throws
+    /// away. An empty configuration exports nothing, so the run leaves no artefacts to upload, ignore or
+    /// commit.
+    /// </para>
+    /// <para>
+    /// What it keeps is the mandatory validators BenchmarkDotNet adds to every configuration, including
+    /// the one that refuses a non-optimized assembly — a smoke run built in Debug would prove nothing,
+    /// and is refused rather than tolerated.
+    /// </para>
+    /// </remarks>
+    private static IConfig SmokeConfig()
+    {
+        return ManualConfig.CreateEmpty()
+            .AddLogger(ConsoleLogger.Default)
+            .AddColumnProvider(DefaultColumnProviders.Instance)
+            .AddJob(Job.Dry.WithToolchain(InProcessNoEmitToolchain.Instance).DontEnforcePowerPlan())
+            .AddFilter(new SimpleFilter(benchmark => !benchmark.Descriptor.Categories.Any(
+                category => BenchmarkCategories.ExcludedFromSmokeRun.Contains(category, StringComparer.OrdinalIgnoreCase))))
+            .WithOptions(ConfigOptions.DisableLogFile);
+    }
+
+    /// <summary>
+    /// Turns what BenchmarkDotNet reported into an exit code.
+    /// </summary>
+    /// <remarks>
+    /// The switcher returns the same way whether the benchmarks ran or threw — a case that fails is a
+    /// row of <c>NA</c> in the summary table and nothing else — so a caller that only watches the exit
+    /// code cannot tell a healthy harness from one that failed on every case. That is what the smoke
+    /// run is checking, so the reports are read here.
+    /// </remarks>
+    private static int Report(IReadOnlyList<Summary> summaries, string[] args)
+    {
+        List<string> failures = [];
+
+        foreach (Summary summary in summaries)
+        {
+            failures.AddRange(summary.ValidationErrors.Where(error => error.IsCritical).Select(error => error.Message));
+            failures.AddRange(summary.Reports.Where(report => !report.Success).Select(report => report.BenchmarkCase.DisplayInfo));
+        }
+
+        if (failures.Count > 0)
+        {
+            Console.Error.WriteLine($"{failures.Count} benchmark(s) did not run to completion:");
+            foreach (string failure in failures.Order(StringComparer.Ordinal))
+            {
+                Console.Error.WriteLine("  " + failure);
+            }
+
+            return 1;
+        }
+
+        if (summaries.Sum(summary => summary.Reports.Length) == 0
+            && !args.Any(argument => printOnlyOptions.Contains(argument, StringComparer.OrdinalIgnoreCase)))
+        {
+            Console.Error.WriteLine(
+                "No benchmark was executed. A filter that matches nothing exits exactly as a healthy run does, "
+                + "so it fails here rather than passing as one.");
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Runs one benchmark with BenchmarkDotNet out of the way, which is what a profiler wants to attach
+    /// to. Nothing calls it — call it from <see cref="Main" /> when you need it.
+    /// </summary>
     private static void DispatchBenchmark()
     {
         var benchmark = new JobDispatchBenchmark();

--- a/src/Quartz.Benchmark/SchedulerBenchmark.cs
+++ b/src/Quartz.Benchmark/SchedulerBenchmark.cs
@@ -6,10 +6,24 @@ using Quartz.Extensibility;
 
 namespace Quartz.Benchmark;
 
+/// <remarks>
+/// Excluded from the <c>BenchmarkSmoke</c> build target's dry run: one case is hundreds of thousands of
+/// job executions through a running scheduler, which is minutes even when it is asked for once. Run it
+/// by name — <c>dotnet run -c Release --project src/Quartz.Benchmark -- --filter *SchedulerBenchmark*</c>
+/// — and expect to wait.
+/// </remarks>
 [MemoryDiagnoser]
+[BenchmarkCategory(BenchmarkCategories.LongRunning)]
 public class SchedulerBenchmark
 {
     private static readonly IJobFactory _jobFactory = new SimpleJobFactory();
+
+    /// <summary>
+    /// The shortest idle wait the scheduler accepts, and what every case that would rather have none
+    /// uses. It is only ever waited when the job store hands the scheduler nothing, which these runs are
+    /// arranged never to do: every trigger they schedule is due at once.
+    /// </summary>
+    private static readonly TimeSpan _minimumIdleWaitTime = TimeSpan.FromSeconds(1);
 
     private IScheduler? _scheduler;
 
@@ -23,7 +37,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 29_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -39,7 +53,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 5,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 1_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -55,7 +69,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -71,7 +85,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 2,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 7_499,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -87,7 +101,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 2,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -103,7 +117,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -119,7 +133,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 3,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1000L),
             repeatCount: 4_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -209,7 +223,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 29_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -225,7 +239,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 5,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 1_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -241,7 +255,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -257,7 +271,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 2,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -273,7 +287,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 1,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 14_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -289,7 +303,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 3,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 4_999,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -305,7 +319,7 @@ public class SchedulerBenchmark
             persistJobDataAfterExecution: false,
             triggersPerJob: 2,
             maxBatchSize: 16,
-            idleWaitTime: TimeSpan.FromTicks(1L), // avoid using Zero since this is ignored on some versions of Quartz.NET
+            idleWaitTime: _minimumIdleWaitTime,
             repeatInterval: TimeSpan.FromTicks(1L),
             repeatCount: 7_499,
             misfireInstruction: MisfireInstruction.IgnoreMisfirePolicy);
@@ -541,8 +555,6 @@ public class SchedulerBenchmark
     {
         RAMJobStore store = TestJobStores.Ram();
 
-        var threadPool = new DefaultThreadPool { MaxConcurrency = threadCount };
-
         QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
 
         builder
@@ -551,10 +563,15 @@ public class SchedulerBenchmark
                 options.InstanceName = name;
                 options.InstanceId = instanceId;
                 options.IdleWaitTime = idleWaitTime;
-                options.MaxBatchSize = maxBatchSize;
+
+                // A batch larger than the pool that has to run it is refused by 4.x, and would not fire
+                // the surplus any sooner if it were not: the triggers are this node's, unfireable by any
+                // other, until a thread frees up. Every case here asks for sixteen, which is more than
+                // the smaller pools have, so each gets the biggest batch its pool can run.
+                options.MaxBatchSize = Math.Min(maxBatchSize, threadCount);
                 options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.Zero;
             })
-            .UseThreadPool(threadPool)
+            .UseDefaultThreadPool(threadCount)
             .UseJobStore(store)
             .UseJobFactory(_jobFactory);
 


### PR DESCRIPTION
`Quartz.Benchmark` is in `Quartz.slnx`, so `Compile` has always caught a benchmark that stopped
compiling. Nothing caught one that compiled and threw — BenchmarkDotNet's switcher returns the same
way whether the benchmarks ran or failed, printing a row of `NA` for a case that threw and exiting
zero.

## What the smoke run covers

`BenchmarkSmoke` runs `dotnet run -c Release --project src/Quartz.Benchmark -- --smoke`, which
executes **249 benchmark cases, once each, in around twenty seconds**. It is a liveness check on the
harness: nothing is measured, published or compared, no artefacts are written, and no build fails
over a number.

`--smoke` is a switch of ours rather than a line of BenchmarkDotNet options, because none of what it
decides can be spelled on that command line:

- **The exclusion.** The switcher selects categories (`--anyCategories`, `--allCategories`) but
  cannot reject one, and this run is defined by what it leaves out — a benchmark written tomorrow is
  in it without anybody remembering to add it, which a list of names in `build/Build.cs` could never
  promise.
- **The toolchain.** `--inProcess` selects the in-process toolchain that emits an assembly per case;
  `InProcessNoEmitToolchain`, which the command line cannot ask for, binds delegates instead.
- **The power plan.** On Windows BenchmarkDotNet switches the machine to High Performance and back
  around *every* case. That alone was 249 cases in 81 seconds against 20 without it, and a smoke run
  has no business touching the machine's power settings for measurements it throws away.

## What it excludes, and why

Two categories in `BenchmarkCategories`, applied to the benchmark rather than listed in the build:

| Category | Benchmark | Why |
|---|---|---|
| `RequiresDatabase` | `ExecutionCeilingBenchmark` (96 cases) | Measures statements against Postgres and SQL Server, which have to be running and named by `QUARTZ_BENCHMARK_*` environment variables. BenchmarkDotNet runs a process per case, so the benchmark cannot own a container. |
| `LongRunning` | `SchedulerBenchmark` (18 cases) | Hundreds of thousands of job executions through a running scheduler per case. One case — at two threads — takes 17 seconds asked for exactly once, so the class is minutes. |

## The benchmark it fixed

The first `--smoke` run found that **every case in `SchedulerBenchmark` had been failing**, and had
been for as long as 4.x has validated scheduler options:

```
Quartz.SchedulerConfigException: IdleWaitTime must be at least 1000ms, was 0.0001ms.
MaxBatchSize is 16, which is more than the thread pool's MaxConcurrency of 10.
```

Three repairs, all in the benchmark:

- `idleWaitTime: TimeSpan.FromTicks(1L)` at sixteen call sites is now one second, the shortest 4.x
  accepts. It is only ever waited when the store hands the scheduler nothing, which these runs are
  arranged never to do.
- `MaxBatchSize` is capped at the thread count. A batch larger than the pool that has to run it is
  refused, and would not fire the surplus sooner if it were not.
- The thread pool was built by hand and handed over as an instance, so
  `ThreadPoolOptions.MaxConcurrency` — what the validator reads and what `UseThreadPool<T>` applies —
  stayed at the default ten. Every `15Threads` and `50Threads` case would have measured ten had it
  run at all. It now says `UseDefaultThreadPool(threadCount)`.

`KeyBenchmark` loses `[DisassemblyDiagnoser]`, which no in-process toolchain supports and which fails
validation for the whole class. `--disasm` gives a disassembly dump for any benchmark on demand.

## Where it runs

`pr-tests-unit` only, after `UnitTest` rather than beside it. Every change reaches `main` through a
pull request, so that is where a broken benchmark is caught while somebody is still looking; the push
and release legs have ten-minute budgets and nothing to do with the benchmarks.

## For a reviewer to decide

- **Stop-at-first-failure.** A benchmark that throws in-process takes the run down with it —
  BenchmarkDotNet's in-process runner does not survive it — so the smoke run reports the exception
  and stops rather than sweeping on. Running out of process would report every failure in one go and
  cost about five times the wall clock; this trades that for a run cheap enough to be on every pull
  request.
- **Log volume.** The run prints BenchmarkDotNet's usual per-case output, about 8,000 lines. That is
  the evidence the benchmarks ran, and it is where the exception text lands when one fails.

## Beside the issue's scope

The last commit is not part of #3439. The root `README.md` said Quartz.NET supports .NET
Core/netstandard 2.0 and .NET Framework 4.6.2 and that building needs MSBuild 17 and the .NET Core
SDK 6.0; it now says net10.0, points the framework sentence at the `3.x` branch where it is still
true, and describes the .NET 10 SDK in `global.json` and the Fallout entry points. The dead AppVeyor
badge (pointing at a `master` branch) becomes the GitHub Actions one, and the MyGet badge goes —
Installation already names Feedz.io. The Gitter badge is left alone: nothing in the tree says whether
that room is still the chat.

`.vscode/launch.json` launched `netcoreapp1.0` and `netcoreapp2.0` assemblies from `bin/Debug`, one
of them from `Quartz.Web`, which no longer exists; it is fixed rather than deleted, launching the
three examples that do exist from `artifacts/bin`. `.vscode/tasks.json` built `Quartz.sln` and tested
two `project.json` files; it builds `Quartz.slnx` and tests `Quartz.Tests.Unit`, with `kind` groups so
the build and test tasks are bindable again. `.vscode/spellright.dict` is untouched.

## Verification

```
dotnet fallout Compile UnitTest BenchmarkSmoke
  Compile           Succeeded  0:11
  UnitTest          Succeeded  1:04    Quartz.Tests.Unit 3536 passed, 4 skipped
                                       Quartz.Tests.AspNetCore 527 passed
  BenchmarkSmoke    Succeeded  0:22    249 benchmarks executed, 19.4s

dotnet build Quartz.slnx                0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit       3536 passed, 0 failed, 4 skipped
```

On this pull request's own `pr-tests-unit` run, `BenchmarkSmoke` took **0:29 on ubuntu-latest** (249
benchmarks in 19.8s), **0:47 on windows-latest** (28.7s) and **0:51 on macos-latest** (32.0s). The
gap between the two figures per platform is `dotnet run`'s incremental Release build.

The failure path was verified by making a benchmark throw: the target failed with
`Process 'dotnet.exe' exited with code 1` and the exception in the log. Integration tests were not
run — they need a Docker daemon, and nothing here touches product code.

Closes #3439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
