### PR TITLE
Job execution's guarantees are asserted rather than described

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1876,6 +1876,104 @@ public abstract class JobStoreContractTest
     protected abstract string StoreInstanceId { get; }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Persisting a job's data map across firings
+    //
+    // PersistJobDataAfterExecution exists for one thing: what the job wrote into its data map is
+    // there the next time it runs. On the in-memory store that is a reference and would pass by
+    // accident; on an ADO store it is a round trip through the serializer and a JOB_DATA update. So
+    // the assertion is not "the store kept it" but "the next firing was handed it".
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task APersistentJobsDataMapIsWrittenBackAndHandedToTheNextFiring()
+    {
+        IJobDetail job = CreateJob<PersistentContractTestJob>("persistent", JobGroupA, new JobDataMap
+        {
+            ["count"] = 1,
+            ["watermark"] = "before",
+        });
+
+        IOperableTrigger trigger = CreateTrigger("persistent", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        await Store.ScheduleJob(job, trigger);
+
+        (IOperableTrigger firing, IJobDetail fired) = await FireOnce(trigger);
+
+        fired.PersistJobDataAfterExecution.Should().BeTrue(
+            "the store has to hand the firing a job detail that knows its data map is persistent, "
+            + "since that is what it reads when the firing ends");
+
+        // What a job does in Execute: it mutates the data map on the detail its context carries.
+        fired.JobDataMap["count"] = 2;
+        fired.JobDataMap["watermark"] = "after";
+
+        await Store.TriggeredJobComplete(firing, fired, SchedulerInstruction.NoInstruction);
+
+        IJobDetail stored = await Store.GetJob(job.Key);
+        stored.JobDataMap["count"].Should().Be(2,
+            "the point of the attribute is that the value the job wrote is the value the store now holds");
+        stored.JobDataMap["watermark"].Should().Be("after");
+
+        (_, IJobDetail refired) = await FireOnce(trigger);
+        refired.JobDataMap["count"].Should().Be(2,
+            "the next firing has to be handed what the previous one wrote, which is the whole reason for the attribute");
+        refired.JobDataMap["watermark"].Should().Be("after");
+    }
+
+    [Test]
+    public async Task AJobThatDoesNotPersistItsDataMapIsHandedTheStoredOneEveryTime()
+    {
+        IJobDetail job = CreateJob<ContractTestJob>("volatile-data", JobGroupA, new JobDataMap
+        {
+            ["count"] = 1,
+        });
+
+        IOperableTrigger trigger = CreateTrigger("volatile-data", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        await Store.ScheduleJob(job, trigger);
+
+        (IOperableTrigger firing, IJobDetail fired) = await FireOnce(trigger);
+
+        fired.PersistJobDataAfterExecution.Should().BeFalse("this job type carries no such attribute");
+
+        fired.JobDataMap["count"] = 99;
+
+        await Store.TriggeredJobComplete(firing, fired, SchedulerInstruction.NoInstruction);
+
+        IJobDetail stored = await Store.GetJob(job.Key);
+        stored.JobDataMap["count"].Should().Be(1,
+            "without the attribute a firing's data map is scratch space, and what it scribbled must not "
+            + "become the schedule's idea of the job");
+
+        (_, IJobDetail refired) = await FireOnce(trigger);
+        refired.JobDataMap["count"].Should().Be(1,
+            "every firing of such a job starts from the same stored map");
+    }
+
+    /// <summary>
+    /// Takes the given trigger through one acquisition and firing, handing back the trigger carrying
+    /// the fire instance and the job detail the store built for it.
+    /// </summary>
+    private async Task<(IOperableTrigger Firing, IJobDetail JobDetail)> FireOnce(IOperableTrigger trigger)
+    {
+        List<IOperableTrigger> acquired = await Store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddHours(2),
+            MaxCount = 1
+        });
+
+        IOperableTrigger firing = acquired.Should().ContainSingle(x => x.Key.Equals(trigger.Key),
+            "the trigger under test is the only one due").Subject;
+
+        List<TriggerFiredResult> fired = await Store.TriggersFired([firing]);
+        TriggerFiredBundle bundle = fired.Should().ContainSingle().Which.TriggerFiredBundle;
+
+        bundle.Should().NotBeNull("the firing has to be committed for its job detail to mean anything");
+
+        return (firing, bundle.JobDetail);
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // Unblocking the triggers of a job that forbids concurrent execution
     //
     // A trigger blocked behind a running execution is out of the acquisition set and out of the
@@ -2089,6 +2187,15 @@ public abstract class JobStoreContractTest
             .Build();
     }
 
+    private static IJobDetail CreateJob<TJob>(string name, string group, JobDataMap jobDataMap) where TJob : IJob
+    {
+        return JobBuilder.Create<TJob>()
+            .WithIdentity(name, group)
+            .WithDescription("job " + name)
+            .UsingJobData(jobDataMap)
+            .Build();
+    }
+
     private static IOperableTrigger CreateTrigger(
         string name,
         string group,
@@ -2138,6 +2245,16 @@ public abstract class JobStoreContractTest
     /// </summary>
     [DisallowConcurrentExecution]
     public sealed class NonConcurrentContractTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A job whose data map survives a firing, which is what makes a store write the map back when the
+    /// firing ends.
+    /// </summary>
+    [PersistJobDataAfterExecution]
+    public sealed class PersistentContractTestJob : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
     }

