### PR TITLE
Each JSON serializer writes only what it can read back

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2636,6 +2636,36 @@ catch (Newtonsoft.Json.JsonSerializationException e)
 catch (Quartz.JsonSerializationException e)
 ```
 
+### System.Text.Json refuses a job data value it cannot read back
+
+The System.Text.Json read side is closed on purpose — a stored job data value comes back as a string, a
+bool, an int, a long, a double, null or a `Dictionary<string, string>`, and there is no polymorphic
+`object` deserialization, which is what keeps a trimmed publish honest. The write side was not closed to
+match, so a `JobDataMap` holding a `List<string>` or a `Dictionary<string, object>` serialized without
+complaint and threw `JsonSerializationException` on read. The blob was in the database by then, and the
+failure belonged to whoever next ran the job.
+
+Writing now refuses such a value, naming the entry and the type:
+
+```
+Job data entry 'recipients' holds a System.Collections.Generic.List`1[[System.String, …]], which a
+persistent store cannot read back. A job data value has to be one of the types JobDataMap declares an
+accessor for (string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan,
+Guid, DateOnly, TimeOnly or an enum), a Dictionary<string, string>, or a type the application declares
+through SystemTextJsonSerializerRegistry.AddTypeInfoResolver. Anything with structure of its own has to
+be serialized by the job and stored as a string.
+```
+
+The set is the one `DataMapExtensions` declares an accessor for, plus `Dictionary<string, string>`, plus
+enums by rule. A type of your own is declared through `AddTypeInfoResolver` — the same registration a
+trimmed or native-AOT publish already needs — and is then written like any other, coming back as the
+string map the store format gives for any object.
+
+Nothing that used to round-trip stops working: what is refused is exactly what used to be written and
+then failed to load. If you were relying on a nested `JobDataMap` or a collection surviving, serialize it
+in the job and store the result as a string. Newtonsoft is unchanged, and `StoreJobDataAsStrings` was
+never affected.
+
 ### Custom trigger and calendar serializers are no longer static
 
 The static registration methods have been removed, because they wrote into process-global dictionaries: two

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2722,6 +2722,33 @@ unpinned it, and the same held for a custom `IJobStore` that persists serialized
 store was never affected: it keeps the pin in the `PREFERRED_NODE` and `PREFERRED_NODE_AUTO` columns and
 reapplies them to every trigger it reads, blob triggers included.
 
+### A Newtonsoft-serialized trigger keeps its time zone
+
+`UseNewtonsoftJsonSerializer` leaves `registerTriggerConverters` off by default, and with it off a trigger is
+written as a plain object graph. A `TimeZoneInfo` written that way came out as its whole public surface —
+`Id`, `DisplayName`, `BaseUtcOffset` and the rest, every one of them read-only — so reading the object back
+set nothing, and the trigger's getter fell through to `TimeZoneInfo.Local`. A trigger stored under
+`Tokyo Standard Time` fired on whichever zone the reading machine was in, and nothing said so.
+
+The serializer now carries a `TimeZoneInfo` converter, so a zone travels as its id — the same spelling the
+trigger and calendar serializers have always used:
+
+```diff
+- "TimeZone": { "Id": "Tokyo Standard Time", "DisplayName": "(UTC+09:00) Osaka, Sapporo, Tokyo", … }
++ "TimeZone": "Tokyo Standard Time"
+```
+
+Both forms are read, so blobs already written in the object form still load and pick their zone out of `Id`.
+`CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and `RecurrenceTriggerImpl` were affected;
+`CronTriggerImpl` was not, because its zone rides on the `CronExpression`, which has always had a converter
+of its own.
+
+The ADO.NET job store persists every trigger type Quartz ships through a persistence delegate rather than as
+a blob, so this reaches a scheduler only through a trigger type the store has to serialize — a custom one —
+or through code that hands a trigger to `IObjectSerializer` itself. The private `timeZoneInfoId` helpers on
+those trigger implementations, which had been meant for exactly this and never worked because Json.NET's
+default contract does not serialize private members, are gone.
+
 ### Newtonsoft types moved out of the core namespaces
 
 The `Quartz.Serialization.Newtonsoft` package used to put types in namespaces that read as if they came from the

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2666,6 +2666,13 @@ then failed to load. If you were relying on a nested `JobDataMap` or a collectio
 in the job and store the result as a string. Newtonsoft is unchanged, and `StoreJobDataAsStrings` was
 never affected.
 
+The check lives in the job data map converter, which the HTTP API shares with the store serializer, so
+it applies there too: a job whose map holds a `List<string>` — in a `RAMJobStore` as much as a
+persistent one — now fails to serialize into a `GET` response with the message above, where before the
+server sent a payload `Quartz.HttpClient` threw on reading. Both ends use the same closed reader, so a
+value the server cannot read back is one the client cannot either, and `AddTypeInfoResolver` is the
+answer on both.
+
 ### Custom trigger and calendar serializers are no longer static
 
 The static registration methods have been removed, because they wrote into process-global dictionaries: two
@@ -2760,8 +2767,8 @@ written as a plain object graph. A `TimeZoneInfo` written that way came out as i
 set nothing, and the trigger's getter fell through to `TimeZoneInfo.Local`. A trigger stored under
 `Tokyo Standard Time` fired on whichever zone the reading machine was in, and nothing said so.
 
-The serializer now carries a `TimeZoneInfo` converter, so a zone travels as its id — the same spelling the
-trigger and calendar serializers have always used:
+A `TimeZoneInfo` converter is now attached to every property *typed* as one, so a zone on a trigger travels
+as its id — the same spelling the trigger and calendar serializers have always used:
 
 ```diff
 - "TimeZone": { "Id": "Tokyo Standard Time", "DisplayName": "(UTC+09:00) Osaka, Sapporo, Tokyo", … }
