### PR TITLE
The operator-facing pages describe the product Stream A shipped

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -817,17 +817,31 @@ firing (`Quartz.Job.Veto`), and one per job store operation (`Quartz.JobStore.Ac
 instance id are attributes. Store-operation spans are the ones to watch for the failures above:
 acquisition latency and its exceptions are where a struggling database first shows.
 
-**Metrics are 4.x only**, and there are exactly two instruments:
-`quartz.job.execution.duration`, a histogram in seconds tagged with `error.type` when the execution
-failed, and `quartz.job.execution.active`, an up-down counter of executions in flight. The histogram
-carries its own count, so execution and failure counts come out of it. That is the whole of it
-today — **there is no misfire counter, no acquisition-latency instrument and no trigger-state
-gauge**, so do not build an alert on one. Quartz 3.x publishes no metrics at all.
+**Metrics are 4.x only** — Quartz 3.x publishes none at all — and there are eight instruments, all on
+a meter named `Quartz`. **Every measurement carries `quartz.scheduler.name` and
+`quartz.scheduler.id`**, so a cluster is separable by node and a process running several schedulers by
+scheduler, with no instrumentation of your own. Four of them answer the failures in this page directly:
 
-For what the instruments do not cover, the store is the source: count `QRTZ_TRIGGERS` grouped by
-`TRIGGER_STATE` and alert on `ERROR` and on `BLOCKED` rows older than your longest job, and count
-`QRTZ_FIRED_TRIGGERS` to see what the cluster believes is running. In 4.x,
-`IScheduler.QueryFireInstances` answers the latter for the whole cluster without SQL.
+- `quartz.job.execution.duration` — a histogram in seconds, tagged `error.type` when the execution
+  failed. Its *count* is the number of executions, so execution and failure counts come out of it and
+  do not need counters of their own.
+- `quartz.job.execution.active` — an up-down counter of executions in flight. Parked at a ceiling is
+  what a starved pool and a saturated execution group both look like.
+- `quartz.trigger.misfire` — firings that were owed and did not happen on time. This is the alert to
+  build for "the schedule is slipping", and it is the one that catches a group parked at its limit.
+- `quartz.trigger.acquisition.duration` — how long the scheduling loop waited on its store for the
+  next batch. A struggling database shows here before it shows anywhere else.
+
+The other four are `quartz.trigger.acquired`, `quartz.cluster.checkin.duration`,
+`quartz.cluster.recovery.trigger` — a node's work being taken over, which is a cluster mis-declaring a
+node made visible — and `quartz.jobstore.operation.duration`, tagged with the operation's name. The
+[OpenTelemetry page](quartz-4.x/packages/opentelemetry-integration.md#metrics) has the full table with
+each instrument's attributes.
+
+**There is still no trigger-state gauge**, so do not build an alert on one. For that the store is the
+source: count `QRTZ_TRIGGERS` grouped by `TRIGGER_STATE` and alert on `ERROR` and on `BLOCKED` rows
+older than your longest job, and count `QRTZ_FIRED_TRIGGERS` to see what the cluster believes is
+running. In 4.x, `IScheduler.QueryFireInstances` answers the latter for the whole cluster without SQL.
 
 **A health check** ships with the ASP.NET Core integration, and it asserts less than its name
 suggests: that the scheduler is in a state that can fire, and that the job store answers a query. It

--- a/docs/documentation/quartz-4.x/db/index.md
+++ b/docs/documentation/quartz-4.x/db/index.md
@@ -17,6 +17,7 @@ When using ADO.NET-based job store (the usual being `LocalTransactionJobStore`),
 | qrtz_simple_triggers | data for very simple repeat triggers |
 | qrtz_simprop_triggers | Reusable table for custom triggers. `ICalendarIntervalTrigger`, `IDailyTimeIntervalTrigger`, and `IRecurrenceTrigger` use this |
 | qrtz_paused_trigger_grps | `IScheduler.PauseTriggers` data |
+| qrtz_paused_job_grps | `IScheduler.PauseJobs` data — one row per paused job group, so a group paused while it holds nothing is still reported as paused |
 
 The scripts to create these tables for various providers can be found [here](https://github.com/quartznet/quartznet/tree/main/database/tables).
 
@@ -33,7 +34,10 @@ These four columns are optional in Quartz.NET 3.x — the scheduler probes for t
 | `PREFERRED_NODE` | `QRTZ_TRIGGERS` | 3.19 |
 | `PREFERRED_NODE_AUTO` | `QRTZ_TRIGGERS` | 3.19 |
 
-Apply [`database/migrations/4.0/`](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0) to add whichever are missing. Every statement is guarded, so it is safe to run on a database that already has some of them.
+4.x also needs a **table** 3.x never had: `QRTZ_PAUSED_JOB_GRPS`, which is what lets a job group be
+paused while it holds nothing and what makes a job group listing report `paused` truthfully.
+
+Apply [`database/migrations/4.0/`](https://github.com/quartznet/quartznet/tree/main/database/migrations/4.0) to add whichever are missing — it covers the table as well as the columns. Every statement is guarded, so it is safe to run on a database that already has some of them. [Database Schema Changes](../../database/schema-changes.md#version-4-0) lists the whole 3.x → 4.x set.
 
 ## The QRTZ_TRIGGERS table
 

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -20,6 +20,7 @@ mechanics.
 | **Tenants known at** | startup | any time | startup |
 | **Add a tenant at runtime** | no (needs a new container) | yes | no |
 | **Per-tenant concurrency limits** | yes, naturally | yes, via execution groups | yes |
+| **Per-tenant dashboard and API access** | yes — [`SchedulerAuthorizationPolicy`](#authorizing-a-tenant-on-its-own-scheduler) | no: Quartz authorizes a scheduler, not a group | yes, if each is its own scheduler |
 | **Cost per tenant** | a scheduling loop, a connection pool, a thread pool | ~nothing | a schema |
 | **Fits** | tens of tenants, strong isolation needs | hundreds or thousands of tenants | regulatory separation of data |
 
@@ -342,7 +343,7 @@ A handful of things are container-wide, shared by every scheduler in the process
 | `SystemTextJsonSerializerRegistry` | one per container by default — the HTTP API and the HTTP client serialize triggers without knowing which scheduler they came from. A named scheduler *can* be given its own, see below |
 | `Meters` | built from the container's `IMeterFactory` |
 | `DataSourceOptions` | named after the **data source**, not the scheduler, so several schedulers can read through the same one |
-| `QuartzHttpApiOptions` | one per process — see [honest limits](#honest-limits) |
+| `QuartzHttpApiOptions`, `QuartzDashboardOptions` | one of each per process: they describe the surfaces, and every scheduler is reached through them. *Which* schedulers a caller reaches is per scheduler — see [Authorizing a tenant on its own scheduler](#authorizing-a-tenant-on-its-own-scheduler) — but what they may do once there is not |
 
 Logging is one per container rather than one per scheduler: every scheduler's parts are injected the
 container's `ILoggerFactory`, and a line says which tenant wrote it through the logging scope the
@@ -496,6 +497,22 @@ Listeners take matchers too, so a per-tenant listener is one registration:
 q.AddJobListener<AuditListener>(Matchers.Group<JobKey>(StringOperator.Equality, tenantId));
 ```
 <!-- endSnippet -->
+
+### What the group model does not partition
+
+The matcher reaches everything that takes one — and the two operator surfaces do not take one. **Quartz
+authorizes a scheduler, never a group**: the resource a policy is evaluated against is a
+`SchedulerResource` carrying a scheduler's name, so under this model every tenant's jobs, triggers and
+history are visible to anyone who reaches the dashboard or the HTTP API at all. There is no
+group-shaped equivalent of
+[`SchedulerAuthorizationPolicy`](#authorizing-a-tenant-on-its-own-scheduler), and a group matcher in a
+query string is a filter rather than a boundary — a caller can simply pass a different one.
+
+If tenants must not see each other on those surfaces, that is the argument for giving them schedulers,
+or for putting your own API in front of Quartz's and never exposing Quartz's to them. It is not an
+argument against the group model for everything else: the isolation the group model *does* give —
+scheduling, pausing, quotas, listeners — is real, and most deployments never expose the dashboard to
+tenants in the first place.
 
 ### Per-tenant concurrency quotas
 
@@ -920,9 +937,12 @@ read one node at a time:
 - **Traces.** `quartz.scheduler.name` and `quartz.scheduler.id` are on every span, and the execution
   span adds `quartz.job.group`, `quartz.job.name`, `quartz.trigger.group`, `quartz.trigger.name` and
   `quartz.fire.instance.id`.
-- **Metrics.** `quartz.scheduler.name` and `quartz.scheduler.id` are on every measurement.
-  `quartz.job.execution.active` and `quartz.job.execution.duration` add `quartz.trigger.group`,
-  `quartz.trigger.name`, `quartz.job.group` and `quartz.job.name`.
+- **Metrics.** `quartz.scheduler.name` and `quartz.scheduler.id` are on **every** measurement, on every
+  instrument — which is what makes a per-tenant metrics dashboard a `group by` rather than extra
+  instrumentation. `quartz.job.execution.active` and `quartz.job.execution.duration` add
+  `quartz.trigger.group`, `quartz.trigger.name`, `quartz.job.group` and `quartz.job.name`. The whole set
+  of instruments, and which attributes each carries, is on the
+  [OpenTelemetry page](packages/opentelemetry-integration.md#metrics).
 
 Under the group-per-tenant model, `quartz.trigger.group` and `quartz.job.group` **are** the tenant, so
 the same dashboards work by grouping on those instead. That is a good reason to make the group the raw
@@ -943,4 +963,6 @@ rest — so a view or a filter can reference them rather than repeat the strings
 - [Execution Groups](tutorial/execution-groups.md) — per-node and cluster-wide thread limits in full
 - [Querying Jobs and Triggers](tutorial/querying-jobs-and-triggers.md) — group-filtered listings
 - [Clustering](tutorial/advanced-enterprise-features.md) — what a shared database gives you
+- [Dashboard](packages/dashboard.md) — the Schedulers page, read-only mode, and how the policy above gates the UI
+- [HTTP API](packages/http-api.md#authorizing-per-scheduler) — the same policy on the other surface, and why it answers 403 before 404
 - [Migration Guide](migration-guide.md) — including why a shut-down scheduler cannot be restarted

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -118,8 +118,8 @@ This section says what each page shows. What the numbers on them *mean* for a cl
 
 ### Overview
 
-`/quartz` — the page a scheduler is judged from. It opens with the scheduler's status and — outside read-only mode —
-the controls that change it: start, stand-by, pause all, resume all and shutdown.
+`/quartz` — the page a scheduler is judged from. It opens with the scheduler's status and, outside
+read-only mode, the controls that change it: start, stand-by, pause all, resume all and shutdown.
 
 Beside the totals — jobs, triggers, firings in flight, triggers in error, nodes — it carries four
 breakdowns, because a total is rarely the thing that explains why work is not being done:
@@ -145,7 +145,9 @@ breakdowns, because a total is rarely the thing that explains why work is not be
 
 The **Nodes** tile is the one with a verdict in it: it carries the node count, and beside it the number
 that are not `Alive` when there are any — a cluster of four is only news when one of them has stopped
-checking in. It is a link to the Cluster page, and it is shown only for a store that has nodes to count.
+checking in, and the tile turns red when it is. It is a link to the Cluster page. A scheduler that is
+not clustered reads `1` here, which is the honest answer rather than a missing tile: it is one node.
+
 Below the breakdowns the page ends with the most recent entries from the [Action Log](#action-log).
 
 ### Jobs, Triggers and Calendars
@@ -284,7 +286,9 @@ does not matter. A scheduler registered with `AddQuartz("acme", …)` therefore 
 view and History page just like the default one; each scheduler gets its own instance of each plugin,
 initialized with its own name, and history entries are attributed to the scheduler that produced them.
 
-It does this with `ConfigureAllQuartzSchedulers`, so nothing extra is written at the call site.
+It does this with `ConfigureAllQuartzSchedulers`, so nothing extra is written at the call site. Which
+schedulers those are is what [the Schedulers page](#schedulers) lists — every registration in the
+container, built or not.
 
 ::: warning Fixed in 4.0.0-alpha.2
 The dashboard's plugins used to be registered without a service key, which meant only a scheduler
@@ -292,9 +296,6 @@ registered by `AddQuartz()` — the unnamed, default one — ever ran them. A na
 scheduler selector and its jobs and triggers rendered, but its Live Logs view and its History page were
 silently always empty. There was nothing to configure to get them; this is a fix rather than a new option.
 :::
-
-Which schedulers those are is [the Schedulers page](#schedulers) — every registration
-in the container, built or not.
 
 ## Hosting under a custom path
 

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -9,6 +9,31 @@ Quartz Dashboard is currently a work in progress.
 The dashboard API surface may change between releases.
 :::
 
+## Features
+
+Ten pages, listed under [The pages](#the-pages). What they are built on, which is what decides where
+the dashboard fits:
+
+- **It reads the schedulers in its own process**, through the `IQuartzApiClient` in the container. No
+  address to configure and no scheduler to point it at; a dashboard over another process is
+  [#3387](https://github.com/quartznet/quartznet/issues/3387) and is 4.1.
+- **Every scheduler the container knows about**, not just the default one — including a registration
+  nothing has built yet, which is shown as such rather than omitted. The header's picker switches
+  between them and every page follows it.
+- **Cluster-aware wherever the store is.** With a persistent job store the executing view, the fire
+  counts and the node listing are the whole cluster's rather than this process's, and the pages say
+  which of the two you are looking at.
+- **Its own execution history**, installed and populated without anything further being written, and
+  bounded by age as well as by count. It is in-memory and per-process unless you
+  [give it a store of your own](#execution-history-and-misfires).
+- **A live event stream** over SignalR, fed by plugins installed into every scheduler in the container.
+- **Authorization at three levels that compose** — who reaches the dashboard, which schedulers they see
+  once they are in, and whether anyone may change anything. See
+  [Production hardening](#production-hardening).
+- **A time zone picker and a theme toggle** in the header. The picker is what the pages render their
+  absolute times in, so a cluster spanning regions can be read in one; the times that are more useful
+  as an age — a last check-in, a last fire — are shown relative as well.
+
 ## Installation
 
 The dashboard package builds on `Quartz.AspNetCore` and brings it along, so one reference is enough:
@@ -82,19 +107,32 @@ dashboard — with the authentication forwarding, execution limits and history s
 is designed in [#3387](https://github.com/quartznet/quartznet/issues/3387).
 :::
 
-## The overview
+## The pages
 
-The **Overview** page at `/quartz` is the one a scheduler is judged from. Beside the totals — jobs,
-triggers, firings in flight, triggers in error, nodes — it carries four breakdowns, because a total is
-rarely the thing that explains why work is not being done:
+Ten of them, all served under `{DashboardPath}` — `/quartz` unless you said otherwise. Every one of
+them renders the scheduler the header's picker has selected, so switching schedulers keeps you on the
+page you were reading.
+
+This section says what each page shows. What the numbers on them *mean* for a cluster in trouble is
+[Operating a Cluster](../operations.md), which these pages link into rather than restate.
+
+### Overview
+
+`/quartz` — the page a scheduler is judged from. It opens with the scheduler's status and — outside read-only mode —
+the controls that change it: start, stand-by, pause all, resume all and shutdown.
+
+Beside the totals — jobs, triggers, firings in flight, triggers in error, nodes — it carries four
+breakdowns, because a total is rarely the thing that explains why work is not being done:
 
 - A **trigger-state histogram**: how many triggers are `Normal`, `Paused`, `Blocked`, `Error` and
   `Complete`. Each count is a link to the Triggers page already narrowed to that state, which is also
   what `/quartz/triggers?state=Paused` does for any state you name. The counts are counting queries, so
   a scheduler with a hundred thousand triggers costs the same as one with ten.
-- A **paused-group** tile: how many trigger groups and how many job groups are paused. A group can be
-  paused while it holds nothing, and this counts such a group — which is exactly the one an operator
-  cannot find by looking at a listing.
+- A **paused-group** tile: how many trigger groups and how many job groups are paused, both kinds in one
+  tile because pausing a trigger group and pausing a job group are different acts with the same
+  consequence. A group can be paused while it holds nothing, and this counts such a group — which is
+  exactly the one an operator cannot find by looking at a listing, and a common and entirely silent
+  answer to [Nothing is firing](../operations.md#nothing-is-firing).
 - A **misfire** tile: how many firings the scheduler missed inside the history store's retention window,
   which the tile names — `Misfires (last 24 h)` at the default `HistoryRetention`, and whatever you
   configured otherwise, so the label cannot promise a day a store set to remember an hour has already
@@ -104,6 +142,112 @@ rarely the thing that explains why work is not being done:
 - An **execution-group panel**: one row per [execution group](../tutorial/execution-groups.md), with the
   limit that governs it, the scope that limit is counted in, what the group has in flight, and the
   headroom left. It is described under [Execution groups](#execution-groups) below.
+
+The **Nodes** tile is the one with a verdict in it: it carries the node count, and beside it the number
+that are not `Alive` when there are any — a cluster of four is only news when one of them has stopped
+checking in. It is a link to the Cluster page, and it is shown only for a store that has nodes to count.
+Below the breakdowns the page ends with the most recent entries from the [Action Log](#action-log).
+
+### Jobs, Triggers and Calendars
+
+`/quartz/jobs`, `/quartz/triggers`, `/quartz/calendars` — the three listings, each with search and
+pagination, each row a link to a detail page.
+
+- **Jobs** lists the job details and their keys; the detail page shows the job's `JobDataMap`, the
+  triggers pointing at it, and — outside read-only mode — trigger-now with overrides, pause, resume and
+  delete.
+- **Triggers** lists triggers with their state, their next and previous fire times and their execution
+  group. `?state=` opens it already narrowed, which is what the overview's histogram counts link to. The
+  detail page shows the trigger's own `JobDataMap`, and outside read-only mode offers pause, resume,
+  unschedule, *reset error state* — the one that clears an `ERROR` trigger once the reason for it is
+  fixed — and, for a cron trigger, an editor that reschedules it with a preview of its next five fires.
+- **Calendars** lists the calendars by name; the detail page shows one, and outside read-only mode a
+  cron calendar can be created, replaced or deleted.
+
+### Currently Executing
+
+`/quartz/executing` — one row per firing: job, trigger, node, execution group, fire time and run time. It is the fire-instance
+listing, so **with a persistent job store it is the whole cluster's**, and the `Node` column is which
+machine owns each firing rather than decoration.
+
+Interrupting from here interrupts *the one firing the row names*, not every firing of its job — the
+distinction matters for a job without `[DisallowConcurrentExecution]`, which can have several in flight.
+
+A row that will not go away is worth reading
+[Fired triggers: backlog or leak](../operations.md#fired-triggers-backlog-or-leak) about: a firing whose
+node died leaves its row behind until another node's check-in sweep takes it over.
+
+### Schedulers
+
+`/quartz/schedulers` — the fleet: one row per scheduler the container knows about, whether or not anything has built it. It
+reads `ISchedulerRegistry`, so a scheduler registered with `AddQuartz("acme", …)` that nothing has
+resolved yet is listed with its origin and a **not created** status rather than being absent — and
+listing it does not build it.
+
+Each row that has a scheduler behind it shows what that scheduler is made of, read from its
+`SchedulerMetadata`: its instance id, whether its job store is persistent and whether it is clustered,
+the store and thread pool it uses, the pool size, when it started (in the time zone the header picker
+selects), how many jobs it has executed, and the version of Quartz running it. The node count beside it
+comes from the cluster-node query, and only for a store that has nodes — a persistent, clustered one. An
+in-memory store is never asked, because the answer would always be "one".
+
+Following a row makes that scheduler the active one and opens its Overview page, which is the same
+switch the header's scheduler picker makes. A registration nothing has built is not a link: there is no
+scheduler behind it for any page to show. The picker offers it too, greyed out, so that a tenant that
+failed to start is visible rather than looking as though it had never been registered. Should such a
+registration end up being the active scheduler anyway — it is the only one there is, or the one that was
+running has just been shut down — the Overview page says it has not been created rather than reporting a
+scheduler it could not find.
+
+### Cluster
+
+`/quartz/cluster` — one row per node of the selected scheduler's cluster, refreshed every five seconds, with the time of
+the last refresh in the header so a stalled page is visible as one. The columns are the node's instance
+id, its state, its last check-in, its check-in interval, and how many firings it holds `Acquired` and
+how many it is `Executing`. The node answering is marked *(this node)*.
+
+The state is `Alive`, `Overdue` or `Failed`, and it is `IScheduler.QueryClusterNodes()`'s verdict —
+decided by the same predicate the store's own recovery sweep applies, so the page and the sweep cannot
+disagree. What the three mean, why a `Failed` node is listed for a short while and then vanishes, and
+what it means when one does not, are in
+[Check-in, node states and failover](../operations.md#check-in-node-states-and-failover) and
+[Reading the cluster](../operations.md#reading-the-cluster).
+
+**A scheduler whose job store is not clustered says so** rather than showing an empty table: such a
+store keeps no check-in state, so the only node is this one. The check-in times are the ones that node
+was configured with rather than the reader's, and the verdicts are read off the answering node's clock —
+on a cluster with skewed clocks two nodes can disagree about a third.
+
+### Execution History
+
+`/quartz/history` — covered in full under [Execution history and misfires](#execution-history-and-misfires): one row per
+execution with the node that ran it, a node filter, four stat cards whose titles say which scope their
+figures cover, and a misfires section beneath.
+
+### Live Logs
+
+`/quartz/live` — the scheduler's events as they happen, over the SignalR hub, fed by a plugin `AddQuartzDashboard`
+installs into every scheduler in the container. Every event names the node that raised it, and the page
+says which node its own process is — which is how a clustered scheduler's stream is readable rather
+than an undifferentiated blur.
+
+Events can be narrowed by type from the header, which is what makes a busy scheduler readable.
+
+It is a live view, not a log: it starts when the page opens, holds the newest hundred events and drops
+the rest. Nothing here survives a reload, and nothing here is the record — see
+[Current limitations](#current-limitations).
+
+### Action Log
+
+`/quartz/actions` — what was done *from this dashboard*: time, scheduler, action, target, whether it succeeded and any
+message, newest first. It is the audit trail for the buttons, and it answers "who paused this" for a
+value of "who" that is the dashboard rather than a user.
+
+The store behind it is in-memory and process-wide, holding the last 250 actions across every scheduler;
+the page takes the most recent 100 of those and shows the ones aimed at the scheduler you have selected,
+so switching schedulers re-filters it. That makes it a recent-activity view rather than an audit store —
+and it records only what *this process's dashboard* did. An action taken through the HTTP API, from
+another node, or by another operator's dashboard is not in it, and nothing in it survives a restart.
 
 ## Execution groups
 
@@ -149,27 +293,8 @@ scheduler selector and its jobs and triggers rendered, but its Live Logs view an
 silently always empty. There was nothing to configure to get them; this is a fix rather than a new option.
 :::
 
-### Schedulers
-
-The **Schedulers** page at `/quartz/schedulers` is the fleet: one row per scheduler the container knows
-about, whether or not anything has built it. It reads `ISchedulerRegistry`, so a scheduler registered
-with `AddQuartz("acme", …)` that nothing has resolved yet is listed with its origin and a **not created**
-status rather than being absent — and listing it does not build it.
-
-Each row that has a scheduler behind it shows what that scheduler is made of, read from its
-`SchedulerMetadata`: its instance id, whether its job store is persistent and whether it is clustered,
-the store and thread pool it uses, the pool size, when it started (in the time zone the header picker
-selects), how many jobs it has executed, and the version of Quartz running it. The node count beside it
-comes from the cluster-node query, and only for a store that has nodes — a persistent, clustered one. An
-in-memory store is never asked, because the answer would always be "one".
-
-Following a row makes that scheduler the active one and opens its Dashboard page, which is the same
-switch the header's scheduler picker makes. A registration nothing has built is not a link: there is no
-scheduler behind it for any page to show. The picker offers it too, greyed out, so that a tenant that
-failed to start is visible rather than looking as though it had never been registered. Should such a
-registration end up being the active scheduler anyway — it is the only one there is, or the one that was
-running has just been shut down — the Dashboard page says it has not been created rather than reporting
-a scheduler it could not find.
+Which schedulers those are is [the Schedulers page](#schedulers) — every registration
+in the container, built or not.
 
 ## Hosting under a custom path
 
@@ -218,10 +343,14 @@ A custom dashboard path is **not** supported when integrating into an existing B
 ## Execution history and misfires
 
 `AddQuartzDashboard()` installs the history plugin itself, so the **History** page at `/quartz/history`
-is populated without anything further being written. Each row carries the node that ran it, so a
-clustered scheduler's history is readable rather than an undifferentiated stream, and the page's node
-filter narrows the listing — and the figures on its stat cards, whose titles then say which node they
-cover — to one machine.
+is populated without anything further being written. Each row names the job, the trigger, the node that
+ran it, when it fired, how long it took, whether it succeeded and the error if it did not.
+
+Above the rows are four figures over the page in view — success rate, failures, average duration and
+P95 duration — and above those three filters: by job, by trigger, and by node. **The node filter is the
+one a cluster needs**: it narrows the listing to one machine, and the stat cards' titles then say so, so
+a success rate cannot be read as the fleet's when it is one node's. Without it a clustered scheduler's
+history is an undifferentiated stream.
 
 Beneath the executions the page lists **misfires**: firings the scheduler missed. Nothing ran, so they
 never appear in the execution history however long a reader stares at it; each row names the trigger,
@@ -343,56 +472,22 @@ responsible for not routing them to one they fail for.
 Leaving it unset is the behaviour every earlier release had: whoever passes `AuthorizationPolicy` sees
 every scheduler in the process.
 
-### API key or custom authorization checks
+### Read-only mode
 
-If you need machine-to-machine access, use your API auth scheme (for example, an API key handler) and bind that to a policy used by `MapQuartzHttpApi()`.
-For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based authorization so the dashboard UI, hub, and API are enforced consistently.
+`ReadOnly = true` hides every mutating control the pages carry: pause, resume, trigger-now,
+trigger-with-overrides, reschedule, reset-from-error-state, unschedule, interrupt, delete, calendar
+create and replace, and the scheduler's own start, stand-by, pause-all, resume-all and shutdown. What
+remains is every listing, every detail page and every live view — which is the whole of the dashboard's
+diagnostic value.
 
-### Deployment guidance for multi-scheduler and clustered setups
+It is one setting for the whole process, not per scheduler and not per operation. The shape to reach for
+when different people need different powers is two dashboards: a read-only one for observers, and a
+write-enabled one behind a policy only operators pass. `SchedulerAuthorizationPolicy` narrows *which
+schedulers* each of those shows; it does not narrow what may be done to the ones it does show.
 
-- **Clustered ADO.NET job stores:** actions in dashboard are scheduler operations and can affect cluster behavior; restrict write access to trusted operator roles.
-- **Many local schedulers in one host:** dashboard scheduler selector supports multiple registered schedulers; use clear scheduler names and environment-specific grouping.
-- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack. The Blazor circuit connects to `/_blazor` (or `{DashboardPath}/_blazor` when a custom `DashboardPath` is configured).
-- **Split operator experiences:** expose a read-only dashboard instance (`ReadOnly = true`) for observers, and a separate write-enabled dashboard for operators.
-- **Operational retention:** the built-in history store is per-process and in-memory, bounded by `HistoryRetention` and `HistoryMaxEntriesPerScheduler`. Every node of a cluster therefore keeps its own; the rows name the node they came from, so registering a shared `IDashboardHistoryStore` gives one page over the whole fleet. Configure external retention/reporting if you need long-term analytics.
-
-## Features
-
-- Scheduler overview and summary cards, with a trigger-state histogram (`Normal`, `Paused`, `Blocked`,
-  `Error`, `Complete`) whose counts link to the Triggers page narrowed to that state, a paused-group
-  tile counting paused trigger groups and job groups — a group paused while it holds nothing included —
-  and a misfire count over the history store's retention window, which the tile names
-- Execution-group panel on the overview — one row per group with its limit, the scope that limit is
-  counted in (`Node` or `Cluster`), what it has in flight and the headroom left; cluster-wide with a
-  persistent job store and per node otherwise, and it says which. See
-  [Execution groups](#execution-groups)
-- Jobs and triggers listing with search and pagination; `?state=` opens the trigger listing filtered
-- Job details and trigger details pages
-- Currently executing jobs view — cluster-wide with a persistent job store, showing which node owns each
-  execution, and interrupting the one execution a row names rather than every execution of its job
-- Schedulers view at `/quartz/schedulers` — one row per scheduler the container knows about, built or
-  merely registered, with its origin and status and, for one that exists, its job store and thread pool,
-  when it started, how many jobs it has executed, its node count when it is clustered, and its version;
-  a row is the link that makes that scheduler the active one
-- Cluster view at `/quartz/cluster` — one row per node with its state (`Alive`, `Overdue`, `Failed`),
-  its last check-in in the selected time zone and as a relative time, its check-in interval, and how
-  many firings it is holding and running; the node answering is marked, and a scheduler whose job store
-  is not clustered says so rather than showing an empty table
-- Execution history at `/quartz/history` — one row per execution with the node that ran it, filterable
-  by job, by trigger and by node, with the page's stat cards saying which scope their figures cover; and
-  a misfires section listing the firings the scheduler missed. Bounded by age as well as by count — see
-  [Execution history and misfires](#execution-history-and-misfires)
-- Live event/log stream for scheduler activity, fed by plugins `AddQuartzDashboard` installs on every
-  scheduler in the container — so a named scheduler streams its own events, each plugin instance
-  initialized with the name of the scheduler it belongs to. Every event names the node that raised it,
-  and the page says which node its own process is
-- Pause, resume, trigger-now, and unschedule/delete actions (when not in read-only mode)
-- Trigger detail cron reschedule and job detail trigger-with-overrides actions
-- Calendar create/replace (cron calendar), details, and delete actions
-- Multi-scheduler selection, over every scheduler the container knows about — the dashboard lists
-  `ISchedulerRegistry`, so a registered scheduler nothing has created yet is offered greyed out rather
-  than omitted
-- Read-only mode support via dashboard options
+Note what read-only is not: it hides the dashboard's controls and does nothing to the HTTP API, which is
+mapped and authorized separately. A dashboard in read-only mode over an API that anyone may post to is
+read-only in appearance alone.
 
 ::: warning Fixed in 4.0.0-alpha.2
 The dashboard's controls did not work. Blazor's event handlers and two-way binding are directive
@@ -410,6 +505,19 @@ opens the dialog was live.
 
 There was nothing to configure to get these working; this is a fix rather than a new option.
 :::
+
+### API key or custom authorization checks
+
+If you need machine-to-machine access, use your API auth scheme (for example, an API key handler) and bind that to a policy used by `MapQuartzHttpApi()`.
+For dashboard-only custom checks, prefer ASP.NET Core policy/handler-based authorization so the dashboard UI, hub, and API are enforced consistently.
+
+### Deployment guidance for multi-scheduler and clustered setups
+
+- **Clustered ADO.NET job stores:** actions in dashboard are scheduler operations and can affect cluster behavior; restrict write access to trusted operator roles.
+- **Many local schedulers in one host:** dashboard scheduler selector supports multiple registered schedulers; use clear scheduler names and environment-specific grouping. Where those schedulers are different tenants, `SchedulerAuthorizationPolicy` is what keeps them apart — see [Multi-tenancy](../multi-tenancy.md#authorizing-a-tenant-on-its-own-scheduler).
+- **Reverse proxy and Blazor Server:** enable WebSocket/SignalR forwarding and sticky sessions where required by your hosting stack. The Blazor circuit connects to `/_blazor` (or `{DashboardPath}/_blazor` when a custom `DashboardPath` is configured).
+- **Split operator experiences:** expose a read-only dashboard instance (`ReadOnly = true`) for observers, and a separate write-enabled dashboard for operators.
+- **Operational retention:** the built-in history store is per-process and in-memory, bounded by `HistoryRetention` and `HistoryMaxEntriesPerScheduler`. Every node of a cluster therefore keeps its own; the rows name the node they came from, so registering a shared `IDashboardHistoryStore` gives one page over the whole fleet. Configure external retention/reporting if you need long-term analytics.
 
 ## Integrating with an existing Blazor Server app
 
@@ -440,6 +548,22 @@ The dashboard pages, layout, CSS, and JavaScript interop are automatically regis
 Do **not** call the parameterless `MapQuartzDashboard()` alongside your own `MapRazorComponents` — this registers two `/_blazor` endpoints and causes the dashboard's interactive pages to fail.
 :::
 
+### What integrated hosting changes
+
+Three things behave differently when the components are hosted under an application's own Blazor root
+rather than the dashboard's. Everything else on this page applies to both modes.
+
+| | Standalone (`MapQuartzDashboard()`) | Integrated (`MapQuartzDashboard(blazor)`) |
+|---|---|---|
+| `DashboardPath` | Honoured; the whole dashboard is self-contained under it | **Rejected** — the page routes are fixed at `/quartz`, and a custom path fails startup with a descriptive exception. There is no `MapQuartzDashboard(blazor, pattern)` for the same reason |
+| The Blazor circuit and framework assets | Dashboard-owned endpoints, which carry the dashboard's own authorization metadata | The host's — so a fail-closed `FallbackPolicy` governs them, and `AllowAnonymous` on your static assets is yours to decide |
+| The *not authorized* frame | Drawn, because the dashboard's layout is in the render tree | **Not drawn** — see [One scheduler at a time](#one-scheduler-at-a-time) |
+
+What does *not* change is every listing the dashboard writes and every hub subscription it makes: both
+are filtered by `SchedulerAuthorizationPolicy` in either mode, so the dashboard itself will never offer
+a visitor a scheduler they fail for. The gap is only an application that routes a visitor to one by
+means of its own.
+
 ## API-only projects (no .razor files)
 
 If your host project has no `.razor` files of its own (for example a pure API project hosting Quartz), you must add the following to your project file:
@@ -454,7 +578,22 @@ This property tells the .NET SDK to include the Blazor framework scripts (`_fram
 
 ## Current limitations
 
-- Live views are near-real-time polling/streaming and are not guaranteed to be lossless event storage
-- No built-in persistence UI for historical analytics; the shipped history store is in-memory and per-process, so history does not survive a restart and one node cannot show another's unless you register a shared `IDashboardHistoryStore`. A database-backed one ships with 4.1 ([#3387](https://github.com/quartznet/quartznet/issues/3387))
-- Advanced management remains intentionally scoped; rich typed editors are currently focused on cron calendars/triggers and operational overrides
-- UX is optimized for Quartz APIs and scheduler operations, not full workflow/business process visualization
+- **The dashboard renders its own process.** There is no address to point it at another one; a remote
+  dashboard is [#3387](https://github.com/quartznet/quartznet/issues/3387) and is 4.1.
+- **Nothing here is the record.** Live Logs is a live view that starts when the page opens and keeps a
+  hundred events; the Action Log keeps 250 and only what this process's dashboard did. Neither survives
+  a restart, and neither is lossless — use logging and
+  [metrics](opentelemetry-integration.md) for anything you need to be able to go back to.
+- **The history store is in-memory and per-process**, so history does not survive a restart and one
+  node cannot show another's unless you register a shared `IDashboardHistoryStore`. A database-backed
+  one ships with 4.1.
+- **Read-only is one setting for the whole process**, not per scheduler and not per operation — "acme
+  may look, globex may act" and "this tenant may pause but not delete" are not expressible. Which
+  *schedulers* a visitor sees is expressible; see [One scheduler at a time](#one-scheduler-at-a-time).
+- **The misfire tile and the Cluster page ask the store what it can answer.** A data source with no
+  misfire feed shows a dash rather than a zero, and a job store with no check-in state reports the one
+  node it is. Neither is a count of zero, and the pages say so rather than implying otherwise.
+- **Typed editors are deliberately narrow**: cron calendars, cron trigger reschedules and job-data
+  overrides. Building an arbitrary trigger of any type from the UI is not offered.
+- **It is a scheduler console, not a workflow tool.** Job dependencies, DAGs and business-process
+  visualisation are outside what Quartz itself models, so they are outside this.

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -68,12 +68,103 @@ given, **the pattern passed to `MapQuartzHttpApi` wins**; the parameterless over
 `ApiPath` says. A pattern given at the map site has to start with `/`, the same rule `ApiPath` is
 validated against.
 
-## Endpoint groups
+## Every endpoint
 
-- **Schedulers**: list schedulers, read metadata/context, list cluster nodes, start, stand-by, shutdown, clear, pause-all, resume-all
-- **Jobs**: query jobs, fetch details by key, check existence, list fire instances, pause/resume, trigger, interrupt, add, delete
-- **Triggers**: query triggers, fetch by key, read state, pause/resume, reset from error state, schedule/unschedule/reschedule
-- **Calendars**: query names, get details, add/replace, delete
+Fifty-seven routes in four groups. `{ApiPath}` is `/quartz-api` unless you said otherwise, and
+`{name}` is the scheduler the request is for — every route but the first carries one, and every route
+that carries one is subject to
+[`SchedulerAuthorizationPolicy`](#authorizing-per-scheduler) when it is set.
+
+The **Answers** column is shorthand for the [response-shape
+conventions](#response-shape-conventions): *empty* means `200` with no body, `{ applied }` is the
+one-flag form, `{ groups }` / `{ jobs }` / `{ triggers }` are the key-set and group-matcher forms, and
+*paged* is the [paged envelope](#listing-endpoints-are-paged). An unknown scheduler is `404` on every
+one of them.
+
+### Schedulers — 13
+
+| Method | Path | Answers |
+|---|---|---|
+| `GET` | `{ApiPath}/schedulers` | Every scheduler the container knows about, built or merely registered — [see below](#the-scheduler-listing-carries-registrations). The one route that names no scheduler, so it filters itself |
+| `GET` | `{ApiPath}/schedulers/{name}` | The scheduler and its `SchedulerMetadata` |
+| `GET` | `{ApiPath}/schedulers/{name}/context` | `{ context }` — [every value as text](#the-scheduler-context-travels-as-text) |
+| `POST` | `{ApiPath}/schedulers/{name}/start` | empty. `?delay=00:00:30` starts it delayed; a negative delay is a `400` |
+| `POST` | `{ApiPath}/schedulers/{name}/standby` | empty |
+| `POST` | `{ApiPath}/schedulers/{name}/shutdown` | empty. `?waitForJobsToComplete=true` waits for running jobs |
+| `POST` | `{ApiPath}/schedulers/{name}/clear` | empty — deletes every job, trigger and calendar |
+| `POST` | `{ApiPath}/schedulers/{name}/pause-all` | empty |
+| `POST` | `{ApiPath}/schedulers/{name}/resume-all` | empty |
+| `GET` | `{ApiPath}/schedulers/{name}/nodes` | The cluster's nodes — [see below](#cluster-nodes) |
+| `GET` | `{ApiPath}/schedulers/{name}/execution-limits` | `{ limits, useTriggerGroupWhenUnset }`; `limits` is `null` when nothing is limited |
+| `POST` | `{ApiPath}/schedulers/{name}/execution-limits` | empty — replaces the whole set |
+| `DELETE` | `{ApiPath}/schedulers/{name}/execution-limits` | empty — the same as posting an empty set |
+
+### Jobs — 20
+
+Every path below is prefixed `{ApiPath}/schedulers/{name}`.
+
+| Method | Path | Answers |
+|---|---|---|
+| `GET` | `…/jobs` | paged job headers |
+| `POST` | `…/jobs/fetch` | Whole job details for a page of keys, at most 1000 |
+| `GET` | `…/jobs/{jobGroup}/{jobName}` | The job detail |
+| `GET` | `…/jobs/{jobGroup}/{jobName}/exists` | `{ exists }` |
+| `GET` | `…/jobs/{jobGroup}/{jobName}/triggers` | Every trigger pointing at that job |
+| `GET` | `…/jobs/fire-instances` | paged fire instances — [see below](#fire-instances) |
+| `POST` | `…/jobs/{jobGroup}/{jobName}/pause` | `{ applied }` |
+| `POST` | `…/jobs/pause` | `{ groups }` — selects by group matcher in the query string |
+| `POST` | `…/jobs/keys/pause` | `{ jobs }` — selects by key set in the body |
+| `POST` | `…/jobs/{jobGroup}/{jobName}/resume` | `{ applied }` |
+| `POST` | `…/jobs/resume` | `{ groups }` |
+| `POST` | `…/jobs/keys/resume` | `{ jobs }` |
+| `POST` | `…/jobs/{jobGroup}/{jobName}/trigger` | empty — fires the job now; body may carry a `JobDataMap` for the one firing |
+| `POST` | `…/jobs/{jobGroup}/{jobName}/interrupt` | `{ applied }` — every execution of that job |
+| `POST` | `…/jobs/interrupt/{fireInstanceId}` | `{ applied }` — the one firing |
+| `DELETE` | `…/jobs/{jobGroup}/{jobName}` | `{ applied }` |
+| `POST` | `…/jobs/delete` | `{ jobs }` |
+| `POST` | `…/jobs` | empty — adds the job; `replace` and `storeNonDurableWhileAwaitingScheduling` are body fields |
+| `GET` | `…/jobs/groups` | paged job groups: `name`, `paused` |
+| `GET` | `…/jobs/groups/{jobGroup}/paused` | `{ paused }` |
+
+### Triggers — 20
+
+| Method | Path | Answers |
+|---|---|---|
+| `GET` | `…/triggers` | paged trigger headers |
+| `POST` | `…/triggers/fetch` | Whole triggers for a page of keys, at most 1000 |
+| `GET` | `…/triggers/{triggerGroup}/{triggerName}` | The trigger |
+| `GET` | `…/triggers/{triggerGroup}/{triggerName}/exists` | `{ exists }` |
+| `GET` | `…/triggers/{triggerGroup}/{triggerName}/state` | `{ state }` — the `TriggerState` name |
+| `POST` | `…/triggers/{triggerGroup}/{triggerName}/reset-from-error-state` | `{ applied }` |
+| `POST` | `…/triggers/keys/reset-from-error-state` | `{ triggers }` |
+| `POST` | `…/triggers/{triggerGroup}/{triggerName}/pause` | `{ applied }` |
+| `POST` | `…/triggers/pause` | `{ groups }` |
+| `POST` | `…/triggers/keys/pause` | `{ triggers }` |
+| `POST` | `…/triggers/{triggerGroup}/{triggerName}/resume` | `{ applied }` |
+| `POST` | `…/triggers/resume` | `{ groups }` |
+| `POST` | `…/triggers/keys/resume` | `{ triggers }` |
+| `GET` | `…/triggers/groups` | paged trigger groups: `name`, `paused` |
+| `GET` | `…/triggers/groups/{triggerGroup}/paused` | `{ paused }` |
+| `POST` | `…/triggers/schedule` | `{ firstFireTimeUtc }` — one job and its trigger |
+| `POST` | `…/triggers/schedule-multiple` | empty — several jobs and their triggers in one call |
+| `POST` | `…/triggers/{triggerGroup}/{triggerName}/unschedule` | `{ applied }` |
+| `POST` | `…/triggers/unschedule` | `{ triggers }` |
+| `POST` | `…/triggers/{triggerGroup}/{triggerName}/reschedule` | `{ firstFireTimeUtc }`, **`null`** when the trigger did not exist |
+
+### Calendars — 4
+
+| Method | Path | Answers |
+|---|---|---|
+| `GET` | `…/calendars` | paged calendar names |
+| `GET` | `…/calendars/{calendarName}` | The calendar |
+| `POST` | `…/calendars` | empty — adds or replaces; `replace` and `updateTriggers` are body fields |
+| `DELETE` | `…/calendars/{calendarName}` | `{ applied }` |
+
+::: tip Why `schedule-multiple` is not `schedule`
+`POST …/triggers/schedule` computes one first fire time and answers with it. The plural form cannot —
+there is one per job — so it is a separate route with an empty body rather than an overload that
+sometimes answers and sometimes does not.
+:::
 
 ## The scheduler listing carries registrations
 

--- a/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
+++ b/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
@@ -77,7 +77,7 @@ and are constants on `Quartz.Diagnostics.ActivityTags`:
 
 ## Metrics
 
-Seven instruments, all on the `Quartz` meter. **Every measurement carries `quartz.scheduler.name` and
+Eight instruments, all on the `Quartz` meter. **Every measurement carries `quartz.scheduler.name` and
 `quartz.scheduler.id`** — the name says which scheduler, the id says which node of it, and a cluster is
 several nodes sharing one name.
 

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -78,7 +78,11 @@ await scheduler.TriggerJob(jobKey, new JobDataMap { ["reason"] = "manual re-run"
 
 `JobDataMap` implements `IDictionary<string, object?>`, so the dictionary surface is all there —
 indexer, `TryGetValue`, `ContainsKey`, `Remove`, `Count`, `Keys`, `Values`, `Clear`, plus
-`ContainsValue` and `IsEmpty`. On top of that come 31 typed accessors, as extension members:
+`ContainsValue` and `IsEmpty`. On top of that come 33 typed accessors, as extension members on
+`DataMapExtensions`. They fall into two families, and the difference between them is the thing to
+know before picking one.
+
+### The fifteen named types, which coerce
 
 **Throwing readers** — the value must be there and must be coercible:
 
@@ -86,31 +90,56 @@ indexer, `TryGetValue`, `ContainsKey`, `Remove`, `Count`, `Keys`, `Values`, `Cle
 `GetDateTime`, `GetDateTimeOffset`, `GetDateOnly`, `GetTimeOnly`, `GetTimeSpan`, `GetGuid`,
 `GetEnum<TEnum>`.
 
-**Try readers** — the same set, returning `false` instead of throwing:
+**Try readers** — the same fifteen, returning `false` instead of throwing:
 
 `TryGetInt`, `TryGetLong`, `TryGetFloat`, `TryGetDouble`, `TryGetDecimal`, `TryGetBoolean`,
 `TryGetChar`, `TryGetString`, `TryGetDateTime`, `TryGetDateTimeOffset`, `TryGetDateOnly`,
 `TryGetTimeOnly`, `TryGetTimeSpan`, `TryGetGuid`, `TryGetEnum<TEnum>`.
 
-**And one generic** — `TryGet<T>(string key, out T value)`, for a type the list does not name:
-
-<!-- snippet: sample_job_data_map_try_get -->
-```csharp
-if (data.TryGet<ReportOptions>("options", out ReportOptions? options))
-{
-    // ...
-}
-```
-<!-- endSnippet -->
-
-Each accessor accepts the value **either as its own type or as an invariant-culture string**. The
+Each of these accepts the value **either as its own type or as an invariant-culture string**. The
 stored type is matched first, a string is parsed with `CultureInfo.InvariantCulture`, and only an
 exotic stored type falls back to `Convert` semantics. That is what makes the same job code work whether
-the store kept `30` as an `int` or as `"30"`.
+the store kept `30` as an `int` or as `"30"`. `GetEnum<TEnum>` parses a string by name and
+case-insensitively, which is what `PutAsString` writes for an enum.
 
 `GetString` is the one that returns `string?` rather than throwing on a missing key — the rest throw.
 Reach for the `TryGet…` form whenever the key is genuinely optional; there is no performance argument
 either way, it is about whether absence is an error.
+
+### The three generic readers, which do not
+
+For a type the list does not name — your own options class, a `Uri`, a `byte[]` — there are three more.
+**They are a pure type test**: no string parsing, no `Convert`, nothing but `is T`. A `"30"` that
+`GetInt` reads as `30` is *not* an `int` to `Get<int>`, and that is deliberate — a generic accessor
+cannot know which invariant format an arbitrary `T` was written in, so it does not guess.
+
+| Accessor | Entry missing | Entry is not a `T` | Entry is a `T` |
+|---|---|---|---|
+| `TryGet<T>(key, out T value)` | `false` | `false` | `true`, value out |
+| `Get<T>(key)` | `KeyNotFoundException` | `InvalidCastException` naming both types | the value |
+| `GetValueOrDefault<T>(key, defaultValue)` | `defaultValue` | `defaultValue` | the value |
+
+<!-- snippet: sample_job_data_map_generic_readers -->
+```csharp
+// False when the entry is missing and when it holds something else.
+if (data.TryGet<ReportOptions>("options", out ReportOptions? options))
+{
+    // ...
+}
+
+// Throws KeyNotFoundException for a missing entry, InvalidCastException for a wrong one -
+// the two mistakes told apart, where TryGet answers false to both.
+ReportOptions required = data.Get<ReportOptions>("options");
+
+// Neither throws nor distinguishes: missing and wrong-typed both give the fallback.
+ReportOptions effective = data.GetValueOrDefault("options", new ReportOptions());
+```
+<!-- endSnippet -->
+
+`Get<T>` is the one to reach for when the entry is a contract rather than an option: it is the same
+test `TryGet<T>` makes, but it says *which* of the two things went wrong instead of answering `false`
+to both. `GetValueOrDefault<T>` deliberately does not distinguish them — a wrong-typed entry gives the
+fallback exactly as a missing one does, so do not use it where a mistyped key needs to be noticed.
 
 ::: tip
 The same accessors are available on `SchedulerContext`, which is the other string-keyed map in the

--- a/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
@@ -76,14 +76,22 @@ public static class JobDataMapSamples
         #endregion
     }
 
-    public static void TheGenericReader(JobDataMap data)
+    public static void TheGenericReaders(JobDataMap data)
     {
-        #region sample_job_data_map_try_get
+        #region sample_job_data_map_generic_readers
 
+        // False when the entry is missing and when it holds something else.
         if (data.TryGet<ReportOptions>("options", out ReportOptions? options))
         {
             // ...
         }
+
+        // Throws KeyNotFoundException for a missing entry, InvalidCastException for a wrong one -
+        // the two mistakes told apart, where TryGet answers false to both.
+        ReportOptions required = data.Get<ReportOptions>("options");
+
+        // Neither throws nor distinguishes: missing and wrong-typed both give the fallback.
+        ReportOptions effective = data.GetValueOrDefault("options", new ReportOptions());
 
         #endregion
     }


### PR DESCRIPTION
The dashboard, HTTP API and multi-tenancy pages were written against alpha.2. Stream A then landed the Cluster page, the Schedulers page, execution-group usage, node-aware history and per-scheduler authorization, each with a paragraph of its own — so the pages mentioned everything and gave a tour of nothing. This is the pass that makes them read as documents again, written against the tree rather than against the issues.

## Page by page

**`packages/dashboard.md`** — the substantial rewrite.

- **One page-by-page section covering all ten pages.** Only the Overview had one; Cluster and Schedulers had paragraphs elsewhere, and Live Logs, the Action Log and the three listings had never been described anywhere but a bullet. Each now says what it shows, what its columns mean, and what it does when the store cannot answer.
- **Features becomes what a features list is for** — the half-dozen facts that decide whether this dashboard fits (it renders its own process, it covers every registration, it is cluster-aware where the store is, it brings its own history). The old list was a second, staler copy of the page inventory and is gone.
- **Read-only mode gets prose** rather than one table cell, beside the two authorization options it composes with, and says what it is not: it hides the dashboard's controls and does nothing to the HTTP API.
- **"What integrated hosting changes"** collects into one table the three differences that were scattered across four warnings — `DashboardPath` rejected, the circuit and framework assets host-owned, the *not authorized* frame not drawn. The warning block #3483 added to `#one-scheduler-at-a-time` survives verbatim and is linked from the new table.
- **The pages link into `operations.md`** for what their numbers mean — node states and check-in for Cluster, the fired-triggers backlog for the executing view, paused groups for the tile — rather than restating it.
- **Current limitations is true again**: it had claimed a database-backed history store was the only gap, and said nothing about read-only being process-wide or about the pages that report "the store cannot say" rather than zero.

**`packages/http-api.md`** — "Endpoint groups" was four prose bullets naming perhaps half the API and giving no path for any of it, so the only way to learn that `POST …/jobs/interrupt/{fireInstanceId}` exists was to read the source. It is replaced by every route, grouped as the endpoint classes are.

**`multi-tenancy.md`** — the authorization section read like what it was, a feature landing. Authorizing a tenant on its own scheduler is now a row in the model-comparison table that decides between the models, and the group-per-tenant section says plainly what it cannot do: **Quartz authorizes a `SchedulerResource`, never a group**, so a group matcher in a query string is a filter and not a boundary. That is the honest argument for giving a tenant its own scheduler, and it belongs where a reader is choosing. The "what is not per scheduler" table pointed at *Honest limits* for the consequence of `QuartzHttpApiOptions` being process-wide — which was the all-or-nothing authorization that is no longer the consequence.

**`db/index.md`** — the table of tables listed eleven of the twelve tables `tables_sqlServer.sql` creates; `QRTZ_PAUSED_JOB_GRPS` (alpha.2, #3371) was missing, so a reader building a schema from that list built one the store cannot pause a job group in. "Columns 4.x requires" gains it too, since it is the one thing 4.x requires that is not a column.

**`tutorial/job-data-map.md`** — `Get<T>` and `GetValueOrDefault<T>` were undocumented, and the inventory said 31 where `DataMapExtensions` has 33. The three generic readers are also split out from the fifteen named ones, because they do not share their defining behaviour: the named accessors coerce an invariant string, the generic ones are a bare `is T` test. A table says what each does with a missing entry and with a wrong-typed one — the distinction `GetValueOrDefault<T>` deliberately does not draw.

**`best-practices.md`** (scoped in by the issue's first comment) — "What to watch" said there are exactly two instruments and named the absences: no misfire counter, no acquisition-latency instrument, no trigger-state gauge. Two of those three now exist, so the page was steering operators away from the alerts that are now the right ones to build. The trigger-state gauge is still absent, so that warning and the count-the-store advice behind it stay.

## The endpoint count, reconciled

`RequestDelegatesAreSourceGeneratedTest.mappedRoutes` is the count of record, and the table matches it file for file:

| Endpoint class | `Map*` calls | Table section |
|---|---|---|
| `SchedulerEndpoints.cs` | 13 | Schedulers — 13 |
| `JobEndpoints.cs` | 20 | Jobs — 20 |
| `TriggerEndpoints.cs` | 20 | Triggers — 20 |
| `CalendarEndpoints.cs` | 4 | Calendars — 4 |
| | **57** | **57** |

That test asserts the same numbers, so a route added without a docs row is a build failure on one side and a stale table on the other.

## Premises corrected

Where the issue and the code disagreed, the code won.

1. **The issue describes a 292-line `dashboard.md` with no Cluster page, no Schedulers page and no per-scheduler authorization.** By the time this was written the page was 460 lines and Stream A had already added all three incrementally. The work was therefore restructuring and completion, not first-time description; roughly half the prose the issue asks for already existed and is kept.
2. **`multi-tenancy.md`'s two named defects were already fixed.** The "enforce that **outside** Quartz" paragraph (`:702`) and "(The scheduler *id* is on spans only.)" (`:806`) are both gone — #3483 replaced the first, and the meters do carry `quartz.scheduler.id`, which I verified in `Meters.cs` rather than assuming. What remained was coherence, which is what this does.
3. **The accessor item is not in the issue comments.** The two comments ask for `QRTZ_PAUSED_JOB_GRPS`, the `operations.md` cross-links and the `best-practices.md` refresh — not `JobDataMap.Get<T>`. The gap is real, so it is fixed anyway, and flagged here rather than attributed to a comment that does not say it.
4. **The Action Log does filter by the selected scheduler.** My first draft said it does not. It shows the newest 100 of a 250-entry process-wide store, narrowed to the active scheduler.
5. **The overview's Nodes tile is unconditional.** My first draft said it appears only for a store with nodes to count — that is the Schedulers page's node column. A non-clustered scheduler reads `1`, because `QueryClusterNodes` answers with the one node it is.
6. **`opentelemetry-integration.md` introduced its own eight-row table as "Seven instruments".** `Meters.cs` creates eight. One-word fix, included because `best-practices.md` now sends readers to that table.

## For a reviewer to decide

- **`best-practices.md` and `opentelemetry-integration.md` are outside the issue's literal "Done means"** but inside its first comment and inside "no claim the tree does not back". Say the word and I will split them out.
- **A stale comment in product code, deliberately left alone.** `Dashboard.razor:59` explains why the misfire tile is not a link: *"#3422 gave the dashboard a misfire feed but no page to show it on, and a tile that goes nowhere is better than one that goes to a 404."* `History.razor` has had a Misfires section since, so the reason no longer holds and the tile could link to it. That is a product change and this is a docs PR, so it is untouched — the page describes the tile as it behaves today.

## Verification

```
dotnet build Quartz.slnx                   Build succeeded. 0 Warning(s) 0 Error(s)
dotnet fallout DocsSnippets                Succeeded
dotnet fallout VerifyDocsSnippets          Documentation snippets are up to date (93 markdown files checked)
npm run docs:check-links                   214 pages, 879 internal links, 527 fragments — no dead links or anchors
dotnet test src/Quartz.Tests.Unit          Passed! Failed: 0, Passed: 3599, Skipped: 4, Total: 3603
dotnet test src/Quartz.Tests.AspNetCore    Passed! Failed: 0, Passed: 547, Total: 547
```

`PackageReadmeTest`, `SourceEncodingTest` and `AgentInstructionsTest` pass as part of that unit run (58 tests on that filter alone). No BOM on any changed file, CRLF preserved, `quartz-3.x/` untouched. Integration tests were not run: they need a Docker daemon, and nothing here touches product code.

Every C# block is a `#region sample_*` in `Quartz.Documentation.Samples` filled by `DocsSnippets`. One region was added — `sample_job_data_map_generic_readers`, replacing `sample_job_data_map_try_get` — and no other product or test code is touched.

Closes #3446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