--- a/src/Quartz.Tests.Unit/Core/CompletionWatchingJobStore.cs
+++ b/src/Quartz.Tests.Unit/Core/CompletionWatchingJobStore.cs
@@ -1,0 +1,84 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// Records how each firing was handed back to the store: through <c>TriggeredJobComplete</c>, with which
+/// instruction, or through <c>ReleaseAcquiredTrigger</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The distinction is the one <c>AGENTS.md</c> records: after <c>TriggersFired</c> the scheduler must
+/// complete a firing rather than release it, because releasing does not unblock the sibling triggers of
+/// a <see cref="DisallowConcurrentExecutionAttribute" /> job. Nothing about that is visible from the
+/// scheduler's own surface, so a test watches the store.
+/// </para>
+/// <para>
+/// Both calls are recorded <em>after</em> the wrapped store has acted on them, so a test that waits on a
+/// record and then asks the store a question is looking at a store that has already settled — which is
+/// what keeps these assertions off the clock.
+/// </para>
+/// </remarks>
+public sealed class CompletionWatchingJobStore : DelegatingJobStore
+{
+    public CompletionWatchingJobStore(IJobStore jobStore) : base(jobStore)
+    {
+    }
+
+    /// <summary>The triggers handed back through <see cref="ReleaseAcquiredTrigger" />.</summary>
+    public CallLog<TriggerKey> Releases { get; } = new();
+
+    /// <summary>The completions the scheduler reported, instruction included.</summary>
+    public CallLog<CompletedFiring> Completions { get; } = new();
+
+    /// <summary>
+    /// Runs immediately before the wrapped store is told a firing is over, so that a test can read the
+    /// state the completion is about to change. Nothing is holding the store's lock at that point, so
+    /// the hook may ask it questions.
+    /// </summary>
+    public Func<ValueTask> BeforeCompletion { get; set; }
+
+    public override async ValueTask ReleaseAcquiredTrigger(IOperableTrigger trigger, CancellationToken cancellationToken = default)
+    {
+        await base.ReleaseAcquiredTrigger(trigger, cancellationToken).ConfigureAwait(false);
+        Releases.Record(trigger.Key);
+    }
+
+    public override async ValueTask TriggeredJobComplete(
+        IOperableTrigger trigger,
+        IJobDetail jobDetail,
+        SchedulerInstruction triggerInstructionCode,
+        CancellationToken cancellationToken = default)
+    {
+        Func<ValueTask> before = BeforeCompletion;
+        if (before is not null)
+        {
+            await before().ConfigureAwait(false);
+        }
+
+        await base.TriggeredJobComplete(trigger, jobDetail, triggerInstructionCode, cancellationToken).ConfigureAwait(false);
+        Completions.Record(new CompletedFiring(trigger.Key, jobDetail.Key, triggerInstructionCode));
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -37,6 +37,12 @@ namespace Quartz.Tests.Unit.Core;
 [NonParallelizable]
 public class QuartzSchedulerTest
 {
+    /// <summary>
+    /// How long a test is willing to wait for a signal before declaring the scheduler stuck. Long enough
+    /// that a loaded build agent never trips it, and never used as a measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
     [Test]
     public void TestVersionInfo()
     {
@@ -147,107 +153,156 @@ public class QuartzSchedulerTest
         A.CallTo(() => listener.JobScheduled(scheduler, jobTrigger, A<CancellationToken>._)).MustHaveHappened();
     }
 
+    /// <summary>
+    /// The listing is of firings that have begun and not yet ended, and it is exactly that at every
+    /// point: nothing before the first one starts, one entry per firing while they are held open, and
+    /// nothing once each has been let go.
+    /// </summary>
+    /// <remarks>
+    /// Every step is driven by a signal a firing raises rather than by an elapsed interval — which is
+    /// what this test used to do, and what made it flaky enough to switch off. A job that sleeps for
+    /// 200ms is executing at 150ms only on a machine with a thread to spare at the instant the test
+    /// wanted one.
+    /// </remarks>
     [Test]
-    [Ignore("Flaky in CI")]
-    public void CurrentlyExecutingJobs()
+    public async Task GetCurrentlyExecutingJobsListsTheFiringsThatHaveStartedAndNotFinished()
     {
-        IReadOnlyCollection<IJobExecutionContext> executingJobs;
+        QuartzScheduler scheduler = await CreateQuartzScheduler("currentlyExecuting", "instance", threadCount: 5);
+        CompletionRecordingJobListener completions = new();
+        scheduler.ListenerManager.AddJobListener(completions);
 
-        var scheduler = CreateQuartzScheduler("A", "B", 5);
-
-        executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs, Is.Empty);
-
-        scheduler.Start().GetAwaiter().GetResult();
-
-        executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs, Is.Empty);
-
-        ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
-        ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
-
-        Thread.Sleep(150);
-
-        executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs, Has.Count.EqualTo(4));
-
-        Thread.Sleep(150);
-
-        executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs, Has.Count.EqualTo(3));
-
-        Thread.Sleep(300);
-
-        executingJobs = scheduler.GetCurrentlyExecutingJobs();
-        Assert.That(executingJobs, Is.Empty);
-
-        scheduler.Shutdown(true).GetAwaiter().GetResult();
-    }
-
-    [Test]
-    [Ignore("Flaky in CI")]
-    public void NumberOfJobsExecuted()
-    {
-        var scheduler = CreateQuartzScheduler("A", "B", 5);
-
-        Assert.That(scheduler.NumberOfJobsExecuted, Is.EqualTo(0));
-
-        scheduler.Start().GetAwaiter().GetResult();
-
-        Assert.That(scheduler.NumberOfJobsExecuted, Is.EqualTo(0));
-
-        ScheduleJobs<DelayedJob>(scheduler, 3, true, false, 1, TimeSpan.FromMilliseconds(1), 1);
-        ScheduleJobs<DelayedJob>(scheduler, 1, true, false, 1, TimeSpan.FromMilliseconds(1), 0);
-
-        Thread.Sleep(150);
-
-        Assert.That(scheduler.NumberOfJobsExecuted, Is.EqualTo(4));
-
-        Thread.Sleep(150);
-
-        Assert.That(scheduler.NumberOfJobsExecuted, Is.EqualTo(7));
-
-        Thread.Sleep(200);
-
-        Assert.That(scheduler.NumberOfJobsExecuted, Is.EqualTo(7));
-
-        scheduler.Shutdown(true).GetAwaiter().GetResult();
-    }
-
-    private static void ScheduleJobs<T>(QuartzScheduler scheduler,
-        int jobCount,
-        bool disableConcurrentExecution,
-        bool persistJobDataAfterExecution,
-        int triggersPerJob,
-        TimeSpan repeatInterval,
-        int repeatCount)
-    {
-        var triggersByJob = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>();
-
-        for (var i = 0; i < jobCount; i++)
+        try
         {
-            var job = CreateJobDetail(typeof(QuartzSchedulerTest).Name,
-                typeof(T),
-                disableConcurrentExecution,
-                persistJobDataAfterExecution);
+            scheduler.GetCurrentlyExecutingJobs().Should().BeEmpty("nothing has fired yet");
 
-            var triggers = new ITrigger[triggersPerJob];
-            for (var j = 0; j < triggersPerJob; j++)
+            await scheduler.Start();
+
+            scheduler.GetCurrentlyExecutingJobs().Should().BeEmpty(
+                "starting a scheduler with nothing scheduled cannot have begun a firing");
+
+            List<ExecutionGate> gates = await ScheduleGatedJobs(scheduler, jobCount: 4);
+
+            await ShouldObserve(
+                Task.WhenAll(gates.Select(gate => gate.Started.Reaches(1))),
+                "all four jobs have to be in flight before the listing means anything");
+
+            scheduler.GetCurrentlyExecutingJobs().Should().HaveCount(4,
+                "every firing that has begun and not ended is listed");
+
+            gates[0].Open();
+            await ShouldObserve(completions.Completed.Reaches(1), "the released job has to finish before it can be missing");
+
+            scheduler.GetCurrentlyExecutingJobs().Should().HaveCount(3,
+                "a firing leaves the listing as soon as it is over, and the other three are still held open");
+
+            foreach (ExecutionGate gate in gates.Skip(1))
             {
-                triggers[j] = CreateTrigger(job, repeatInterval, repeatCount);
+                gate.Open();
             }
 
-            triggersByJob.Add(job, triggers);
-        }
+            await ShouldObserve(completions.Completed.Reaches(4), "every firing has to finish");
 
-        scheduler.ScheduleJobs(triggersByJob).GetAwaiter().GetResult();
+            scheduler.GetCurrentlyExecutingJobs().Should().BeEmpty(
+                "with every firing over there is nothing left to list");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
     }
 