@@ -2772,6 +2779,12 @@ Both forms are read, so blobs already written in the object form still load and 
 `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and `RecurrenceTriggerImpl` were affected;
 `CronTriggerImpl` was not, because its zone rides on the `CronExpression`, which has always had a converter
 of its own.
+
+The converter is attached per property rather than registered on the serializer, so it changes typed members
+only. A `TimeZoneInfo` stored as a *value* in a `JobDataMap` sits in an `object`-typed slot and is written
+exactly as before, `$type` and all — that payload has never been readable back (a `TimeZoneInfo` has no
+constructor Json.NET can call), and this change neither introduces that nor repairs it. Store the zone's id
+if a job needs one in its data.
 
 The ADO.NET job store persists every trigger type Quartz ships through a persistence delegate rather than as
 a blob, so this reaches a scheduler only through a trigger type the store has to serialize — a custom one —

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -167,6 +167,13 @@ stay readable by the new version — a renamed property on a stored options clas
 its next fire, months after the deploy that renamed it. Standard framework types are safe; your own
 types are a versioning commitment.
 
+With System.Text.Json — the default — a persistent store accepts exactly the types the accessors above
+cover (`string`, `bool`, `char`, the numeric types, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`,
+`DateOnly`, `TimeOnly` and enums) plus `Dictionary<string, string>`, and refuses anything else when the
+job is stored rather than writing a blob that fails to load later. To store a type of your own, declare
+it with `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — the same registration a trimmed or
+native-AOT publish needs — or serialize it yourself and store the result as a string.
+
 **String mode.** `AdoJobStoreOptions.StoreJobDataAsStrings` (the flat key is still
 `quartz.jobStore.useProperties`) makes the store persist the map as name/value string pairs instead of
 a serialized blob:

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TimeZoneInfoConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TimeZoneInfoConverter.cs
@@ -1,0 +1,62 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Quartz.Serialization.Newtonsoft;
+
+/// <summary>
+/// A time zone travels as its id, which is the only part of a <see cref="TimeZoneInfo" /> that means
+/// anything to another process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, a trigger written as a plain object graph — which is what
+/// <see cref="Quartz.Impl.NewtonsoftJsonObjectSerializer.RegisterTriggerConverters" /> being off
+/// means, and off is the default — lost its zone outright. Json.NET's default contract writes a
+/// <see cref="TimeZoneInfo" /> as its public properties, every one of which is read-only, so reading
+/// the object back set nothing and the trigger's getter fell through to
+/// <see cref="TimeZoneInfo.Local" />. A trigger stored under Tokyo came back running on whichever
+/// zone the reading machine happened to be in, and nothing said so.
+/// </para>
+/// <para>
+/// Both forms are read. The object form is what is sitting in job store blobs written before this
+/// converter existed, and it carries the id under <c>Id</c>; the string form is what is written from
+/// now on, and it is the same spelling the trigger and calendar serializers have always used for a
+/// zone.
+/// </para>
+/// </remarks>
+internal sealed class TimeZoneInfoConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        writer.WriteValue(((TimeZoneInfo) value!).Id);
+    }
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+                return null;
+
+            case JsonToken.String:
+                return TimeZones.FindById((string) reader.Value!);
+
+            case JsonToken.StartObject:
+                // The shape Json.NET's default contract used to write: every public property of a
+                // TimeZoneInfo, of which only the id is portable.
+                JObject source = JObject.Load(reader);
+                string? id = source.Value<string>("Id");
+                if (string.IsNullOrEmpty(id))
+                {
+                    throw new Quartz.JsonSerializationException($"Could not read a time zone from {source.ToString(Formatting.None)}: no Id");
+                }
+
+                return TimeZones.FindById(id);
+
+            default:
+                throw new Quartz.JsonSerializationException($"Could not read a time zone from a {reader.TokenType} token");
+        }
+    }
+
+    public override bool CanConvert(Type objectType) => objectType == typeof(TimeZoneInfo);
+}

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TimeZoneInfoConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TimeZoneInfoConverter.cs
@@ -21,7 +21,16 @@ namespace Quartz.Serialization.Newtonsoft;
 /// Both forms are read. The object form is what is sitting in job store blobs written before this
 /// converter existed, and it carries the id under <c>Id</c>; the string form is what is written from
 /// now on, and it is the same spelling the trigger and calendar serializers have always used for a
-/// zone.
+/// zone. Reading the object form is not optional even after the fix, because a typed member in a blob
+/// written before it still carries one.
+/// </para>
+/// <para>
+/// <c>QuartzContractResolver</c> attaches this per property, to members typed as a
+/// <see cref="TimeZoneInfo" />, and it is deliberately <em>not</em> in the serializer's converter list:
+/// that list is consulted for a value's runtime type wherever the value appears, so a zone held as an
+/// <see cref="object" /> — a job data map value — would be written as a bare string and lose the
+/// <c>$type</c> that path carries. Scoped to typed members, this reaches every trigger's
+/// <c>TimeZone</c> and nothing else.
 /// </para>
 /// </remarks>
 internal sealed class TimeZoneInfoConverter : JsonConverter

--- a/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
@@ -91,6 +91,7 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
                 new NameValueCollectionConverter(),
                 new StringKeyDirtyFlagMapConverter(),
                 new CronExpressionConverter(),
+                new TimeZoneInfoConverter(),
                 new CalendarConverter(Registry)
             },
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
@@ -91,7 +91,6 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
                 new NameValueCollectionConverter(),
                 new StringKeyDirtyFlagMapConverter(),
                 new CronExpressionConverter(),
-                new TimeZoneInfoConverter(),
                 new CalendarConverter(Registry)
             },
             ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,

--- a/src/Quartz.Serialization.Newtonsoft/QuartzContractResolver.cs
+++ b/src/Quartz.Serialization.Newtonsoft/QuartzContractResolver.cs
@@ -27,6 +27,17 @@ namespace Quartz.Serialization.Newtonsoft;
 /// firing every day.
 /// </para>
 /// <para>
+/// <b>A property typed as a <see cref="TimeZoneInfo" /> travels as its id.</b> The default contract writes
+/// a zone as its whole public surface, every member of which is read-only, so reading one back set nothing
+/// and the owning trigger's getter fell through to <see cref="TimeZoneInfo.Local" /> — a trigger stored under
+/// Tokyo fired on whichever zone the reading machine was in. <see cref="TimeZoneInfoConverter" /> is attached
+/// here, per property, rather than registered on the serializer, because the serializer's converter list is
+/// consulted for a value's runtime type wherever it appears: a <see cref="TimeZoneInfo" /> sitting in a job
+/// data map would be written as a bare string and read back as one, losing the <c>$type</c> that path
+/// carries. Scoped to typed members, the change reaches every trigger's <c>TimeZone</c> and leaves
+/// <see cref="object" />-typed slots exactly as they were.
+/// </para>
+/// <para>
 /// This is a resolver rather than a <c>JsonConverter</c> on purpose: a converter registered on the serializer
 /// is not consulted for a value whose type came from a <c>$type</c> property — a key held in a job data map,
 /// say — and the rules here apply on every path.
@@ -34,6 +45,8 @@ namespace Quartz.Serialization.Newtonsoft;
 /// </remarks>
 internal sealed class QuartzContractResolver : DefaultContractResolver
 {
+    private static readonly TimeZoneInfoConverter timeZoneInfoConverter = new();
+
     public QuartzContractResolver()
     {
         IgnoreSerializableInterface = true;
@@ -64,6 +77,11 @@ internal sealed class QuartzContractResolver : DefaultContractResolver
         if (property.Writable && IsReadOnlyCollection(property.PropertyType))
         {
             property.ObjectCreationHandling = ObjectCreationHandling.Replace;
+        }
+
+        if (property.PropertyType == typeof(TimeZoneInfo))
+        {
+            property.Converter = timeZoneInfoConverter;
         }
 
         return property;

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -78,13 +78,22 @@ public class StdAdoDelegateTest
         jdm["key2"] = null;
         jdm["key3"] = new NonSerializableTestClass();
 
-        try
+        Action serializeApplicationType = () => del.SerializeJobData(jdm);
+
+        if (serializer is SystemTextJsonObjectSerializer)
         {
-            del.SerializeJobData(jdm);
+            // The read side has no polymorphic object deserialization, so a class of the application's
+            // own could never come back as itself. Writing it would put a blob in JOB_DATA that the next
+            // load of this job fails on, which is why the refusal happens here instead.
+            serializeApplicationType.Should().Throw<JsonSerializationException>(
+                    "System.Text.Json refuses at write time a value it could not read back")
+                .Which.Message.Should().Contain("AddTypeInfoResolver",
+                    "the failure has to name the way an application declares a type of its own");
         }
-        catch (SerializationException e)
+        else
         {
-            Assert.Fail($"Private types should be serializable when not using binary serialization: {e}");
+            serializeApplicationType.Should().NotThrow(
+                "with binary serialization out of the picture, a private type is no obstacle to Newtonsoft");
         }
     }
 

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -19,8 +19,11 @@
 
 #endregion
 
+using System.Text.Json.Serialization;
+
 using Quartz.Extensibility;
 using Quartz.Impl;
+using Quartz.Serialization.SystemTextJson;
 
 namespace Quartz.Tests.Unit.Simpl;
 
@@ -33,8 +36,9 @@ namespace Quartz.Tests.Unit.Simpl;
 /// <remarks>
 /// The set covered here is the set <see cref="DataMapExtensions" /> declares an accessor for: those
 /// are the types Quartz teaches an application to store, and so the ones the store format owes an
-/// answer for. Everything past them is the application's own choice — see
-/// <c>QuartzStoreJsonContext</c>, whose remarks spell the closed read side out.
+/// answer for. Everything past them is the application's own choice — see <c>JobDataValues</c>, which
+/// declares what System.Text.Json will write and what it hands back, and refuses the rest at the one
+/// moment anyone can still be told.
 /// </remarks>
 public class JobDataMapPortabilityTest
 {
@@ -116,24 +120,81 @@ public class JobDataMapPortabilityTest
     }
 
     /// <summary>
+    /// The values System.Text.Json refuses to write, because it could never read them back. Each of
+    /// these used to serialize without complaint and throw on the way out, by which time the blob was
+    /// in the database and the failure belonged to whoever next ran the job.
+    /// </summary>
+    private static IEnumerable<TestCaseData> UnreadableValues()
+    {
+        yield return Refused("list", new List<string> { "a", "b" }, "System.Collections.Generic.List");
+        yield return Refused("dictionaryOfObject", new Dictionary<string, object> { ["inner"] = 1 }, "System.Collections.Generic.Dictionary");
+        yield return Refused("nested", new JobDataMap { { "inner", "value" } }, "Quartz.JobDataMap");
+    }
+
+    private static TestCaseData Refused(string key, object value, string expectedTypeName)
+    {
+        return new TestCaseData(key, value, expectedTypeName).SetName("{m}(" + key + ")");
+    }
+
+    [TestCaseSource(nameof(UnreadableValues))]
+    public void AValueTheReaderCannotAcceptIsRefusedOnWrite(string key, object value, string expectedTypeName)
+    {
+        JobDataMap original = new JobDataMap { { key, value } };
+
+        Action write = () => systemTextJsonSerializer.Serialize(original);
+
+        write.Should().Throw<JsonSerializationException>(
+                "a value written now and unreadable later is a blob in the database nobody can load, and the write is the last moment anyone can be told")
+            .Which.Message.Should().Contain(key, "the failure has to say which entry it is about")
+            .And.Contain(expectedTypeName, "and what was in it")
+            .And.Contain("AddTypeInfoResolver", "and how an application declares a type of its own");
+    }
+
+    /// <summary>
+    /// Refusing on write must not close the door an application is told to use. A type declared through
+    /// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" /> is written, and reading it
+    /// back gives what the store format gives for any object: a
+    /// <c>Dictionary&lt;string, string&gt;</c>.
+    /// </summary>
+    [Test]
+    public void ATypeTheApplicationDeclaredIsWrittenAndRead()
+    {
+        JobDataMap original = new JobDataMap { { "report", new ApplicationJobDataValue { Name = "monthly" } } };
+
+        Action withoutDeclaration = () => systemTextJsonSerializer.Serialize(original);
+        withoutDeclaration.Should().Throw<JsonSerializationException>(
+            "an application type Quartz has not been told about is exactly the case the refusal exists for");
+
+        SystemTextJsonSerializerRegistry registry = new();
+        registry.AddTypeInfoResolver(ApplicationJobDataContext.Default);
+        IObjectSerializer declared = new SystemTextJsonObjectSerializer(registry);
+
+        JobDataMap restored = declared.Deserialize<JobDataMap>(declared.Serialize(original))!;
+
+        restored["report"].Should().BeEquivalentTo(new Dictionary<string, string> { ["Name"] = "monthly" },
+            "declaring a type is what lets it be written; the store format still hands an object back as a string map");
+    }
+
+    /// <summary>
     /// Nesting is where the two formats stop agreeing, so this is the guarantee an application gets:
-    /// none. A nested map never comes back as the <see cref="JobDataMap" /> it went in as, and the two
-    /// serializers do not agree on what it does come back as — System.Text.Json's read side is closed
-    /// over the primitives plus <c>Dictionary&lt;string, string&gt;</c>, while Newtonsoft hands back
-    /// its own <c>JObject</c>. Job code that needs structure has to serialize the structure itself and
-    /// store the result as a string.
+    /// none. Newtonsoft writes a nested map and hands back its own <c>JObject</c> or a string map,
+    /// never the <see cref="JobDataMap" /> that went in; System.Text.Json refuses to write one at all.
+    /// Job code that needs structure has to serialize the structure itself and store the result as a
+    /// string.
     /// </summary>
     [Test]
     public void ANestedMapIsNotPartOfThePortableFormat()
     {
         JobDataMap original = new JobDataMap { { "nested", new JobDataMap { { "inner", "value" } } } };
 
-        foreach ((string label, IObjectSerializer writer, IObjectSerializer reader) in Pairings())
+        byte[] written = newtonsoftSerializer.Serialize(original);
+
+        foreach (IObjectSerializer reader in new[] { newtonsoftSerializer, systemTextJsonSerializer })
         {
-            JobDataMap restored = reader.Deserialize<JobDataMap>(writer.Serialize(original))!;
+            JobDataMap restored = reader.Deserialize<JobDataMap>(written)!;
 
             restored["nested"].Should().NotBeOfType<JobDataMap>(
-                "{0}: neither format carries a nested map's identity, so job code must not expect one back", label);
+                "neither format carries a nested map's identity, so job code must not expect one back");
         }
     }
 
@@ -145,3 +206,17 @@ public class JobDataMapPortabilityTest
         yield return ("system.text.json -> system.text.json", systemTextJsonSerializer, systemTextJsonSerializer);
     }
 }
+
+/// <summary>A job data value type of the application's own, which no contract of Quartz's can name.</summary>
+public sealed class ApplicationJobDataValue
+{
+    public string Name { get; set; }
+}
+
+/// <summary>
+/// The metadata an application hands to <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />
+/// so that Quartz will write a job data value of its own.
+/// </summary>
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(ApplicationJobDataValue))]
+internal sealed partial class ApplicationJobDataContext : JsonSerializerContext;

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System.Text;
+using System.Text.Json;
 
 using Quartz.Extensibility;
 using Quartz.Impl;
@@ -293,11 +294,24 @@ public class NewtonsoftLegacyTimeZonePayloadTest
 /// data map — where the slot is typed <see cref="object" /> — is written exactly as it always was.
 /// </summary>
 /// <remarks>
-/// The map payload below is verbatim output of the code at 347392bd, captured before the converter
-/// existed, and the current serializer reproduces it byte for byte. Scoping is what keeps that true: a
-/// converter on the serializer's list is consulted for a value's runtime type wherever it appears, so
-/// a global one would have written the zone as a bare string and dropped the <c>$type</c> that the
-/// object-typed path carries.
+/// <para>
+/// Scoping is what keeps that true: a converter on the serializer's list is consulted for a value's
+/// runtime type wherever it appears, so a global one would have written the zone as a bare string and
+/// dropped the <c>$type</c> that the object-typed path carries.
+/// </para>
+/// <para>
+/// The written shape is asserted member by member rather than against a captured string, because most
+/// of what Json.NET writes for a zone is the running OS's own text: Windows says
+/// <c>"(UTC+09:00) Osaka, Sapporo, Tokyo"</c> where Linux says
+/// <c>"(UTC+09:00) Japan Standard Time (Tokyo)"</c>, and the standard and daylight names differ with
+/// them. Only <c>$type</c> and <c>Id</c> mean the same thing everywhere — and the id is compared
+/// against the zone the test itself resolved rather than a literal, since a Windows id resolves to an
+/// IANA one on Unix and the spelling belongs to the platform.
+/// </para>
+/// <para>
+/// <see cref="JobDataMapWithZone" /> is verbatim output of the code at 347392bd and is used for reading
+/// only, which is safe: what makes that read fail has nothing to do with the names in it.
+/// </para>
 /// </remarks>
 [TestFixture]
 public class NewtonsoftJobDataTimeZoneTest
@@ -309,32 +323,40 @@ public class NewtonsoftJobDataTimeZoneTest
     public void AZoneInAJobDataMapIsWrittenAsItAlwaysWas()
     {
         IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
-        JobDataMap map = new JobDataMap { { "zone", TimeZones.FindById("Tokyo Standard Time") } };
+        TimeZoneInfo tokyo = TimeZones.FindById("Tokyo Standard Time");
+        JobDataMap map = new JobDataMap { { "zone", tokyo } };
 
-        string written = Encoding.UTF8.GetString(serializer.Serialize(map));
+        using JsonDocument written = JsonDocument.Parse(serializer.Serialize(map));
+        JsonElement zone = written.RootElement.GetProperty("zone");
 
-        written.Should().Be(JobDataMapWithZone,
-            "the converter is scoped to typed members, so an object-typed slot keeps the shape - and the $type - that every payload already in a JOB_DATA column carries");
+        zone.ValueKind.Should().Be(JsonValueKind.Object,
+            "the converter is scoped to typed members, so an object-typed slot is left alone - a global one would have collapsed the zone to a bare string");
+        zone.GetProperty("$type").GetString().Should().Be("System.TimeZoneInfo, System.Private.CoreLib",
+            "the $type is what every payload already in a JOB_DATA column carries, and losing it would change the shape of a stored blob");
+        zone.GetProperty("Id").GetString().Should().Be(tokyo.Id,
+            "the id is the one member of a written zone that means the same thing on every platform");
     }
 
     [Test]
     public void ATriggerWritesItsZoneAsTheIdInstead()
     {
         IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+        TimeZoneInfo tokyo = TimeZones.FindById("Tokyo Standard Time");
         CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
         {
             Key = new TriggerKey("calendarInterval", "group"),
             RepeatIntervalUnit = IntervalUnit.Hour,
-            TimeZone = TimeZones.FindById("Tokyo Standard Time"),
+            TimeZone = tokyo,
             StartTimeUtc = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero)
         };
 
-        string written = Encoding.UTF8.GetString(serializer.Serialize(trigger));
+        using JsonDocument written = JsonDocument.Parse(serializer.Serialize(trigger));
+        JsonElement zone = written.RootElement.GetProperty("TimeZone");
 
-        written.Should().Contain("""
-                                 "TimeZone":"Tokyo Standard Time"
-                                 """,
-            "a typed member is where the converter applies, and the id is the only part of a zone another process can use");
+        zone.ValueKind.Should().Be(JsonValueKind.String,
+            "a typed member is where the converter applies, so the whole object collapses to one value");
+        zone.GetString().Should().Be(tokyo.Id,
+            "the id is the only part of a zone another process can use, and its spelling is the resolving platform's own");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System.Text;
+
 using Quartz.Extensibility;
 using Quartz.Impl;
 using Quartz.Impl.Triggers;
@@ -32,19 +34,46 @@ namespace Quartz.Tests.Unit.Simpl;
 /// constructor on every trigger implementation - a constructor whose only parameter has a default
 /// value does not count as one - so each of the five gets a round trip here.
 /// </summary>
-[TestFixture]
+/// <remarks>
+/// Both settings are exercised, because both are shapes a stored trigger comes back through and the
+/// two agree on nothing automatically: with the converters on a trigger is rebuilt from a schedule
+/// builder, and with them off it is a property-by-property read of the object graph. The zone is
+/// asserted on every trigger that carries one, which is what #3494 was: written as an object graph of
+/// read-only properties, a zone read back as nothing at all and the trigger silently adopted the
+/// reading machine's.
+/// </remarks>
+[TestFixture(false)]
+[TestFixture(true)]
 public class NewtonsoftTriggerRoundTripTest
 {
     private static readonly DateTimeOffset startTime = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero);
 
+    /// <summary>
+    /// A zone this machine is not in, so that a trigger whose zone was dropped comes back visibly
+    /// wrong rather than accidentally right. Tokyo unless the test is running there, which is the
+    /// only case the fallback exists for.
+    /// </summary>
+    internal static readonly TimeZoneInfo NonLocalZone = PickNonLocalZone();
+
+    private readonly bool registerTriggerConverters;
+
     private NewtonsoftJsonObjectSerializer serializer;
+
+    public NewtonsoftTriggerRoundTripTest(bool registerTriggerConverters)
+    {
+        this.registerTriggerConverters = registerTriggerConverters;
+    }
 
     [SetUp]
     public void SetUp()
     {
-        // Deliberately left at its default: this is the shape that has to keep working, because the
-        // converters that would otherwise construct the trigger are not registered.
-        serializer = new NewtonsoftJsonObjectSerializer();
+        serializer = new NewtonsoftJsonObjectSerializer { RegisterTriggerConverters = registerTriggerConverters };
+    }
+
+    private static TimeZoneInfo PickNonLocalZone()
+    {
+        TimeZoneInfo tokyo = TimeZones.FindById("Tokyo Standard Time");
+        return tokyo.Equals(TimeZoneInfo.Local) ? TimeZones.FindById("Eastern Standard Time") : tokyo;
     }
 
     [Test]
@@ -74,7 +103,7 @@ public class NewtonsoftTriggerRoundTripTest
             Key = new TriggerKey("cron", "group"),
             JobKey = new JobKey("job", "jobGroup"),
             CronExpressionString = "0/5 * * * * ?",
-            TimeZone = TimeZoneInfo.Utc,
+            TimeZone = NonLocalZone,
             StartTimeUtc = startTime,
             EndTimeUtc = startTime.AddDays(1)
         };
@@ -82,7 +111,7 @@ public class NewtonsoftTriggerRoundTripTest
         CronTriggerImpl restored = RoundTrip(trigger);
 
         restored.CronExpressionString.Should().Be("0/5 * * * * ?");
-        restored.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        restored.TimeZone.Should().Be(NonLocalZone);
     }
 
     [Test]
@@ -94,7 +123,7 @@ public class NewtonsoftTriggerRoundTripTest
             JobKey = new JobKey("job", "jobGroup"),
             RepeatInterval = 3,
             RepeatIntervalUnit = IntervalUnit.Hour,
-            TimeZone = TimeZoneInfo.Utc,
+            TimeZone = NonLocalZone,
             StartTimeUtc = startTime
         };
 
@@ -102,6 +131,8 @@ public class NewtonsoftTriggerRoundTripTest
 
         restored.RepeatInterval.Should().Be(3);
         restored.RepeatIntervalUnit.Should().Be(IntervalUnit.Hour);
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "a day or month interval is counted in the stored zone, so reading it back as the machine's own zone reschedules the job");
     }
 
     [Test]
@@ -116,7 +147,7 @@ public class NewtonsoftTriggerRoundTripTest
             StartTimeOfDay = new TimeOnly(3, 30),
             EndTimeOfDay = new TimeOnly(4, 40),
             DaysOfWeek = [DayOfWeek.Monday, DayOfWeek.Wednesday],
-            TimeZone = TimeZoneInfo.Utc,
+            TimeZone = NonLocalZone,
             StartTimeUtc = startTime
         };
 
@@ -127,6 +158,8 @@ public class NewtonsoftTriggerRoundTripTest
         restored.StartTimeOfDay.Should().Be(new TimeOnly(3, 30));
         restored.EndTimeOfDay.Should().Be(new TimeOnly(4, 40));
         restored.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday });
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "the daily window is wall-clock time in the stored zone, so a lost zone moves every firing");
     }
 
     [Test]
@@ -138,6 +171,7 @@ public class NewtonsoftTriggerRoundTripTest
             JobKey = new JobKey("job", "jobGroup"),
             RecurrenceRule = "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
             TimesTriggered = 3,
+            TimeZone = NonLocalZone,
             StartTimeUtc = startTime,
             EndTimeUtc = startTime.AddDays(30)
         };
@@ -147,6 +181,8 @@ public class NewtonsoftTriggerRoundTripTest
         restored.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
             "the rule is the whole schedule, so a trigger that loses it fires on nothing");
         restored.TimesTriggered.Should().Be(3);
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "the rule is evaluated in the stored zone, so a lost zone is a silently rewritten schedule");
     }
 
     private T RoundTrip<T>(T trigger) where T : class, IOperableTrigger
@@ -160,5 +196,92 @@ public class NewtonsoftTriggerRoundTripTest
         restored.StartTimeUtc.Should().Be(trigger.StartTimeUtc);
         restored.EndTimeUtc.Should().Be(trigger.EndTimeUtc);
         return restored;
+    }
+}
+
+/// <summary>
+/// The plain object graph as it was written before #3494 was fixed, with the whole
+/// <see cref="TimeZoneInfo" /> spelled out. Blobs in this shape are in job store columns now, so the
+/// converter that writes the id from here on has to keep reading them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The literals are verbatim output of the code at 347392bd - <c>NewtonsoftJsonObjectSerializer</c>
+/// with its default settings, serializing a trigger whose zone was Tokyo - captured before the
+/// converter was written, so "it still reads" is a fact about the bytes rather than a reconstruction
+/// of them. The display and standard names are the Windows spellings the capturing machine had; only
+/// <c>Id</c> is ever read, which is exactly why the rest of the object was worthless.
+/// </para>
+/// <para>
+/// Converters off throughout, because this shape is only ever written with them off - with them on the
+/// payload is the <c>TriggerType</c> form <see cref="LegacyJsonPayloadTest" /> covers.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class NewtonsoftLegacyTimeZonePayloadTest
+{
+    private const string LegacyCalendarIntervalTrigger =
+        """{"$type":"Quartz.Impl.Triggers.CalendarIntervalTriggerImpl, Quartz","StartTimeUtc":"2024-07-01T00:00:00+00:00","MisfireInstruction":0,"RepeatIntervalUnit":3,"RepeatInterval":3,"TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"PreserveHourOfDayAcrossDaylightSavings":false,"SkipDayIfHourDoesNotExist":false,"TimesTriggered":0,"MayFireAgain":false,"Key":{"Name":"calendarInterval","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"PreferredNode":{"IsAutomatic":false,"IsNone":true},"JobDataMap":{},"MisfireInstructionCode":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private const string LegacyDailyTimeIntervalTrigger =
+        """{"$type":"Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl, Quartz","StartTimeUtc":"2024-07-01T00:00:00+00:00","RepeatCount":-1,"RepeatIntervalUnit":1,"RepeatInterval":42,"TimesTriggered":0,"TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"MayFireAgain":false,"DaysOfWeek":{"$type":"System.Collections.Generic.HashSet`1[[System.DayOfWeek, System.Private.CoreLib]], System.Private.CoreLib","$values":[1,3]},"StartTimeOfDay":"03:30:00","EndTimeOfDay":"04:40:00","MisfireInstruction":0,"Key":{"Name":"dailyTimeInterval","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"PreferredNode":{"IsAutomatic":false,"IsNone":true},"JobDataMap":{},"MisfireInstructionCode":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private const string LegacyRecurrenceTrigger =
+        """{"$type":"Quartz.Impl.Triggers.RecurrenceTriggerImpl, Quartz","RecurrenceRule":"FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR","TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"TimesTriggered":0,"StartTimeUtc":"2024-07-01T00:00:00+00:00","MisfireInstruction":0,"MayFireAgain":false,"Key":{"Name":"recurrence","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"PreferredNode":{"IsAutomatic":false,"IsNone":true},"JobDataMap":{},"MisfireInstructionCode":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private const string LegacyCronTrigger =
+        """{"$type":"Quartz.Impl.Triggers.CronTriggerImpl, Quartz","CronExpressionString":"0/5 * * * * ?","CronExpression":{"$type":"Quartz.CronExpression, Quartz","CronExpression":"0/5 * * * * ?","TimeZoneId":"Tokyo Standard Time"},"StartTimeUtc":"2024-07-01T00:00:00+00:00","TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"MisfireInstruction":0,"MayFireAgain":false,"Key":{"Name":"cron","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"PreferredNode":{"IsAutomatic":false,"IsNone":true},"JobDataMap":{},"MisfireInstructionCode":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private static TimeZoneInfo Tokyo => TimeZones.FindById("Tokyo Standard Time");
+
+    [Test]
+    public void CalendarIntervalTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        CalendarIntervalTriggerImpl trigger = Deserialize<CalendarIntervalTriggerImpl>(LegacyCalendarIntervalTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.RepeatInterval.Should().Be(3, "the rest of the payload has to read as it always did");
+        trigger.RepeatIntervalUnit.Should().Be(IntervalUnit.Hour);
+    }
+
+    [Test]
+    public void DailyTimeIntervalTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        DailyTimeIntervalTriggerImpl trigger = Deserialize<DailyTimeIntervalTriggerImpl>(LegacyDailyTimeIntervalTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.StartTimeOfDay.Should().Be(new TimeOnly(3, 30));
+        trigger.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday });
+    }
+
+    [Test]
+    public void RecurrenceTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        RecurrenceTriggerImpl trigger = Deserialize<RecurrenceTriggerImpl>(LegacyRecurrenceTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR");
+    }
+
+    /// <summary>
+    /// The cron trigger was the one that escaped the bug, because its zone rides on the
+    /// <see cref="CronExpression" />, which has had a converter all along. It is here so that the
+    /// object form beside it - which is now read too - cannot start contradicting the expression.
+    /// </summary>
+    [Test]
+    public void CronTriggerReadsTheTimeZoneObjectAndTheExpressionAgree()
+    {
+        CronTriggerImpl trigger = Deserialize<CronTriggerImpl>(LegacyCronTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.CronExpression!.TimeZone.Should().Be(Tokyo);
+        trigger.CronExpressionString.Should().Be("0/5 * * * * ?");
+    }
+
+    private static T Deserialize<T>(string json) where T : class
+    {
+        // The default settings, which is what wrote these payloads.
+        IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+        return serializer.Deserialize<T>(Encoding.UTF8.GetBytes(json))!;
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
@@ -285,3 +285,73 @@ public class NewtonsoftLegacyTimeZonePayloadTest
         return serializer.Deserialize<T>(Encoding.UTF8.GetBytes(json))!;
     }
 }