-
-    private static QuartzScheduler CreateQuartzScheduler(string name, string instanceId, int threadCount)
+    /// <summary>
+    /// The count is of firings that began, and it counts each of them once.
+    /// </summary>
+    /// <remarks>
+    /// Seven firings are asked for and seven are waited for; the schedule then has nothing left, and the
+    /// shutdown that follows is what makes "and no more than seven" a fact rather than the verdict of a
+    /// sleep that happened to be long enough.
+    /// </remarks>
+    [Test]
+    public async Task NumberOfJobsExecutedCountsEveryFiringOnce()
     {
-        var threadPool = new DefaultThreadPool { MaxConcurrency = threadCount };
-        threadPool.Initialize();
+        QuartzScheduler scheduler = await CreateQuartzScheduler("jobsExecuted", "instance", threadCount: 5);
+        CompletionRecordingJobListener completions = new();
+        scheduler.ListenerManager.AddJobListener(completions);
+
+        try
+        {
+            scheduler.NumberOfJobsExecuted.Should().Be(0, "nothing has fired yet");
+
+            await scheduler.Start();
+
+            scheduler.NumberOfJobsExecuted.Should().Be(0,
+                "starting a scheduler with nothing scheduled cannot have fired anything");
+
+            // Three jobs whose trigger fires twice and one whose trigger fires once: seven firings, and
+            // no schedule left over afterwards.
+            await ScheduleJobs<CountedJob>(scheduler, jobCount: 3, repeatCount: 1);
+            await ScheduleJobs<CountedJob>(scheduler, jobCount: 1, repeatCount: 0);
+
+            await ShouldObserve(completions.Completed.Reaches(7), "every firing the schedule calls for has to happen");
+
+            scheduler.NumberOfJobsExecuted.Should().Be(7, "the seven firings that ran are seven firings counted");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        scheduler.NumberOfJobsExecuted.Should().Be(7,
+            "the schedule is exhausted and the scheduler is down, so nothing further can have been counted");
+        scheduler.GetCurrentlyExecutingJobs().Should().BeEmpty("every firing ended before the shutdown returned");
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// Schedules <paramref name="jobCount" /> jobs that each hold their firing open until the gate
+    /// handed back for them is opened, one trigger and one firing apiece.
+    /// </summary>
+    private static async Task<List<ExecutionGate>> ScheduleGatedJobs(QuartzScheduler scheduler, int jobCount)
+    {
+        List<ExecutionGate> gates = new(jobCount);
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersByJob = new();
+
+        for (int i = 0; i < jobCount; i++)
+        {
+            ExecutionGate gate = new();
+            gates.Add(gate);
+
+            IJobDetail job = CreateJobDetail<GatedJob>(new JobDataMap { [ExecutionGate.JobDataKey] = gate });
+            triggersByJob.Add(job, [CreateTrigger(job, repeatCount: 0)]);
+        }
+
+        await scheduler.ScheduleJobs(triggersByJob);
+        return gates;
+    }
+
+    private static async Task ScheduleJobs<TJob>(QuartzScheduler scheduler, int jobCount, int repeatCount)
+        where TJob : IJob
+    {
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersByJob = new();
+
+        for (int i = 0; i < jobCount; i++)
+        {
+            IJobDetail job = CreateJobDetail<TJob>(new JobDataMap());
+            triggersByJob.Add(job, [CreateTrigger(job, repeatCount)]);
+        }
+
+        await scheduler.ScheduleJobs(triggersByJob);
+    }
+
+    private static async Task<QuartzScheduler> CreateQuartzScheduler(string name, string instanceId, int threadCount)
+    {
+        DefaultThreadPool threadPool = new() { MaxConcurrency = threadCount };
+        await threadPool.Initialize();
+
+        RAMJobStore jobStore = TestJobStores.Ram();
+        await jobStore.Initialize(TestJobStores.Identity(name, instanceId));
 
         QuartzSchedulerResources res = new QuartzSchedulerResources
         {
@@ -255,47 +310,98 @@ public class QuartzSchedulerTest
             InstanceId = instanceId,
             ThreadPool = threadPool,
             JobRunShellFactory = new StdJobRunShellFactory(NullLogger<JobRunShell>.Instance),
-            JobStore = TestJobStores.Ram(),
+            JobStore = jobStore,
             IdleWaitTime = TimeSpan.FromMilliseconds(10),
             MaxBatchSize = threadCount,
             BatchTimeWindow = TimeSpan.FromMilliseconds(10)
         };
 
-        var scheduler = new QuartzScheduler(res);
+        QuartzScheduler scheduler = new QuartzScheduler(res);
         scheduler.JobFactory = new SimpleJobFactory();
         return scheduler;
     }
 
-    private static ITrigger CreateTrigger(IJobDetail job, TimeSpan repeatInterval, int repeatCount)
+    private static ITrigger CreateTrigger(IJobDetail job, int repeatCount)
     {
         return TriggerBuilder.Create()
             .ForJob(job)
             .WithSimpleSchedule(
                 sb => sb.WithRepeatCount(repeatCount)
-                    .WithInterval(repeatInterval)
+                    .WithInterval(TimeSpan.FromMilliseconds(1))
                     .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
             .Build();
     }
 
-    private static IJobDetail CreateJobDetail(string group,
-        Type jobType,
-        bool disableConcurrentExecution,
-        bool persistJobDataAfterExecution)
+    private static IJobDetail CreateJobDetail<TJob>(JobDataMap jobDataMap) where TJob : IJob
     {
-        return JobBuilder.Create().OfType(jobType)
-            .WithIdentity(Guid.NewGuid().ToString(), group)
-            .DisallowConcurrentExecution(disableConcurrentExecution)
-            .PersistJobDataAfterExecution(persistJobDataAfterExecution)
+        return JobBuilder.Create<TJob>()
+            .WithIdentity(Guid.NewGuid().ToString(), nameof(QuartzSchedulerTest))
+            .DisallowConcurrentExecution()
+            .UsingJobData(jobDataMap)
             .Build();
     }
 
-    public class DelayedJob : IJob
+    /// <summary>
+    /// One firing's half of the conversation with the test: it says when it has started, and waits to be
+    /// let go. Handed to the job through its data map, so nothing is static and two tests cannot see each
+    /// other's firings.
+    /// </summary>
+    private sealed class ExecutionGate
     {
-        private static readonly TimeSpan _delay = TimeSpan.FromMilliseconds(200);
+        public const string JobDataKey = "gate";
 
+        private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>The firings of this job that have begun.</summary>
+        public CallLog<JobKey> Started { get; } = new();
+
+        /// <summary>Completes when <see cref="Open" /> is called, and never before.</summary>
+        public Task Released => release.Task;
+
+        public void Open() => release.TrySetResult();
+    }
+
+    /// <summary>
+    /// A job that begins and then runs until the test lets it stop.
+    /// </summary>
+    public sealed class GatedJob : IJob
+    {
         public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
-            await Task.Delay(_delay).ConfigureAwait(false);
+            ExecutionGate gate = (ExecutionGate) context.MergedJobDataMap[ExecutionGate.JobDataKey];
+            gate.Started.Record(context.JobDetail.Key);
+            await gate.Released.ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// A job that does nothing, for the tests that count firings rather than watch them.
+    /// </summary>
+    public sealed class CountedJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// Records each firing as it ends.
+    /// </summary>
+    /// <remarks>
+    /// The scheduler notifies its own <c>ExecutingJobsManager</c> before any listener the application
+    /// registered, so by the time this records a firing the scheduler has already dropped it from
+    /// <see cref="QuartzScheduler.GetCurrentlyExecutingJobs" /> — which is what makes it safe to assert
+    /// on that listing the moment this signals.
+    /// </remarks>
+    private sealed class CompletionRecordingJobListener : IJobListener
+    {
+        public CallLog<JobKey> Completed { get; } = new();
+
+        public ValueTask JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            Completed.Record(context.JobDetail.Key);
+            return default;
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Core/ShutdownJobInterruptionTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ShutdownJobInterruptionTest.cs
@@ -1,0 +1,227 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// Whether a shutting-down scheduler signals cancellation to the jobs still running, in each of the
+/// four settings and on both kinds of shutdown.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ShutdownJobInterruption" /> exists because interrupting running jobs is a reasonable
+/// thing to want on a shutdown that waits for them, on one that does not, on both, or on neither. Only
+/// the mapping from configuration keys to the enum was tested; what the scheduler then does with it was
+/// not, so three of the four values could have meant anything.
+/// </para>
+/// <para>
+/// The interrupt happens between "the scheduler listeners were told it is shutting down" and "the
+/// thread pool was torn down", and neither of those is a length of time. The pool under test says when
+/// the shutdown has reached it, which is strictly after the interrupt decision was made and acted on —
+/// so the case that expects no interruption can assert the absence of one instead of waiting to see
+/// whether it turns up.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class ShutdownJobInterruptionTest
+{
+    private const string Group = "shutdown-interruption";
+
+    /// <summary>
+    /// How long a test is willing to wait for the shutdown to reach the thread pool. Long enough that a
+    /// loaded build agent never trips it, and never used as a measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    [TestCase(ShutdownJobInterruption.Never, false, false)]
+    [TestCase(ShutdownJobInterruption.Never, true, false)]
+    [TestCase(ShutdownJobInterruption.WhenNotWaitingForJobs, false, true)]
+    [TestCase(ShutdownJobInterruption.WhenNotWaitingForJobs, true, false)]
+    [TestCase(ShutdownJobInterruption.WhenWaitingForJobs, false, false)]
+    [TestCase(ShutdownJobInterruption.WhenWaitingForJobs, true, true)]
+    [TestCase(ShutdownJobInterruption.Always, false, true)]
+    [TestCase(ShutdownJobInterruption.Always, true, true)]
+    public async Task TheSettingDecidesWhetherAShutdownCancelsTheRunningJobs(
+        ShutdownJobInterruption setting,
+        bool waitForJobsToComplete,
+        bool expectedToBeInterrupted)
+    {
+        RunningJob.Gate gate = new();
+        TeardownAnnouncingThreadPool pool = new();
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options =>
+            {
+                options.InstanceName = $"{Group}-{setting}-{waitForJobsToComplete}";
+                options.ShutdownJobInterruption = setting;
+            })
+            .UseThreadPool(pool)
+            .BuildScheduler();
+
+        IJobDetail job = JobBuilder.Create<RunningJob>()
+            .WithIdentity("job", Group)
+            .UsingJobData(new JobDataMap { [RunningJob.Gate.JobDataKey] = gate })
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("trigger", Group)
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+        await scheduler.Start();
+
+        await ShouldObserve(gate.Started, "the job has to be running before a shutdown can interrupt it");
+
+        Task shutdown = scheduler.Shutdown(waitForJobsToComplete).AsTask();
+
+        // The pool is torn down after the interruption decision has been made and acted on, so this is
+        // the first moment at which "it was not interrupted" is a fact rather than a guess.
+        await ShouldObserve(pool.TeardownReached, "the shutdown has to reach the thread pool");
+
+        gate.Interrupted.IsCompleted.Should().Be(expectedToBeInterrupted,
+            expectedToBeInterrupted
+                ? $"{setting} interrupts running jobs on a shutdown with waitForJobsToComplete: {waitForJobsToComplete}"
+                : $"{setting} leaves running jobs alone on a shutdown with waitForJobsToComplete: {waitForJobsToComplete}");
+
+        gate.Open();
+
+        // Waited for in its own right rather than through the shutdown: a shutdown that does not wait
+        // for its jobs returns while this one is still finishing, so awaiting only the shutdown would
+        // read what the job saw before the job had looked.
+        await ShouldObserve(gate.Finished, "the job has to end before what it saw can be read");
+        await ShouldObserve(shutdown, "the shutdown has to finish once the job it may be waiting for has ended");
+
+        gate.SawCancellationRequested.Should().Be(expectedToBeInterrupted,
+            "what the job reads from its own token has to agree with what the scheduler did to it");
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// A job that runs until the test lets it stop, and says whether anything cancelled it meanwhile.
+    /// </summary>
+    public sealed class RunningJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Gate gate = (Gate) context.MergedJobDataMap[Gate.JobDataKey];
+
+            // Registered rather than polled: the callback runs inside Cancel(), so by the time the
+            // scheduler's interrupt call has returned the test can already see it.
+            await using CancellationTokenRegistration registration = cancellationToken.Register(gate.RecordInterrupt);
+
+            gate.RecordStarted();
+            await gate.Released.ConfigureAwait(false);
+
+            gate.SawCancellationRequested = cancellationToken.IsCancellationRequested;
+            gate.RecordFinished();
+        }
+
+        /// <summary>
+        /// The signals one firing exchanges with the test, handed to it through its data map so that
+        /// nothing here is static and no two cases can see each other's firing.
+        /// </summary>
+        public sealed class Gate
+        {
+            public const string JobDataKey = "gate";
+
+            private readonly TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource interrupted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task Started => started.Task;
+
+            public Task Interrupted => interrupted.Task;
+
+            public Task Released => release.Task;
+
+            /// <summary>
+            /// Completes once the job has read its token and is on its way out, which is the only point
+            /// at which <see cref="SawCancellationRequested" /> means anything.
+            /// </summary>
+            public Task Finished => finished.Task;
+
+            /// <summary>What the job read from its own token, once it was let go.</summary>
+            public bool SawCancellationRequested { get; set; }
+
+            public void RecordStarted() => started.TrySetResult();
+
+            public void RecordInterrupt() => interrupted.TrySetResult();
+
+            public void RecordFinished() => finished.TrySetResult();
+
+            public void Open() => release.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// The default pool, plus a signal for the moment the shutdown reaches it.
+    /// </summary>
+    /// <remarks>
+    /// Both of the pool's teardown members are strictly after the block in <c>QuartzScheduler.Shutdown</c>
+    /// that decides whether to interrupt: a shutdown that waits calls <see cref="Drain" />, one that does
+    /// not calls <see cref="Shutdown" />, and either way the interrupting is over by then.
+    /// </remarks>
+    private sealed class TeardownAnnouncingThreadPool : IThreadPool
+    {
+        private readonly DefaultThreadPool inner = new() { MaxConcurrency = 5 };
+        private readonly TaskCompletionSource teardownReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task TeardownReached => teardownReached.Task;
+
+        public int PoolSize => inner.PoolSize;
+
+        public ValueTask Initialize(CancellationToken cancellationToken = default) => inner.Initialize(cancellationToken);
+
+        public ValueTask<int> WaitForAvailableThreads(CancellationToken cancellationToken = default)
+        {
+            return inner.WaitForAvailableThreads(cancellationToken);
+        }
+
+        public ValueTask<bool> TryRun(Func<ValueTask> action, CancellationToken cancellationToken = default)
+        {
+            return inner.TryRun(action, cancellationToken);
+        }
+
+        public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default)
+        {
+            teardownReached.TrySetResult();
+            return inner.Shutdown(waitForJobsToComplete, cancellationToken);
+        }
+
+        public ValueTask<bool> Drain(CancellationToken cancellationToken = default)
+        {
+            teardownReached.TrySetResult();
+            return inner.Drain(cancellationToken);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/ThrowingJobListenerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ThrowingJobListenerTest.cs
@@ -1,0 +1,363 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What the scheduler does when a job listener throws, on either side of the job.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two sides are not symmetrical, and the asymmetry is the point. A listener that throws in
+/// <see cref="IJobListener.JobToBeExecuted" /> stops the firing — the job does not run — and the run
+/// shell has to hand the trigger back anyway, or a job that forbids concurrent execution would stay
+/// blocked behind a firing that never happened. A listener that throws in
+/// <see cref="IJobListener.JobWasExecuted" /> is too late to stop anything: the job has run, the trigger
+/// has already decided what it wants done, and that verdict still has to reach the store.
+/// </para>
+/// <para>
+/// Both failures are announced to the scheduler listeners and neither stops the scheduler, which is why
+/// each test goes on to fire a second job the listener leaves alone.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class ThrowingJobListenerTest
+{
+    private const string Group = "throwing-job-listener";
+
+    /// <summary>
+    /// How long a test is willing to wait for a firing to reach the store. Long enough that a loaded
+    /// build agent never trips it, and never used as a measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task AListenerThrowingBeforeTheJobStopsTheFiringAndStillFreesTheTrigger()
+    {
+        ExecutionRecord record = new();
+        ThrowingJobListener listener = new(new JobKey("job", Group), failOnToBeExecuted: true);
+        ErrorRecordingSchedulerListener errors = new();
+
+        CompletionWatchingJobStore store = null;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "throws-before-the-job")
+            .UseJobStore(provider =>
+            {
+                store = new CompletionWatchingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+            scheduler.ListenerManager.AddSchedulerListener(errors);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [ExecutionRecord.JobDataKey] = record })
+                .Build();
+
+            ITrigger fired = TriggerBuilder.Create()
+                .WithIdentity("fired", Group)
+                .ForJob(job)
+                .StartNow()
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build();
+
+            ITrigger sibling = TriggerBuilder.Create()
+                .WithIdentity("sibling", Group)
+                .ForJob(job)
+                .StartAt(DateTimeOffset.UtcNow.AddHours(2))
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build();
+
+            await scheduler.ScheduleJob(job, [fired, sibling]);
+
+            TriggerState siblingDuringFiring = TriggerState.None;
+            store.BeforeCompletion = async () => siblingDuringFiring = await store.GetTriggerState(sibling.Key);
+
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the abandoned firing still has to be reported to the store");
+
+            record.Ran.Should().BeFalse(
+                "a listener that failed on the way in stops the firing, which is what the message says it does");
+
+            store.Completions.Entries.Should().Equal(
+                [new CompletedFiring(fired.Key, job.Key, SchedulerInstruction.NoInstruction)],
+                "a firing that never happened settles nothing about the schedule");
+
+            store.Releases.Entries.Should().BeEmpty(
+                "the firing was already committed, so it is completed rather than released - releasing "
+                + "would leave the job's other triggers blocked behind a job that never ran");
+
+            siblingDuringFiring.Should().Be(TriggerState.Blocked,
+                "committing the firing blocked the job's other trigger, whatever the listeners then did");
+
+            (await scheduler.GetTriggerState(fired.Key)).Should().Be(TriggerState.Normal,
+                "the trigger has firings ahead of it and a failed listener does not take them away");
+            (await scheduler.GetTriggerState(sibling.Key)).Should().Be(TriggerState.Normal,
+                "completing the firing is what lets the blocked trigger go again");
+
+            SchedulerErrorContext error = errors.Errors.Entries.Should().ContainSingle(
+                "the failure is the scheduler listeners' only sight of it").Subject;
+
+            error.Message.Should().Contain("Job will NOT be executed",
+                "the report has to say that the failure cost the firing");
+            error.TriggerKey.Should().Be(fired.Key);
+            error.JobKey.Should().Be(job.Key);
+            error.Exception.Should().BeOfType<JobExecutionProcessException>(
+                "the listener's own exception is wrapped in the one that names the listener and the firing");
+
+            await ShouldGoOnScheduling(scheduler);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task AListenerThrowingAfterTheJobDoesNotUndoTheFiring()
+    {
+        ExecutionRecord record = new();
+        ThrowingJobListener listener = new(new JobKey("job", Group), failOnToBeExecuted: false);
+        ErrorRecordingSchedulerListener errors = new();
+        RecordingTriggerListener triggerListener = new();
+
+        CompletionWatchingJobStore store = null;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "throws-after-the-job")
+            .UseJobStore(provider =>
+            {
+                store = new CompletionWatchingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+            scheduler.ListenerManager.AddTriggerListener(triggerListener);
+            scheduler.ListenerManager.AddSchedulerListener(errors);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [ExecutionRecord.JobDataKey] = record })
+                .Build();
+
+            // A trigger with one firing in it, so that the instruction the trigger reaches is not the one
+            // a failed notification would fall back to: DeleteTrigger has to survive the failure.
+            ITrigger once = TriggerBuilder.Create()
+                .WithIdentity("once", Group)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, once);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the finished firing still has to be reported to the store");
+
+            record.Ran.Should().BeTrue(
+                "the listener throws after the job, so the job has to have run for this test to prove anything");
+
+            store.Completions.Entries.Should().Equal(
+                [new CompletedFiring(once.Key, job.Key, SchedulerInstruction.DeleteTrigger)],
+                "the trigger decided it was finished before any listener was told, and that verdict is not "
+                + "the failed listener's to overturn");
+
+            (await scheduler.GetTriggerState(once.Key)).Should().Be(TriggerState.None,
+                "the trigger was deleted, and a trigger that is gone has no state");
+
+            triggerListener.Completed.Entries.Should().BeEmpty(
+                "the run shell abandons the notifications at the one that failed, so the trigger listeners "
+                + "are not told about a completion the job listeners could not be told about");
+
+            SchedulerErrorContext error = errors.Errors.Entries.Should().ContainSingle().Subject;
+
+            error.Message.Should().Contain("error will be ignored",
+                "the report has to say that the failure cost nothing, which is the opposite of the other side");
+            error.TriggerKey.Should().Be(once.Key);
+            error.JobKey.Should().Be(job.Key);
+
+            await ShouldGoOnScheduling(scheduler);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Fires a job the throwing listener leaves alone, which is how a test says the scheduler is still
+    /// working rather than merely still running.
+    /// </summary>
+    private static async Task ShouldGoOnScheduling(IScheduler scheduler)
+    {
+        ExecutionRecord record = new();
+
+        IJobDetail job = JobBuilder.Create<RecordingJob>()
+            .WithIdentity("unaffected", Group)
+            .UsingJobData(new JobDataMap { [ExecutionRecord.JobDataKey] = record })
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("unaffected", Group)
+            .ForJob(job)
+            .StartNow()
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+
+        await ShouldObserve(record.Executed,
+            "one listener failing must not stop the scheduler firing everything else it holds");
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// Whether the job ran, handed to it through its data map so that nothing here is static.
+    /// </summary>
+    private sealed class ExecutionRecord
+    {
+        public const string JobDataKey = "record";
+
+        private readonly TaskCompletionSource executed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool Ran { get; private set; }
+
+        public Task Executed => executed.Task;
+
+        public void Record()
+        {
+            Ran = true;
+            executed.TrySetResult();
+        }
+    }
+
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentRecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((ExecutionRecord) context.MergedJobDataMap[ExecutionRecord.JobDataKey]).Record();
+            return default;
+        }
+    }
+
+    public sealed class RecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((ExecutionRecord) context.MergedJobDataMap[ExecutionRecord.JobDataKey]).Record();
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Fails on one side of one named job, and does nothing anywhere else — so a test can watch the
+    /// scheduler carry on with a job this listener has no quarrel with.
+    /// </summary>
+    /// <remarks>
+    /// The failure arrives as a faulted task, which is the shape an <c>async</c> listener produces and
+    /// the shape the scheduler is written to handle: <c>QuartzScheduler.NotifyJobListeners</c> awaits
+    /// what the listener returned inside its try block. A listener that instead throws
+    /// <em>synchronously</em> — a guard clause in a method that is not <c>async</c> — is not handled the
+    /// same way, because the call producing the task is evaluated outside that try. That is a real hole
+    /// and it is reported rather than papered over here; this fixture is about the handled path.
+    /// </remarks>
+    private sealed class ThrowingJobListener : IJobListener
+    {
+        private readonly JobKey failFor;
+        private readonly bool failOnToBeExecuted;
+
+        public ThrowingJobListener(JobKey failFor, bool failOnToBeExecuted)
+        {
+            this.failFor = failFor;
+            this.failOnToBeExecuted = failOnToBeExecuted;
+        }
+
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (failOnToBeExecuted && context.JobDetail.Key.Equals(failFor))
+            {
+                return ValueTask.FromException(new InvalidOperationException("the listener could not prepare for this job"));
+            }
+
+            return default;
+        }
+
+        public ValueTask JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            if (!failOnToBeExecuted && context.JobDetail.Key.Equals(failFor))
+            {
+                return ValueTask.FromException(new InvalidOperationException("the listener could not record this job"));
+            }
+
+            return default;
+        }
+    }
+
+    private sealed class RecordingTriggerListener : ITriggerListener
+    {
+        public CallLog<TriggerKey> Completed { get; } = new();
+
+        public ValueTask TriggerComplete(
+            ITrigger trigger,
+            IJobExecutionContext context,
+            SchedulerInstruction triggerInstructionCode,
+            CancellationToken cancellationToken = default)
+        {
+            Completed.Record(trigger.Key);
+            return default;
+        }
+    }
+
+    private sealed class ErrorRecordingSchedulerListener : ISchedulerListener
+    {
+        public CallLog<SchedulerErrorContext> Errors { get; } = new();
+
+        public ValueTask SchedulerError(
+            IScheduler scheduler,
+            SchedulerErrorContext error,
+            CancellationToken cancellationToken = default)
+        {
+            Errors.Record(error);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/VetoedFiringTest.cs
+++ b/src/Quartz.Tests.Unit/Core/VetoedFiringTest.cs
@@ -1,0 +1,293 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What a vetoed firing leaves behind in the job store.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A veto is decided by a trigger listener, but it is settled in the store: the trigger the scheduler
+/// took out of the waiting set has to go back into it, and the sibling triggers that
+/// <see cref="DisallowConcurrentExecutionAttribute" /> blocked when the firing was committed have to be
+/// let go. The run shell does that by completing the firing rather than releasing the acquired trigger —
+/// only the first of the two unblocks the siblings — and nothing pinned it.
+/// </para>
+/// <para>
+/// Nothing here waits for a length of time. The store records what the scheduler asked of it after it
+/// has acted on the request, so every assertion runs once the firing is genuinely over.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class VetoedFiringTest
+{
+    private const string Group = "vetoed-firing";
+
+    /// <summary>
+    /// How long a test is willing to wait for the firing to reach the store. Long enough that a loaded
+    /// build agent never trips it, and never used as a measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task AVetoedFiringReleasesItsTriggerAndUnblocksTheJobsOtherTriggers()
+    {
+        ExecutionRecord record = new();
+        VetoingTriggerListener veto = new(new TriggerKey("vetoed", Group));
+        RecordingJobListener jobListener = new();
+
+        CompletionWatchingJobStore store = null;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "vetoed-firing-unblocks")
+            .UseJobStore(provider =>
+            {
+                store = new CompletionWatchingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddTriggerListener(veto);
+            scheduler.ListenerManager.AddJobListener(jobListener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [ExecutionRecord.JobDataKey] = record })
+                .Build();
+
+            // Repeating, so that the veto is the only reason the trigger has nothing more to do right
+            // now: a trigger with nothing left to fire is deleted rather than released, which is the
+            // other case and has its own test below.
+            ITrigger vetoed = TriggerBuilder.Create()
+                .WithIdentity("vetoed", Group)
+                .ForJob(job)
+                .StartNow()
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build();
+
+            ITrigger sibling = TriggerBuilder.Create()
+                .WithIdentity("sibling", Group)
+                .ForJob(job)
+                .StartAt(DateTimeOffset.UtcNow.AddHours(2))
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build();
+
+            await scheduler.ScheduleJob(job, [vetoed, sibling]);
+
+            // Read while the vetoed firing is still open, so that "and then it was let go" is a claim
+            // about something that had actually been blocked.
+            TriggerState siblingDuringFiring = TriggerState.None;
+            store.BeforeCompletion = async () => siblingDuringFiring = await store.GetTriggerState(sibling.Key);
+
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the vetoed firing has to reach the store before there is anything to assert about it");
+
+            siblingDuringFiring.Should().Be(TriggerState.Blocked,
+                "committing a firing of a job that forbids concurrent execution blocks the job's other triggers");
+
+            store.Completions.Entries.Should().Equal(
+                [new CompletedFiring(vetoed.Key, job.Key, SchedulerInstruction.NoInstruction)],
+                "a veto settles nothing about the schedule, so the firing is completed with no instruction");
+
+            store.Releases.Entries.Should().BeEmpty(
+                "a committed firing is handed back through TriggeredJobComplete and never through "
+                + "ReleaseAcquiredTrigger, which would leave the job's other triggers blocked forever");
+
+            (await scheduler.GetTriggerState(vetoed.Key)).Should().Be(TriggerState.Normal,
+                "the vetoed trigger still has firings ahead of it and has to be waiting for the next one");
+
+            (await scheduler.GetTriggerState(sibling.Key)).Should().Be(TriggerState.Normal,
+                "completing the firing is what lets the blocked trigger go again");
+
+            record.Ran.Should().BeFalse("a vetoed job does not run, which is the whole point of vetoing it");
+
+            jobListener.Vetoed.Entries.Should().Equal([job.Key],
+                "the job listeners are told the execution was vetoed");
+            jobListener.ToBeExecuted.Entries.Should().BeEmpty(
+                "the veto happens before the job listeners are told the job is about to be executed");
+            jobListener.Executed.Entries.Should().BeEmpty("nothing executed, so nothing was executed");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// The other arm of the veto branch: a trigger that was on its last firing is finished whether that
+    /// firing happened or not, and the scheduler still says so.
+    /// </summary>
+    [Test]
+    public async Task AVetoedFiringOfATriggersLastRunStillFinalizesIt()
+    {
+        ExecutionRecord record = new();
+        VetoingTriggerListener veto = new(new TriggerKey("once", Group));
+        FinalizedTriggerListener finalized = new();
+
+        CompletionWatchingJobStore store = null;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "vetoed-firing-finalizes")
+            .UseJobStore(provider =>
+            {
+                store = new CompletionWatchingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .BuildScheduler();
+
+        try
+        {
+            scheduler.ListenerManager.AddTriggerListener(veto);
+            scheduler.ListenerManager.AddSchedulerListener(finalized);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [ExecutionRecord.JobDataKey] = record })
+                .Build();
+
+            ITrigger once = TriggerBuilder.Create()
+                .WithIdentity("once", Group)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, once);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the vetoed firing has to reach the store before there is anything to assert about it");
+
+            store.Completions.Entries.Should().Equal(
+                [new CompletedFiring(once.Key, job.Key, SchedulerInstruction.DeleteTrigger)],
+                "a trigger with nothing left to fire is finished, veto or no veto");
+
+            await ShouldObserve(finalized.Finalized.Reaches(1),
+                "a trigger that will never fire again is announced as finalized even when its last firing was vetoed");
+
+            finalized.Finalized.Entries.Should().Equal([once.Key]);
+
+            (await scheduler.GetTriggerState(once.Key)).Should().Be(TriggerState.None,
+                "the trigger is gone, and a trigger that is gone has no state");
+
+            record.Ran.Should().BeFalse("a vetoed job does not run");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// Whether the job ran, handed to it through its data map so that nothing here is static.
+    /// </summary>
+    private sealed class ExecutionRecord
+    {
+        public const string JobDataKey = "record";
+
+        public bool Ran { get; set; }
+    }
+
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentRecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((ExecutionRecord) context.MergedJobDataMap[ExecutionRecord.JobDataKey]).Ran = true;
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Vetoes one named trigger and nothing else.
+    /// </summary>
+    private sealed class VetoingTriggerListener : ITriggerListener
+    {
+        private readonly TriggerKey vetoed;
+
+        public VetoingTriggerListener(TriggerKey vetoed)
+        {
+            this.vetoed = vetoed;
+        }
+
+        public ValueTask<bool> VetoJobExecution(
+            ITrigger trigger,
+            IJobExecutionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<bool>(trigger.Key.Equals(vetoed));
+        }
+    }
+
+    private sealed class RecordingJobListener : IJobListener
+    {
+        public CallLog<JobKey> ToBeExecuted { get; } = new();
+
+        public CallLog<JobKey> Executed { get; } = new();
+
+        public CallLog<JobKey> Vetoed { get; } = new();
+
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ToBeExecuted.Record(context.JobDetail.Key);
+            return default;
+        }
+
+        public ValueTask JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            Executed.Record(context.JobDetail.Key);
+            return default;
+        }
+
+        public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Vetoed.Record(context.JobDetail.Key);
+            return default;
+        }
+    }
+
+    private sealed class FinalizedTriggerListener : ISchedulerListener
+    {
+        public CallLog<TriggerKey> Finalized { get; } = new();
+
+        public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            Finalized.Record(trigger.Key);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/AnnualCalendarTest.cs
@@ -80,12 +80,45 @@ public class AnnualCalendarTest : SerializationTestSupport<AnnualCalendar, ICale
     [Test]
     public void TestExclusionAndNextIncludedTime()
     {
+        // Both the instant and the zone are pinned. The answer to "and the next included day?" is the
+        // start of the next *local* day, which is twenty-four hours later only in a zone with no
+        // transition that night — so built from DateTimeOffset.UtcNow.Date and the machine's own zone
+        // this passed every night of the year but the two the zone moves on (#3465).
+        calendar.TimeZone = TimeZoneInfo.Utc;
         calendar.DaysExcluded.Should().BeEmpty();
-        DateTimeOffset test = DateTimeOffset.UtcNow.Date;
-        Assert.That(calendar.GetNextIncludedTimeUtc(test), Is.EqualTo(test), "Did not get today as date when nothing was excluded");
 
-        calendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(test.Date)));
-        Assert.That(calendar.GetNextIncludedTimeUtc(test), Is.EqualTo(test.AddDays(1)), "Did not get next day when current day excluded");
+        DateTimeOffset test = new DateTimeOffset(2026, 3, 6, 0, 0, 0, TimeSpan.Zero);
+
+        calendar.GetNextIncludedTimeUtc(test).Should().Be(test,
+            "with nothing excluded the queried instant is itself included, so it comes back unchanged");
+
+        calendar.AddExcludedDay(MonthDay.From(DateOnly.FromDateTime(test.UtcDateTime)));
+
+        calendar.GetNextIncludedTimeUtc(test).Should().Be(test.AddDays(1),
+            "excluding the queried day moves the answer to the first instant of the next one");
+    }
+
+    /// <summary>
+    /// The companion to the case above, and the reason it had to be pinned to a zone of its own.
+    /// </summary>
+    [Test]
+    public void TestNextIncludedTimeIsTheStartOfTheNextLocalDayAcrossATransition()
+    {
+        // A day begins when its zone says it does, so the day after an excluded one starts twenty-three
+        // hours later on a spring-forward night rather than twenty-four. "Tomorrow is UtcNow plus a day"
+        // is therefore wrong two nights a year in any zone that moves, which is what made the machine
+        // clock the wrong thing to build the expectation from.
+        TimeZoneInfo zone = TestTimeZones.Helsinki;
+        TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 31, 3, 30, 0));
+
+        calendar.TimeZone = zone;
+        calendar.AddExcludedDay(new MonthDay(3, 31));
+
+        DateTimeOffset startOfExcludedDay = new DateTimeOffset(2024, 3, 30, 22, 0, 0, TimeSpan.Zero);
+
+        calendar.GetNextIncludedTimeUtc(startOfExcludedDay).Should().Be(
+            new DateTimeOffset(2024, 3, 31, 21, 0, 0, TimeSpan.Zero),
+            "the first instant of 1 April is 21:00 UTC on 31 March, because the zone gained an hour overnight");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
@@ -1,5 +1,7 @@
 using FakeItEasy;
 
+using Microsoft.Extensions.Time.Testing;
+
 using Quartz.Extensibility;
 using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
@@ -179,6 +181,145 @@ public sealed class TriggeredJobCompleteTest
 
         (await store.GetTriggerState(sibling.Key)).Should().Be(TriggerState.Normal,
             "completion is what lets the blocked siblings go, and it does so even when the instruction itself decides nothing");
+    }
+
+    /// <summary>
+    /// A trigger that sat blocked past its own fire time has its misfire policy applied as it is let
+    /// go, because completion is the first thing that can settle the debt.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A blocked trigger is out of the acquisition set and out of the misfire sweep's, so a store that
+    /// left the policy to the next acquisition would hand a caller a past-due fire time in the window
+    /// between — the divergence #3463 reported and #3471 closed.
+    /// </para>
+    /// <para>
+    /// The contract suite asserts the same thing against both stores, but it runs only in the
+    /// integration leg, whose coverage the Sonar gate does not read. This is the in-memory half of it
+    /// in the fast suite, on a clock the test owns so that "rescheduled to now" is an exact instant
+    /// rather than a window.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task RamStoreAppliesTheMisfirePolicyOfATriggerItUnblocks()
+    {
+        FakeTimeProvider clock = new(new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero));
+        RAMJobStore store = TestJobStores.Ram(timeProvider: clock);
+        store.MisfireThreshold = TimeSpan.FromMinutes(1);
+
+        IJobDetail job = CreateJob<DisallowConcurrentCompletionTestJob>();
+        IOperableTrigger firing = await GivenABlockingFiring(store, clock, job);
+
+        // FireNow on a one-shot: the missed firing is owed, so the policy hands the trigger back due
+        // now rather than due in the past.
+        IOperableTrigger blocked = CreateOverdueOneShot("blocked", job, clock, SimpleTriggerMisfireInstruction.FireNow);
+        await store.AddTrigger(blocked, replace: false);
+
+        (await store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Blocked,
+            "a trigger added while the job is already running is blocked as it arrives");
+
+        await store.TriggeredJobComplete(firing, job, SchedulerInstruction.NoInstruction);
+
+        (await store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Normal,
+            "the trigger has a firing left to do, so completing the execution that blocked it leaves it waiting");
+
+        IOperableTrigger readBack = await store.GetTrigger(blocked.Key);
+
+        readBack.NextFireTimeUtc.Should().Be(clock.GetUtcNow(),
+            "the policy was applied while the completion was unblocking the trigger, not left to the next "
+            + "acquisition - which would still be reporting the fire time the trigger missed");
+    }
+
+    [Test]
+    public async Task RamStoreRemovesAnUnblockedTriggerWithNothingLeftToFire()
+    {
+        FakeTimeProvider clock = new(new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero));
+        RAMJobStore store = TestJobStores.Ram(timeProvider: clock);
+        store.MisfireThreshold = TimeSpan.FromMinutes(1);
+
+        IJobDetail job = CreateJob<DisallowConcurrentCompletionTestJob>();
+        IOperableTrigger firing = await GivenABlockingFiring(store, clock, job);
+
+        // Reschedule to the next firing after now, of which a one-shot whose only firing was missed
+        // has none: the policy writes the missed firing off and leaves the trigger finished.
+        IOperableTrigger blocked = CreateOverdueOneShot("blocked", job, clock, SimpleTriggerMisfireInstruction.NextWithRemainingCount);
+        await store.AddTrigger(blocked, replace: false);
+
+        await store.TriggeredJobComplete(firing, job, SchedulerInstruction.NoInstruction);
+
+        (await store.GetTrigger(blocked.Key)).Should().BeNull(
+            "a trigger whose policy left it with nothing to fire is finished, and a store that kept it "
+            + "would go on handing callers a trigger that can never fire again");
+        (await store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.None,
+            "a trigger that is gone has no state");
+        (await store.GetJob(job.Key)).Should().NotBeNull(
+            "the job still has the trigger that was running, so removing the finished one must not take it");
+    }
+
+    /// <summary>
+    /// Fires one trigger of a job that forbids concurrent execution, leaving the job blocked and the
+    /// firing open for the caller to complete.
+    /// </summary>
+    private static async Task<IOperableTrigger> GivenABlockingFiring(
+        RAMJobStore store,
+        FakeTimeProvider clock,
+        IJobDetail job)
+    {
+        IOperableTrigger running = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("running", "completion")
+            .ForJob(job)
+            .StartAt(clock.GetUtcNow())
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+        running.ComputeFirstFireTimeUtc(calendar: null);
+
+        await store.ScheduleJob(job, running);
+
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = clock.GetUtcNow().AddMinutes(1),
+            MaxCount = 1,
+        });
+
+        IOperableTrigger firing = acquired.Should().ContainSingle(x => x.Key.Equals(running.Key),
+            "the trigger due now is the one whose firing blocks the job").Subject;
+
+        List<TriggerFiredResult> results = await store.TriggersFired([firing]);
+        results.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull(
+            "the firing has to be committed for the job to count as running");
+
+        return firing;
+    }
+
+    /// <summary>
+    /// A one-shot trigger whose only firing was an hour ago and which nobody got around to firing.
+    /// </summary>
+    /// <remarks>
+    /// The fire time is written back by hand because <see cref="IOperableTrigger.ComputeFirstFireTimeUtc" />
+    /// is what a scheduler would have called before storing it, and a trigger that is overdue is one
+    /// whose stored fire time has since gone past.
+    /// </remarks>
+    private static IOperableTrigger CreateOverdueOneShot(
+        string name,
+        IJobDetail job,
+        FakeTimeProvider clock,
+        SimpleTriggerMisfireInstruction misfireInstruction)
+    {
+        DateTimeOffset missed = clock.GetUtcNow().AddHours(-1);
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity(name, "completion")
+            .ForJob(job)
+            .StartAt(missed)
+            .WithSimpleSchedule(x => x
+                .WithRepeatCount(0)
+                .WithInterval(TimeSpan.Zero)
+                .WithMisfireInstruction(misfireInstruction))
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(calendar: null);
+        trigger.NextFireTimeUtc = missed;
+        return trigger;
     }
 
     #endregion

--- a/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/MicrosoftDependencyInjectionJobFactoryTest.cs
@@ -17,11 +17,106 @@ namespace Quartz.Tests.Unit.Simpl;
 public class MicrosoftDependencyInjectionJobFactoryTest
 {
     [Test]
-    [Ignore("WIP")]
-    public async Task DisposedServiceProviderShouldThrowSchedulerException()
+    public async Task ShouldThrowObjectDisposedExceptionWhenTheContainerIsGone()
     {
-        var factory = new MicrosoftDependencyInjectionJobFactory(new TestServiceProvider());
-        await factory.CreateJob(TestUtil.NewMinimalTriggerFiredBundle(), null!);
+        // A container disposed while a firing is in flight is what a host shutting down looks like from
+        // here, and the exception type is load-bearing: JobRunShell reads it to tell a shutdown race
+        // apart from a job that cannot be built, and completes the firing with NoInstruction rather than
+        // putting every trigger of the job into Error. The test below pins the other half of that.
+        ServiceCollection serviceCollection = [];
+        serviceCollection.AddTransient<ScopedJob>();
+        serviceCollection.AddScoped<ScopedDependency>();
+        ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+        await serviceProvider.DisposeAsync();
+
+        MicrosoftDependencyInjectionJobFactory factory = new(serviceProvider);
+
+        Func<Task> act = async () => await factory.CreateJob(NewBundleFor<ScopedJob>(), NewScheduler());
+
+        await act.Should().ThrowAsync<ObjectDisposedException>(
+            "the scope for the firing cannot be opened once the container it would come from is disposed");
+    }
+
+    [Test]
+    public async Task ShouldLeaveTheTriggerOutOfErrorStateWhenTheContainerIsGone()
+    {
+        // The consequence of the exception type above. A trigger left in Error needs a human to reset
+        // it, and a container that went away underneath a firing is not a configuration problem — it is
+        // the application stopping.
+        ServiceCollection serviceCollection = [];
+        serviceCollection.AddTransient<ScopedJob>();
+        serviceCollection.AddScoped<ScopedDependency>();
+        ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+        CompletionRecordingJobStore store = null!;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "disposed-container")
+            .UseJobStore(provider =>
+            {
+                store = new CompletionRecordingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .UseJobFactory(new MicrosoftDependencyInjectionJobFactory(serviceProvider))
+            .BuildScheduler();
+
+        try
+        {
+            IJobDetail jobDetail = JobBuilder.Create<ScopedJob>()
+                .WithIdentity("job", "disposed-container")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("trigger", "disposed-container")
+                .ForJob(jobDetail)
+                .StartNow()
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build();
+
+            await scheduler.ScheduleJob(jobDetail, trigger);
+
+            // Disposed before the scheduler is ever started, so the first firing is the one that finds
+            // the container gone.
+            await serviceProvider.DisposeAsync();
+
+            await scheduler.Start();
+
+            SchedulerInstruction instruction = await store.FirstCompletion.WaitAsync(TimeSpan.FromSeconds(30));
+
+            instruction.Should().Be(SchedulerInstruction.NoInstruction,
+                "a firing whose container has been disposed settles nothing, so the trigger is left as it was");
+
+            (await scheduler.GetTriggerState(trigger.Key)).Should().NotBe(TriggerState.Error,
+                "a container that went away is the application stopping, and must not leave a trigger needing a manual reset");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Records the instruction the first finished firing was completed with, so a test can await the
+    /// completion rather than sleep for it.
+    /// </summary>
+    private sealed class CompletionRecordingJobStore : DelegatingJobStore
+    {
+        private readonly TaskCompletionSource<SchedulerInstruction> completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public CompletionRecordingJobStore(IJobStore jobStore) : base(jobStore)
+        {
+        }
+
+        public Task<SchedulerInstruction> FirstCompletion => completed.Task;
+
+        public override async ValueTask TriggeredJobComplete(
+            IOperableTrigger trigger,
+            IJobDetail jobDetail,
+            SchedulerInstruction triggerInstructionCode,
+            CancellationToken cancellationToken = default)
+        {
+            await base.TriggeredJobComplete(trigger, jobDetail, triggerInstructionCode, cancellationToken).ConfigureAwait(false);
+            completed.TrySetResult(triggerInstructionCode);
+        }
     }
 
     [Test]
@@ -308,14 +403,6 @@ public class MicrosoftDependencyInjectionJobFactoryTest
         {
             Disposed = true;
             DisposedSignal.TrySetResult();
-        }
-    }
-
-    private sealed class TestServiceProvider : IServiceProvider
-    {
-        public object GetService(Type serviceType)
-        {
-            return Activator.CreateInstance(serviceType);
         }
     }
 


### PR DESCRIPTION
`PersistJobDataAfterExecution` was named by ten test files and asserted by none of them, a vetoed
firing was untested from the store's side, and three fixtures were switched off. This is all tests:
no product file is touched, and no public API moves.

## What each new fixture proves

**`JobStoreContractTest` — the data map round trip, on both stores.** Two cases, run against
`RAMJobStore` and against SQLite. A job with the attribute has the map it mutated written back *and
handed to the next firing*, which is the thing the attribute exists for; a job without it does not,
so a firing's scratch space never becomes the schedule's idea of the job. The assertion is on the
next firing's `TriggerFiredBundle.JobDetail` rather than only on `GetJob`, because being handed the
value back is the promise. The two stores reach it by different means — the in-memory store re-stores
a copy of the map, the ADO store round-trips it through the serializer into a `JOB_DATA` update it
only issues when the map is dirty — which is exactly why it belongs in the contract suite.
Skipping the write-back in `RAMJobStore` fails the in-memory case with *expected 2, found 1*.

**`VetoedFiringTest` — a veto is completed, not released.** A veto is decided by a trigger listener
and settled in the store: the trigger has to go back into the waiting set, and the siblings that
`[DisallowConcurrentExecution]` blocked when the firing was committed have to be let go. That only
happens because the run shell calls `TriggeredJobComplete` rather than `ReleaseAcquiredTrigger` —
the distinction `AGENTS.md` records — and nothing pinned it. The sibling's blocked state is read from
a hook that runs while the vetoed firing is still open, so "and then it was let go" is a claim about
something that had actually been blocked. A second case covers a veto of a trigger's last firing,
which is still deleted and still announced as finalized. Both fail if `NotifyJobStoreJobVetoed` is
changed to release the trigger.

**`ThrowingJobListenerTest` — the two sides of a failing job listener.** They are deliberately unlike
each other. A failure in `JobToBeExecuted` stops the firing, and the trigger still has to be handed
back or the job's other triggers stay blocked behind a firing that never happened. A failure in
`JobWasExecuted` is too late to stop anything: the job ran, and the verdict the trigger reached
before any listener was asked still has to reach the store — which is why that case uses a trigger
whose last firing it was, so `DeleteTrigger` has to survive the failure rather than the completion
falling back to the same instruction either way. Each case asserts what the scheduler listeners are
told, and then fires a second job the listener leaves alone, so "the scheduler carried on" is a claim
about work it did.

**`ShutdownJobInterruptionTest` — all eight combinations.** The four settings were tested only as far
as the property; what the scheduler does with them was not, so three of the four could have meant
anything. The job registers on its own cancellation token rather than polling it, and the thread pool
under test says when the shutdown has reached it — strictly after the interrupt decision is made and
acted on, which is what lets the four "no interruption" cases assert an absence instead of waiting to
see whether one turns up. Setting the `Always` arm to `false` fails exactly the two `Always` cases, in
milliseconds.

**`TriggeredJobCompleteTest` — the in-memory unblock path, in the fast suite.** #3471's behaviour was
pinned only by the contract suite, which runs in the integration leg, whose coverage the Sonar gate
does not read. The in-memory half now also runs on a clock the test owns, so "rescheduled to now" is
an exact instant rather than a window.

## The three switched-off fixtures

- **`QuartzSchedulerTest.CurrentlyExecutingJobs` and `.NumberOfJobsExecuted`** were `[Ignore("Flaky
  in CI")]`, and both were flaky for one reason: they scheduled jobs that slept 200ms and asserted
  what the scheduler was doing at 150ms, 300ms and 600ms. Each firing now says when it has begun and
  waits to be let go, and a job listener records each one as it ends — the scheduler notifies its own
  `ExecutingJobsManager` before any application listener, so a firing has already left the listing by
  the time the test hears about it. The count is asserted after all seven firings the schedule calls
  for, and again after a draining shutdown, which is what makes "and no more than seven" a fact. The
  gate travels in the job data map, so nothing is static.
- **`MicrosoftDependencyInjectionJobFactoryTest.DisposedServiceProviderShouldThrowSchedulerException`**
  was `[Ignore("WIP")]` and named for something that does not happen — see below. Replaced by two
  tests that assert what does.

No `[Ignore]` was re-worded, and none is left in either file.

## Premises corrected

- **"the whole fixture" is not ignored.** `MicrosoftDependencyInjectionJobFactoryTest` had one
  `[Ignore("WIP")]` test out of ten; the other nine run. Only that one is rewritten.
- **`DisposedServiceProviderShouldThrowSchedulerException` asserts something untrue.**
  `MicrosoftDependencyInjectionJobFactory` opens the scope before its `try`, so a disposed container
  comes out as a plain `ObjectDisposedException`, never wrapped in a `SchedulerException`. The
  exception *type* is load-bearing though — `JobRunShell` reads it to tell a shutdown race apart from
  a job that cannot be built — so the rewrite pins the type and then the consequence: the firing is
  completed with `NoInstruction` and the trigger is left out of `Error`.
- **On `RAMJobStore` the write-back is not "a reference that passes by accident".**
  `JobDetailImpl.Clone()` deep-copies the data map and `TriggersFired` hands out a clone, so a test
  that mutates the bundle's map does not reach the stored one. Removing the persist block genuinely
  fails the in-memory case. The test is worth having on both stores, but not for the stated reason.
- **`GetCurrentlyExecutingJobs` is gone from `IScheduler`** (it survives on `QuartzScheduler`), so the
  rewritten lifecycle tests still drive the core class directly, as the originals did.

## Defects found, deliberately left alone

Both are in `QuartzScheduler.NotifyJobListeners`, both are reachable today, and neither is a change I
was asked to make here — the issue says a test that cannot be made to pass is a bug report.

1. **A job listener that throws *synchronously* wedges the firing.** `NotifySingle` wraps the
   `await`, but the call that produces the task —
   `NotifySingle(notifyAction(jl, context, …), jl, context)` — is evaluated outside its `try`. A
   listener whose `JobToBeExecuted` is not `async` and throws from a guard clause therefore escapes
   as a raw `InvalidOperationException`, which `JobRunShell.NotifyListenersBeginning`'s
   `catch (SchedulerException)` does not catch. `TriggeredJobComplete` is never called: the trigger
   stays as `TriggersFired` left it and, for a `[DisallowConcurrentExecution]` job, so do all its
   siblings — permanently. I hit this while writing the fixture; the first draft of
   `ThrowingJobListener` threw synchronously and both tests hung for the full 30s deadline. The
   fixture now returns `ValueTask.FromException`, which is the shape an `async` listener produces,
   and its `<remarks>` says so. The trigger-listener notifications do not have this hole — their
   calls are inside the `try`.
2. **A firing whose `JobToBeExecuted` notification failed is listed as executing forever.** The
   internal `ExecutingJobsManager` is notified first and records the firing; when a later listener
   fails, the loop aborts and `JobWasExecuted` is never reached, so nothing removes it. Probed
   directly: after the completion has reached the store, `NumberOfJobsExecutingHere` is still 1. The
   store side is clean — `TriggeredJobComplete` releases the fire instance, so `QueryFireInstances`
   is unaffected — but `GetCurrentlyExecutingJobs`, `NumberOfJobsExecutingHere` and the shutdown
   interrupt loop all see a firing that ended long ago.

A third, smaller inconsistency, noted without a test: the run shell announces
`NotifySchedulerListenersFinalized` for a trigger with nothing left to fire on the veto path
(`JobRunShell.cs`) and on the trigger-listener-failure path, but not on the job-listener-failure
path. Two of the three compensate; the third looks like an oversight rather than a decision.

## What a reviewer may want to decide

- `CompletionWatchingJobStore` is new shared test scaffolding in `Quartz.Tests.Unit/Core`. It records
  `ReleaseAcquiredTrigger` and `TriggeredJobComplete` *after* the wrapped store has acted, so a test
  that waits on a record is looking at a settled store; `FaultInjectingJobStore` records before, which
  its own tests need and mine cannot use. Its `BeforeCompletion` hook exists so a test can read the
  state a completion is about to change, which is what makes the "the sibling really was blocked"
  assertion non-vacuous.
- The three findings above: whether any of them wants a fix in this release, and whether the second
  one is a bug or the intended reading of "a listener that throws has abandoned the notification".

## Verification

Rebased onto `origin/main` at `77edc8571` (which now carries #3493, so the RAM-store assertions are
against the notify-after-unlock behaviour).

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj          (run 1)
  Passed! - Failed: 0, Passed: 3619, Skipped: 1, Total: 3620, Duration: 1 m 5 s

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj          (run 2)
  Passed! - Failed: 0, Passed: 3619, Skipped: 1, Total: 3620, Duration: 1 m 1 s

dotnet test src/Quartz.Tests.Integration  (the basic leg: every db-* category negated)
  Passed! - Failed: 0, Passed: 335, Skipped: 0, Total: 335, Duration: 2 m 51 s

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed! - Failed: 0, Passed: 547, Skipped: 0, Total: 547, Duration: 8 s
```

The two unit runs are the flake check, and they earned their keep: the first pair of runs before this
one failed once in three on `ShutdownJobInterruptionTest`, in my own code — the job wrote what it saw
on its token after the assertion had read it, on the shutdowns that do not wait for their jobs. The
job now signals that it has finished and the test waits for that as well as for the shutdown.
`ShutdownJobInterruptionTest` was then run five more times on its own, all green.

No docs changed, so `VerifyDocsSnippets` is not implicated. Integration legs that need Docker were not
run; SQLite needs no container and is in the `basic` leg.

Closes #3437