+
+/// <summary>
+/// The converter is attached to typed <see cref="TimeZoneInfo" /> members by
+/// <c>QuartzContractResolver</c>, not registered on the serializer, and this is the difference that
+/// makes: a trigger's <c>TimeZone</c> property is written as its id, while a zone sitting in a job
+/// data map — where the slot is typed <see cref="object" /> — is written exactly as it always was.
+/// </summary>
+/// <remarks>
+/// The map payload below is verbatim output of the code at 347392bd, captured before the converter
+/// existed, and the current serializer reproduces it byte for byte. Scoping is what keeps that true: a
+/// converter on the serializer's list is consulted for a value's runtime type wherever it appears, so
+/// a global one would have written the zone as a bare string and dropped the <c>$type</c> that the
+/// object-typed path carries.
+/// </remarks>
+[TestFixture]
+public class NewtonsoftJobDataTimeZoneTest
+{
+    private const string JobDataMapWithZone =
+        """{"zone":{"$type":"System.TimeZoneInfo, System.Private.CoreLib","Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false}}""";
+
+    [Test]
+    public void AZoneInAJobDataMapIsWrittenAsItAlwaysWas()
+    {
+        IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+        JobDataMap map = new JobDataMap { { "zone", TimeZones.FindById("Tokyo Standard Time") } };
+
+        string written = Encoding.UTF8.GetString(serializer.Serialize(map));
+
+        written.Should().Be(JobDataMapWithZone,
+            "the converter is scoped to typed members, so an object-typed slot keeps the shape - and the $type - that every payload already in a JOB_DATA column carries");
+    }
+
+    [Test]
+    public void ATriggerWritesItsZoneAsTheIdInstead()
+    {
+        IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            Key = new TriggerKey("calendarInterval", "group"),
+            RepeatIntervalUnit = IntervalUnit.Hour,
+            TimeZone = TimeZones.FindById("Tokyo Standard Time"),
+            StartTimeUtc = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        string written = Encoding.UTF8.GetString(serializer.Serialize(trigger));
+
+        written.Should().Contain("""
+                                 "TimeZone":"Tokyo Standard Time"
+                                 """,
+            "a typed member is where the converter applies, and the id is the only part of a zone another process can use");
+    }
+
+    /// <summary>
+    /// Reading that job data payload back has never worked: <c>IgnoreSerializableInterface</c> keeps
+    /// Json.NET off <see cref="TimeZoneInfo" />'s <c>ISerializable</c> implementation, and every public
+    /// member it writes instead is read-only, so there is nothing to construct the zone from. Recorded
+    /// here because it is a limitation this change deliberately neither introduces nor repairs — the
+    /// scoping is what proves it unchanged, and a job that needs a zone in its data should store the id.
+    /// </summary>
+    [Test]
+    public void ReadingThatZoneBackHasNeverWorked()
+    {
+        IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+
+        Action read = () => serializer.Deserialize<JobDataMap>(Encoding.UTF8.GetBytes(JobDataMapWithZone));
+
+        read.Should().Throw<JsonSerializationException>(
+            "a TimeZoneInfo has no constructor Json.NET can call, which is why a job data map should hold the id and not the zone");
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/StoreFormatSourceGenerationTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/StoreFormatSourceGenerationTest.cs
@@ -162,6 +162,26 @@ public class StoreFormatSourceGenerationTest
             "every type DataMapExtensions declares an accessor for is a type Quartz teaches an application to store, so a trimmed application must be able to write it");
     }
 
+    /// <summary>
+    /// <c>JobDataValues</c> is the one list the writer refuses against, so every type on it has to be
+    /// answerable without reflection too. A type accepted on write and unanswerable in a trimmed
+    /// publish would be refused nothing and then fail at the writer anyway, which is the failure the
+    /// refusal exists to replace.
+    /// </summary>
+    [Test]
+    public void EveryAcceptedJobDataValueTypeIsAnsweredWithoutReflection()
+    {
+        JsonSerializerOptions options = new TestSerializer(new SystemTextJsonSerializerRegistry(), withoutReflection: true).Options();
+
+        foreach (Type accepted in JobDataValues.Accepted)
+        {
+            Action resolve = () => options.GetTypeInfo(accepted);
+
+            resolve.Should().NotThrow(
+                $"{accepted.Name} is a value the writer accepts, so QuartzStoreJsonContext has to name it");
+        }
+    }
+
     [Test]
     public void CronExpressionAndNameValueCollectionRoundTripWithoutReflection()
     {

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -59,17 +59,6 @@ public class CalendarIntervalTriggerImpl : TriggerBase, ICalendarIntervalTrigger
     private int repeatInterval;
     internal TimeZoneInfo? timeZone;
 
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doing the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value is null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
-
     /// <summary>
     /// Create a <see cref="ICalendarIntervalTrigger" /> with no settings.
     /// </summary>

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -182,22 +182,11 @@ public class CronTriggerImpl : TriggerBase, ICronTrigger
     private DateTimeOffset startTimeUtc = DateTimeOffset.MinValue;
     private DateTimeOffset? endTimeUtc;
 
+    // With binary serialization the time zone does not need serializing, since it is part of the
+    // CronExpression. With JSON serialization the cron expression is written as a string as well as an
+    // object, so the zone is written separately - as its id, by TimeZoneInfoConverter on the Newtonsoft
+    // side and by the trigger serializers on both.
     [NonSerialized] private TimeZoneInfo? timeZone;
-
-    // With binary serialization, the timeZone doesn't need serialized since it is part of the CronExpression.
-    // With json serialization, however, the cron expression is only serialized as a string (CronExpressionString),
-    // so the TimeZone needs serialized separately.
-    //
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doing the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value is null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
 
     /// <summary>
     /// Create a <see cref="CronTriggerImpl" /> with no settings.

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -103,17 +103,6 @@ public class DailyTimeIntervalTriggerImpl : TriggerBase, IDailyTimeIntervalTrigg
     private int repeatCount = RepeatIndefinitely;
     internal TimeZoneInfo? timeZone;
 
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value is null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
-
     /// <summary>
     /// Create a  <see cref="IDailyTimeIntervalTrigger"/> with no settings.
     /// </summary>

--- a/src/Quartz/Serialization/SystemTextJson/Converters/JobDataMapConverter.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Converters/JobDataMapConverter.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Quartz.Serialization.SystemTextJson.Converters;
 
-internal sealed class JobDataMapConverter : JsonConverter<JobDataMap>
+internal sealed class JobDataMapConverter(SystemTextJsonSerializerRegistry registry) : JsonConverter<JobDataMap>
 {
     public override JobDataMap Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -23,7 +23,13 @@ internal sealed class JobDataMapConverter : JsonConverter<JobDataMap>
     {
         try
         {
-            writer.WriteJobDataMapValue(value, options);
+            writer.WriteJobDataMapValue(value, options, registry);
+        }
+        // A refusal already says which entry it is about and what to do; wrapping it in a second
+        // exception of the same type would only bury that behind "Failed to serialize JobDataMap".
+        catch (JsonSerializationException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Quartz/Serialization/SystemTextJson/Converters/TriggerConverter.cs
+++ b/src/Quartz/Serialization/SystemTextJson/Converters/TriggerConverter.cs
@@ -99,7 +99,7 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
             writer.WriteString(options.GetPropertyName("Description"), value.Description);
             writer.WriteString(options.GetPropertyName("CalendarName"), value.CalendarName);
             writer.WritePropertyName(options.GetPropertyName("JobDataMap"));
-            writer.WriteJobDataMapValue(value.JobDataMap, options);
+            writer.WriteJobDataMapValue(value.JobDataMap, options, registry);
             writer.WriteNumber(options.GetPropertyName("MisfireInstruction"), value.MisfireInstructionCode);
             writer.WriteString(options.GetPropertyName("StartTimeUtc"), value.StartTimeUtc);
             writer.WriteString(options.GetPropertyName("EndTimeUtc"), value.EndTimeUtc);
@@ -121,6 +121,12 @@ internal sealed class TriggerConverter(SystemTextJsonSerializerRegistry registry
 
             triggerSerializer.SerializeFields(writer, value, options);
             writer.WriteEndObject();
+        }
+        // A job data value the reader could not accept is refused by name; wrapping that in a second
+        // exception of the same type would only bury which entry it was about.
+        catch (JsonSerializationException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
+++ b/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
@@ -1,0 +1,159 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Frozen;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Quartz.Serialization.SystemTextJson;
+
+/// <summary>
+/// What a job data value may be, in both directions: the set <see cref="Refuse" /> lets past on the
+/// way in, and the shapes <see cref="Read" /> hands back on the way out.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two halves live here together because they were apart, and disagreed. The read side has always
+/// been closed — a stored value comes back as a string, a bool, an int, a long, a double, null or a
+/// <c>Dictionary&lt;string, string&gt;</c>, and there is no polymorphic <see cref="object" />
+/// deserialization, which is what keeps a trimmed publish honest. The write side was not closed to
+/// match: it wrote whatever the runtime could serialize, so a <c>List&lt;string&gt;</c> went into the
+/// database happily and threw on the way back out — by which time the blob was already stored, and
+/// unreadable. A writer that consults the same declaration cannot drift from the reader again.
+/// </para>
+/// <para>
+/// <see cref="Accepted" /> is the set <see cref="DataMapExtensions" /> declares an accessor for, plus
+/// the one object shape the reader produces. Several of them are not read back as themselves — a
+/// <see cref="char" /> is written as a string, a <see cref="decimal" /> as a number — and that is the
+/// store format rather than an oversight: the accessors coerce, which is what they are for. Enums are
+/// accepted by rule rather than by name, because they are written as their number and read back as
+/// one, and no list can enumerate an application's own.
+/// </para>
+/// <para>
+/// Past those, a value is the application's own choice, and
+/// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" /> is how it declares one. That is
+/// the same escape hatch a trimmed publish needs, so a type an application has already answered for is
+/// a type this refuses nothing about.
+/// </para>
+/// </remarks>
+internal static class JobDataValues
+{
+    /// <summary>
+    /// The value types a persistent store's JSON accepts by name. Every one of them is answered by
+    /// <see cref="QuartzStoreJsonContext" /> too, so a trimmed publish can write them all;
+    /// <c>StoreFormatSourceGenerationTest</c> is what fails when the two stop agreeing.
+    /// </summary>
+    internal static readonly FrozenSet<Type> Accepted = FrozenSet.ToFrozenSet(
+    [
+        // Read back as themselves.
+        typeof(string),
+        typeof(bool),
+        typeof(int),
+        typeof(long),
+        typeof(double),
+        typeof(Dictionary<string, string>),
+
+        // Written as a string or a number, and read back as one; the DataMapExtensions accessors coerce.
+        typeof(char),
+        typeof(float),
+        typeof(decimal),
+        typeof(DateTime),
+        typeof(DateTimeOffset),
+        typeof(TimeSpan),
+        typeof(Guid),
+        typeof(DateOnly),
+        typeof(TimeOnly)
+    ]);
+
+    /// <summary>
+    /// Throws unless <paramref name="value" /> is one the reader will accept back.
+    /// </summary>
+    /// <remarks>
+    /// The check is by runtime type rather than by trying the write and inspecting what came out,
+    /// because refusing has to happen before a single byte reaches the column.
+    /// </remarks>
+    /// <exception cref="JsonSerializationException">
+    /// The value is of a type no reader can turn back into it, and the application has not declared one.
+    /// </exception>
+    public static void Refuse(string key, object? value, JsonSerializerOptions options, SystemTextJsonSerializerRegistry registry)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        Type type = value.GetType();
+        if (Accepted.Contains(type) || type.IsEnum || registry.DeclaresJobDataValueType(type, options))
+        {
+            return;
+        }
+
+        throw new JsonSerializationException(
+            $"Job data entry '{key}' holds a {type.FullName}, which a persistent store cannot read back. " +
+            "A job data value has to be one of the types JobDataMap declares an accessor for " +
+            "(string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid, DateOnly, TimeOnly or an enum), " +
+            "a Dictionary<string, string>, or a type the application declares through SystemTextJsonSerializerRegistry.AddTypeInfoResolver. " +
+            "Anything with structure of its own has to be serialized by the job and stored as a string.");
+    }
+
+    /// <summary>
+    /// Turns one stored entry back into the value a job reads, which is the whole of what a job data
+    /// blob can say.
+    /// </summary>
+    public static object? Read(JsonElement value, JsonSerializerOptions options)
+    {
+        switch (value.ValueKind)
+        {
+            case JsonValueKind.String:
+                return value.GetString();
+
+            case JsonValueKind.True:
+                return true;
+
+            case JsonValueKind.False:
+                return false;
+
+            case JsonValueKind.Null:
+                return null;
+
+            case JsonValueKind.Number:
+                if (value.TryGetInt32(out int intValue))
+                {
+                    return intValue;
+                }
+
+                if (value.TryGetInt64(out long longValue))
+                {
+                    return longValue;
+                }
+
+                return value.GetDouble();
+
+            case JsonValueKind.Object:
+                // The one shape past the primitives a job data value comes back as, and the reason
+                // Dictionary<string, string> is both named in QuartzStoreJsonContext and accepted above.
+                return value.Deserialize((JsonTypeInfo<Dictionary<string, string>>) options.GetTypeInfo(typeof(Dictionary<string, string>)));
+
+            default:
+                throw new JsonException($"Unsupported value kind: {value.ValueKind}");
+        }
+    }
+}

--- a/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
+++ b/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
@@ -53,6 +53,14 @@ namespace Quartz.Serialization.SystemTextJson;
 /// the same escape hatch a trimmed publish needs, so a type an application has already answered for is
 /// a type this refuses nothing about.
 /// </para>
+/// <para>
+/// The gate lives in <c>JobDataMapConverter</c>, which <c>AddQuartzConverters</c> registers for the
+/// store serializer and for the HTTP API alike — so the refusal reaches a job data map on its way into
+/// an HTTP response too, and deliberately: the client's reader is this same closed one, so a value the
+/// server could not read back is one the client cannot either. That is why the message says "Quartz's
+/// JSON format" rather than naming a database, and why the way out it names —
+/// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" /> — is the right one on both.
+/// </para>
 /// </remarks>
 internal static class JobDataValues
 {
@@ -107,7 +115,7 @@ internal static class JobDataValues
         }
 
         throw new JsonSerializationException(
-            $"Job data entry '{key}' holds a {type.FullName}, which a persistent store cannot read back. " +
+            $"Job data entry '{key}' holds a {type.FullName}, which Quartz's JSON format cannot read back. " +
             "A job data value has to be one of the types JobDataMap declares an accessor for " +
             "(string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid, DateOnly, TimeOnly or an enum), " +
             "a Dictionary<string, string>, or a type the application declares through SystemTextJsonSerializerRegistry.AddTypeInfoResolver. " +

--- a/src/Quartz/Serialization/SystemTextJson/QuartzStoreJsonContext.cs
+++ b/src/Quartz/Serialization/SystemTextJson/QuartzStoreJsonContext.cs
@@ -73,12 +73,12 @@ namespace Quartz.Serialization.SystemTextJson;
 /// </item>
 /// <item>
 /// <description>
-/// What a <see cref="JobDataMap" /> holds. The read side is closed —
-/// <c>SerializationExtensions.GetJobDataMap</c> produces a string, a bool, an int, a long, a double,
-/// null or a <c>Dictionary&lt;string, string&gt;</c> and nothing else — and the write side is not, but
-/// the types <c>DataMapExtensions</c> declares an accessor for are the ones Quartz teaches an
-/// application to store. Anything past them is the application's own choice, and reaches Quartz
-/// through <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />.
+/// What a <see cref="JobDataMap" /> holds. Both sides are closed, over the one set
+/// <see cref="JobDataValues" /> declares: the reader produces a string, a bool, an int, a long, a
+/// double, null or a <c>Dictionary&lt;string, string&gt;</c> and nothing else, and the writer refuses
+/// a value it could not produce. Every type in that set is listed here, so a trimmed application can
+/// write all of it. Anything past them is the application's own choice, and reaches Quartz through
+/// <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />.
 /// </description>
 /// </item>
 /// </list>
@@ -122,5 +122,7 @@ namespace Quartz.Serialization.SystemTextJson;
 [JsonSerializable(typeof(DateTimeOffset))]
 [JsonSerializable(typeof(TimeSpan))]
 [JsonSerializable(typeof(Guid))]
+[JsonSerializable(typeof(DateOnly))]
+[JsonSerializable(typeof(TimeOnly))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
 internal sealed partial class QuartzStoreJsonContext : JsonSerializerContext;

--- a/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SerializationExtensions.cs
@@ -285,18 +285,35 @@ internal static class Utf8JsonWriterExtensions
     }
 
     /// <summary>
-    /// Writes a job data map's entries, each value as whatever the application stored.
+    /// Writes a job data map's entries, each value as whatever the application stored — and refuses
+    /// one the reader will not be able to turn back into it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The value is written as <see cref="object" />, so its runtime type is looked up through the
     /// options' resolver chain — the closed set Quartz names, then the scheduler's registry, then
     /// reflection where a publish left any. Asking for that metadata here rather than passing the
     /// options to <see cref="JsonSerializer" /> is what makes this method trimming- and AOT-clean: the
     /// overloads taking <see cref="JsonSerializerOptions" /> are <c>RequiresUnreferencedCode</c> and
     /// <c>RequiresDynamicCode</c> wholesale, whatever they are handed.
+    /// </para>
+    /// <para>
+    /// Reflection being able to write a value is not the same as the reader being able to read it, and
+    /// that gap is what <see cref="JobDataValues.Refuse" /> closes. It runs before the entry's name is
+    /// written, so a map with one unreadable value in it puts nothing at all in the column.
+    /// </para>
     /// </remarks>
-    public static void WriteJobDataMapValue(this Utf8JsonWriter writer, JobDataMap jobDataMap, JsonSerializerOptions options)
+    public static void WriteJobDataMapValue(
+        this Utf8JsonWriter writer,
+        JobDataMap jobDataMap,
+        JsonSerializerOptions options,
+        SystemTextJsonSerializerRegistry registry)
     {
+        foreach (var pair in jobDataMap)
+        {
+            JobDataValues.Refuse(pair.Key, pair.Value, options, registry);
+        }
+
         writer.WriteStartObject();
 
         JsonTypeInfo valueTypeInfo = options.GetTypeInfo(typeof(object));
@@ -315,45 +332,7 @@ internal static class Utf8JsonWriterExtensions
 
         foreach (JsonProperty property in jsonElement.EnumerateObject())
         {
-            object? value;
-            switch (property.Value.ValueKind)
-            {
-                case JsonValueKind.String:
-                    value = property.Value.GetString();
-                    break;
-                case JsonValueKind.True:
-                    value = true;
-                    break;
-                case JsonValueKind.False:
-                    value = false;
-                    break;
-                case JsonValueKind.Null:
-                    value = null;
-                    break;
-                case JsonValueKind.Number:
-                    if (property.Value.TryGetInt32(out int intValue))
-                    {
-                        value = intValue;
-                    }
-                    else if (property.Value.TryGetInt64(out long longValue))
-                    {
-                        value = longValue;
-                    }
-                    else
-                    {
-                        value = property.Value.GetDouble();
-                    }
-                    break;
-                case JsonValueKind.Object:
-                    // The one shape past the primitives a job data value comes back as, and the reason
-                    // Dictionary<string, string> is named in QuartzStoreJsonContext.
-                    value = property.Value.Deserialize((JsonTypeInfo<Dictionary<string, string>>) options.GetTypeInfo(typeof(Dictionary<string, string>)));
-                    break;
-                default:
-                    throw new JsonException($"Unsupported value kind: {property.Value.ValueKind}");
-            }
-
-            result.Add(property.Name, value);
+            result.Add(property.Name, JobDataValues.Read(property.Value, options));
         }
 
         result.ClearDirtyFlag();

--- a/src/Quartz/Serialization/SystemTextJson/SystemTextJsonSerializerRegistry.cs
+++ b/src/Quartz/Serialization/SystemTextJson/SystemTextJsonSerializerRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -40,14 +41,16 @@ public sealed class SystemTextJsonSerializerRegistry
     private readonly SerializerMap<ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
     private readonly SerializerMap<ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<Type, Func<JsonSerializerOptions, JsonConverter, JsonTypeInfo>> registeredTypeInfos = [];
-    private readonly List<IJsonTypeInfoResolver> resolvers;
+    private readonly RegisteredTypeResolver registeredTypeResolver;
+    private readonly List<IJsonTypeInfoResolver> applicationResolvers = [];
+    private readonly ConcurrentDictionary<Type, bool> declaredJobDataValueTypes = new();
 
     /// <summary>
     /// Creates a registry holding the serializers for the built-in trigger and calendar types.
     /// </summary>
     public SystemTextJsonSerializerRegistry()
     {
-        resolvers = [new RegisteredTypeResolver(registeredTypeInfos)];
+        registeredTypeResolver = new RegisteredTypeResolver(registeredTypeInfos);
 
         AddTriggerSerializer<CalendarIntervalTriggerImpl>(new CalendarIntervalTriggerSerializer());
         AddTriggerSerializer<CronTriggerImpl>(new CronTriggerSerializer());
@@ -128,7 +131,8 @@ public sealed class SystemTextJsonSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(resolver);
 
-        resolvers.Add(resolver);
+        applicationResolvers.Add(resolver);
+        declaredJobDataValueTypes.Clear();
         return this;
     }
 
@@ -137,7 +141,44 @@ public sealed class SystemTextJsonSerializerRegistry
     /// the types registered here first, then whatever the application handed to
     /// <see cref="AddTypeInfoResolver" />.
     /// </summary>
-    internal IReadOnlyList<IJsonTypeInfoResolver> TypeInfoResolvers => resolvers;
+    internal IReadOnlyList<IJsonTypeInfoResolver> TypeInfoResolvers => [registeredTypeResolver, .. applicationResolvers];
+
+    /// <summary>
+    /// Whether the application has declared metadata for <paramref name="type" /> through
+    /// <see cref="AddTypeInfoResolver" />, which is what makes it a job data value Quartz will write.
+    /// </summary>
+    /// <remarks>
+    /// Only the application's own resolvers are asked. Quartz's contract is not, because it answers for
+    /// the store's own shapes — a <see cref="JobDataMap" />, a trigger, a calendar — and none of those
+    /// is something a job data map may hold; and reflection is not, because being able to write a value
+    /// is exactly what the reader has never been able to honour. The answers are cached, since a job
+    /// data map holding an application's type is written again on every store update.
+    /// </remarks>
+    internal bool DeclaresJobDataValueType(Type type, JsonSerializerOptions options)
+    {
+        if (applicationResolvers.Count == 0)
+        {
+            return false;
+        }
+
+        if (declaredJobDataValueTypes.TryGetValue(type, out bool declared))
+        {
+            return declared;
+        }
+
+        declared = false;
+        for (int i = 0; i < applicationResolvers.Count; i++)
+        {
+            if (applicationResolvers[i].GetTypeInfo(type, options) is not null)
+            {
+                declared = true;
+                break;
+            }
+        }
+
+        declaredJobDataValueTypes[type] = declared;
+        return declared;
+    }
 
     internal ITriggerSerializer GetTriggerSerializer(string? typeName)
     {

--- a/src/Quartz/SystemTextJsonConfigurationExtensions.cs
+++ b/src/Quartz/SystemTextJsonConfigurationExtensions.cs
@@ -49,7 +49,7 @@ public static class SystemTextJsonConfigurationExtensions
     {
         options.Converters.Add(new CalendarConverter(registry, newtonsoftCompatibilityMode));
         options.Converters.Add(new CronExpressionConverter());
-        options.Converters.Add(new JobDataMapConverter());
+        options.Converters.Add(new JobDataMapConverter(registry));
         options.Converters.Add(new JobKeyConverter());
         options.Converters.Add(new TriggerKeyConverter());
         options.Converters.Add(new NameValueCollectionConverter());


### PR DESCRIPTION
Two serialization defects #3491's round-trip work turned up. One commit each; both are about the same
thing from opposite ends — a writer that put something in the database the reader could not get back
out.

Closes #3494
Closes #3495

## A trigger written as a plain object graph keeps its time zone (#3494)

`UseNewtonsoftJsonSerializer` leaves `registerTriggerConverters` off by default, and with it off a
trigger is written property by property. Json.NET's default contract wrote a `TimeZoneInfo` as its
whole public surface — `Id`, `DisplayName`, `BaseUtcOffset`, all read-only — so reading the object back
set nothing and the trigger's getter fell through to `TimeZoneInfo.Local`. A trigger stored under Tokyo
fired on whichever zone the reading machine was in, silently.

`TimeZoneInfoConverter` (internal) writes the id and reads both the id and the old object form. It is
attached per property by `QuartzContractResolver` to members *typed* as a `TimeZoneInfo`, and is
deliberately not in the serializer's converter list — that list is consulted for a value's runtime type
wherever it appears, so a zone held in an `object`-typed slot (a job data map value) would have been
written as a bare string and lost the `$type` that path carries. Scoped this way it reaches every
trigger's `TimeZone` and nothing else; a job-data zone is written byte for byte as before.
`CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and `RecurrenceTriggerImpl` were
affected; `CronTriggerImpl` escaped because its zone rides on the `CronExpression`, which has always
had a converter. The private `timeZoneInfoId` helpers on those trigger implementations were meant for
exactly this and never worked — `DefaultContractResolver` does not serialize private members — so they
are gone and the converter does the job.

**What the tests prove.** `NewtonsoftTriggerRoundTripTest` is now parameterized on
`registerTriggerConverters`, so all five triggers round-trip both ways, and the zone is asserted on
every trigger that carries one against a zone the test machine is not in. Six of the new assertions
fail on the unfixed tree: the three affected triggers' converters-off round trips and the three legacy
reads.

**Legacy fixture provenance.** The payloads in `NewtonsoftLegacyTimeZonePayloadTest` are verbatim
output of the code at `347392bd` — `NewtonsoftJsonObjectSerializer` with its default settings,
serializing a trigger whose zone was `Tokyo Standard Time` — dumped to disk from a throwaway test
*before* the converter was written and pasted in unedited, Windows display names and all. "It still
reads" is therefore a fact about those bytes rather than a reconstruction of what they probably were.
Only `Id` is ever read, which is precisely why the rest of the object was worthless.

**Reviewer decision: the `3.x` companion.** Not opened, per the brief. It is mechanical, with four
things to know: the converter drops into 3.x's `Quartz.Converters` namespace and the same
`CreateSerializerSettings` list; there are **four** dead `timeZoneInfoId` helpers there, not three,
because 3.x's `RecurrenceTriggerImpl` has one too; 3.x source files carry a BOM; and the tests have to
be written fresh, because none of #3491's four exist on that branch. The existing
`JsonObjectSerializerTest_*.verified.txt` snapshots are the converters-*on* form (`"TimeZone": "UTC"`),
so they do not move.

## System.Text.Json refuses a job data value it cannot read back (#3495)

The read side is closed on purpose — string, bool, int, long, double, null or
`Dictionary<string, string>`, with no polymorphic `object` deserialization, which is what keeps a
trimmed publish honest. The write side was not closed to match, so a `JobDataMap` holding a
`List<string>` serialized happily and threw on read, with the blob already in the database.

`JobDataValues` is now the one declaration both halves read from — the set the writer admits and the
shapes the reader hands back, in one file. The refusal runs before the first byte is written, so a map
with one bad value in it puts nothing at all in the column, and the message names the entry, its
runtime type and `SystemTextJsonSerializerRegistry.AddTypeInfoResolver`. Enums are accepted by rule
rather than by name: they go out as a number and come back as one, and no list can enumerate an
application's own.

`DateOnly` and `TimeOnly` join `QuartzStoreJsonContext`. They have `DataMapExtensions` accessors and so
belong to the accepted set, and every type on that set has to be answerable with reflection off —
`StoreFormatSourceGenerationTest` now fails if the list and the context stop agreeing. This also closes
a latent gap: a `DateOnly` in job data would have failed a trimmed publish before.

**What the tests prove.** `JobDataMapPortabilityTest` gains the three negative cases (`List<string>`,
`Dictionary<string, object>`, a nested `JobDataMap`), each asserting the message names the key, the
type and `AddTypeInfoResolver`; and a positive control where an application type is refused without
`AddTypeInfoResolver`, written with it, and read back as the string map the store format gives for any
object. All four fail with the gate neutralised.

### Two things a reviewer should weigh

**1. The refusal is in `JobDataMapConverter`, so it applies to the HTTP API too.** That converter is
registered by `AddQuartzConverters`, which both the store serializer and `HttpApiJson` use, and both
have the same closed reader. Today a `List<string>` in job data means the server writes a response the
client cannot parse; after this the server refuses instead. Both are failures — the new one is earlier
and says what to do — but it is a behaviour change beyond the store, and putting the check only in the
store path would mean two gates instead of one list. The #3495 migration note now states this outcome
explicitly, and the exception says "Quartz's JSON format" rather than naming a database so that it reads
correctly in front of an HTTP caller. `Quartz.Tests.AspNetCore` is green (527 tests).

**2. `StdAdoDelegateTest.TestSerializeJobData` changed its expectation.** It asserted that a private
application class serializes once binary serialization is out of the picture. That still holds for
Newtonsoft and is now deliberately false for System.Text.Json, so the test states each case per
serializer. Flagging it because flipping a green test is worth a second opinion — the alternative is
letting `SystemTextJsonObjectSerializer` keep writing a blob that cannot be loaded.

## Verification

Run on Windows, against a live Docker daemon (29.5.3):

| | |
|---|---|
| `dotnet build Quartz.slnx` | Build succeeded, **0 Warning(s), 0 Error(s)** — trim/AOT analyzers clean, no new baseline entry |
| `dotnet test src/Quartz.Tests.Unit` | **Failed: 0, Passed: 3616, Skipped: 4, Total: 3620** |
| `dotnet test src/Quartz.Tests.AspNetCore` | **Failed: 0, Passed: 527** |
| integration, `basic` leg | **Failed: 0, Passed: 329** |
| integration, `postgres` leg | **Failed: 0, Passed: 149** (`AdoSchedulerTest`, which runs both serializers, is 18 of them) |
| `dotnet fallout PublishTrimmed` | Succeeded — canary passes every trigger, calendar, `JobDataMap`, `NameValueCollection` and `CronExpression`, plus the SQLite store and configuration binding, with `IsReflectionEnabledByDefault: False` |
| `dotnet fallout VerifyDocsSnippets` | Succeeded — 93 markdown files up to date |

The public API baselines did not move: the new converter and `JobDataValues` are internal, the removed
trigger members were private, and the registry gained only an internal method. `PublicApiTest` is green
inside the unit run above.

The `IntegrationTest` target is gated to `Host is GitHubActions && Linux`, so the two legs were
reproduced directly with the same `QUARTZ_TEST_DATABASE` value and category filter the target builds.
There is no `Quartz.Tests.AOT` project on this base — `Quartz.Trimming.Canary`, via `PublishTrimmed`
above, is what covers that ground.

## A `TimeZoneInfo` held as a job data *value*

Scoping the converter leaves this path exactly as it was, which is the point — but "as it was" means
broken, and that is worth knowing rather than assuming. Captured from the base tree: it writes
`{"$type":"System.TimeZoneInfo, …","Id":"Tokyo Standard Time", …}` and **throws on read**.
`QuartzContractResolver` sets `IgnoreSerializableInterface = true`, so Json.NET never uses
`TimeZoneInfo`'s `ISerializable` implementation; the public members it writes instead are all read-only
and there is no constructor to feed. Writing `$type` explicitly does not rescue it either — with the
slot declared `object`, Json.NET resolves the type name and then takes the object-contract path instead
of dispatching to the converter, so no converter can fix this case.

`NewtonsoftJobDataTimeZoneTest` therefore pins what scoping guarantees (the payload is unchanged,
asserted against the captured bytes) and records the read failure as the pre-existing limitation it is.
A job that needs a zone in its data should store the id. Repairing the `object`-typed case needs
something other than a converter and belongs in its own issue.

## Documentation

- `docs/documentation/quartz-4.x/migration-guide.md` — a section per issue, in the JSON Serialization
  part.
- `docs/documentation/quartz-4.x/tutorial/job-data-map.md` — which value types a persistent store
  accepts and how to declare one, under "Why string-safe storage matters".
- `docs/documentation/quartz-3.x/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
