### PR TITLE
Paging, projections and parameter names are structure rather than convention

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -11,8 +11,8 @@ a delegate of its own.
 ::: tip Start here
 **Do not implement `IDriverDelegate`.** Nothing in the product does; it is a hundred-odd members, and
 almost all of them are the same SQL on every database. Subclass `StdAdoDelegate` and override the
-handful that differ. The six shipped dialects override **eight distinct members between them**, out of
-roughly a hundred and ten.
+handful that differ. The six shipped dialects override **nine distinct members between them**, out of
+roughly a hundred and ten — and four of the six override two or fewer.
 :::
 
 ## The seam
@@ -28,12 +28,13 @@ public sealed class MyDatabaseDelegate : StdAdoDelegate
 ```
 <!-- endSnippet -->
 
-Eight members are the dialect contract. Everything else on `StdAdoDelegate` is an implementation step
+Nine members are the dialect contract. Everything else on `StdAdoDelegate` is an implementation step
 that happens to be `protected virtual` so the class can be composed — treat them as private.
 
 | Member | Override when |
 |---|---|
-| `protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)` | your database limits rows differently from ANSI |
+| `protected virtual SqlRowLimit GetRowLimit(int count)` | your database can limit the rows a statement returns |
+| `protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)` | the acquisition statement needs something else besides — MySQL's index hint is the only shipped case |
 | `protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count)` | the same, for the misfire scan; `count == -1` means "no limit" |
 | `protected virtual string GetCountMisfiredTriggersInStateSql()` | the counting form needs a different shape |
 | `protected virtual string ApplyPaging(string sql, bool takeLimited)` | `OFFSET … FETCH NEXT …` is not understood |
@@ -44,28 +45,34 @@ that happens to be `protected virtual` so the class can be composed — treat th
 
 ### Row limiting
 
-The default `GetSelectNextTriggerToAcquireSql` ignores `shape.MaxCount` entirely — *"by default we
-don't support limits, this is db specific"* — so a dialect that can limit rows should say so. Four
-shapes appear among the shipped dialects:
+There is no ANSI row limit, so `StdAdoDelegate` applies none and a dialect that can limit rows says
+where its clause goes. Two statements carry one — trigger acquisition and the misfire scan — and both
+ask the same member, so a dialect says it once:
 
 <!-- snippet: sample_dialect_delegate_row_limiting -->
 ```csharp
-// append (PostgreSQL, Firebird)
-protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    => base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
+// … LIMIT n (PostgreSQL, MySQL, SQLite) — or "ROWS" on Firebird
+protected override SqlRowLimit GetRowLimit(int count)
+    => SqlRowLimit.AtStatementEnd("LIMIT", count);
 
-// splice a prefix (SQL Server: SELECT TOP n)
-// wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
-// append with an index hint (MySQL: FORCE INDEX (…) … LIMIT n)
+// SELECT TOP n …                              SqlRowLimit.InProjection("TOP", count)
+// SELECT * FROM ( … ) WHERE rownum <= n       SqlRowLimit.InEnclosingSelect("rownum", count)
 ```
 <!-- endSnippet -->
 
+`SqlRowLimit` names the three places a limit can sit, and the statement is built with the clause
+already in it. Nothing is spliced into finished SQL, so a dialect no longer depends on the statement
+starting with a particular keyword or ending with a particular clause. `count` is always at least
+one: the `-1` that means "every row" is turned into `SqlRowLimit.Unlimited` before the member is
+called, so an override never has to test for it.
+
 `TriggerAcquisitionSqlShape` carries everything about an acquisition attempt that changes the text of
-the statement — the row limit, and how many job-type exclusion terms the `NOT IN` clause needs. Read
-`shape.MaxCount` and hand the whole shape to `base`: a dimension added later becomes a property on
-the record, so an override written today keeps compiling and keeps applying it. It is also the key
-the finished statement is cached under, which is why it holds the bucketed exclusion count rather
-than the caller's exact one.
+the statement — the row limit's count, and how many job-type exclusion terms the `NOT IN` clause
+needs. It is also the key the finished statement is cached under, which is why it holds the bucketed
+exclusion count rather than the caller's exact one. Override
+`GetSelectNextTriggerToAcquireSql(shape)` only for something a row limit cannot express; MySQL is the
+one shipped dialect that does, for its `FORCE INDEX` hint, and it still calls `base` and leaves the
+limit alone.
 
 ### Paging
 
@@ -148,7 +155,7 @@ For a delegate in your own assembly this means two things:
 substitutes it. Statements the base class returns still contain it; the caller substitutes.
 
 ::: tip
-"Customize one statement" is not a supported operation, and that is deliberate. The five SQL hooks
+"Customize one statement" is not a supported operation, and that is deliberate. The six SQL hooks
 above cover the statements that actually differ between databases; the other ~76 are inlined
 `ReplaceTablePrefix(StdAdoConstants.X)` call sites, and the delegate *is* the seam — override the
 method that issues the statement. Additional `GetXxxSql()` hooks can be added later without breaking

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5146,16 +5146,51 @@ protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlS
 Its parameter is new: `TriggerAcquisitionSqlShape` carries everything about an acquisition attempt
 that changes the statement's text — `MaxCount`, and `ExcludedJobTypeBucket` for the job-type
 exclusion clause — so the next acquisition dimension is a property on the record rather than another
-parameter here. Read `shape.MaxCount` and pass the whole shape to `base`. It is still the only thing
-the dialects differed in: `FirebirdDelegate` appends
-`ROWS n`, `SqlServerDelegate` splices in `SELECT TOP n`, `OracleDelegate` wraps the statement in a
-`rownum` filter, and the rest append `LIMIT n`. **A dialect delegate of your own should keep its
-`GetSelectNextTriggerToAcquireSql` override and delete the other three.**
+parameter here. **A dialect delegate of your own should delete the three removed overrides**; if the
+one it keeps exists only to hang a row limit off the statement, delete that too and say the limit
+once — see [Row limiting is a slot, not a splice](#row-limiting-is-a-slot-not-a-splice).
 
 The node-affinity parameters the statement now always carries are bound for you by the protected
 `AddPreferredNodeParameters(cmd, liveNodeCutoff)`, so an override that rewrites the statement text
 still does not have to know their names or the order they are bound in. The cutoff parameter is a
 `DateTimeOffset`; the binder converts it to the stored tick value itself.
+
+### Row limiting is a slot, not a splice
+
+Two statements come in a row-limited form — trigger acquisition and the misfire scan — and each of the
+six dialects used to produce its own by editing the finished SQL: `SqlServerDelegate` cut the first
+six characters off and pasted `SELECT TOP n` back on, `OracleDelegate` wrapped the whole thing in a
+`rownum` filter, and the rest appended `LIMIT n` or `ROWS n`. Correct, and correct only while the
+statement began with exactly `SELECT` — which nothing enforced — and repeated once per statement per
+dialect, each with its own `count == -1` test.
+
+A dialect now says where its clause goes, once, and the statement is built with it already there:
+
+```csharp
+protected virtual SqlRowLimit GetRowLimit(int count)
+```
+
+`SqlRowLimit` is new and names the three placements: `InProjection("TOP", count)` for SQL Server,
+`AtStatementEnd("LIMIT", count)` for PostgreSQL, MySQL and SQLite, `AtStatementEnd("ROWS", count)`
+for Firebird, `InEnclosingSelect("rownum", count)` for Oracle, and `Unlimited` for a database that
+cannot limit rows, which is what `StdAdoDelegate` returns. `count` is never the `-1` sentinel: that is
+turned into `Unlimited` before the member is called.
+
+`GetSelectNextTriggerToAcquireSql(shape)` and `GetSelectMisfiredTriggersToRecoverSql(count)` are still
+`protected virtual`, and still the seam for a statement that needs something a row limit cannot say —
+`MySQLDelegate` overrides both for its `FORCE INDEX` hint. The five other dialect delegates no longer
+override either.
+
+**If your dialect delegate overrides one of the two only to add a row limit, replace both overrides
+with a single `GetRowLimit`.** Nothing breaks if you do not: the two hooks behave as they always did,
+and an override that appends its own clause still works. It just spells the same thing twice, against
+a statement it does not own.
+
+One shipped statement changed as a result. `MySQLDelegate`'s misfire scan carries its
+`FORCE INDEX (IDX_…_T_NFT_ST_MISFIRE)` hint for an unlimited sweep as well now; it used to lose the
+hint in exactly that case, because the hint and the row limit shared one early return. Which index
+the sweep should read does not depend on how many rows it returns, and the unlimited sweep is the one
+that reads the most.
 
 ## The connection manager is gone
 
@@ -7996,7 +8031,9 @@ Parameters and behavior are unchanged:
 | `IDriverDelegate.UpdateFiredTrigger` removed | `ApplyTriggerFired` writes the fired-trigger row as one command of its batch, and nothing else called it; an override of it would have stopped taking effect silently — see [Batched trigger fire](#batched-trigger-fire) |
 | `StdAdoDelegate`'s column probes removed | The three `Has*Column` properties, the three `Supports*Column` probes and `VerifyTriggersTableReachable`. The columns they probed for are required on 4.x, so the schema migration replaces them — see [The optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone) |
 | `GetSelectNextTriggerToAcquireWith*Sql` removed | The `…WithExecutionGroupSql`, `…WithPreferredNodeSql` and `…WithPreferredNodeOnlySql` hooks, on `StdAdoDelegate` and all six dialect delegates. One statement covers every case now, so a dialect delegate keeps only its `GetSelectNextTriggerToAcquireSql` override — see [The three extra acquisition SQL hooks went with them](#the-three-extra-acquisition-sql-hooks-went-with-them) |
-| `StdAdoDelegate.GetSelectNextTriggerToAcquireSql(int maxCount)` | `GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)`; a custom dialect override reads `shape.MaxCount` for its row limit and passes the whole shape to `base`, so the next acquisition dimension is a property on the record rather than another parameter |
+| `StdAdoDelegate.GetSelectNextTriggerToAcquireSql(int maxCount)` | `GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)`; a custom dialect override passes the whole shape to `base`, so the next acquisition dimension is a property on the record rather than another parameter |
+| `StdAdoDelegate.GetRowLimit(int count)` added | Where a dialect's row-limiting clause goes, said once for both statements that carry one, as a `SqlRowLimit` rather than an edit to finished SQL. Five of the six dialect delegates stopped overriding `GetSelectNextTriggerToAcquireSql` and `GetSelectMisfiredTriggersToRecoverSql` entirely; both hooks stay `protected virtual` and an override that splices its own clause still works — see [Row limiting is a slot, not a splice](#row-limiting-is-a-slot-not-a-splice) |
+| `Quartz.Impl.AdoJobStore.SqlRowLimit` added | A `readonly record struct` naming the three placements a row limit can take — `InProjection`, `AtStatementEnd`, `InEnclosingSelect` — and `Unlimited` for a database that cannot limit rows |
 | `IDbConnectionManager` / `DbConnectionManager` removed | The container is the provider registry, keyed by scheduler name; register a provider with `UseConnectionProvider` — see [The connection manager is gone](#the-connection-manager-is-gone) |
 | `AdoJobStoreOptions.TxIsolationLevelSerializable` is `TransactionIsolationLevel` | An `IsolationLevel?` rather than a `bool`, so `Snapshot` and the rest are expressible. The legacy key still translates — see [The isolation level is an isolation level](#the-isolation-level-is-an-isolation-level) |
 | `AdoJobStoreOptions.CommandTimeout` added | Bounds every statement the store issues, the lock handler's included; it reaches them through `DriverDelegateContext.CommandTimeout` and `SemaphoreContext.CommandTimeout`. Unset keeps each provider's own default, so nothing changes for a store that does not set it. 3.x had no way to say this at all — there was no `quartz.*` key for it, so nothing needs translating |

--- a/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
@@ -24,13 +24,12 @@ internal sealed class DialectDelegateOverrides : StdAdoDelegate
 {
     #region sample_dialect_delegate_row_limiting
 
-    // append (PostgreSQL, Firebird)
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-        => base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
+    // … LIMIT n (PostgreSQL, MySQL, SQLite) — or "ROWS" on Firebird
+    protected override SqlRowLimit GetRowLimit(int count)
+        => SqlRowLimit.AtStatementEnd("LIMIT", count);
 
-    // splice a prefix (SQL Server: SELECT TOP n)
-    // wrap the whole statement (Oracle: SELECT * FROM ( … ) WHERE rownum <= n)
-    // append with an index hint (MySQL: FORCE INDEX (…) … LIMIT n)
+    // SELECT TOP n …                              SqlRowLimit.InProjection("TOP", count)
+    // SELECT * FROM ( … ) WHERE rownum <= n       SqlRowLimit.InEnclosingSelect("rownum", count)
 
     #endregion
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
@@ -72,7 +72,7 @@ public class AcquisitionSqlTest
     [Test]
     public async Task TheExclusionClauseSitsBetweenTheNodeFilterAndTheOrdering()
     {
-        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 4);
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 4, SqlRowLimit.Unlimited);
 
         // Placement is what makes "no per-dialect SQL change" true: every dialect splices its row
         // limit into the projection or around the whole statement, so a clause that landed after

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AcquisitionSqlTest.cs
@@ -5,27 +5,34 @@ using Quartz.Impl.AdoJobStore;
 namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 
 /// <summary>
-/// The acquisition statement every shipped dialect produces when nothing is excluded, pinned as a
-/// snapshot.
+/// The two row-limited statements every shipped dialect produces, pinned as snapshots.
 /// </summary>
 /// <remarks>
-/// The statement is assembled from a shared template, a per-dialect row-limiting splice and an
-/// optional job-type exclusion clause. The text here is the one from before that assembly was
-/// consolidated into a single template, so a change that is meant to leave the no-exclusion
-/// statement alone has to prove it did — including the parts that look like whitespace and are not,
-/// such as SQL Server's <c>Substring(6)</c> splice and MySQL's index hint, both of which are
-/// positional and would break silently if the projection moved.
+/// Each is assembled from a shared template, a per-dialect row-limiting clause and — for acquisition
+/// — an optional job-type exclusion clause. The text here is the one from before that assembly was
+/// consolidated, so a change that is meant to leave a statement alone has to prove it did —
+/// including the parts that look like whitespace and are not, such as SQL Server's row-limit splice
+/// and MySQL's index hint, both of which used to be positional and would have broken silently if the
+/// projection moved.
 /// </remarks>
 public class AcquisitionSqlTest
 {
     private const int MaxCount = 5;
+
+    /// <summary>
+    /// A misfire recovery batch size, and the sentinel that asks for an unlimited one. Both are
+    /// snapshotted, because the row limit is what tells the two apart.
+    /// </summary>
+    private const int MisfireCount = 20;
+
+    private const int Unlimited = -1;
 
     [Test]
     public async Task EveryDialectBuildsTheAcquisitionStatementItAlwaysDidWhenNothingIsExcluded()
     {
         StringBuilder statements = new StringBuilder();
 
-        foreach (IAcquisitionSql dialect in Dialects())
+        foreach (IDialectSql dialect in Dialects())
         {
             statements.Append("=== ").Append(dialect.GetType().BaseType!.Name).AppendLine(" ===");
             statements.AppendLine(dialect.NoExclusions(MaxCount));
@@ -35,6 +42,30 @@ public class AcquisitionSqlTest
         await Verify(statements.ToString(), extension: "txt")
             .UseDirectory("../../Verify")
             .UseFileName("AcquisitionSqlTest_NoExclusions")
+            .DisableRequireUniquePrefix();
+    }
+
+    [Test]
+    public async Task EveryDialectBuildsTheMisfireRecoveryStatementItAlwaysDid()
+    {
+        StringBuilder statements = new StringBuilder();
+
+        foreach (IDialectSql dialect in Dialects())
+        {
+            string name = dialect.GetType().BaseType!.Name;
+
+            statements.Append("=== ").Append(name).AppendLine(" ===");
+            statements.AppendLine(dialect.MisfireRecovery(MisfireCount));
+            statements.AppendLine();
+
+            statements.Append("=== ").Append(name).AppendLine(" (unlimited) ===");
+            statements.AppendLine(dialect.MisfireRecovery(Unlimited));
+            statements.AppendLine();
+        }
+
+        await Verify(statements.ToString(), extension: "txt")
+            .UseDirectory("../../Verify")
+            .UseFileName("AcquisitionSqlTest_MisfireRecovery")
             .DisableRequireUniquePrefix();
     }
 
@@ -52,7 +83,7 @@ public class AcquisitionSqlTest
             .DisableRequireUniquePrefix();
     }
 
-    private static IAcquisitionSql[] Dialects() =>
+    private static IDialectSql[] Dialects() =>
     [
         new AcquisitionSqlStdAdoDelegate(),
         new AcquisitionSqlSqlServerDelegate(),
@@ -64,47 +95,63 @@ public class AcquisitionSqlTest
     ];
 
     /// <summary>
-    /// What each dialect is asked for. The hook is protected, so reaching it means deriving — which
-    /// is what a dialect author does anyway.
+    /// What each dialect is asked for. The hooks are protected, so reaching them means deriving —
+    /// which is what a dialect author does anyway.
     /// </summary>
-    private interface IAcquisitionSql
+    private interface IDialectSql
     {
         string NoExclusions(int maxCount);
+
+        string MisfireRecovery(int count);
     }
 
-    private sealed class AcquisitionSqlStdAdoDelegate : StdAdoDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlStdAdoDelegate : StdAdoDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlSqlServerDelegate : SqlServerDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlSqlServerDelegate : SqlServerDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlPostgreSQLDelegate : PostgreSQLDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlPostgreSQLDelegate : PostgreSQLDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlMySQLDelegate : MySQLDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlMySQLDelegate : MySQLDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlSQLiteDelegate : SQLiteDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlSQLiteDelegate : SQLiteDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlOracleDelegate : OracleDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlOracleDelegate : OracleDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
-    private sealed class AcquisitionSqlFirebirdDelegate : FirebirdDelegate, IAcquisitionSql
+    private sealed class AcquisitionSqlFirebirdDelegate : FirebirdDelegate, IDialectSql
     {
         public string NoExclusions(int maxCount) => GetSelectNextTriggerToAcquireSql(Shape(maxCount));
+
+        public string MisfireRecovery(int count) => GetSelectMisfiredTriggersToRecoverSql(count);
     }
 
     private static TriggerAcquisitionSqlShape Shape(int maxCount) =>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoUtilTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoUtilTest.cs
@@ -72,6 +72,7 @@ public class AdoUtilTest
         var act = () => AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_");
 
         act.Should().NotThrow();
-        AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_").Should().StartWith("SELECT * FROM QRTZ_SIMPROP_TRIGGERS WHERE");
+        AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_").Should().Contain("FROM QRTZ_SIMPROP_TRIGGERS WHERE",
+            "the table prefix is the one brace pair the statement does mean to substitute");
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/Common/DbMetadataParameterNameTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/Common/DbMetadataParameterNameTest.cs
@@ -1,0 +1,76 @@
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore.Common;
+
+/// <summary>
+/// The prefixed spelling of a parameter name is worked out once per name, not once per parameter
+/// bound.
+/// </summary>
+public class DbMetadataParameterNameTest
+{
+    private static DbMetadata Metadata(string prefix) => new() { ParameterNamePrefix = prefix, BindByName = true };
+
+    [Test]
+    public void PrefixesTheName()
+    {
+        Metadata("@").GetParameterName("schedulerName").Should().Be("@schedulerName");
+        Metadata(":").GetParameterName("schedulerName").Should().Be(":schedulerName");
+    }
+
+    [Test]
+    public void HandsBackTheSameStringForTheSameName()
+    {
+        DbMetadata metadata = Metadata("@");
+
+        metadata.GetParameterName("triggerName").Should().BeSameAs(metadata.GetParameterName("triggerName"),
+            "a name asked for twice was spelled once; the second call has nothing to build");
+    }
+
+    [Test]
+    public void ADescriptionWithNoPrefixHandsBackWhatItWasGiven()
+    {
+        // Nothing to prepend, so nothing to build and nothing to remember.
+        string name = "schedulerName";
+
+        Metadata(null).GetParameterName(name).Should().BeSameAs(name);
+        Metadata("").GetParameterName(name).Should().BeSameAs(name);
+    }
+
+    [Test]
+    public void RememberingOneNameDoesNotMakeTwoDescriptionsDiffer()
+    {
+        DbMetadata used = Metadata("@");
+        DbMetadata fresh = Metadata("@");
+
+        used.GetParameterName("schedulerName");
+
+        used.Should().Be(fresh,
+            "the cache hangs off the description rather than sitting in a field on it, because a record compares every field it has");
+    }
+
+    [Test]
+    public void BindingTheSameNamesAgainAllocatesNothing()
+    {
+        // The seven parameters a trigger acquisition binds, which is the smallest of the hot paths.
+        string[] names = ["schedulerName", "state", "noLaterThan", "noEarlierThan", "instanceId", "autoPinSentinel", "liveNodeCutoff"];
+        DbMetadata metadata = Metadata("@");
+
+        // Warm the cache, then measure the round every acquisition after the first one pays.
+        Bind(metadata, names);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Bind(metadata, names);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        allocated.Should().Be(0,
+            "binding a parameter used to concatenate its name with the driver's prefix, which put an allocation under every parameter of every statement the store issues");
+    }
+
+    private static void Bind(DbMetadata metadata, string[] names)
+    {
+        foreach (string name in names)
+        {
+            _ = metadata.GetParameterName(name);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -65,14 +65,15 @@ public class MySQLDelegateTest
     }
 
     [Test]
-    public void GetSelectMisfiredTriggersToRecoverSql_WithMinusOne_ShouldNotContainLimit()
+    public void GetSelectMisfiredTriggersToRecoverSql_WithMinusOne_ShouldNotContainLimitButKeepTheHint()
     {
         var del = new TestMySQLDelegate();
 
         var sql = del.GetSelectMisfiredTriggersToRecoverSqlPublic(-1);
 
-        sql.Should().NotContain("LIMIT");
-        sql.Should().NotContain("FORCE INDEX");
+        sql.Should().NotContain("LIMIT", "-1 is the sentinel that asks for every misfired row");
+        sql.Should().Contain("{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)",
+            "which index the sweep should read does not depend on how many rows it returns, and an unlimited sweep is the one that reads the most");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ProjectionDataReader.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ProjectionDataReader.cs
@@ -1,0 +1,193 @@
+#nullable enable
+
+using System.Collections;
+using System.Data.Common;
+using System.Globalization;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// A reader over exactly the columns a statement projects, which refuses any other and remembers
+/// which of its own were asked for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is what makes "the named column list is the list the reader reads" a test rather than a
+/// comment. A reader asking for a column the statement does not project fails here the way it would
+/// against a database — <see cref="GetOrdinal" /> throws — and a statement projecting a column no
+/// reader wants is left over in <see cref="Unread" /> at the end.
+/// </para>
+/// <para>
+/// The values are made up but type-plausible, because the readers do real work with them: a cron
+/// expression is parsed, a time zone id is resolved, and a stored state is mapped onto
+/// <see cref="Quartz.Extensibility.StoredTriggerState" />.
+/// </para>
+/// </remarks>
+internal sealed class ProjectionDataReader : DbDataReader
+{
+    private readonly string[] columns;
+    private readonly bool[] wasRead;
+    private int rowsLeft;
+
+    public ProjectionDataReader(IReadOnlyCollection<string> columns, int rows = 1)
+    {
+        this.columns = [.. columns];
+        wasRead = new bool[this.columns.Length];
+        rowsLeft = rows;
+    }
+
+    /// <summary>
+    /// A reader with no columns and no rows, for a statement a test drives past but does not measure.
+    /// </summary>
+    public static ProjectionDataReader Empty => new([], rows: 0);
+
+    /// <summary>
+    /// The projected columns nothing asked for, which are the ones the statement is fetching for
+    /// nobody.
+    /// </summary>
+    public IReadOnlyList<string> Unread => [.. columns.Where((_, i) => !wasRead[i])];
+
+    public override int GetOrdinal(string name)
+    {
+        int index = Array.IndexOf(columns, name);
+        if (index < 0)
+        {
+            throw new IndexOutOfRangeException(
+                $"The statement does not project '{name}'. It projects: {string.Join(", ", columns)}");
+        }
+
+        wasRead[index] = true;
+        return index;
+    }
+
+    /// <summary>
+    /// A value of the type the column holds, keyed by name so that one reader serves every statement.
+    /// </summary>
+    private static object ValueOf(string column) => column switch
+    {
+        AdoConstants.ColumnTriggerName => "trigger",
+        AdoConstants.ColumnTriggerGroup => "group",
+        AdoConstants.ColumnJobName => "job",
+        AdoConstants.ColumnJobGroup => "jobs",
+        AdoConstants.ColumnInstanceName => "node",
+        AdoConstants.ColumnEntryId => "entry",
+
+        // EXECUTING rather than ACQUIRED: an acquired row has no job yet, and the reader skips its
+        // job columns, which would leave them looking like columns nothing reads.
+        AdoConstants.ColumnEntryState => AdoConstants.StateExecuting,
+
+        AdoConstants.ColumnCronExpression => "0 0 12 * * ?",
+        AdoConstants.ColumnTimeZoneId => "UTC",
+
+        // Stored as UTC ticks.
+        AdoConstants.ColumnFiredTime or AdoConstants.ColumnScheduledTime or AdoConstants.ColumnLastCheckinTime => 638_000_000_000_000_000L,
+
+        // Stored as whole milliseconds.
+        AdoConstants.ColumnCheckinInterval or AdoConstants.ColumnRepeatInterval => 15_000L,
+
+        AdoConstants.ColumnPriority or AdoConstants.ColumnRepeatCount or AdoConstants.ColumnTimesTriggered => 5,
+        AdoConstants.ColumnIsNonConcurrent or AdoConstants.ColumnRequestsRecovery => true,
+
+        // SIMPROP_TRIGGERS. STR_PROP_1 carries an IntervalUnit name for the calendar-interval type.
+        "STR_PROP_1" => nameof(IntervalUnit.Day),
+        "STR_PROP_2" or "STR_PROP_3" => "text",
+        "INT_PROP_1" or "INT_PROP_2" => 1,
+        "LONG_PROP_1" or "LONG_PROP_2" => 1L,
+        "DEC_PROP_1" or "DEC_PROP_2" => 1m,
+        "BOOL_PROP_1" or "BOOL_PROP_2" => true,
+
+        _ => throw new InvalidOperationException(
+            $"ProjectionDataReader has no value for '{column}'. Add one beside the columns it already knows.")
+    };
+
+    public override object GetValue(int ordinal) => ValueOf(columns[ordinal]);
+
+    public override string GetString(int ordinal) => (string) GetValue(ordinal);
+
+    public override bool GetBoolean(int ordinal) => Convert.ToBoolean(GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    public override int GetInt32(int ordinal) => Convert.ToInt32(GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    public override long GetInt64(int ordinal) => Convert.ToInt64(GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    public override decimal GetDecimal(int ordinal) => Convert.ToDecimal(GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    public override bool IsDBNull(int ordinal) => false;
+
+    public override string GetName(int ordinal) => columns[ordinal];
+
+    public override Type GetFieldType(int ordinal) => GetValue(ordinal).GetType();
+
+    public override string GetDataTypeName(int ordinal) => GetFieldType(ordinal).Name;
+
+    public override int FieldCount => columns.Length;
+
+    public override object this[int ordinal] => GetValue(ordinal);
+
+    public override object this[string name] => GetValue(GetOrdinal(name));
+
+    public override bool HasRows => rowsLeft > 0;
+
+    public override bool Read() => rowsLeft-- > 0;
+
+    public override int Depth => 0;
+
+    public override bool IsClosed => false;
+
+    public override int RecordsAffected => 0;
+
+    public override bool NextResult() => false;
+
+    public override IEnumerator GetEnumerator() => throw new NotSupportedException();
+
+    public override int GetValues(object[] values) => throw new NotSupportedException();
+
+    public override byte GetByte(int ordinal) => throw new NotSupportedException();
+
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+
+    public override char GetChar(int ordinal) => throw new NotSupportedException();
+
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length) => throw new NotSupportedException();
+
+    public override DateTime GetDateTime(int ordinal) => throw new NotSupportedException();
+
+    public override double GetDouble(int ordinal) => throw new NotSupportedException();
+
+    public override float GetFloat(int ordinal) => throw new NotSupportedException();
+
+    public override Guid GetGuid(int ordinal) => throw new NotSupportedException();
+
+    public override short GetInt16(int ordinal) => throw new NotSupportedException();
+}
+
+/// <summary>
+/// A command that answers with one prepared reader, so that a reader living inside
+/// <see cref="Quartz.Impl.AdoJobStore.StdAdoDelegate" /> can be driven without a database.
+/// </summary>
+internal sealed class ReaderStubCommand : DbCommand
+{
+    private readonly ProjectionDataReader reader;
+
+    public ReaderStubCommand(ProjectionDataReader reader) => this.reader = reader;
+
+    protected override DbDataReader ExecuteDbDataReader(System.Data.CommandBehavior behavior) => reader;
+
+    [System.Diagnostics.CodeAnalysis.AllowNull]
+    public override string CommandText { get; set; } = "";
+
+    public override int CommandTimeout { get; set; }
+    public override System.Data.CommandType CommandType { get; set; }
+    public override System.Data.UpdateRowSource UpdatedRowSource { get; set; }
+    public override bool DesignTimeVisible { get; set; }
+    protected override DbConnection? DbConnection { get; set; }
+    protected override DbParameterCollection DbParameterCollection { get; } = new RecordingParameterCollection();
+    protected override DbTransaction? DbTransaction { get; set; }
+    protected override DbParameter CreateDbParameter() => new StubDbParameter();
+    public override void Cancel() { }
+    public override int ExecuteNonQuery() => 0;
+    public override object? ExecuteScalar() => null;
+    public override void Prepare() { }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectColumnListTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectColumnListTest.cs
@@ -1,0 +1,236 @@
+using System.Data.Common;
+
+using FakeItEasy;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Every statement that used to read <c>SELECT *</c> now names its columns, and each named list is
+/// exactly what the code reading the rows asks for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both halves matter. A list missing a column the reader wants is a runtime failure on a database
+/// and nowhere else; a list carrying a column no reader wants is bytes off the wire for nobody. So
+/// each case drives the real reader against a <see cref="ProjectionDataReader" /> built from the
+/// statement's own projection: an unprojected column throws, and an unread column is left over.
+/// </para>
+/// <para>
+/// The projection is taken from the statement text rather than from the constant it was built out
+/// of, so what is measured is what the database would be sent.
+/// </para>
+/// </remarks>
+public class SelectColumnListTest
+{
+    [Test]
+    public void CronTriggerStatementsNameWhatTheirDelegateReads()
+    {
+        CronTriggerPersistenceDelegate persistence = new();
+        persistence.Initialize(PersistenceContext());
+
+        ReadsExactly(
+            StdAdoConstants.SqlSelectCronTriggers,
+            reader => persistence.ReadTriggerPropertyBundle(reader));
+
+        ReadsExactly(
+            StdAdoConstants.SqlSelectCronTriggersByKeysPrefix,
+            reader =>
+            {
+                persistence.ReadTriggerPropertyBundle(reader);
+                ReadBatchKey(reader);
+            });
+    }
+
+    [Test]
+    public void SimpleTriggerStatementsNameWhatTheirDelegateReads()
+    {
+        SimpleTriggerPersistenceDelegate persistence = new();
+        persistence.Initialize(PersistenceContext());
+
+        ReadsExactly(
+            StdAdoConstants.SqlSelectSimpleTrigger,
+            reader => persistence.ReadTriggerPropertyBundle(reader));
+
+        ReadsExactly(
+            StdAdoConstants.SqlSelectSimpleTriggersByKeysPrefix,
+            reader =>
+            {
+                persistence.ReadTriggerPropertyBundle(reader);
+                ReadBatchKey(reader);
+            });
+    }
+
+    [Test]
+    public void TheSimplePropertiesStatementNamesWhatTheBaseDelegateReads()
+    {
+        // Every simple-properties type shares one table and one row reader, so the delegate asked here
+        // stands for all of them.
+        CalendarIntervalTriggerPersistenceDelegate persistence = new();
+        persistence.Initialize(PersistenceContext());
+
+        ReadsExactly(
+            StdAdoConstants.SqlSelectSimpropTriggersByKeysPrefix,
+            reader =>
+            {
+                persistence.ReadTriggerPropertyBundle(reader);
+                ReadBatchKey(reader);
+            });
+    }
+
+    [Test]
+    public async Task TheSchedulerStateStatementsNameWhatTheRecordIsMadeOf()
+    {
+        // One statement per shape of the same read: by instance, and every instance of the scheduler.
+        await ReadsExactly(StdAdoConstants.SqlSelectSchedulerState,
+            (del, conn) => del.SelectSchedulerStateRecords(conn, "node").AsTask());
+
+        await ReadsExactly(StdAdoConstants.SqlSelectSchedulerStates,
+            (del, conn) => del.SelectSchedulerStateRecords(conn, instanceId: null).AsTask());
+    }
+
+    [Test]
+    public async Task TheFiredTriggerStatementNamesWhatTheRecordIsMadeOf()
+    {
+        await ReadsExactly(StdAdoConstants.SqlSelectFiredTriggers,
+            (del, conn) => del.SelectFiredTriggerRecords(conn, new FiredTriggerQuery()).AsTask());
+    }
+
+    [Test]
+    public async Task TheRecoverableFiredTriggerStatementNamesWhatTheRecoveryTriggerIsMadeOf()
+    {
+        await ReadsExactly(StdAdoConstants.SqlSelectInstancesRecoverableFiredTriggers,
+            (del, conn) => del.SelectTriggersForRecoveringJobs(conn).AsTask(),
+            // Each recovered trigger's job data map is read by a second statement, which this test
+            // does not measure; an empty result leaves the map empty.
+            trailingReaders: 1);
+    }
+
+    /// <summary>
+    /// The two key columns a batch lookup projects on top of the row's own, read the way the batch
+    /// loops read them.
+    /// </summary>
+    private static void ReadBatchKey(DbDataReader reader)
+    {
+        _ = new TriggerKey(
+            (string) reader[AdoConstants.ColumnTriggerName],
+            (string) reader[AdoConstants.ColumnTriggerGroup]);
+    }
+
+    /// <summary>
+    /// Drives a reader function against the statement's own projection and asserts the two agree.
+    /// </summary>
+    private static void ReadsExactly(string sql, Action<DbDataReader> read)
+    {
+        ProjectionDataReader reader = new(ProjectionOf(sql));
+
+        reader.Read();
+        read(reader);
+
+        reader.Unread.Should().BeEmpty(
+            "'{0}' projects columns nothing reads, which is bytes off the wire for nobody", Projection(sql));
+    }
+
+    /// <summary>
+    /// The same, for a statement whose reader lives inside <see cref="StdAdoDelegate" /> and is only
+    /// reachable by issuing it.
+    /// </summary>
+    private static async Task ReadsExactly(
+        string sql,
+        Func<StdAdoDelegate, ConnectionAndTransactionHolder, Task> issue,
+        int trailingReaders = 0)
+    {
+        ProjectionDataReader reader = new(ProjectionOf(sql));
+
+        ReaderStubDelegate del = ReaderStubDelegate.Create();
+        del.Enqueue(reader);
+        for (int i = 0; i < trailingReaders; i++)
+        {
+            del.Enqueue(ProjectionDataReader.Empty);
+        }
+
+        using ConnectionAndTransactionHolder conn = new(new StubBatchingConnection(), transaction: null);
+        await issue(del, conn);
+
+        del.Statements[0].Should().Be(AdoJobStoreUtil.ReplaceTablePrefix(sql, "QRTZ_"),
+            "the statement measured has to be the statement issued");
+        reader.Unread.Should().BeEmpty(
+            "'{0}' projects columns nothing reads, which is bytes off the wire for nobody", Projection(sql));
+    }
+
+    /// <summary>
+    /// The column names a statement projects. Taken from the text, because that is what the database
+    /// is sent.
+    /// </summary>
+    private static string[] ProjectionOf(string sql) =>
+        [.. Projection(sql).Split(',').Select(column => column.Trim())];
+
+    private static string Projection(string sql)
+    {
+        const string Select = "SELECT ";
+        const string From = " FROM ";
+
+        int start = sql.IndexOf(Select, StringComparison.Ordinal);
+        int end = sql.IndexOf(From, StringComparison.Ordinal);
+        start.Should().Be(0, "these statements start with their projection");
+        end.Should().BePositive("a projection is followed by a FROM clause");
+
+        return sql[Select.Length..end];
+    }
+
+    private static TriggerPersistenceDelegateContext PersistenceContext() => new()
+    {
+        TablePrefix = "QRTZ_",
+        SchedulerName = "INSTANCE",
+        DbAccessor = ReaderStubDelegate.Create()
+    };
+
+    /// <summary>
+    /// A delegate that answers each statement it is asked to prepare with the next queued reader,
+    /// which is how a reader that lives inside the delegate can be driven without a database.
+    /// </summary>
+    private sealed class ReaderStubDelegate : StdAdoDelegate
+    {
+        private readonly Queue<ProjectionDataReader> readers = new();
+
+        public static ReaderStubDelegate Create()
+        {
+            IDbProvider dbProvider = A.Fake<IDbProvider>();
+            A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata { ParameterNamePrefix = "@", BindByName = true });
+
+            ReaderStubDelegate del = new();
+            del.Initialize(new DriverDelegateContext
+            {
+                TablePrefix = "QRTZ_",
+                InstanceId = "TESTSCHED",
+                SchedulerName = "INSTANCE",
+                TypeLoader = new SimpleTypeLoader(),
+                UseProperties = false,
+                DbProvider = dbProvider,
+                ObjectSerializer = A.Fake<IObjectSerializer>(),
+                TimeProvider = TimeProvider.System
+            });
+
+            return del;
+        }
+
+        public List<string> Statements { get; } = [];
+
+        public void Enqueue(ProjectionDataReader reader) => readers.Enqueue(reader);
+
+        public override DbCommand PrepareCommand(ConnectionAndTransactionHolder cth, string commandText)
+        {
+            Statements.Add(commandText);
+            ReaderStubCommand cmd = new(readers.Count > 0 ? readers.Dequeue() : ProjectionDataReader.Empty)
+            {
+                CommandText = commandText
+            };
+            cth.Attach(cmd);
+            return cmd;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlParametersTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlParametersTest.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The parameter names the statements carry and the names the binders pass are one constant, and the
+/// statements are still statements.
+/// </summary>
+public class SqlParametersTest
+{
+    private static readonly string[] statements =
+    [
+        .. typeof(StdAdoConstants)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(string))
+            .Select(field => (string) field.GetValue(null)!)
+    ];
+
+    [Test]
+    public void NoStatementCarriesAConstantReferenceInsteadOfItsValue()
+    {
+        // A statement is built by interpolation, so `@{SqlParameters.TriggerName}` becomes
+        // `@triggerName`. Written into a string that is *not* interpolated, the same text stays
+        // literal and reaches the database, which is a failure this catches at build time rather
+        // than on whichever provider is asked first.
+        statements.Should().NotContain(sql => sql.Contains("SqlParameters", StringComparison.Ordinal),
+            "a statement holding the text 'SqlParameters' is an interpolation hole that landed in a plain string literal");
+    }
+
+    [Test]
+    public void EveryPlaceholderIsAKnownParameter()
+    {
+        string[] declared =
+        [
+            .. typeof(SqlParameters)
+                .GetFields(BindingFlags.Public | BindingFlags.Static)
+                .Select(field => (string) field.GetValue(null)!)
+        ];
+
+        // Statements also mention the fixed-width generated names, which are built per index from a
+        // single function rather than declared here.
+        string[] generated = ["excludedJobType", "tkn", "tkg", "jkn", "jkg", "oldState"];
+
+        List<string> unknown =
+        [
+            .. statements
+                .SelectMany(Placeholders)
+                .Distinct()
+                .Where(name => !declared.Contains(name, StringComparer.Ordinal))
+                .Where(name => !generated.Any(prefix => name.StartsWith(prefix, StringComparison.Ordinal)))
+        ];
+
+        unknown.Should().BeEmpty(
+            "every placeholder is spelled from a constant the binder also uses, so one that is not a constant is one nothing binds");
+    }
+
+    private static IEnumerable<string> Placeholders(string sql)
+    {
+        for (int i = sql.IndexOf('@', StringComparison.Ordinal); i >= 0; i = sql.IndexOf('@', i + 1))
+        {
+            int end = i + 1;
+            while (end < sql.Length && (char.IsAsciiLetterOrDigit(sql[end]) || sql[end] == '_'))
+            {
+                end++;
+            }
+
+            if (end > i + 1)
+            {
+                yield return sql[(i + 1)..end];
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlRowLimitTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlRowLimitTest.cs
@@ -1,0 +1,65 @@
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The three places a row limit can go, and the one case where it goes nowhere.
+/// </summary>
+/// <remarks>
+/// The statements themselves are pinned by <see cref="AcquisitionSqlTest" />; this is about the slot
+/// values in isolation, including the spaces they carry, which are what make an unlimited statement
+/// the text it was before there was a slot to fill. The template below is the shape of the real ones:
+/// the <c>SELECT</c> keyword, then a line break before the projection.
+/// </remarks>
+public class SqlRowLimitTest
+{
+    [Test]
+    public void UnlimitedFillsNothing()
+    {
+        Fill(SqlRowLimit.Unlimited).Should().Be("SELECT\n  A\nFROM T",
+            "a dialect that cannot limit rows has to get the statement back byte for byte, or every statement changes the day a slot is added");
+    }
+
+    [Test]
+    public void DefaultIsUnlimited()
+    {
+        default(SqlRowLimit).Should().Be(SqlRowLimit.Unlimited,
+            "the delegate compares against Unlimited to decide whether a statement can be served from the cache");
+    }
+
+    [Test]
+    public void InProjectionSitsBetweenTheSelectKeywordAndTheColumns()
+    {
+        Fill(SqlRowLimit.InProjection("TOP", 5)).Should().Be("SELECT TOP 5 \n  A\nFROM T");
+    }
+
+    [Test]
+    public void AtStatementEndFollowsEverythingElse()
+    {
+        Fill(SqlRowLimit.AtStatementEnd("LIMIT", 5)).Should().Be("SELECT\n  A\nFROM T LIMIT 5");
+    }
+
+    [Test]
+    public void InEnclosingSelectWrapsTheWholeStatement()
+    {
+        Fill(SqlRowLimit.InEnclosingSelect("rownum", 5)).Should().Be("SELECT * FROM (SELECT\n  A\nFROM T) WHERE rownum <= 5");
+    }
+
+    [Test]
+    public void TwoLimitsThatSayTheSameThingAreEqual()
+    {
+        SqlRowLimit.AtStatementEnd("LIMIT", 5).Should().Be(SqlRowLimit.AtStatementEnd("LIMIT", 5));
+        SqlRowLimit.AtStatementEnd("LIMIT", 5).Should().NotBe(SqlRowLimit.AtStatementEnd("ROWS", 5),
+            "the keyword is part of what a limit says");
+        SqlRowLimit.AtStatementEnd("LIMIT", 5).Should().NotBe(SqlRowLimit.AtStatementEnd("LIMIT", 6));
+        SqlRowLimit.AtStatementEnd("LIMIT", 5).Should().NotBe(SqlRowLimit.InProjection("LIMIT", 5),
+            "where the clause goes is part of what a limit says");
+    }
+
+    /// <summary>
+    /// Builds a statement the way <c>StdAdoConstants</c> does: the two slots in the template, then the
+    /// enclosing select around the finished text.
+    /// </summary>
+    private static string Fill(SqlRowLimit limit) =>
+        limit.Enclose("SELECT" + limit.AfterSelect + "\n  A\nFROM T" + limit.AtEnd);
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -84,7 +84,7 @@ public class StdAdoConstantsTest
     [Test]
     public void BuildSqlSelectNextTriggerToAcquire_WithNoExclusions_ShouldKeepExistingSqlExactly()
     {
-        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 0);
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 0, SqlRowLimit.Unlimited);
 
         sql.Should().BeSameAs(StdAdoConstants.SqlSelectNextTriggerToAcquire,
             "the two are one template with an empty exclusion clause, so asking for no exclusions hands back the very string every exclusion-free caller already uses rather than an equal copy built beside it");
@@ -93,7 +93,7 @@ public class StdAdoConstantsTest
     [Test]
     public void BuildSqlSelectNextTriggerToAcquire_ShouldUseFixedWidthExclusionParameters()
     {
-        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 16);
+        string sql = StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(excludedJobTypeBucket: 16, SqlRowLimit.Unlimited);
 
         sql.Should().Contain("AND jd.JOB_CLASS_NAME NOT IN (@excludedJobType0000, @excludedJobType0001");
         sql.Should().Contain("@excludedJobType0009, @excludedJobType0010");

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_MisfireRecovery.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_MisfireRecovery.verified.txt
@@ -1,0 +1,490 @@
+﻿=== StdAdoDelegate ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== StdAdoDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== SqlServerDelegate ===
+SELECT TOP 20  
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== SqlServerDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== PostgreSQLDelegate ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC LIMIT 20
+
+=== PostgreSQLDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== MySQLDelegate ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC LIMIT 20
+
+=== MySQLDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== SQLiteDelegate ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC LIMIT 20
+
+=== SQLiteDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== OracleDelegate ===
+SELECT * FROM (SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC) WHERE rownum <= 20
+
+=== OracleDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+
+=== FirebirdDelegate ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC ROWS 20
+
+=== FirebirdDelegate (unlimited) ===
+SELECT 
+                JOB_NAME,
+                JOB_GROUP,
+                DESCRIPTION,
+                NEXT_FIRE_TIME,
+                PREV_FIRE_TIME,
+                TRIGGER_TYPE,
+                START_TIME,
+                END_TIME,
+                CALENDAR_NAME,
+                MISFIRE_INSTR,
+                PRIORITY,
+                JOB_DATA,
+                CRON_EXPRESSION,
+                TIME_ZONE_ID,
+                REPEAT_COUNT,
+                REPEAT_INTERVAL,
+                TIMES_TRIGGERED,
+                t.MISFIRE_ORIG_FIRE_TIME,
+                t.EXECUTION_GROUP,
+                t.PREFERRED_NODE,
+                t.PREFERRED_NODE_AUTO,
+                t.TRIGGER_NAME,
+                t.TRIGGER_GROUP
+            FROM
+                {0}TRIGGERS t
+            LEFT JOIN
+                {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
+            LEFT JOIN
+                {0}CRON_TRIGGERS ct ON (ct.SCHED_NAME = t.SCHED_NAME AND ct.TRIGGER_GROUP = t.TRIGGER_GROUP AND ct.TRIGGER_NAME = t.TRIGGER_NAME)
+            WHERE
+                t.SCHED_NAME = @schedulerName AND t.MISFIRE_INSTR <> -1 AND t.NEXT_FIRE_TIME <= @nextFireTime AND t.TRIGGER_STATE = @state
+            ORDER BY t.NEXT_FIRE_TIME ASC, t.PRIORITY DESC
+

--- a/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_MisfireRecovery.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/AcquisitionSqlTest_MisfireRecovery.verified.txt
@@ -269,7 +269,7 @@ SELECT
                 t.TRIGGER_NAME,
                 t.TRIGGER_GROUP
             FROM
-                {0}TRIGGERS t
+                {0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)
             LEFT JOIN
                 {0}SIMPLE_TRIGGERS st ON (st.SCHED_NAME = t.SCHED_NAME AND st.TRIGGER_GROUP = t.TRIGGER_GROUP AND st.TRIGGER_NAME = t.TRIGGER_NAME)
             LEFT JOIN

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -2386,8 +2386,7 @@ namespace Quartz.Impl.AdoJobStore
     public class FirebirdDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public FirebirdDelegate() { }
-        protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public sealed class FiredTriggerQuery : System.IEquatable<Quartz.Impl.AdoJobStore.FiredTriggerQuery>
     {
@@ -2562,6 +2561,7 @@ namespace Quartz.Impl.AdoJobStore
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetCountMisfiredTriggersInStateSql() { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
         protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
         protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
     }
@@ -2575,14 +2575,12 @@ namespace Quartz.Impl.AdoJobStore
         public OracleDelegate() { }
         public override bool GetBooleanFromDbValue(object columnValue) { }
         public override object GetDbBooleanValue(bool booleanValue) { }
-        protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public class PostgreSQLDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public PostgreSQLDelegate() { }
-        protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public class PostgreSqlSelectForUpdateSemaphore : Quartz.Impl.AdoJobStore.SelectForUpdateSemaphore
     {
@@ -2616,8 +2614,7 @@ namespace Quartz.Impl.AdoJobStore
         public SQLiteDelegate() { }
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
-        protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public enum SchedulerLock
     {
@@ -2716,12 +2713,18 @@ namespace Quartz.Impl.AdoJobStore
         public bool TryDescribeUpdateExtendedTriggerProperties(Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState state, Quartz.IJobDetail jobDetail, System.Collections.Generic.ICollection<Quartz.Impl.AdoJobStore.SqlStatement> statements) { }
         public System.Threading.Tasks.ValueTask<int> UpdateExtendedTriggerProperties(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
     }
+    public readonly struct SqlRowLimit : System.IEquatable<Quartz.Impl.AdoJobStore.SqlRowLimit>
+    {
+        public static Quartz.Impl.AdoJobStore.SqlRowLimit Unlimited { get; }
+        public static Quartz.Impl.AdoJobStore.SqlRowLimit AtStatementEnd(string keyword, int count) { }
+        public static Quartz.Impl.AdoJobStore.SqlRowLimit InEnclosingSelect(string pseudoColumn, int count) { }
+        public static Quartz.Impl.AdoJobStore.SqlRowLimit InProjection(string keyword, int count) { }
+    }
     public class SqlServerDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public SqlServerDelegate() { }
         public override void AddCommandParameter(System.Data.Common.DbCommand cmd, string paramName, object? paramValue, System.Enum? dataType = null, int? size = default) { }
-        protected override string GetSelectMisfiredTriggersToRecoverSql(int count) { }
-        protected override string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
+        protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public sealed class SqlServerMemoryOptimizedUpdateRowSemaphore : Quartz.Impl.AdoJobStore.UpdateRowSemaphore
     {
@@ -2784,6 +2787,7 @@ namespace Quartz.Impl.AdoJobStore
         protected object? GetKeyOfNonSerializableValue(Quartz.JobDataMap data) { }
         protected virtual System.Threading.Tasks.ValueTask<T?> GetObjectFromBlob<T>(System.Data.Common.DbDataReader rs, int colIndex, System.Threading.CancellationToken cancellationToken = default)
             where T :  class { }
+        protected virtual Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
         protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count) { }
         protected virtual string GetSelectNextTriggerToAcquireSql(Quartz.Impl.AdoJobStore.TriggerAcquisitionSqlShape shape) { }
         public System.TimeSpan? GetTimeSpanFromDbValue(object columnValue) { }

--- a/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
@@ -512,7 +512,7 @@ internal sealed class AdoUtil : IAdoUtil
             var paddedCount = RoundUpTriggerKeyCount(length);
 
             using var cmd = dbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(sqlPrefix + BuildTriggerKeyPredicate(paddedCount), tablePrefix));
-            dbAccessor.AddCommandParameter(cmd, "schedulerName", schedulerName);
+            dbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
             for (var i = 0; i < paddedCount; i++)
             {

--- a/src/Quartz/Impl/AdoJobStore/Common/DbMetadata.cs
+++ b/src/Quartz/Impl/AdoJobStore/Common/DbMetadata.cs
@@ -19,6 +19,7 @@
 
 #endregion
 
+using System.Collections.Concurrent;
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
@@ -290,10 +291,24 @@ public sealed record DbMetadata
     /// Gets the name of the parameter which includes the parameter prefix for this
     /// database.
     /// </summary>
+    /// <remarks>
+    /// Called once per parameter bound, which is seven times for a trigger acquisition and fifteen
+    /// for a trigger write, and it was a concatenation each time. The set of names is small and
+    /// settled — the statements name about eighty-five between them, and the generated ones
+    /// (<c>tkn000</c>, <c>oldState00</c>, <c>excludedJobType0000</c>) are bounded by the predicate
+    /// sizes — so each spelling is worked out once and handed back thereafter.
+    /// </remarks>
     /// <param name="parameterName">Name of the parameter.</param>
     public string GetParameterName(string parameterName)
     {
-        return ParameterNamePrefix + parameterName;
+        // A driver that spells parameters with no prefix at all wants the name it was given, and
+        // there is nothing to remember.
+        if (string.IsNullOrEmpty(ParameterNamePrefix))
+        {
+            return parameterName;
+        }
+
+        return Derived.GetParameterName(ParameterNamePrefix, parameterName);
     }
 
     /// <summary>
@@ -313,14 +328,15 @@ public sealed record DbMetadata
     }
 
     /// <summary>
-    /// The members derived from this description by reflection, worked out once per description.
+    /// What is worked out from this description rather than said by it: the reflective lookups, done
+    /// once, and the parameter-name spellings, remembered as they are asked for.
     /// </summary>
     /// <remarks>
     /// <para>
     /// Kept beside the record rather than in fields on it. A record's generated equality compares every
     /// instance field, so a memoization field would make two descriptions that say the same thing about
     /// a driver compare unequal as soon as one of them had been used. The description stays what it
-    /// always was — a value — and what reflection makes of it hangs off it here.
+    /// always was — a value — and what is made of it hangs off it here.
     /// </para>
     /// <para>
     /// <see cref="DbBinaryType" /> used to run <see cref="Enum.Parse(Type, string)" /> on every read and
@@ -372,6 +388,37 @@ public sealed record DbMetadata
 
             ParameterDbTypeProperty = property;
             ParameterDbTypeSetter = MethodInvoker.Create(property.SetMethod);
+        }
+
+        /// <summary>
+        /// The prefixed spelling of every parameter name this driver has been asked for.
+        /// </summary>
+        /// <remarks>
+        /// Bounded rather than unbounded, because <see cref="DbMetadata.GetParameterName" /> is public
+        /// and a delegate of someone's own may name a parameter after its data. The cap is well past
+        /// what Quartz itself can reach — around eighty-five fixed names, four hundred trigger-key and
+        /// five hundred job-key names, eleven state names and at most a thousand job-type exclusions —
+        /// so the cache never stops working for the statements this assembly issues, and a caller that
+        /// mints names simply stops adding to it and pays the concatenation it used to pay.
+        /// </remarks>
+        private readonly ConcurrentDictionary<string, string> parameterNames = new(StringComparer.Ordinal);
+
+        private const int MaxCachedParameterNames = 4096;
+
+        public string GetParameterName(string prefix, string parameterName)
+        {
+            if (parameterNames.TryGetValue(parameterName, out string? cached))
+            {
+                return cached;
+            }
+
+            string prefixed = prefix + parameterName;
+            if (parameterNames.Count < MaxCachedParameterNames)
+            {
+                parameterNames[parameterName] = prefixed;
+            }
+
+            return prefixed;
         }
 
         public Enum? DbBinaryType { get; }

--- a/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/CronTriggerPersistenceDelegate.cs
@@ -63,9 +63,9 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlDeleteCronTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -80,11 +80,11 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         ICronTrigger cronTrigger = (ICronTrigger) trigger;
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlInsertCronTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-        DbAccessor.AddCommandParameter(cmd, "triggerCronExpression", cronTrigger.CronExpressionString);
-        DbAccessor.AddCommandParameter(cmd, "triggerTimeZone", cronTrigger.TimeZone.Id);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerCronExpression, cronTrigger.CronExpressionString);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerTimeZone, cronTrigger.TimeZone.Id);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -95,9 +95,9 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlSelectCronTriggers, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -175,11 +175,11 @@ public sealed class CronTriggerPersistenceDelegate : ITriggerPersistenceDelegate
 
         return
         [
-            new SqlStatementParameter("schedulerName", SchedulerName),
-            new SqlStatementParameter("triggerCronExpression", cronTrigger.CronExpressionString),
-            new SqlStatementParameter("timeZoneId", cronTrigger.TimeZone.Id),
-            new SqlStatementParameter("triggerName", trigger.Key.Name),
-            new SqlStatementParameter("triggerGroup", trigger.Key.Group)
+            new SqlStatementParameter(SqlParameters.SchedulerName, SchedulerName),
+            new SqlStatementParameter(SqlParameters.TriggerCronExpression, cronTrigger.CronExpressionString),
+            new SqlStatementParameter(SqlParameters.TimeZoneId, cronTrigger.TimeZone.Id),
+            new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name),
+            new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group)
         ];
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
@@ -6,21 +6,7 @@ namespace Quartz.Impl.AdoJobStore;
 public class FirebirdDelegate : StdAdoDelegate
 {
     /// <summary>
-    /// Gets the select next trigger to acquire SQL clause.
-    /// FireBird version with ROWS support.
+    /// Firebird limits rows with a trailing <c>ROWS n</c>.
     /// </summary>
-    /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    {
-        return base.GetSelectNextTriggerToAcquireSql(shape) + " ROWS " + shape.MaxCount;
-    }
-
-    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
-    {
-        if (count != -1)
-        {
-            return StdAdoConstants.SqlSelectMisfiredTriggersToRecover + " ROWS " + count;
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
-    }
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("ROWS", count);
 }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -56,30 +56,34 @@ public class MySQLDelegate : StdAdoDelegate
     }
 
     /// <summary>
-    /// Gets the select next trigger to acquire SQL clause.
-    /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST.
+    /// MySQL limits rows with a trailing <c>LIMIT n</c>.
+    /// </summary>
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("LIMIT", count);
+
+    /// <summary>
+    /// The acquisition statement carries a FORCE INDEX hint pointing at IDX_*_T_NFT_ST.
     /// </summary>
     protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
         return base.GetSelectNextTriggerToAcquireSql(shape)
-            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)")
-            + " LIMIT " + shape.MaxCount;
+            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST)");
     }
 
     /// <summary>
-    /// MySQL version with LIMIT support and a FORCE INDEX hint pointing at IDX_*_T_NFT_ST_MISFIRE.
+    /// The misfire recovery statement carries a FORCE INDEX hint pointing at IDX_*_T_NFT_ST_MISFIRE.
     /// The hint attaches to the aliased TRIGGERS table, since this statement joins the type tables onto
     /// it rather than selecting from TRIGGERS alone.
     /// </summary>
+    /// <remarks>
+    /// Applied whatever the batch size, including an unlimited sweep. It used to be skipped for the
+    /// unlimited one, which was an artefact of the row limit and the hint sharing an early return
+    /// rather than a decision: the index a statement should read is not a function of how many rows
+    /// it returns, and an unlimited sweep is the case that reads the most.
+    /// </remarks>
     protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
     {
-        if (count != -1)
-        {
-            return StdAdoConstants.SqlSelectMisfiredTriggersToRecover
-                .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)")
-                + " LIMIT " + count;
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
+        return base.GetSelectMisfiredTriggersToRecoverSql(count)
+            .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
     }
 
     protected override string GetCountMisfiredTriggersInStateSql()

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -37,8 +37,8 @@ public class MySQLDelegate : StdAdoDelegate
     protected override string ApplyPaging(string sql, bool takeLimited)
     {
         return takeLimited
-            ? sql + " LIMIT @pageTake OFFSET @pageSkip"
-            : sql + " LIMIT 18446744073709551615 OFFSET @pageSkip";
+            ? sql + " LIMIT @" + SqlParameters.PageTake + " OFFSET @" + SqlParameters.PageSkip
+            : sql + " LIMIT 18446744073709551615 OFFSET @" + SqlParameters.PageSkip;
     }
 
     /// <summary>
@@ -49,10 +49,10 @@ public class MySQLDelegate : StdAdoDelegate
     {
         if (takeLimited)
         {
-            AddCommandParameter(cmd, "pageTake", take);
+            AddCommandParameter(cmd, SqlParameters.PageTake, take);
         }
 
-        AddCommandParameter(cmd, "pageSkip", skip);
+        AddCommandParameter(cmd, SqlParameters.PageSkip, skip);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -28,21 +28,9 @@ namespace Quartz.Impl.AdoJobStore;
 public class OracleDelegate : StdAdoDelegate
 {
     /// <summary>
-    /// Creates the SQL for select next trigger to acquire.
+    /// Oracle limits rows from an enclosing select: <c>SELECT * FROM (…) WHERE rownum &lt;= n</c>.
     /// </summary>
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    {
-        return "SELECT * FROM (" + base.GetSelectNextTriggerToAcquireSql(shape) + ") WHERE rownum <= " + shape.MaxCount;
-    }
-
-    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
-    {
-        if (count != -1)
-        {
-            return "SELECT * FROM (" + StdAdoConstants.SqlSelectMisfiredTriggersToRecover + ") WHERE rownum <= " + count;
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
-    }
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.InEnclosingSelect("rownum", count);
 
     /// <summary>
     /// Gets the db presentation for boolean value. For Oracle we use true/false of "1"/"0".

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -28,21 +28,7 @@ namespace Quartz.Impl.AdoJobStore;
 public class PostgreSQLDelegate : StdAdoDelegate
 {
     /// <summary>
-    /// Gets the select next trigger to acquire SQL clause.
-    /// MySQL version with LIMIT support.
+    /// PostgreSQL limits rows with a trailing <c>LIMIT n</c>.
     /// </summary>
-    /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    {
-        return base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
-    }
-
-    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
-    {
-        if (count != -1)
-        {
-            return StdAdoConstants.SqlSelectMisfiredTriggersToRecover + " LIMIT " + count;
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
-    }
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("LIMIT", count);
 }

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -51,21 +51,7 @@ public class SQLiteDelegate : StdAdoDelegate
     }
 
     /// <summary>
-    /// Gets the select next trigger to acquire SQL clause.
-    /// SQLite version with LIMIT support.
+    /// SQLite limits rows with a trailing <c>LIMIT n</c>.
     /// </summary>
-    /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    {
-        return base.GetSelectNextTriggerToAcquireSql(shape) + " LIMIT " + shape.MaxCount;
-    }
-
-    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
-    {
-        if (count != -1)
-        {
-            return StdAdoConstants.SqlSelectMisfiredTriggersToRecover + " LIMIT " + count;
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
-    }
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("LIMIT", count);
 }

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -32,8 +32,8 @@ public class SQLiteDelegate : StdAdoDelegate
     protected override string ApplyPaging(string sql, bool takeLimited)
     {
         return takeLimited
-            ? sql + " LIMIT @pageTake OFFSET @pageSkip"
-            : sql + " LIMIT -1 OFFSET @pageSkip";
+            ? sql + " LIMIT @" + SqlParameters.PageTake + " OFFSET @" + SqlParameters.PageSkip
+            : sql + " LIMIT -1 OFFSET @" + SqlParameters.PageSkip;
     }
 
     /// <summary>
@@ -44,10 +44,10 @@ public class SQLiteDelegate : StdAdoDelegate
     {
         if (takeLimited)
         {
-            AddCommandParameter(cmd, "pageTake", take);
+            AddCommandParameter(cmd, SqlParameters.PageTake, take);
         }
 
-        AddCommandParameter(cmd, "pageSkip", skip);
+        AddCommandParameter(cmd, SqlParameters.PageSkip, skip);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
@@ -57,7 +57,20 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
     protected const string ColumnBoolProp2 = "BOOL_PROP_2";
     protected const string ColumnTimeZoneId = "TIME_ZONE_ID";
 
-    private const string SelectSimplePropsTrigger = "SELECT *" + " FROM "
+    /// <summary>
+    /// Every column <see cref="ReadTriggerPropertyBundle" /> reads, and only those. Shared with the
+    /// batch lookup in <c>StdAdoConstants</c>, so the single-key and batch read paths cannot drift
+    /// apart, and named rather than starred so that a column a migration or a user adds to the table
+    /// does not change what comes back.
+    /// </summary>
+    internal const string SelectColumns =
+        ColumnStrProp1 + ", " + ColumnStrProp2 + ", " + ColumnStrProp3 + ", "
+        + ColumnIntProp1 + ", " + ColumnIntProp2 + ", "
+        + ColumnLongProp1 + ", " + ColumnLongProp2 + ", "
+        + ColumnDecProp1 + ", " + ColumnDecProp2 + ", "
+        + ColumnBoolProp1 + ", " + ColumnBoolProp2 + ", " + ColumnTimeZoneId;
+
+    private const string SelectSimplePropsTrigger = "SELECT " + SelectColumns + " FROM "
                                                                  + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " WHERE "
                                                                  + AdoConstants.ColumnSchedulerName + " = @schedulerName"
                                                                  + " AND " + AdoConstants.ColumnTriggerName + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";

--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
@@ -72,13 +72,13 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
 
     private const string SelectSimplePropsTrigger = "SELECT " + SelectColumns + " FROM "
                                                                  + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " WHERE "
-                                                                 + AdoConstants.ColumnSchedulerName + " = @schedulerName"
-                                                                 + " AND " + AdoConstants.ColumnTriggerName + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
+                                                                 + AdoConstants.ColumnSchedulerName + " = @" + SqlParameters.SchedulerName
+                                                                 + " AND " + AdoConstants.ColumnTriggerName + " = @" + SqlParameters.TriggerName + " AND " + AdoConstants.ColumnTriggerGroup + " = @" + SqlParameters.TriggerGroup;
 
     private const string DeleteSimplePropsTrigger = "DELETE FROM "
                                                       + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " WHERE "
-                                                      + AdoConstants.ColumnSchedulerName + " = @schedulerName"
-                                                      + " AND " + AdoConstants.ColumnTriggerName + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
+                                                      + AdoConstants.ColumnSchedulerName + " = @" + SqlParameters.SchedulerName
+                                                      + " AND " + AdoConstants.ColumnTriggerName + " = @" + SqlParameters.TriggerName + " AND " + AdoConstants.ColumnTriggerGroup + " = @" + SqlParameters.TriggerGroup;
 
     private const string InsertSimplePropsTrigger = "INSERT INTO "
                                                       + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " ("
@@ -89,18 +89,18 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
                                                       + ColumnLongProp1 + ", " + ColumnLongProp2 + ", "
                                                       + ColumnDecProp1 + ", " + ColumnDecProp2 + ", "
                                                       + ColumnBoolProp1 + ", " + ColumnBoolProp2 + ", " + ColumnTimeZoneId
-                                                      + ") " + " VALUES(@schedulerName" + ", @triggerName, @triggerGroup, @string1, @string2, @string3, @int1, @int2, @long1, @long2, @decimal1, @decimal2, @boolean1, @boolean2, @timeZoneId)";
+                                                      + ") " + " VALUES(@" + SqlParameters.SchedulerName + ", @" + SqlParameters.TriggerName + ", @" + SqlParameters.TriggerGroup + ", @" + SqlParameters.String1 + ", @" + SqlParameters.String2 + ", @" + SqlParameters.String3 + ", @" + SqlParameters.Int1 + ", @" + SqlParameters.Int2 + ", @" + SqlParameters.Long1 + ", @" + SqlParameters.Long2 + ", @" + SqlParameters.Decimal1 + ", @" + SqlParameters.Decimal2 + ", @" + SqlParameters.Boolean1 + ", @" + SqlParameters.Boolean2 + ", @" + SqlParameters.TimeZoneId + ")";
 
     private const string UpdateSimplePropsTrigger = "UPDATE "
                                                       + StdAdoConstants.TablePrefixSubst + TableSimplePropertiesTriggers + " SET "
-                                                      + ColumnStrProp1 + " = @string1, " + ColumnStrProp2 + " = @string2, " + ColumnStrProp3 + " = @string3, "
-                                                      + ColumnIntProp1 + " = @int1, " + ColumnIntProp2 + " = @int2, "
-                                                      + ColumnLongProp1 + " = @long1, " + ColumnLongProp2 + " = @long2, "
-                                                      + ColumnDecProp1 + " = @decimal1, " + ColumnDecProp2 + " = @decimal2, "
-                                                      + ColumnBoolProp1 + " = @boolean1, " + ColumnBoolProp2
-                                                      + " = @boolean2, " + ColumnTimeZoneId + " = @timeZoneId WHERE " + AdoConstants.ColumnSchedulerName + " = @schedulerName"
+                                                      + ColumnStrProp1 + " = @" + SqlParameters.String1 + ", " + ColumnStrProp2 + " = @" + SqlParameters.String2 + ", " + ColumnStrProp3 + " = @" + SqlParameters.String3 + ", "
+                                                      + ColumnIntProp1 + " = @" + SqlParameters.Int1 + ", " + ColumnIntProp2 + " = @" + SqlParameters.Int2 + ", "
+                                                      + ColumnLongProp1 + " = @" + SqlParameters.Long1 + ", " + ColumnLongProp2 + " = @" + SqlParameters.Long2 + ", "
+                                                      + ColumnDecProp1 + " = @" + SqlParameters.Decimal1 + ", " + ColumnDecProp2 + " = @" + SqlParameters.Decimal2 + ", "
+                                                      + ColumnBoolProp1 + " = @" + SqlParameters.Boolean1 + ", " + ColumnBoolProp2
+                                                      + " = @" + SqlParameters.Boolean2 + ", " + ColumnTimeZoneId + " = @" + SqlParameters.TimeZoneId + " WHERE " + AdoConstants.ColumnSchedulerName + " = @" + SqlParameters.SchedulerName
                                                       + " AND " + AdoConstants.ColumnTriggerName
-                                                      + " = @triggerName AND " + AdoConstants.ColumnTriggerGroup + " = @triggerGroup";
+                                                      + " = @" + SqlParameters.TriggerName + " AND " + AdoConstants.ColumnTriggerGroup + " = @" + SqlParameters.TriggerGroup;
 
     public void Initialize(TriggerPersistenceDelegateContext context)
     {
@@ -135,9 +135,9 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(DeleteSimplePropsTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -152,22 +152,22 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
         SimplePropertiesTriggerProperties properties = GetTriggerProperties(trigger);
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(InsertSimplePropsTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
 
-        DbAccessor.AddCommandParameter(cmd, "string1", properties.String1);
-        DbAccessor.AddCommandParameter(cmd, "string2", properties.String2);
-        DbAccessor.AddCommandParameter(cmd, "string3", properties.String3);
-        DbAccessor.AddCommandParameter(cmd, "int1", properties.Int1);
-        DbAccessor.AddCommandParameter(cmd, "int2", properties.Int2);
-        DbAccessor.AddCommandParameter(cmd, "long1", properties.Long1);
-        DbAccessor.AddCommandParameter(cmd, "long2", properties.Long2);
-        DbAccessor.AddCommandParameter(cmd, "decimal1", properties.Decimal1);
-        DbAccessor.AddCommandParameter(cmd, "decimal2", properties.Decimal2);
-        DbAccessor.AddCommandParameter(cmd, "boolean1", DbAccessor.GetDbBooleanValue(properties.Boolean1));
-        DbAccessor.AddCommandParameter(cmd, "boolean2", DbAccessor.GetDbBooleanValue(properties.Boolean2));
-        DbAccessor.AddCommandParameter(cmd, "timeZoneId", properties.TimeZoneId);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.String1, properties.String1);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.String2, properties.String2);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.String3, properties.String3);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Int1, properties.Int1);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Int2, properties.Int2);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Long1, properties.Long1);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Long2, properties.Long2);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Decimal1, properties.Decimal1);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Decimal2, properties.Decimal2);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Boolean1, DbAccessor.GetDbBooleanValue(properties.Boolean1));
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.Boolean2, DbAccessor.GetDbBooleanValue(properties.Boolean2));
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TimeZoneId, properties.TimeZoneId);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -178,9 +178,9 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(SelectSimplePropsTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -248,21 +248,21 @@ public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerP
 
         return
         [
-            new SqlStatementParameter("schedulerName", SchedulerName),
-            new SqlStatementParameter("string1", properties.String1),
-            new SqlStatementParameter("string2", properties.String2),
-            new SqlStatementParameter("string3", properties.String3),
-            new SqlStatementParameter("int1", properties.Int1),
-            new SqlStatementParameter("int2", properties.Int2),
-            new SqlStatementParameter("long1", properties.Long1),
-            new SqlStatementParameter("long2", properties.Long2),
-            new SqlStatementParameter("decimal1", properties.Decimal1),
-            new SqlStatementParameter("decimal2", properties.Decimal2),
-            new SqlStatementParameter("boolean1", DbAccessor.GetDbBooleanValue(properties.Boolean1)),
-            new SqlStatementParameter("boolean2", DbAccessor.GetDbBooleanValue(properties.Boolean2)),
-            new SqlStatementParameter("triggerName", trigger.Key.Name),
-            new SqlStatementParameter("triggerGroup", trigger.Key.Group),
-            new SqlStatementParameter("timeZoneId", properties.TimeZoneId)
+            new SqlStatementParameter(SqlParameters.SchedulerName, SchedulerName),
+            new SqlStatementParameter(SqlParameters.String1, properties.String1),
+            new SqlStatementParameter(SqlParameters.String2, properties.String2),
+            new SqlStatementParameter(SqlParameters.String3, properties.String3),
+            new SqlStatementParameter(SqlParameters.Int1, properties.Int1),
+            new SqlStatementParameter(SqlParameters.Int2, properties.Int2),
+            new SqlStatementParameter(SqlParameters.Long1, properties.Long1),
+            new SqlStatementParameter(SqlParameters.Long2, properties.Long2),
+            new SqlStatementParameter(SqlParameters.Decimal1, properties.Decimal1),
+            new SqlStatementParameter(SqlParameters.Decimal2, properties.Decimal2),
+            new SqlStatementParameter(SqlParameters.Boolean1, DbAccessor.GetDbBooleanValue(properties.Boolean1)),
+            new SqlStatementParameter(SqlParameters.Boolean2, DbAccessor.GetDbBooleanValue(properties.Boolean2)),
+            new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name),
+            new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group),
+            new SqlStatementParameter(SqlParameters.TimeZoneId, properties.TimeZoneId)
         ];
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
@@ -61,9 +61,9 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlDeleteSimpleTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -78,12 +78,12 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
         ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlInsertSimpleTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-        DbAccessor.AddCommandParameter(cmd, "triggerRepeatCount", simpleTrigger.RepeatCount);
-        DbAccessor.AddCommandParameter(cmd, "triggerRepeatInterval", DbAccessor.GetDbTimeSpanValue(simpleTrigger.RepeatInterval));
-        DbAccessor.AddCommandParameter(cmd, "triggerTimesTriggered", simpleTrigger.TimesTriggered);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerRepeatCount, simpleTrigger.RepeatCount);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerRepeatInterval, DbAccessor.GetDbTimeSpanValue(simpleTrigger.RepeatInterval));
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerTimesTriggered, simpleTrigger.TimesTriggered);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -94,9 +94,9 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
         CancellationToken cancellationToken = default)
     {
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlSelectSimpleTrigger, TablePrefix));
-        DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedulerName);
-        DbAccessor.AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        DbAccessor.AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        DbAccessor.AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -172,12 +172,12 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
 
         return
         [
-            new SqlStatementParameter("schedulerName", SchedulerName),
-            new SqlStatementParameter("triggerRepeatCount", simpleTrigger.RepeatCount),
-            new SqlStatementParameter("triggerRepeatInterval", DbAccessor.GetDbTimeSpanValue(simpleTrigger.RepeatInterval)),
-            new SqlStatementParameter("triggerTimesTriggered", simpleTrigger.TimesTriggered),
-            new SqlStatementParameter("triggerName", trigger.Key.Name),
-            new SqlStatementParameter("triggerGroup", trigger.Key.Group)
+            new SqlStatementParameter(SqlParameters.SchedulerName, SchedulerName),
+            new SqlStatementParameter(SqlParameters.TriggerRepeatCount, simpleTrigger.RepeatCount),
+            new SqlStatementParameter(SqlParameters.TriggerRepeatInterval, DbAccessor.GetDbTimeSpanValue(simpleTrigger.RepeatInterval)),
+            new SqlStatementParameter(SqlParameters.TriggerTimesTriggered, simpleTrigger.TimesTriggered),
+            new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name),
+            new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group)
         ];
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
@@ -1,0 +1,182 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// The names of the parameters the statements in <see cref="StdAdoConstants" /> carry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of these used to be written twice: spelled <c>@triggerName</c> inside the statement and
+/// again as a bare <c>"triggerName"</c> where the value is bound, with nothing but care holding the
+/// two together. A misspelling on either side compiled, and surfaced as a provider complaining about
+/// an unbound parameter — or, on a provider that adapts named parameters positionally, as a value
+/// bound to the wrong column.
+/// </para>
+/// <para>
+/// One constant now goes into both: <c>@{SqlParameters.TriggerName}</c> in the statement,
+/// <c>SqlParameters.TriggerName</c> in the binder. The two spellings cannot drift, and a name that
+/// does not exist is a build error rather than a runtime one.
+/// </para>
+/// <para>
+/// Names generated per index — the key-set predicates' <c>tkn000</c>, the state predicates'
+/// <c>oldState00</c>, the acquisition exclusions' <c>excludedJobType0000</c> — are not here, because
+/// they already come from one function that both the statement builder and the binder call.
+/// </para>
+/// <para>
+/// The lock statements' names are not here either: those statements and their binding live in the
+/// same lock handler, which is a seam of its own.
+/// </para>
+/// </remarks>
+internal static class SqlParameters
+{
+    // The scheduler and its nodes
+
+    public const string SchedulerName = "schedulerName";
+    public const string InstanceName = "instanceName";
+    public const string InstanceId = "instanceId";
+    public const string LastCheckinTime = "lastCheckinTime";
+    public const string CheckinInterval = "checkinInterval";
+
+    /// <summary>Matches the sentinel that asks for an auto-pin nothing has claimed yet.</summary>
+    public const string AutoPinSentinel = "autoPinSentinel";
+
+    /// <summary>The instant before which a node's last check-in makes it stale.</summary>
+    public const string LiveNodeCutoff = "liveNodeCutoff";
+
+    // Group listings, which name a group without saying whether it is a job's or a trigger's
+
+    public const string GroupName = "groupName";
+
+    // JOB_DETAILS
+
+    public const string JobName = "jobName";
+    public const string JobGroup = "jobGroup";
+    public const string JobDescription = "jobDescription";
+    public const string JobType = "jobType";
+    public const string JobDurable = "jobDurable";
+    public const string JobVolatile = "jobVolatile";
+    public const string JobStateful = "jobStateful";
+    public const string JobRequestsRecovery = "jobRequestsRecovery";
+    public const string JobDataMap = "jobDataMap";
+
+    // TRIGGERS, addressed by key or by state
+
+    public const string TriggerName = "triggerName";
+    public const string TriggerGroup = "triggerGroup";
+    public const string State = "state";
+    public const string NewState = "newState";
+    public const string OldState = "oldState";
+    public const string NextFireTime = "nextFireTime";
+    public const string NoLaterThan = "noLaterThan";
+    public const string NoEarlierThan = "noEarlierThan";
+    public const string MisfireOrigFireTime = "misfireOrigFireTime";
+    public const string ExecutionGroup = "executionGroup";
+
+    // TRIGGERS, written as a whole row. The trigger* family is the one the INSERT and the several
+    // UPDATEs share, so a column added to the row adds a name here rather than to the family above.
+
+    public const string TriggerJobName = "triggerJobName";
+    public const string TriggerJobGroup = "triggerJobGroup";
+    public const string TriggerDescription = "triggerDescription";
+    public const string TriggerNextFireTime = "triggerNextFireTime";
+    public const string TriggerPreviousFireTime = "triggerPreviousFireTime";
+    public const string TriggerState = "triggerState";
+    public const string TriggerType = "triggerType";
+    public const string TriggerStartTime = "triggerStartTime";
+    public const string TriggerEndTime = "triggerEndTime";
+    public const string TriggerCalendarName = "triggerCalendarName";
+    public const string TriggerMisfireInstruction = "triggerMisfireInstruction";
+    public const string TriggerMisfireOrigFireTime = "triggerMisfireOrigFireTime";
+    public const string TriggerPriority = "triggerPriority";
+    public const string TriggerJobJobDataMap = "triggerJobJobDataMap";
+    public const string TriggerExecutionGroup = "triggerExecutionGroup";
+    public const string TriggerRepeatCount = "triggerRepeatCount";
+    public const string TriggerRepeatInterval = "triggerRepeatInterval";
+    public const string TriggerTimesTriggered = "triggerTimesTriggered";
+    public const string TriggerCronExpression = "triggerCronExpression";
+    public const string TriggerTimeZone = "triggerTimeZone";
+    public const string TimeZoneId = "timeZoneId";
+
+    // Node affinity, which is written by compare-and-swap and so names both the value to write and
+    // the value it must still hold
+
+    public const string TriggerPreferredNode = "triggerPreferredNode";
+    public const string TriggerPreferredNodeAuto = "triggerPreferredNodeAuto";
+    public const string ExpectedPreferredNode = "expectedPreferredNode";
+    public const string ExpectedPreferredNodeAuto = "expectedPreferredNodeAuto";
+    public const string NewPreferredNode = "newPreferredNode";
+    public const string NewPreferredNodeAuto = "newPreferredNodeAuto";
+    public const string OldPreferredNode = "oldPreferredNode";
+    public const string OldPreferredNodeAuto = "oldPreferredNodeAuto";
+
+    // FIRED_TRIGGERS
+
+    public const string EntryId = "entryId";
+    public const string EntryState = "entryState";
+    public const string ExecutingState = "executingState";
+    public const string FiredTime = "firedTime";
+    public const string ScheduledTime = "scheduledTime";
+    public const string IsNonConcurrent = "isNonConcurrent";
+    public const string RequestsRecovery = "requestsRecovery";
+
+    /// <summary>
+    /// The fired-trigger UPDATE's spelling of <see cref="RequestsRecovery" />, a syllable short of it.
+    /// Two names for one column is not worth a schema-compatible statement change to fix, but it is
+    /// worth being able to see: both are here, next to each other, rather than a letter apart in two
+    /// unrelated strings.
+    /// </summary>
+    public const string RequestsRecover = "requestsRecover";
+
+    public const string TriggerEntryId = "triggerEntryId";
+    public const string TriggerInstanceName = "triggerInstanceName";
+    public const string TriggerFireTime = "triggerFireTime";
+    public const string TriggerScheduledTime = "triggerScheduledTime";
+    public const string TriggerJobStateful = "triggerJobStateful";
+    public const string TriggerJobRequestsRecovery = "triggerJobRequestsRecovery";
+
+    // CALENDARS and BLOB_TRIGGERS
+
+    public const string CalendarName = "calendarName";
+    public const string Calendar = "calendar";
+    public const string Blob = "blob";
+
+    // SIMPROP_TRIGGERS, whose columns are numbered rather than named: which property each holds is
+    // decided by the trigger type's persistence delegate.
+
+    public const string String1 = "string1";
+    public const string String2 = "string2";
+    public const string String3 = "string3";
+    public const string Int1 = "int1";
+    public const string Int2 = "int2";
+    public const string Long1 = "long1";
+    public const string Long2 = "long2";
+    public const string Decimal1 = "decimal1";
+    public const string Decimal2 = "decimal2";
+    public const string Boolean1 = "boolean1";
+    public const string Boolean2 = "boolean2";
+
+    // Paging, for the dialects whose clause takes its bounds as parameters
+
+    public const string PageSkip = "pageSkip";
+    public const string PageTake = "pageTake";
+}

--- a/src/Quartz/Impl/AdoJobStore/SqlRowLimit.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlRowLimit.cs
@@ -1,0 +1,131 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Runtime.InteropServices;
+
+using static System.FormattableString;
+
+namespace Quartz.Impl.AdoJobStore;
+
+/// <summary>
+/// How a dialect says "at most this many rows", as a slot the statement has for it rather than as an
+/// edit to finished SQL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// There is no ANSI row limit, so every database spells it somewhere else in the statement, and a
+/// dialect used to reach into a statement it does not own to put it there — SQL Server cut the first
+/// six characters off and pasted its own <c>SELECT</c> back on, which was correct only while the
+/// statement began with exactly that keyword and nothing said it had to. A dialect now says which of
+/// the three places its clause belongs in, and the statement is built with it already there.
+/// </para>
+/// <para>
+/// The three cover every shipped dialect and, as far as row limiting goes, every SQL database:
+/// <see cref="InProjection" /> for SQL Server's <c>TOP</c>, <see cref="AtStatementEnd" /> for the
+/// <c>LIMIT</c> of PostgreSQL, MySQL and SQLite and the <c>ROWS</c> of Firebird, and
+/// <see cref="InEnclosingSelect" /> for Oracle's <c>rownum</c>.
+/// </para>
+/// <para>
+/// The count is spliced into the text rather than bound as a parameter, because a row limit is part
+/// of the statement's shape on several of these databases — SQL Server will not take <c>TOP</c> from
+/// a parameter without parentheses, and a limit that varies per call would churn the plan cache
+/// anyway. The value is Quartz's own batch size, never anything a caller supplies.
+/// </para>
+/// </remarks>
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct SqlRowLimit
+{
+    private readonly Placement placement;
+    private readonly string? clause;
+    private readonly int count;
+
+    private SqlRowLimit(Placement placement, string clause, int count)
+    {
+        this.placement = placement;
+        this.clause = clause;
+        this.count = count;
+    }
+
+    /// <summary>
+    /// No limit at all: the statement is built exactly as it would be for a database that cannot
+    /// limit rows, which is what <see cref="StdAdoDelegate" /> itself assumes.
+    /// </summary>
+    public static SqlRowLimit Unlimited => default;
+
+    /// <summary>
+    /// A limit that sits in the projection, immediately after the <c>SELECT</c> keyword —
+    /// <c>SELECT TOP 5 …</c>.
+    /// </summary>
+    /// <param name="keyword">The keyword introducing the limit, <c>TOP</c> on SQL Server.</param>
+    /// <param name="count">The most rows the statement may return.</param>
+    public static SqlRowLimit InProjection(string keyword, int count) => new(Placement.Projection, keyword, count);
+
+    /// <summary>
+    /// A limit that follows the whole statement, after its <c>ORDER BY</c> — <c>… LIMIT 5</c>.
+    /// </summary>
+    /// <param name="keyword">
+    /// The keyword introducing the limit: <c>LIMIT</c> on PostgreSQL, MySQL and SQLite, <c>ROWS</c>
+    /// on Firebird.
+    /// </param>
+    /// <param name="count">The most rows the statement may return.</param>
+    public static SqlRowLimit AtStatementEnd(string keyword, int count) => new(Placement.StatementEnd, keyword, count);
+
+    /// <summary>
+    /// A limit expressed by an enclosing <c>SELECT</c> that filters on a row-number pseudo-column —
+    /// <c>SELECT * FROM (…) WHERE rownum &lt;= 5</c>.
+    /// </summary>
+    /// <param name="pseudoColumn">The pseudo-column carrying the row number, <c>rownum</c> on Oracle.</param>
+    /// <param name="count">The most rows the statement may return.</param>
+    public static SqlRowLimit InEnclosingSelect(string pseudoColumn, int count) => new(Placement.EnclosingSelect, pseudoColumn, count);
+
+    /// <summary>
+    /// What goes immediately after the <c>SELECT</c> keyword, or nothing.
+    /// </summary>
+    /// <remarks>
+    /// Carries its own spaces on both sides, so that a statement with no limit is the same text it
+    /// was before there was a slot to fill.
+    /// </remarks>
+    internal string AfterSelect => placement == Placement.Projection ? Invariant($" {clause} {count} ") : "";
+
+    /// <summary>
+    /// What goes after the last of the statement's own clauses, or nothing.
+    /// </summary>
+    internal string AtEnd => placement == Placement.StatementEnd ? Invariant($" {clause} {count}") : "";
+
+    /// <summary>
+    /// Wraps a finished statement in the enclosing <c>SELECT</c> this limit asked for, or hands it
+    /// back untouched. Unlike the other two this needs no slot: it assumes nothing about the
+    /// statement beyond its being one.
+    /// </summary>
+    internal string Enclose(string sql) =>
+        placement == Placement.EnclosingSelect
+            ? Invariant($"SELECT * FROM ({sql}) WHERE {clause} <= {count}")
+            : sql;
+
+    private enum Placement
+    {
+        /// <summary>No limit. The default, so that <c>default(SqlRowLimit)</c> is <see cref="Unlimited" />.</summary>
+        None = 0,
+        Projection,
+        StatementEnd,
+        EnclosingSelect
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -30,29 +30,9 @@ namespace Quartz.Impl.AdoJobStore;
 public class SqlServerDelegate : StdAdoDelegate
 {
     /// <summary>
-    /// Gets the select next trigger to acquire SQL clause.
-    /// SQL Server specific version with TOP functionality
+    /// SQL Server names its row limit in the projection: <c>SELECT TOP n …</c>.
     /// </summary>
-    /// <returns></returns>
-    protected override string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
-    {
-        string sqlSelectNextTriggerToAcquire = base.GetSelectNextTriggerToAcquireSql(shape);
-
-        // add limit clause to correct place
-        sqlSelectNextTriggerToAcquire = "SELECT TOP " + shape.MaxCount + " " + sqlSelectNextTriggerToAcquire.Substring(6);
-
-        return sqlSelectNextTriggerToAcquire;
-    }
-
-    protected override string GetSelectMisfiredTriggersToRecoverSql(int count)
-    {
-        if (count != -1)
-        {
-            // add limit clause to correct place
-            return "SELECT TOP " + count + " " + StdAdoConstants.SqlSelectMisfiredTriggersToRecover.Substring(6);
-        }
-        return base.GetSelectMisfiredTriggersToRecoverSql(count);
-    }
+    protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.InProjection("TOP", count);
 
     public override void AddCommandParameter(
         DbCommand cmd,

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -293,7 +293,8 @@ internal static class StdAdoConstants
     // literally the no-exclusion case of this template rather than a second copy kept in step by eye,
     // and a change to the projection, the join, the predicates or the ORDER BY is a change in one
     // place. The clause carries its own leading newline and indent, so passing an empty one yields
-    // the statement byte for byte as it was before there was a clause to pass.
+    // the statement byte for byte as it was before there was a clause to pass. The dialect's row
+    // limit is the same idea: two named slots and an enclosing SELECT, all three empty by default.
     //
     // PREFERRED_NODE is filtered entirely in PreferredNodeWhereClause and is not projected —
     // acquisition never reads it from the result (the trigger is reloaded via GetTrigger).
@@ -303,8 +304,8 @@ internal static class StdAdoConstants
     // now - MisfireThreshold the sweep asks about, so a waiting trigger belongs either to acquisition
     // or to the misfire handler and never to both. Acquiring one the store already counts as misfired
     // would fire it late without ever applying the policy it asked for.
-    private static string SelectNextTriggerToAcquire(string exclusionClause) =>
-        Invariant($@"SELECT
+    private static string SelectNextTriggerToAcquire(string exclusionClause, SqlRowLimit rowLimit) =>
+        rowLimit.Enclose(Invariant($@"SELECT{rowLimit.AfterSelect}
                 t.{AdoConstants.ColumnTriggerName}, t.{AdoConstants.ColumnTriggerGroup}, jd.{AdoConstants.ColumnJobClass}, t.{AdoConstants.ColumnExecutionGroup}
               FROM
                 {TablePrefixSubst}{AdoConstants.TableTriggers} t
@@ -314,9 +315,9 @@ internal static class StdAdoConstants
                 t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} > @noEarlierThan))
                 {PreferredNodeWhereClause}{exclusionClause}
               ORDER BY
-                {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC");
+                {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC{rowLimit.AtEnd}"));
 
-    public static readonly string SqlSelectNextTriggerToAcquire = SelectNextTriggerToAcquire(exclusionClause: "");
+    public static readonly string SqlSelectNextTriggerToAcquire = SelectNextTriggerToAcquire(exclusionClause: "", SqlRowLimit.Unlimited);
 
     /// <summary>
     /// Exclusion counts are rounded up and padded to one of these sizes, limiting the acquisition
@@ -351,13 +352,21 @@ internal static class StdAdoConstants
     }
 
     /// <summary>
-    /// Builds the trigger-acquisition query for an already-rounded job-type exclusion bucket.
+    /// Builds the trigger-acquisition query for an already-rounded job-type exclusion bucket and the
+    /// dialect's row limit.
     /// </summary>
-    internal static string BuildSqlSelectNextTriggerToAcquire(int excludedJobTypeBucket)
+    /// <remarks>
+    /// Only the unlimited statements are cached here. A limited one is a pure function of the same
+    /// two inputs, but <c>StdAdoDelegate</c> already remembers the finished statement against the
+    /// acquisition shape it was built for, so caching it twice would buy nothing.
+    /// </remarks>
+    internal static string BuildSqlSelectNextTriggerToAcquire(int excludedJobTypeBucket, SqlRowLimit rowLimit)
     {
         if (excludedJobTypeBucket == 0)
         {
-            return SqlSelectNextTriggerToAcquire;
+            return rowLimit == SqlRowLimit.Unlimited
+                ? SqlSelectNextTriggerToAcquire
+                : SelectNextTriggerToAcquire(exclusionClause: "", rowLimit);
         }
 
         int bucketIndex = Array.IndexOf(excludedJobTypeBuckets, excludedJobTypeBucket);
@@ -366,13 +375,18 @@ internal static class StdAdoConstants
             Throw.ArgumentOutOfRangeException(nameof(excludedJobTypeBucket), "Excluded job type count must be rounded to a query bucket first");
         }
 
+        if (rowLimit != SqlRowLimit.Unlimited)
+        {
+            return SelectNextTriggerToAcquire(ExcludedJobTypeWhereClause(excludedJobTypeBucket), rowLimit);
+        }
+
         string? cached = sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket[bucketIndex];
         if (cached is not null)
         {
             return cached;
         }
 
-        string predicateSql = SelectNextTriggerToAcquire(ExcludedJobTypeWhereClause(excludedJobTypeBucket));
+        string predicateSql = SelectNextTriggerToAcquire(ExcludedJobTypeWhereClause(excludedJobTypeBucket), rowLimit);
 
         sqlSelectNextTriggerToAcquireByExcludedJobTypeBucket[bucketIndex] = predicateSql;
         return predicateSql;
@@ -488,16 +502,29 @@ internal static class StdAdoConstants
     /// with the key columns appended (they are ambiguous across the joined tables, hence the alias).
     /// </summary>
     /// <remarks>
-    /// Must start with the <c>SELECT</c> keyword — <see cref="SqlServerDelegate" /> splices its
-    /// <c>TOP n</c> in at that offset.
+    /// The dialect's row limit goes in one of the two slots, or around the whole statement; a dialect
+    /// that has no way to limit rows leaves all three empty and gets the statement unchanged.
     /// </remarks>
-    public static readonly string SqlSelectMisfiredTriggersToRecover =
-        Invariant($@"SELECT {TriggerSelectColumns},
+    private static string SelectMisfiredTriggersToRecover(SqlRowLimit rowLimit) =>
+        rowLimit.Enclose(Invariant($@"SELECT{rowLimit.AfterSelect} {TriggerSelectColumns},
                 t.{AdoConstants.ColumnTriggerName},
                 t.{AdoConstants.ColumnTriggerGroup}{TriggerSelectFastPathFrom}
             WHERE
                 t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND t.{AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{AdoConstants.ColumnNextFireTime} <= @nextFireTime AND t.{AdoConstants.ColumnTriggerState} = @state
-            ORDER BY t.{AdoConstants.ColumnNextFireTime} ASC, t.{AdoConstants.ColumnPriority} DESC");
+            ORDER BY t.{AdoConstants.ColumnNextFireTime} ASC, t.{AdoConstants.ColumnPriority} DESC{rowLimit.AtEnd}"));
+
+    /// <inheritdoc cref="SelectMisfiredTriggersToRecover" />
+    public static readonly string SqlSelectMisfiredTriggersToRecover = SelectMisfiredTriggersToRecover(SqlRowLimit.Unlimited);
+
+    /// <summary>
+    /// Builds the misfire recovery statement for the dialect's row limit, which is the only thing
+    /// that varies about it. <c>StdAdoDelegate</c> remembers the result against the batch size it was
+    /// built for.
+    /// </summary>
+    internal static string BuildSqlSelectMisfiredTriggersToRecover(SqlRowLimit rowLimit) =>
+        rowLimit == SqlRowLimit.Unlimited
+            ? SqlSelectMisfiredTriggersToRecover
+            : SelectMisfiredTriggersToRecover(rowLimit);
 
     /// <summary>
     /// Prefix of the batch trigger lookup; the caller appends a key-set predicate built by

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -165,13 +165,19 @@ internal static class StdAdoConstants
         Invariant($"SELECT {AdoConstants.ColumnBlob}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
 
     /// <summary>
+    /// The key columns a batch lookup projects beside the row's own, so that the caller can match each
+    /// row back to the key it asked for.
+    /// </summary>
+    private const string TriggerKeySelectColumns = $"{AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}";
+
+    /// <summary>
     /// Prefix of the batch simple-properties trigger lookup; the caller appends a key-set predicate built
     /// by <c>AdoUtil.BuildTriggerKeyPredicate</c>. All simple-properties trigger types
     /// (calendar-interval, daily-time-interval, recurrence, and any custom ones) share this one table, so a
     /// single query covers them all — the per-row discriminator comes from TRIGGERS.TRIGGER_TYPE.
     /// </summary>
     public static readonly string SqlSelectSimpropTriggersByKeysPrefix =
-        Invariant($"SELECT * FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {SimplePropertiesTriggerPersistenceDelegateBase.SelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
 
     public static readonly string SqlSelectCalendar =
         Invariant($"SELECT {AdoConstants.ColumnCalendar} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
@@ -179,15 +185,28 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectCalendarExistence =
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
 
+    /// <summary>
+    /// Every column <c>CronTriggerPersistenceDelegate.ReadTriggerPropertyBundle</c> reads, and only
+    /// those. Shared by the single-key and batch lookups so the two cannot drift apart.
+    /// </summary>
+    private const string CronTriggerSelectColumns = $"{AdoConstants.ColumnCronExpression}, {AdoConstants.ColumnTimeZoneId}";
+
     public static readonly string SqlSelectCronTriggers =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {CronTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+
+    /// <summary>
+    /// Every column <c>StdAdoDelegate.ReadFiredTriggerRecord</c> reads, and only those — EXECUTION_GROUP
+    /// is on the row but not on <see cref="FiredTriggerRecord" />, so it is not fetched.
+    /// </summary>
+    private const string FiredTriggerSelectColumns =
+        $"{AdoConstants.ColumnEntryId}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnEntryState}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnRequestsRecovery}, {AdoConstants.ColumnPriority}";
 
     /// <summary>
     /// Selects every fired trigger of the scheduler; the caller appends the predicates of a
     /// <see cref="FiredTriggerQuery" /> to narrow it.
     /// </summary>
     public static readonly string SqlSelectFiredTriggers =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {FiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
 
     // FIRED_TRIGGERS predicates, shared by the select and the delete so the two cannot filter
     // differently. They are appended — and their parameters bound — in the order declared here,
@@ -208,8 +227,16 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectCountExecutingFiredTriggersOfJob =
         Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup AND {AdoConstants.ColumnEntryState} = @executingState");
 
+    /// <summary>
+    /// Every column <c>StdAdoDelegate.SelectTriggersForRecoveringJobs</c> reads, and only those. It
+    /// builds a recovery trigger rather than a <see cref="FiredTriggerRecord" />, so it needs fewer
+    /// columns than <see cref="SqlSelectFiredTriggers" /> does.
+    /// </summary>
+    private const string RecoverableFiredTriggerSelectColumns =
+        $"{AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnPriority}";
+
     public static readonly string SqlSelectInstancesRecoverableFiredTriggers =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName AND {AdoConstants.ColumnRequestsRecovery} = @requestsRecovery");
+        Invariant($"SELECT {RecoverableFiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName AND {AdoConstants.ColumnRequestsRecovery} = @requestsRecovery");
 
     /// <summary>
     /// Column list shared by <see cref="SqlSelectJobDetail" /> and <see cref="SqlSelectJobDetailsByKeysPrefix" />,
@@ -438,14 +465,28 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectReferencedCalendar =
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
 
+    /// <summary>
+    /// The three columns a <see cref="SchedulerStateRecord" /> is made of. SCHED_NAME is the fourth
+    /// column of the table and is not projected: it is the parameter the statement filters on.
+    /// </summary>
+    private const string SchedulerStateSelectColumns =
+        $"{AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnLastCheckinTime}, {AdoConstants.ColumnCheckinInterval}";
+
     public static readonly string SqlSelectSchedulerState =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName");
+        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName");
 
     public static readonly string SqlSelectSchedulerStates =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+
+    /// <summary>
+    /// Every column <c>SimpleTriggerPersistenceDelegate.ReadTriggerPropertyBundle</c> reads, and only
+    /// those. Shared by the single-key and batch lookups so the two cannot drift apart.
+    /// </summary>
+    private const string SimpleTriggerSelectColumns =
+        $"{AdoConstants.ColumnRepeatCount}, {AdoConstants.ColumnRepeatInterval}, {AdoConstants.ColumnTimesTriggered}";
 
     public static readonly string SqlSelectSimpleTrigger =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {SimpleTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
 
     /// <summary>
     /// Column list shared by <see cref="SqlSelectTrigger" /> and <see cref="SqlSelectMisfiredTriggersToRecover" />,
@@ -544,14 +585,14 @@ internal static class StdAdoConstants
     /// <c>AdoUtil.BuildTriggerKeyPredicate</c>.
     /// </summary>
     public static readonly string SqlSelectSimpleTriggersByKeysPrefix =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {SimpleTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
 
     /// <summary>
     /// Prefix of the batch cron-trigger lookup; the caller appends a key-set predicate built by
     /// <c>AdoUtil.BuildTriggerKeyPredicate</c>.
     /// </summary>
     public static readonly string SqlSelectCronTriggersByKeysPrefix =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {CronTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
 
     public static readonly string SqlSelectTriggerData =
         Invariant($"SELECT {AdoConstants.ColumnJobDataMap} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -66,95 +66,95 @@ internal static class StdAdoConstants
 
     // DELETE
     public static readonly string SqlDeleteBlobTrigger =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlDeleteCalendar =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     public static readonly string SqlDeleteCronTrigger =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlDeleteFiredTrigger =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnEntryId} = @triggerEntryId");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnEntryId} = @{SqlParameters.TriggerEntryId}");
 
     /// <summary>
     /// Deletes every fired trigger of the scheduler; the caller appends the predicates of a
     /// <see cref="FiredTriggerQuery" /> to narrow it.
     /// </summary>
     public static readonly string SqlDeleteFiredTriggers =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlDeleteJobDetail =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlDeletePausedTriggerGroupEquals =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlDeletePausedTriggerGroupLike =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause}");
 
     public static readonly string SqlDeletePausedJobGroupEquals =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlDeletePausedJobGroupLike =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} LIKE @jobGroup{SqlLikeEscapeClause}");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} LIKE @{SqlParameters.JobGroup}{SqlLikeEscapeClause}");
 
     public static readonly string SqlDeleteSchedulerState =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}");
 
     public static readonly string SqlDeleteSimpleTrigger =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlDeleteTrigger =
-        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
-    public static readonly string SqlDeleteAllSimpleTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllSimpropTriggers = Invariant($"DELETE FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllCronTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllBlobTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllJobDetails = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllCalendars = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllPausedTriggerGrps = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllPausedJobGrps = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+    public static readonly string SqlDeleteAllSimpleTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllSimpropTriggers = Invariant($"DELETE FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllCronTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllBlobTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllJobDetails = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllCalendars = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllPausedTriggerGrps = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
+    public static readonly string SqlDeleteAllPausedJobGrps = Invariant($"DELETE FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     // INSERT
 
     public static readonly string SqlInsertBlobTrigger =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableBlobTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnBlob})  VALUES(@schedulerName, @triggerName, @triggerGroup, @blob)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableBlobTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnBlob})  VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerName}, @{SqlParameters.TriggerGroup}, @{SqlParameters.Blob})");
 
     public static readonly string SqlInsertCalendar =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableCalendars} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnCalendarName}, {AdoConstants.ColumnCalendar})  VALUES(@schedulerName, @calendarName, @calendar)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableCalendars} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnCalendarName}, {AdoConstants.ColumnCalendar})  VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.CalendarName}, @{SqlParameters.Calendar})");
 
     public static readonly string SqlInsertCronTrigger =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableCronTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnCronExpression}, {AdoConstants.ColumnTimeZoneId}) VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerCronExpression, @triggerTimeZone)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableCronTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnCronExpression}, {AdoConstants.ColumnTimeZoneId}) VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerName}, @{SqlParameters.TriggerGroup}, @{SqlParameters.TriggerCronExpression}, @{SqlParameters.TriggerTimeZone})");
 
     public static readonly string SqlInsertFiredTrigger =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableFiredTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnEntryId}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnEntryState}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnRequestsRecovery}, {AdoConstants.ColumnPriority}, {AdoConstants.ColumnExecutionGroup}) VALUES(@schedulerName, @triggerEntryId, @triggerName, @triggerGroup, @triggerInstanceName, @triggerFireTime, @triggerScheduledTime, @triggerState, @triggerJobName, @triggerJobGroup, @triggerJobStateful, @triggerJobRequestsRecovery, @triggerPriority, @triggerExecutionGroup)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableFiredTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnEntryId}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnEntryState}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnRequestsRecovery}, {AdoConstants.ColumnPriority}, {AdoConstants.ColumnExecutionGroup}) VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerEntryId}, @{SqlParameters.TriggerName}, @{SqlParameters.TriggerGroup}, @{SqlParameters.TriggerInstanceName}, @{SqlParameters.TriggerFireTime}, @{SqlParameters.TriggerScheduledTime}, @{SqlParameters.TriggerState}, @{SqlParameters.TriggerJobName}, @{SqlParameters.TriggerJobGroup}, @{SqlParameters.TriggerJobStateful}, @{SqlParameters.TriggerJobRequestsRecovery}, @{SqlParameters.TriggerPriority}, @{SqlParameters.TriggerExecutionGroup})");
 
     public static readonly string SqlInsertJobDetail =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableJobDetails} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnJobClass}, {AdoConstants.ColumnIsDurable}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnIsUpdateData}, {AdoConstants.ColumnRequestsRecovery}, {AdoConstants.ColumnJobDataMap})  VALUES(@schedulerName, @jobName, @jobGroup, @jobDescription, @jobType, @jobDurable, @jobVolatile, @jobStateful, @jobRequestsRecovery, @jobDataMap)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableJobDetails} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnJobClass}, {AdoConstants.ColumnIsDurable}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnIsUpdateData}, {AdoConstants.ColumnRequestsRecovery}, {AdoConstants.ColumnJobDataMap})  VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.JobName}, @{SqlParameters.JobGroup}, @{SqlParameters.JobDescription}, @{SqlParameters.JobType}, @{SqlParameters.JobDurable}, @{SqlParameters.JobVolatile}, @{SqlParameters.JobStateful}, @{SqlParameters.JobRequestsRecovery}, @{SqlParameters.JobDataMap})");
 
     public static readonly string SqlInsertPausedTriggerGroup =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TablePausedTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerGroup}) VALUES (@schedulerName, @triggerGroup)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TablePausedTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerGroup}) VALUES (@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerGroup})");
 
     public static readonly string SqlInsertPausedJobGroup =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TablePausedJobs} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnJobGroup}) VALUES (@schedulerName, @jobGroup)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TablePausedJobs} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnJobGroup}) VALUES (@{SqlParameters.SchedulerName}, @{SqlParameters.JobGroup})");
 
     public static readonly string SqlInsertSchedulerState =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableSchedulerState} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnLastCheckinTime}, {AdoConstants.ColumnCheckinInterval}) VALUES(@schedulerName, @instanceName, @lastCheckinTime, @checkinInterval)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableSchedulerState} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnLastCheckinTime}, {AdoConstants.ColumnCheckinInterval}) VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.InstanceName}, @{SqlParameters.LastCheckinTime}, @{SqlParameters.CheckinInterval})");
 
     public static readonly string SqlInsertSimpleTrigger =
-        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnRepeatCount}, {AdoConstants.ColumnRepeatInterval}, {AdoConstants.ColumnTimesTriggered})  VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerRepeatCount, @triggerRepeatInterval, @triggerTimesTriggered)");
+        Invariant($"INSERT INTO {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnRepeatCount}, {AdoConstants.ColumnRepeatInterval}, {AdoConstants.ColumnTimesTriggered})  VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerName}, @{SqlParameters.TriggerGroup}, @{SqlParameters.TriggerRepeatCount}, @{SqlParameters.TriggerRepeatInterval}, @{SqlParameters.TriggerTimesTriggered})");
 
     public static readonly string SqlInsertTrigger =
         Invariant($@"INSERT INTO {TablePrefixSubst}{AdoConstants.TableTriggers} ({AdoConstants.ColumnSchedulerName}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnNextFireTime}, {AdoConstants.ColumnPreviousFireTime}, {AdoConstants.ColumnTriggerState}, {AdoConstants.ColumnTriggerType}, {AdoConstants.ColumnStartTime}, {AdoConstants.ColumnEndTime}, {AdoConstants.ColumnCalendarName}, {AdoConstants.ColumnMisfireInstruction}, {AdoConstants.ColumnJobDataMap}, {AdoConstants.ColumnPriority}, {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnPreferredNode}, {AdoConstants.ColumnPreferredNodeAuto})
-                        VALUES(@schedulerName, @triggerName, @triggerGroup, @triggerJobName, @triggerJobGroup, @triggerDescription, @triggerNextFireTime, @triggerPreviousFireTime, @triggerState, @triggerType, @triggerStartTime, @triggerEndTime, @triggerCalendarName, @triggerMisfireInstruction, @triggerJobJobDataMap, @triggerPriority, @triggerExecutionGroup, @triggerPreferredNode, @triggerPreferredNodeAuto)");
+                        VALUES(@{SqlParameters.SchedulerName}, @{SqlParameters.TriggerName}, @{SqlParameters.TriggerGroup}, @{SqlParameters.TriggerJobName}, @{SqlParameters.TriggerJobGroup}, @{SqlParameters.TriggerDescription}, @{SqlParameters.TriggerNextFireTime}, @{SqlParameters.TriggerPreviousFireTime}, @{SqlParameters.TriggerState}, @{SqlParameters.TriggerType}, @{SqlParameters.TriggerStartTime}, @{SqlParameters.TriggerEndTime}, @{SqlParameters.TriggerCalendarName}, @{SqlParameters.TriggerMisfireInstruction}, @{SqlParameters.TriggerJobJobDataMap}, @{SqlParameters.TriggerPriority}, @{SqlParameters.TriggerExecutionGroup}, @{SqlParameters.TriggerPreferredNode}, @{SqlParameters.TriggerPreferredNodeAuto})");
 
     // SELECT
 
     public static readonly string SqlSelectBlobTrigger =
-        Invariant($"SELECT {AdoConstants.ColumnBlob} FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnBlob} FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Prefix of the batch blob-trigger lookup; the caller appends a key-set predicate built by
@@ -162,7 +162,7 @@ internal static class StdAdoConstants
     /// can stay in sequential-access mode.
     /// </summary>
     public static readonly string SqlSelectBlobTriggersByKeysPrefix =
-        Invariant($"SELECT {AdoConstants.ColumnBlob}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {AdoConstants.ColumnBlob}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableBlobTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     /// <summary>
     /// The key columns a batch lookup projects beside the row's own, so that the caller can match each
@@ -177,13 +177,13 @@ internal static class StdAdoConstants
     /// single query covers them all — the per-row discriminator comes from TRIGGERS.TRIGGER_TYPE.
     /// </summary>
     public static readonly string SqlSelectSimpropTriggersByKeysPrefix =
-        Invariant($"SELECT {SimplePropertiesTriggerPersistenceDelegateBase.SelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {SimplePropertiesTriggerPersistenceDelegateBase.SelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     public static readonly string SqlSelectCalendar =
-        Invariant($"SELECT {AdoConstants.ColumnCalendar} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"SELECT {AdoConstants.ColumnCalendar} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     public static readonly string SqlSelectCalendarExistence =
-        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     /// <summary>
     /// Every column <c>CronTriggerPersistenceDelegate.ReadTriggerPropertyBundle</c> reads, and only
@@ -192,7 +192,7 @@ internal static class StdAdoConstants
     private const string CronTriggerSelectColumns = $"{AdoConstants.ColumnCronExpression}, {AdoConstants.ColumnTimeZoneId}";
 
     public static readonly string SqlSelectCronTriggers =
-        Invariant($"SELECT {CronTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {CronTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Every column <c>StdAdoDelegate.ReadFiredTriggerRecord</c> reads, and only those — EXECUTION_GROUP
@@ -206,26 +206,26 @@ internal static class StdAdoConstants
     /// <see cref="FiredTriggerQuery" /> to narrow it.
     /// </summary>
     public static readonly string SqlSelectFiredTriggers =
-        Invariant($"SELECT {FiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {FiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     // FIRED_TRIGGERS predicates, shared by the select and the delete so the two cannot filter
     // differently. They are appended — and their parameters bound — in the order declared here,
     // because providers with bindByName = false adapt named parameters positionally.
 
     public static readonly string SqlFiredTriggerTriggerPredicate =
-        Invariant($" AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($" AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlFiredTriggerJobPredicate =
-        Invariant($" AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($" AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlFiredTriggerInstancePredicate =
-        Invariant($" AND {AdoConstants.ColumnInstanceName} = @instanceName");
+        Invariant($" AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}");
 
     public static readonly string SqlSelectFiredTriggerInstanceNames =
-        Invariant($"SELECT DISTINCT {AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT DISTINCT {AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlSelectCountExecutingFiredTriggersOfJob =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup AND {AdoConstants.ColumnEntryState} = @executingState");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup} AND {AdoConstants.ColumnEntryState} = @{SqlParameters.ExecutingState}");
 
     /// <summary>
     /// Every column <c>StdAdoDelegate.SelectTriggersForRecoveringJobs</c> reads, and only those. It
@@ -236,7 +236,7 @@ internal static class StdAdoConstants
         $"{AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnPriority}";
 
     public static readonly string SqlSelectInstancesRecoverableFiredTriggers =
-        Invariant($"SELECT {RecoverableFiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName AND {AdoConstants.ColumnRequestsRecovery} = @requestsRecovery");
+        Invariant($"SELECT {RecoverableFiredTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName} AND {AdoConstants.ColumnRequestsRecovery} = @{SqlParameters.RequestsRecovery}");
 
     /// <summary>
     /// Column list shared by <see cref="SqlSelectJobDetail" /> and <see cref="SqlSelectJobDetailsByKeysPrefix" />,
@@ -250,26 +250,26 @@ internal static class StdAdoConstants
         $"{AdoConstants.ColumnJobName},{AdoConstants.ColumnJobGroup},{AdoConstants.ColumnDescription},{AdoConstants.ColumnJobClass},{AdoConstants.ColumnIsDurable},{AdoConstants.ColumnRequestsRecovery},{AdoConstants.ColumnJobDataMap},{AdoConstants.ColumnIsNonConcurrent},{AdoConstants.ColumnIsUpdateData}";
 
     public static readonly string SqlSelectJobDetail =
-        Invariant($"SELECT {JobDetailSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT {JobDetailSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     /// <summary>
     /// Prefix of the batch job lookup; the caller appends a key-set predicate built by
     /// <c>AdoUtil.BuildJobKeyPredicate</c>.
     /// </summary>
     public static readonly string SqlSelectJobDetailsByKeysPrefix =
-        Invariant($"SELECT {JobDetailSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {JobDetailSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     public static readonly string SqlSelectJobExistence =
-        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlSelectJobForTrigger =
-        Invariant($"SELECT J.{AdoConstants.ColumnJobName}, J.{AdoConstants.ColumnJobGroup}, J.{AdoConstants.ColumnIsDurable}, J.{AdoConstants.ColumnJobClass}, J.{AdoConstants.ColumnRequestsRecovery} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} T, {TablePrefixSubst}{AdoConstants.TableJobDetails} J WHERE T.{AdoConstants.ColumnSchedulerName} = @schedulerName AND T.{AdoConstants.ColumnSchedulerName} = J.{AdoConstants.ColumnSchedulerName} AND T.{AdoConstants.ColumnTriggerName} = @triggerName AND T.{AdoConstants.ColumnTriggerGroup} = @triggerGroup AND T.{AdoConstants.ColumnJobName} = J.{AdoConstants.ColumnJobName} AND T.{AdoConstants.ColumnJobGroup} = J.{AdoConstants.ColumnJobGroup}");
+        Invariant($"SELECT J.{AdoConstants.ColumnJobName}, J.{AdoConstants.ColumnJobGroup}, J.{AdoConstants.ColumnIsDurable}, J.{AdoConstants.ColumnJobClass}, J.{AdoConstants.ColumnRequestsRecovery} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} T, {TablePrefixSubst}{AdoConstants.TableJobDetails} J WHERE T.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND T.{AdoConstants.ColumnSchedulerName} = J.{AdoConstants.ColumnSchedulerName} AND T.{AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND T.{AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND T.{AdoConstants.ColumnJobName} = J.{AdoConstants.ColumnJobName} AND T.{AdoConstants.ColumnJobGroup} = J.{AdoConstants.ColumnJobGroup}");
 
     public static readonly string SqlSelectJobsInGroupLike =
-        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} LIKE @jobGroup{SqlLikeEscapeClause}");
+        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} LIKE @{SqlParameters.JobGroup}{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectJobsInGroup =
-        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     /// <summary>
     /// The cheap count the misfire handler peeks with before it takes the trigger lock. It has to
@@ -284,7 +284,7 @@ internal static class StdAdoConstants
     /// strictly greater, and <see cref="SqlSelectNextTriggerToAcquire" /> takes the complement of it.
     /// </remarks>
     public static readonly string SqlCountMisfiredTriggersInStates =
-        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {AdoConstants.ColumnNextFireTime} <= @nextFireTime AND {AdoConstants.ColumnTriggerState} = @state");
+        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {AdoConstants.ColumnNextFireTime} <= @{SqlParameters.NextFireTime} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.State}");
 
     /// <summary>
     /// Sentinel stored in PREFERRED_NODE to request auto-pin that has not yet been claimed by
@@ -312,8 +312,8 @@ internal static class StdAdoConstants
     // bindByName=false adapt named parameters positionally and a reused name would produce more
     // placeholders than bound parameters.
     private static readonly string PreferredNodeWhereClause =
-        Invariant($@"AND (t.{AdoConstants.ColumnPreferredNode} IS NULL OR t.{AdoConstants.ColumnPreferredNode} = @instanceId OR t.{AdoConstants.ColumnPreferredNode} = @autoPinSentinel
-                     OR t.{AdoConstants.ColumnPreferredNode} NOT IN (SELECT ss.{AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} ss WHERE ss.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND ss.{AdoConstants.ColumnLastCheckinTime} + ss.{AdoConstants.ColumnCheckinInterval} * 10000 >= @liveNodeCutoff))");
+        Invariant($@"AND (t.{AdoConstants.ColumnPreferredNode} IS NULL OR t.{AdoConstants.ColumnPreferredNode} = @{SqlParameters.InstanceId} OR t.{AdoConstants.ColumnPreferredNode} = @{SqlParameters.AutoPinSentinel}
+                     OR t.{AdoConstants.ColumnPreferredNode} NOT IN (SELECT ss.{AdoConstants.ColumnInstanceName} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} ss WHERE ss.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND ss.{AdoConstants.ColumnLastCheckinTime} + ss.{AdoConstants.ColumnCheckinInterval} * 10000 >= @{SqlParameters.LiveNodeCutoff}))");
 
     // The one acquisition statement. Everything a caller can vary about it is the job-type exclusion
     // clause, which is empty when nothing is excluded - so SqlSelectNextTriggerToAcquire below is
@@ -339,7 +339,7 @@ internal static class StdAdoConstants
               JOIN
                 {TablePrefixSubst}{AdoConstants.TableJobDetails} jd ON (jd.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND  jd.{AdoConstants.ColumnJobGroup} = t.{AdoConstants.ColumnJobGroup} AND jd.{AdoConstants.ColumnJobName} = t.{AdoConstants.ColumnJobName})
               WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state AND {AdoConstants.ColumnNextFireTime} <= @noLaterThan AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} > @noEarlierThan))
+                t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.State} AND {AdoConstants.ColumnNextFireTime} <= @{SqlParameters.NoLaterThan} AND ({AdoConstants.ColumnMisfireInstruction} = -1 OR ({AdoConstants.ColumnMisfireInstruction} <> -1 AND {AdoConstants.ColumnNextFireTime} > @{SqlParameters.NoEarlierThan}))
                 {PreferredNodeWhereClause}{exclusionClause}
               ORDER BY
                 {AdoConstants.ColumnNextFireTime} ASC, {AdoConstants.ColumnPriority} DESC{rowLimit.AtEnd}"));
@@ -454,16 +454,16 @@ internal static class StdAdoConstants
         "excludedJobType" + index.ToString("D4", CultureInfo.InvariantCulture);
 
     public static readonly string SqlSelectNumTriggersForJob =
-        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT COUNT({AdoConstants.ColumnTriggerName}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlSelectPausedTriggerGroup =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectPausedJobGroup =
-        Invariant($"SELECT {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlSelectReferencedCalendar =
-        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     /// <summary>
     /// The three columns a <see cref="SchedulerStateRecord" /> is made of. SCHED_NAME is the fourth
@@ -473,10 +473,10 @@ internal static class StdAdoConstants
         $"{AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnLastCheckinTime}, {AdoConstants.ColumnCheckinInterval}";
 
     public static readonly string SqlSelectSchedulerState =
-        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName");
+        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}");
 
     public static readonly string SqlSelectSchedulerStates =
-        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {SchedulerStateSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSchedulerState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     /// <summary>
     /// Every column <c>SimpleTriggerPersistenceDelegate.ReadTriggerPropertyBundle</c> reads, and only
@@ -486,7 +486,7 @@ internal static class StdAdoConstants
         $"{AdoConstants.ColumnRepeatCount}, {AdoConstants.ColumnRepeatInterval}, {AdoConstants.ColumnTimesTriggered}";
 
     public static readonly string SqlSelectSimpleTrigger =
-        Invariant($"SELECT {SimpleTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {SimpleTriggerSelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Column list shared by <see cref="SqlSelectTrigger" /> and <see cref="SqlSelectMisfiredTriggersToRecover" />,
@@ -534,7 +534,7 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectTrigger =
         Invariant($@"SELECT {TriggerSelectColumns}{TriggerSelectFastPathFrom}
             WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND t.{AdoConstants.ColumnTriggerName} = @triggerName AND t.{AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+                t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND t.{AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND t.{AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Selects the misfired triggers to recover as fully populated rows, so a whole misfire recovery
@@ -551,7 +551,7 @@ internal static class StdAdoConstants
                 t.{AdoConstants.ColumnTriggerName},
                 t.{AdoConstants.ColumnTriggerGroup}{TriggerSelectFastPathFrom}
             WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND t.{AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{AdoConstants.ColumnNextFireTime} <= @nextFireTime AND t.{AdoConstants.ColumnTriggerState} = @state
+                t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND t.{AdoConstants.ColumnMisfireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND t.{AdoConstants.ColumnNextFireTime} <= @{SqlParameters.NextFireTime} AND t.{AdoConstants.ColumnTriggerState} = @{SqlParameters.State}
             ORDER BY t.{AdoConstants.ColumnNextFireTime} ASC, t.{AdoConstants.ColumnPriority} DESC{rowLimit.AtEnd}"));
 
     /// <inheritdoc cref="SelectMisfiredTriggersToRecover" />
@@ -578,36 +578,36 @@ internal static class StdAdoConstants
                 t.{AdoConstants.ColumnTriggerName},
                 t.{AdoConstants.ColumnTriggerGroup}{TriggerSelectFastPathFrom}
             WHERE
-                t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+                t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     /// <summary>
     /// Prefix of the batch simple-trigger lookup; the caller appends a key-set predicate built by
     /// <c>AdoUtil.BuildTriggerKeyPredicate</c>.
     /// </summary>
     public static readonly string SqlSelectSimpleTriggersByKeysPrefix =
-        Invariant($"SELECT {SimpleTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {SimpleTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     /// <summary>
     /// Prefix of the batch cron-trigger lookup; the caller appends a key-set predicate built by
     /// <c>AdoUtil.BuildTriggerKeyPredicate</c>.
     /// </summary>
     public static readonly string SqlSelectCronTriggersByKeysPrefix =
-        Invariant($"SELECT {CronTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"SELECT {CronTriggerSelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableCronTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     public static readonly string SqlSelectTriggerData =
-        Invariant($"SELECT {AdoConstants.ColumnJobDataMap} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnJobDataMap} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectTriggerExistence =
-        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectTriggerGroupsEquals =
-        Invariant($"SELECT DISTINCT({AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT DISTINCT({AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectTriggerGroupsLike =
-        Invariant($"SELECT DISTINCT({AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
+        Invariant($"SELECT DISTINCT({AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectTriggerState =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerState} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerState} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Whether the trigger of the surrounding TRIGGERS row has an execution in flight. EXECUTING is only
@@ -625,7 +625,7 @@ internal static class StdAdoConstants
         Invariant($"EXISTS (SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} FT WHERE FT.{AdoConstants.ColumnSchedulerName} = {TablePrefixSubst}{AdoConstants.TableTriggers}.{AdoConstants.ColumnSchedulerName} AND FT.{AdoConstants.ColumnTriggerName} = {TablePrefixSubst}{AdoConstants.TableTriggers}.{AdoConstants.ColumnTriggerName} AND FT.{AdoConstants.ColumnTriggerGroup} = {TablePrefixSubst}{AdoConstants.TableTriggers}.{AdoConstants.ColumnTriggerGroup} AND FT.{AdoConstants.ColumnEntryState} = '{AdoConstants.StateExecuting}')");
 
     public static readonly string SqlSelectTriggerStateWithExecuting =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerState}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerState}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     /// <summary>
     /// Carries TRIGGER_TYPE alongside the state so that the fire path learns in one read what it used to
@@ -633,28 +633,28 @@ internal static class StdAdoConstants
     /// schedule. All four columns come off the same row, so the extra ones are free.
     /// </summary>
     public static readonly string SqlSelectTriggerHeader =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerState}, {AdoConstants.ColumnNextFireTime}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnTriggerType} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerState}, {AdoConstants.ColumnNextFireTime}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnTriggerType} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectTriggersForCalendar =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     public static readonly string SqlSelectTriggersForJob =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlSelectTriggersForJobInState =
-        Invariant($"{SqlSelectTriggersForJob} AND {AdoConstants.ColumnTriggerState} = @state");
+        Invariant($"{SqlSelectTriggersForJob} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.State}");
 
     public static readonly string SqlSelectTriggersInGroupLike =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause}");
 
     public static readonly string SqlSelectTriggersInGroup =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlSelectTriggersInState =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerState} = @state");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.State}");
 
     public static readonly string SqlSelectTriggerType =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerType} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerType} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     // PAGED LISTINGS
     //
@@ -664,38 +664,38 @@ internal static class StdAdoConstants
     // to the count statement too, so a total count sees exactly the same WHERE.
 
     public static readonly string SqlSelectJobHeaders =
-        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnJobClass}, {AdoConstants.ColumnIsDurable}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnIsUpdateData}, {AdoConstants.ColumnRequestsRecovery} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnJobClass}, {AdoConstants.ColumnIsDurable}, {AdoConstants.ColumnIsNonConcurrent}, {AdoConstants.ColumnIsUpdateData}, {AdoConstants.ColumnRequestsRecovery} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountJobHeaders =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
-    public static readonly string SqlJobGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+    public static readonly string SqlJobGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
-    public static readonly string SqlJobGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} LIKE @jobGroup{SqlLikeEscapeClause}");
+    public static readonly string SqlJobGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} LIKE @{SqlParameters.JobGroup}{SqlLikeEscapeClause}");
 
-    public static readonly string SqlJobNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @jobName");
+    public static readonly string SqlJobNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName}");
 
-    public static readonly string SqlJobNameLikePredicate = Invariant($" AND {AdoConstants.ColumnJobName} LIKE @jobName{SqlLikeEscapeClause}");
+    public static readonly string SqlJobNameLikePredicate = Invariant($" AND {AdoConstants.ColumnJobName} LIKE @{SqlParameters.JobName}{SqlLikeEscapeClause}");
 
     public static readonly string SqlOrderByJobGroupAndName = Invariant($" ORDER BY {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnJobName}");
 
     public static readonly string SqlSelectTriggerHeaders =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnTriggerType}, {AdoConstants.ColumnTriggerState}, {AdoConstants.ColumnStartTime}, {AdoConstants.ColumnEndTime}, {AdoConstants.ColumnNextFireTime}, {AdoConstants.ColumnPreviousFireTime}, {AdoConstants.ColumnCalendarName}, {AdoConstants.ColumnPriority}, {AdoConstants.ColumnExecutionGroup}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnDescription}, {AdoConstants.ColumnTriggerType}, {AdoConstants.ColumnTriggerState}, {AdoConstants.ColumnStartTime}, {AdoConstants.ColumnEndTime}, {AdoConstants.ColumnNextFireTime}, {AdoConstants.ColumnPreviousFireTime}, {AdoConstants.ColumnCalendarName}, {AdoConstants.ColumnPriority}, {AdoConstants.ColumnExecutionGroup}, CASE WHEN {SqlExecutingFiredTriggerExists} THEN 1 ELSE 0 END FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountTriggerHeaders =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
-    public static readonly string SqlTriggerGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+    public static readonly string SqlTriggerGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
-    public static readonly string SqlTriggerGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
+    public static readonly string SqlTriggerGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause}");
 
-    public static readonly string SqlTriggerNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} = @triggerName");
+    public static readonly string SqlTriggerNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName}");
 
-    public static readonly string SqlTriggerNameLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} LIKE @triggerName{SqlLikeEscapeClause}");
+    public static readonly string SqlTriggerNameLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} LIKE @{SqlParameters.TriggerName}{SqlLikeEscapeClause}");
 
-    public static readonly string SqlTriggerJobPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+    public static readonly string SqlTriggerJobPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
-    public static readonly string SqlTriggerCalendarPredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} = @calendarName");
+    public static readonly string SqlTriggerCalendarPredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     /// <summary>
     /// Opening of the trigger state filter; the caller appends <c>@state0[, @state1...])</c> for the
@@ -729,10 +729,10 @@ internal static class StdAdoConstants
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} pg WHERE pg.{AdoConstants.ColumnSchedulerName} = j.{AdoConstants.ColumnSchedulerName} AND pg.{AdoConstants.ColumnJobGroup} = j.{AdoConstants.ColumnJobGroup}");
 
     public static readonly string SqlSelectJobGroupsWithPausedFlag =
-        Invariant($"SELECT DISTINCT j.{AdoConstants.ColumnJobGroup}, CASE WHEN EXISTS ({PausedJobGroupExists}) THEN 1 ELSE 0 END AS IS_PAUSED FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT DISTINCT j.{AdoConstants.ColumnJobGroup}, CASE WHEN EXISTS ({PausedJobGroupExists}) THEN 1 ELSE 0 END AS IS_PAUSED FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountJobGroups =
-        Invariant($"SELECT COUNT(DISTINCT j.{AdoConstants.ColumnJobGroup}) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(DISTINCT j.{AdoConstants.ColumnJobGroup}) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     /// <summary>
     /// The paused job group listing, read straight from PAUSED_JOB_GRPS so that a group paused while
@@ -741,26 +741,26 @@ internal static class StdAdoConstants
     /// a marker row here.
     /// </summary>
     public static readonly string SqlSelectPausedJobGroups =
-        Invariant($"SELECT {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountPausedJobGroups =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedJobs} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlSelectUnpausedJobGroups =
-        Invariant($"SELECT DISTINCT j.{AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @schedulerName AND NOT EXISTS ({PausedJobGroupExists})");
+        Invariant($"SELECT DISTINCT j.{AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND NOT EXISTS ({PausedJobGroupExists})");
 
     public static readonly string SqlCountUnpausedJobGroups =
-        Invariant($"SELECT COUNT(DISTINCT j.{AdoConstants.ColumnJobGroup}) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @schedulerName AND NOT EXISTS ({PausedJobGroupExists})");
+        Invariant($"SELECT COUNT(DISTINCT j.{AdoConstants.ColumnJobGroup}) FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} j WHERE j.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND NOT EXISTS ({PausedJobGroupExists})");
 
     /// <summary>
     /// Exact-name filter for the job group listing read straight from PAUSED_JOB_GRPS.
     /// </summary>
-    public static readonly string SqlJobGroupNamePredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} = @groupName");
+    public static readonly string SqlJobGroupNamePredicate = Invariant($" AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.GroupName}");
 
     /// <summary>
     /// Exact-name filter for the job group listings that read from JOB_DETAILS under the alias 'j'.
     /// </summary>
-    public static readonly string SqlAliasedJobGroupNamePredicate = Invariant($" AND j.{AdoConstants.ColumnJobGroup} = @groupName");
+    public static readonly string SqlAliasedJobGroupNamePredicate = Invariant($" AND j.{AdoConstants.ColumnJobGroup} = @{SqlParameters.GroupName}");
 
     public static readonly string SqlOrderByJobGroup = Invariant($" ORDER BY {AdoConstants.ColumnJobGroup}");
 
@@ -773,10 +773,10 @@ internal static class StdAdoConstants
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} pg WHERE pg.{AdoConstants.ColumnSchedulerName} = t.{AdoConstants.ColumnSchedulerName} AND pg.{AdoConstants.ColumnTriggerGroup} = t.{AdoConstants.ColumnTriggerGroup}");
 
     public static readonly string SqlSelectTriggerGroupsWithPausedFlag =
-        Invariant($"SELECT DISTINCT t.{AdoConstants.ColumnTriggerGroup}, CASE WHEN EXISTS ({PausedTriggerGroupExists}) THEN 1 ELSE 0 END AS IS_PAUSED FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT DISTINCT t.{AdoConstants.ColumnTriggerGroup}, CASE WHEN EXISTS ({PausedTriggerGroupExists}) THEN 1 ELSE 0 END AS IS_PAUSED FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountTriggerGroups =
-        Invariant($"SELECT COUNT(DISTINCT t.{AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(DISTINCT t.{AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     /// <summary>
     /// Excludes the "everything is paused" marker <see cref="AdoConstants.AllGroupsPaused" /> from a
@@ -788,40 +788,40 @@ internal static class StdAdoConstants
         Invariant($" AND {AdoConstants.ColumnTriggerGroup} <> '{AdoConstants.AllGroupsPaused}'");
 
     public static readonly string SqlSelectPausedTriggerGroups =
-        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName{ExceptAllGroupsPausedMarker}");
+        Invariant($"SELECT {AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}{ExceptAllGroupsPausedMarker}");
 
     public static readonly string SqlCountPausedTriggerGroups =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName{ExceptAllGroupsPausedMarker}");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TablePausedTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}{ExceptAllGroupsPausedMarker}");
 
     public static readonly string SqlSelectUnpausedTriggerGroups =
-        Invariant($"SELECT DISTINCT t.{AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND NOT EXISTS ({PausedTriggerGroupExists})");
+        Invariant($"SELECT DISTINCT t.{AdoConstants.ColumnTriggerGroup} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND NOT EXISTS ({PausedTriggerGroupExists})");
 
     public static readonly string SqlCountUnpausedTriggerGroups =
-        Invariant($"SELECT COUNT(DISTINCT t.{AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @schedulerName AND NOT EXISTS ({PausedTriggerGroupExists})");
+        Invariant($"SELECT COUNT(DISTINCT t.{AdoConstants.ColumnTriggerGroup}) FROM {TablePrefixSubst}{AdoConstants.TableTriggers} t WHERE t.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND NOT EXISTS ({PausedTriggerGroupExists})");
 
     /// <summary>
     /// Exact-name filter for the trigger group listing read straight from PAUSED_TRIGGER_GRPS.
     /// </summary>
-    public static readonly string SqlTriggerGroupNamePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @groupName");
+    public static readonly string SqlTriggerGroupNamePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.GroupName}");
 
     /// <summary>
     /// Exact-name filter for the trigger group listings that read from TRIGGERS under the alias 't'.
     /// </summary>
-    public static readonly string SqlAliasedTriggerGroupNamePredicate = Invariant($" AND t.{AdoConstants.ColumnTriggerGroup} = @groupName");
+    public static readonly string SqlAliasedTriggerGroupNamePredicate = Invariant($" AND t.{AdoConstants.ColumnTriggerGroup} = @{SqlParameters.GroupName}");
 
     public static readonly string SqlOrderByTriggerGroup = Invariant($" ORDER BY {AdoConstants.ColumnTriggerGroup}");
 
     public static readonly string SqlOrderByAliasedTriggerGroup = Invariant($" ORDER BY t.{AdoConstants.ColumnTriggerGroup}");
 
     public static readonly string SqlSelectCalendarNames =
-        Invariant($"SELECT {AdoConstants.ColumnCalendarName} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnCalendarName} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountCalendarNames =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
-    public static readonly string SqlCalendarNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} = @calendarName");
+    public static readonly string SqlCalendarNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
-    public static readonly string SqlCalendarNameLikePredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} LIKE @calendarName{SqlLikeEscapeClause}");
+    public static readonly string SqlCalendarNameLikePredicate = Invariant($" AND {AdoConstants.ColumnCalendarName} LIKE @{SqlParameters.CalendarName}{SqlLikeEscapeClause}");
 
     public static readonly string SqlOrderByCalendarName = Invariant($" ORDER BY {AdoConstants.ColumnCalendarName}");
 
@@ -835,10 +835,10 @@ internal static class StdAdoConstants
     /// positionally, and carries the ORDER BY that paging requires.
     /// </remarks>
     public static readonly string SqlSelectFireInstances =
-        Invariant($"SELECT {AdoConstants.ColumnEntryId}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnEntryState}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnExecutionGroup} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT {AdoConstants.ColumnEntryId}, {AdoConstants.ColumnTriggerName}, {AdoConstants.ColumnTriggerGroup}, {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup}, {AdoConstants.ColumnInstanceName}, {AdoConstants.ColumnEntryState}, {AdoConstants.ColumnFiredTime}, {AdoConstants.ColumnScheduledTime}, {AdoConstants.ColumnExecutionGroup} FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     public static readonly string SqlCountFireInstances =
-        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName");
+        Invariant($"SELECT COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName}");
 
     /// <summary>
     /// The cluster's in-flight work per execution group, which is what a cluster-scoped execution limit
@@ -874,29 +874,29 @@ internal static class StdAdoConstants
     /// </para>
     /// </remarks>
     public static readonly string SqlSelectExecutionGroupsInFlight =
-        Invariant($"SELECT {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}, COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName GROUP BY {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}");
+        Invariant($"SELECT {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}, COUNT(*) FROM {TablePrefixSubst}{AdoConstants.TableFiredTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} GROUP BY {AdoConstants.ColumnExecutionGroup}, {AdoConstants.ColumnTriggerGroup}");
 
-    public static readonly string SqlFireInstanceTriggerGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+    public static readonly string SqlFireInstanceTriggerGroupEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
-    public static readonly string SqlFireInstanceTriggerGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause}");
+    public static readonly string SqlFireInstanceTriggerGroupLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause}");
 
-    public static readonly string SqlFireInstanceTriggerNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} = @triggerName");
+    public static readonly string SqlFireInstanceTriggerNameEqualsPredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName}");
 
-    public static readonly string SqlFireInstanceTriggerNameLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} LIKE @triggerName{SqlLikeEscapeClause}");
+    public static readonly string SqlFireInstanceTriggerNameLikePredicate = Invariant($" AND {AdoConstants.ColumnTriggerName} LIKE @{SqlParameters.TriggerName}{SqlLikeEscapeClause}");
 
-    public static readonly string SqlFireInstanceJobPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+    public static readonly string SqlFireInstanceJobPredicate = Invariant($" AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
-    public static readonly string SqlFireInstanceInstancePredicate = Invariant($" AND {AdoConstants.ColumnInstanceName} = @instanceName");
+    public static readonly string SqlFireInstanceInstancePredicate = Invariant($" AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}");
 
     /// <summary>
     /// The state filter. A fire instance is either reserved or running, so the two
     /// <see cref="Quartz.FireInstanceState" /> members map onto stored states rather than onto one
     /// column value each: everything that is not ACQUIRED is an execution the store has started.
     /// </summary>
-    public static readonly string SqlFireInstanceStateEqualsPredicate = Invariant($" AND {AdoConstants.ColumnEntryState} = @entryState");
+    public static readonly string SqlFireInstanceStateEqualsPredicate = Invariant($" AND {AdoConstants.ColumnEntryState} = @{SqlParameters.EntryState}");
 
     /// <inheritdoc cref="SqlFireInstanceStateEqualsPredicate" />
-    public static readonly string SqlFireInstanceStateNotEqualsPredicate = Invariant($" AND {AdoConstants.ColumnEntryState} <> @entryState");
+    public static readonly string SqlFireInstanceStateNotEqualsPredicate = Invariant($" AND {AdoConstants.ColumnEntryState} <> @{SqlParameters.EntryState}");
 
     /// <summary>
     /// Trigger group and name are not unique across fire instances — one trigger can have several
@@ -908,31 +908,31 @@ internal static class StdAdoConstants
     // UPDATE
 
     public static readonly string SqlUpdateBlobTrigger =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableBlobTriggers} SET {AdoConstants.ColumnBlob} = @blob WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableBlobTriggers} SET {AdoConstants.ColumnBlob} = @{SqlParameters.Blob} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateCalendar =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableCalendars} SET {AdoConstants.ColumnCalendar} = @calendar WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnCalendarName} = @calendarName");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableCalendars} SET {AdoConstants.ColumnCalendar} = @{SqlParameters.Calendar} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");
 
     public static readonly string SqlUpdateCronTrigger =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableCronTriggers} SET {AdoConstants.ColumnCronExpression} = @triggerCronExpression, {AdoConstants.ColumnTimeZoneId} = @timeZoneId WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableCronTriggers} SET {AdoConstants.ColumnCronExpression} = @{SqlParameters.TriggerCronExpression}, {AdoConstants.ColumnTimeZoneId} = @{SqlParameters.TimeZoneId} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateJobData =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableJobDetails} SET {AdoConstants.ColumnJobDataMap} = @jobDataMap WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableJobDetails} SET {AdoConstants.ColumnJobDataMap} = @{SqlParameters.JobDataMap} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlUpdateJobDetail =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableJobDetails} SET {AdoConstants.ColumnDescription} = @jobDescription, {AdoConstants.ColumnJobClass} = @jobType, {AdoConstants.ColumnIsDurable} = @jobDurable, {AdoConstants.ColumnIsNonConcurrent} = @jobVolatile, {AdoConstants.ColumnIsUpdateData} = @jobStateful, {AdoConstants.ColumnRequestsRecovery} = @jobRequestsRecovery, {AdoConstants.ColumnJobDataMap} = @jobDataMap  WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableJobDetails} SET {AdoConstants.ColumnDescription} = @{SqlParameters.JobDescription}, {AdoConstants.ColumnJobClass} = @{SqlParameters.JobType}, {AdoConstants.ColumnIsDurable} = @{SqlParameters.JobDurable}, {AdoConstants.ColumnIsNonConcurrent} = @{SqlParameters.JobVolatile}, {AdoConstants.ColumnIsUpdateData} = @{SqlParameters.JobStateful}, {AdoConstants.ColumnRequestsRecovery} = @{SqlParameters.JobRequestsRecovery}, {AdoConstants.ColumnJobDataMap} = @{SqlParameters.JobDataMap}  WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlUpdateJobTriggerStates =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @state WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.State} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
     public static readonly string SqlUpdateJobTriggerStatesFromOtherState =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @state WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnJobName} = @jobName AND {AdoConstants.ColumnJobGroup} = @jobGroup AND {AdoConstants.ColumnTriggerState} = @oldState");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.State} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.OldState}");
 
     public static readonly string SqlUpdateSchedulerState =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableSchedulerState} SET {AdoConstants.ColumnLastCheckinTime} = @lastCheckinTime WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnInstanceName} = @instanceName");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableSchedulerState} SET {AdoConstants.ColumnLastCheckinTime} = @{SqlParameters.LastCheckinTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}");
 
     public static readonly string SqlUpdateSimpleTrigger =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} SET {AdoConstants.ColumnRepeatCount} = @triggerRepeatCount, {AdoConstants.ColumnRepeatInterval} = @triggerRepeatInterval, {AdoConstants.ColumnTimesTriggered} = @triggerTimesTriggered WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableSimpleTriggers} SET {AdoConstants.ColumnRepeatCount} = @{SqlParameters.TriggerRepeatCount}, {AdoConstants.ColumnRepeatInterval} = @{SqlParameters.TriggerRepeatInterval}, {AdoConstants.ColumnTimesTriggered} = @{SqlParameters.TriggerTimesTriggered} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     // The preferred node columns are only written when the pin was actually changed on the trigger
     // instance, so each UPDATE comes in two flavours. Writing the pin back unconditionally would
@@ -940,88 +940,88 @@ internal static class StdAdoConstants
     // with the value that happened to be loaded at acquire time. Folding the columns into the main
     // UPDATE — rather than issuing a second statement — keeps it to one round-trip either way.
     private const string PreferredNodeSetClause =
-        $", {AdoConstants.ColumnPreferredNode} = @triggerPreferredNode, {AdoConstants.ColumnPreferredNodeAuto} = @triggerPreferredNodeAuto";
+        $", {AdoConstants.ColumnPreferredNode} = @{SqlParameters.TriggerPreferredNode}, {AdoConstants.ColumnPreferredNodeAuto} = @{SqlParameters.TriggerPreferredNodeAuto}";
 
     public static readonly string SqlUpdateTrigger =
-        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @triggerJobName, {AdoConstants.ColumnJobGroup} = @triggerJobGroup, {AdoConstants.ColumnDescription} = @triggerDescription, {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnTriggerType} = @triggerType, {AdoConstants.ColumnStartTime} = @triggerStartTime, {AdoConstants.ColumnEndTime} = @triggerEndTime, {AdoConstants.ColumnCalendarName} = @triggerCalendarName, {AdoConstants.ColumnMisfireInstruction} = @triggerMisfireInstruction, {AdoConstants.ColumnPriority} = @triggerPriority, {AdoConstants.ColumnJobDataMap} = @triggerJobJobDataMap, {AdoConstants.ColumnExecutionGroup} = @triggerExecutionGroup
-                        WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @{SqlParameters.TriggerJobName}, {AdoConstants.ColumnJobGroup} = @{SqlParameters.TriggerJobGroup}, {AdoConstants.ColumnDescription} = @{SqlParameters.TriggerDescription}, {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime},
+                        {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnTriggerType} = @{SqlParameters.TriggerType}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnEndTime} = @{SqlParameters.TriggerEndTime}, {AdoConstants.ColumnCalendarName} = @{SqlParameters.TriggerCalendarName}, {AdoConstants.ColumnMisfireInstruction} = @{SqlParameters.TriggerMisfireInstruction}, {AdoConstants.ColumnPriority} = @{SqlParameters.TriggerPriority}, {AdoConstants.ColumnJobDataMap} = @{SqlParameters.TriggerJobJobDataMap}, {AdoConstants.ColumnExecutionGroup} = @{SqlParameters.TriggerExecutionGroup}
+                        WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateTriggerWithPreferredNode =
-        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @triggerJobName, {AdoConstants.ColumnJobGroup} = @triggerJobGroup, {AdoConstants.ColumnDescription} = @triggerDescription, {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnTriggerType} = @triggerType, {AdoConstants.ColumnStartTime} = @triggerStartTime, {AdoConstants.ColumnEndTime} = @triggerEndTime, {AdoConstants.ColumnCalendarName} = @triggerCalendarName, {AdoConstants.ColumnMisfireInstruction} = @triggerMisfireInstruction, {AdoConstants.ColumnPriority} = @triggerPriority, {AdoConstants.ColumnJobDataMap} = @triggerJobJobDataMap, {AdoConstants.ColumnExecutionGroup} = @triggerExecutionGroup{PreferredNodeSetClause}
-                        WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @{SqlParameters.TriggerJobName}, {AdoConstants.ColumnJobGroup} = @{SqlParameters.TriggerJobGroup}, {AdoConstants.ColumnDescription} = @{SqlParameters.TriggerDescription}, {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime},
+                        {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnTriggerType} = @{SqlParameters.TriggerType}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnEndTime} = @{SqlParameters.TriggerEndTime}, {AdoConstants.ColumnCalendarName} = @{SqlParameters.TriggerCalendarName}, {AdoConstants.ColumnMisfireInstruction} = @{SqlParameters.TriggerMisfireInstruction}, {AdoConstants.ColumnPriority} = @{SqlParameters.TriggerPriority}, {AdoConstants.ColumnJobDataMap} = @{SqlParameters.TriggerJobJobDataMap}, {AdoConstants.ColumnExecutionGroup} = @{SqlParameters.TriggerExecutionGroup}{PreferredNodeSetClause}
+                        WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
-    public static readonly string SqlUpdateFiredTrigger = Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableFiredTriggers} SET {AdoConstants.ColumnInstanceName} = @instanceName, {AdoConstants.ColumnFiredTime} = @firedTime, {AdoConstants.ColumnScheduledTime} = @scheduledTime, {AdoConstants.ColumnEntryState} = @entryState, {AdoConstants.ColumnJobName} = @jobName, {AdoConstants.ColumnJobGroup} = @jobGroup, {AdoConstants.ColumnIsNonConcurrent} = @isNonConcurrent, {AdoConstants.ColumnRequestsRecovery} = @requestsRecover, {AdoConstants.ColumnExecutionGroup} = @executionGroup WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnEntryId} = @entryId");
+    public static readonly string SqlUpdateFiredTrigger = Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableFiredTriggers} SET {AdoConstants.ColumnInstanceName} = @{SqlParameters.InstanceName}, {AdoConstants.ColumnFiredTime} = @{SqlParameters.FiredTime}, {AdoConstants.ColumnScheduledTime} = @{SqlParameters.ScheduledTime}, {AdoConstants.ColumnEntryState} = @{SqlParameters.EntryState}, {AdoConstants.ColumnJobName} = @{SqlParameters.JobName}, {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}, {AdoConstants.ColumnIsNonConcurrent} = @{SqlParameters.IsNonConcurrent}, {AdoConstants.ColumnRequestsRecovery} = @{SqlParameters.RequestsRecover}, {AdoConstants.ColumnExecutionGroup} = @{SqlParameters.ExecutionGroup} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnEntryId} = @{SqlParameters.EntryId}");
 
     public static readonly string SqlUpdateTriggerGroupStateFromStateEquals =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup AND {AdoConstants.ColumnTriggerState} = @oldState");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.OldState}");
 
     public static readonly string SqlUpdateTriggerGroupStateFromStateLike =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} LIKE @triggerGroup{SqlLikeEscapeClause} AND {AdoConstants.ColumnTriggerState} = @oldState");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.TriggerGroup}{SqlLikeEscapeClause} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.OldState}");
 
     /// <summary>
     /// Prefix of the group state transition; the caller appends an old-state predicate built by
     /// <c>AdoUtil.BuildTriggerStatePredicate</c>.
     /// </summary>
     public static readonly string SqlUpdateTriggerGroupStateFromStatesEqualsPrefix =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} = @groupName AND ");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.GroupName} AND ");
 
     /// <inheritdoc cref="SqlUpdateTriggerGroupStateFromStatesEqualsPrefix" />
     public static readonly string SqlUpdateTriggerGroupStateFromStatesLikePrefix =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerGroup} LIKE @groupName{SqlLikeEscapeClause} AND ");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerGroup} LIKE @{SqlParameters.GroupName}{SqlLikeEscapeClause} AND ");
 
     public static readonly string SqlUpdateTriggerSkipData =
-        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @triggerJobName, {AdoConstants.ColumnJobGroup} = @triggerJobGroup, {AdoConstants.ColumnDescription} = @triggerDescription, {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnTriggerType} = @triggerType, {AdoConstants.ColumnStartTime} = @triggerStartTime, {AdoConstants.ColumnEndTime} = @triggerEndTime, {AdoConstants.ColumnCalendarName} = @triggerCalendarName, {AdoConstants.ColumnMisfireInstruction} = @triggerMisfireInstruction, {AdoConstants.ColumnPriority} = @triggerPriority, {AdoConstants.ColumnExecutionGroup} = @triggerExecutionGroup
-                    WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @{SqlParameters.TriggerJobName}, {AdoConstants.ColumnJobGroup} = @{SqlParameters.TriggerJobGroup}, {AdoConstants.ColumnDescription} = @{SqlParameters.TriggerDescription}, {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime},
+                        {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnTriggerType} = @{SqlParameters.TriggerType}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnEndTime} = @{SqlParameters.TriggerEndTime}, {AdoConstants.ColumnCalendarName} = @{SqlParameters.TriggerCalendarName}, {AdoConstants.ColumnMisfireInstruction} = @{SqlParameters.TriggerMisfireInstruction}, {AdoConstants.ColumnPriority} = @{SqlParameters.TriggerPriority}, {AdoConstants.ColumnExecutionGroup} = @{SqlParameters.TriggerExecutionGroup}
+                    WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateTriggerSkipDataWithPreferredNode =
-        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @triggerJobName, {AdoConstants.ColumnJobGroup} = @triggerJobGroup, {AdoConstants.ColumnDescription} = @triggerDescription, {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime,
-                        {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnTriggerType} = @triggerType, {AdoConstants.ColumnStartTime} = @triggerStartTime, {AdoConstants.ColumnEndTime} = @triggerEndTime, {AdoConstants.ColumnCalendarName} = @triggerCalendarName, {AdoConstants.ColumnMisfireInstruction} = @triggerMisfireInstruction, {AdoConstants.ColumnPriority} = @triggerPriority, {AdoConstants.ColumnExecutionGroup} = @triggerExecutionGroup{PreferredNodeSetClause}
-                    WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($@"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnJobName} = @{SqlParameters.TriggerJobName}, {AdoConstants.ColumnJobGroup} = @{SqlParameters.TriggerJobGroup}, {AdoConstants.ColumnDescription} = @{SqlParameters.TriggerDescription}, {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime},
+                        {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnTriggerType} = @{SqlParameters.TriggerType}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnEndTime} = @{SqlParameters.TriggerEndTime}, {AdoConstants.ColumnCalendarName} = @{SqlParameters.TriggerCalendarName}, {AdoConstants.ColumnMisfireInstruction} = @{SqlParameters.TriggerMisfireInstruction}, {AdoConstants.ColumnPriority} = @{SqlParameters.TriggerPriority}, {AdoConstants.ColumnExecutionGroup} = @{SqlParameters.TriggerExecutionGroup}{PreferredNodeSetClause}
+                    WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     // Compare-and-swap for the auto-pin claim/steal: only writes when the columns still hold the
     // values observed at acquisition time, so a concurrent re-pin or clear wins over the claim.
     public static readonly string SqlUpdateTriggerPreferredNodeConditional =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnPreferredNode} = @triggerPreferredNode, {AdoConstants.ColumnPreferredNodeAuto} = @triggerPreferredNodeAuto WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup AND {AdoConstants.ColumnPreferredNode} = @expectedPreferredNode AND {AdoConstants.ColumnPreferredNodeAuto} = @expectedPreferredNodeAuto");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnPreferredNode} = @{SqlParameters.TriggerPreferredNode}, {AdoConstants.ColumnPreferredNodeAuto} = @{SqlParameters.TriggerPreferredNodeAuto} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND {AdoConstants.ColumnPreferredNode} = @{SqlParameters.ExpectedPreferredNode} AND {AdoConstants.ColumnPreferredNodeAuto} = @{SqlParameters.ExpectedPreferredNodeAuto}");
 
     // Failover reset: only auto-claimed pins belonging to the dead node are released back to the
     // "*" sentinel. Explicit pins are left alone so the original node reclaims them.
     public static readonly string SqlRepinTriggersFromDeadNode =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnPreferredNode} = @newPreferredNode, {AdoConstants.ColumnPreferredNodeAuto} = @newPreferredNodeAuto WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnPreferredNode} = @oldPreferredNode AND {AdoConstants.ColumnPreferredNodeAuto} = @oldPreferredNodeAuto");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnPreferredNode} = @{SqlParameters.NewPreferredNode}, {AdoConstants.ColumnPreferredNodeAuto} = @{SqlParameters.NewPreferredNodeAuto} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnPreferredNode} = @{SqlParameters.OldPreferredNode} AND {AdoConstants.ColumnPreferredNodeAuto} = @{SqlParameters.OldPreferredNodeAuto}");
 
     public static readonly string SqlUpdateTriggerState =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @state WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.State} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateTriggerStateFromState =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup AND {AdoConstants.ColumnTriggerState} = @oldState");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.OldState}");
 
     /// <summary>
     /// Prefix of the single-trigger state transition; the caller appends an old-state predicate built
     /// by <c>AdoUtil.BuildTriggerStatePredicate</c>.
     /// </summary>
     public static readonly string SqlUpdateTriggerStateFromStatesPrefix =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup AND ");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND ");
 
     public static readonly string SqlUpdateTriggerStateFromStateWithNextFireTime =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup AND {AdoConstants.ColumnTriggerState} = @oldState AND {AdoConstants.ColumnNextFireTime} = @nextFireTime");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND {AdoConstants.ColumnTriggerState} = @{SqlParameters.OldState} AND {AdoConstants.ColumnNextFireTime} = @{SqlParameters.NextFireTime}");
 
     /// <summary>
     /// Prefix of the store-wide state transition; the caller appends an old-state predicate built by
     /// <c>AdoUtil.BuildTriggerStatePredicate</c>.
     /// </summary>
     public static readonly string SqlUpdateTriggerStatesFromOtherStatesPrefix =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @newState WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND ");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     public static readonly string SqlUpdateMisfireOrigFireTime =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnMisfireOriginalFireTime} = @misfireOrigFireTime WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnMisfireOriginalFireTime} = @{SqlParameters.MisfireOrigFireTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     // Targeted misfire recovery UPDATE — only touches columns that change during UpdateAfterMisfire.
     // START_TIME is included because SimpleTrigger's RescheduleNowWith* policies modify it.
     public static readonly string SqlUpdateTriggerMisfire =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime, {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnStartTime} = @triggerStartTime WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateTriggerMisfireWithOrigFireTime =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @triggerNextFireTime, {AdoConstants.ColumnPreviousFireTime} = @triggerPreviousFireTime, {AdoConstants.ColumnTriggerState} = @triggerState, {AdoConstants.ColumnStartTime} = @triggerStartTime, {AdoConstants.ColumnMisfireOriginalFireTime} = @triggerMisfireOrigFireTime WHERE {AdoConstants.ColumnSchedulerName} = @schedulerName AND {AdoConstants.ColumnTriggerName} = @triggerName AND {AdoConstants.ColumnTriggerGroup} = @triggerGroup");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnMisfireOriginalFireTime} = @{SqlParameters.TriggerMisfireOrigFireTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Calendars.cs
@@ -14,9 +14,9 @@ public partial class StdAdoDelegate
         byte[]? baos = SerializeObject(calendar);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertCalendar));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendarName", calendarName);
-        AddCommandParameter(cmd, "calendar", baos, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
+        AddCommandParameter(cmd, SqlParameters.Calendar, baos, DbProvider.Metadata.BinaryParameterType);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -31,9 +31,9 @@ public partial class StdAdoDelegate
         byte[]? baos = SerializeObject(calendar);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateCalendar));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendar", baos, DbProvider.Metadata.BinaryParameterType);
-        AddCommandParameter(cmd, "calendarName", calendarName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.Calendar, baos, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -45,8 +45,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectCalendarExistence));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendarName", calendarName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -62,8 +62,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectCalendar));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendarName", calendarName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
         using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
         ICalendar? calendar = null;
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -86,8 +86,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectReferencedCalendar));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendarName", calendarName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -104,8 +104,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteCalendar));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "calendarName", calendarName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -23,16 +23,16 @@ public partial class StdAdoDelegate
         var jobData = SerializeJobData(job.JobDataMap);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobDetail));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobDescription", job.Description);
-        AddCommandParameter(cmd, "jobType", job.JobType.FullName);
-        AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
-        AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
-        AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));
-        AddCommandParameter(cmd, "jobRequestsRecovery", GetDbBooleanValue(job.RequestsRecovery));
-        AddCommandParameter(cmd, "jobDataMap", jobData, DbProvider.Metadata.BinaryParameterType);
-        AddCommandParameter(cmd, "jobName", job.Key.Name);
-        AddCommandParameter(cmd, "jobGroup", job.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobDescription, job.Description);
+        AddCommandParameter(cmd, SqlParameters.JobType, job.JobType.FullName);
+        AddCommandParameter(cmd, SqlParameters.JobDurable, GetDbBooleanValue(job.Durable));
+        AddCommandParameter(cmd, SqlParameters.JobVolatile, GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
+        AddCommandParameter(cmd, SqlParameters.JobStateful, GetDbBooleanValue(job.PersistJobDataAfterExecution));
+        AddCommandParameter(cmd, SqlParameters.JobRequestsRecovery, GetDbBooleanValue(job.RequestsRecovery));
+        AddCommandParameter(cmd, SqlParameters.JobDataMap, jobData, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.JobName, job.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, job.Key.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -62,12 +62,12 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
         if (state is not null)
         {
-            AddCommandParameter(cmd, "state", state.Value.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.State, state.Value.ToStoredValue());
         }
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -94,9 +94,9 @@ public partial class StdAdoDelegate
             logger.JobDeleting(jobKey);
         }
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -107,9 +107,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectJobExistence));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
         using var dr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await dr.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -128,10 +128,10 @@ public partial class StdAdoDelegate
         var jobData = SerializeJobData(job.JobDataMap);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobData));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobDataMap", jobData, DbProvider.Metadata.BinaryParameterType);
-        AddCommandParameter(cmd, "jobName", job.Key.Name);
-        AddCommandParameter(cmd, "jobGroup", job.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobDataMap, jobData, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.JobName, job.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, job.Key.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -144,9 +144,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectJobDetail));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
         using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
         IJobDetail? job = null;
 
@@ -206,7 +206,7 @@ public partial class StdAdoDelegate
     {
         int paddedCount = AdoUtil.RoundUpJobKeyCount(length);
         DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(sqlPrefix + AdoUtil.BuildJobKeyPredicate(paddedCount)));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
         for (int i = 0; i < paddedCount; i++)
         {
@@ -325,9 +325,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectJobForTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -424,16 +424,16 @@ public partial class StdAdoDelegate
         var jobData = SerializeJobData(job.JobDataMap);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertJobDetail));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", job.Key.Name);
-        AddCommandParameter(cmd, "jobGroup", job.Key.Group);
-        AddCommandParameter(cmd, "jobDescription", job.Description);
-        AddCommandParameter(cmd, "jobType", job.JobType.FullName);
-        AddCommandParameter(cmd, "jobDurable", GetDbBooleanValue(job.Durable));
-        AddCommandParameter(cmd, "jobVolatile", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
-        AddCommandParameter(cmd, "jobStateful", GetDbBooleanValue(job.PersistJobDataAfterExecution));
-        AddCommandParameter(cmd, "jobRequestsRecovery", GetDbBooleanValue(job.RequestsRecovery));
-        AddCommandParameter(cmd, "jobDataMap", jobData, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, job.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, job.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.JobDescription, job.Description);
+        AddCommandParameter(cmd, SqlParameters.JobType, job.JobType.FullName);
+        AddCommandParameter(cmd, SqlParameters.JobDurable, GetDbBooleanValue(job.Durable));
+        AddCommandParameter(cmd, SqlParameters.JobVolatile, GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
+        AddCommandParameter(cmd, SqlParameters.JobStateful, GetDbBooleanValue(job.PersistJobDataAfterExecution));
+        AddCommandParameter(cmd, SqlParameters.JobRequestsRecovery, GetDbBooleanValue(job.RequestsRecovery));
+        AddCommandParameter(cmd, SqlParameters.JobDataMap, jobData, DbProvider.Metadata.BinaryParameterType);
 
         var insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -447,8 +447,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertPausedJobGroup));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobGroup", groupName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, groupName);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -462,8 +462,8 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlDeletePausedJobGroupEquals, StdAdoConstants.SqlDeletePausedJobGroupLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobGroup", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, parameter);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -475,8 +475,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectPausedJobGroup));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobGroup", groupName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, groupName);
 
         return await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
     }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
@@ -48,8 +48,8 @@ public partial class StdAdoDelegate
     protected virtual string ApplyPaging(string sql, bool takeLimited)
     {
         return takeLimited
-            ? sql + " OFFSET @pageSkip ROWS FETCH NEXT @pageTake ROWS ONLY"
-            : sql + " OFFSET @pageSkip ROWS";
+            ? sql + " OFFSET @" + SqlParameters.PageSkip + " ROWS FETCH NEXT @" + SqlParameters.PageTake + " ROWS ONLY"
+            : sql + " OFFSET @" + SqlParameters.PageSkip + " ROWS";
     }
 
     /// <summary>
@@ -64,10 +64,10 @@ public partial class StdAdoDelegate
     /// <param name="takeLimited">Whether the page has an upper bound.</param>
     protected virtual void AddPagingParameters(DbCommand cmd, int skip, int take, bool takeLimited)
     {
-        AddCommandParameter(cmd, "pageSkip", skip);
+        AddCommandParameter(cmd, SqlParameters.PageSkip, skip);
         if (takeLimited)
         {
-            AddCommandParameter(cmd, "pageTake", take);
+            AddCommandParameter(cmd, SqlParameters.PageTake, take);
         }
     }
 
@@ -237,7 +237,7 @@ public partial class StdAdoDelegate
         if (IsCountOnly(query))
         {
             using DbCommand countCmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountJobHeaders + predicate));
-            AddCommandParameter(countCmd, "schedulerName", schedulerName);
+            AddCommandParameter(countCmd, SqlParameters.SchedulerName, schedulerName);
             BindJobHeaderFilters(countCmd, groupParameter, nameParameter);
 
             return CountOnlyResult<JobHeader>(query, await SelectCount(countCmd, cancellationToken).ConfigureAwait(false));
@@ -248,7 +248,7 @@ public partial class StdAdoDelegate
 
         using (DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(BuildPagedSql(StdAdoConstants.SqlSelectJobHeaders + predicate + StdAdoConstants.SqlOrderByJobGroupAndName, query))))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindJobHeaderFilters(cmd, groupParameter, nameParameter);
             BindPaging(cmd, query);
 
@@ -259,7 +259,7 @@ public partial class StdAdoDelegate
         if (query.IncludeTotalCount)
         {
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountJobHeaders + predicate));
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindJobHeaderFilters(cmd, groupParameter, nameParameter);
 
             totalCount = await SelectCount(cmd, cancellationToken).ConfigureAwait(false);
@@ -276,12 +276,12 @@ public partial class StdAdoDelegate
     {
         if (groupParameter is not null)
         {
-            AddCommandParameter(cmd, "jobGroup", groupParameter);
+            AddCommandParameter(cmd, SqlParameters.JobGroup, groupParameter);
         }
 
         if (nameParameter is not null)
         {
-            AddCommandParameter(cmd, "jobName", nameParameter);
+            AddCommandParameter(cmd, SqlParameters.JobName, nameParameter);
         }
     }
 
@@ -366,7 +366,7 @@ public partial class StdAdoDelegate
         if (IsCountOnly(query))
         {
             using DbCommand countCmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountTriggerHeaders + predicate));
-            AddCommandParameter(countCmd, "schedulerName", schedulerName);
+            AddCommandParameter(countCmd, SqlParameters.SchedulerName, schedulerName);
             foreach (KeyValuePair<string, object?> parameter in parameters)
             {
                 AddCommandParameter(countCmd, parameter.Key, parameter.Value);
@@ -380,7 +380,7 @@ public partial class StdAdoDelegate
 
         using (DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(BuildPagedSql(StdAdoConstants.SqlSelectTriggerHeaders + predicate + StdAdoConstants.SqlOrderByTriggerGroupAndName, query))))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             foreach (KeyValuePair<string, object?> parameter in parameters)
             {
                 AddCommandParameter(cmd, parameter.Key, parameter.Value);
@@ -395,7 +395,7 @@ public partial class StdAdoDelegate
         if (query.IncludeTotalCount)
         {
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountTriggerHeaders + predicate));
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             foreach (KeyValuePair<string, object?> parameter in parameters)
             {
                 AddCommandParameter(cmd, parameter.Key, parameter.Value);
@@ -472,7 +472,7 @@ public partial class StdAdoDelegate
         if (IsCountOnly(query))
         {
             using DbCommand countCmd = PrepareCommand(conn, ReplaceTablePrefix(countSql + predicate));
-            AddCommandParameter(countCmd, "schedulerName", schedulerName);
+            AddCommandParameter(countCmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(countCmd, query.Name);
 
             return CountOnlyResult<JobGroup>(query, await SelectCount(countCmd, cancellationToken).ConfigureAwait(false));
@@ -483,7 +483,7 @@ public partial class StdAdoDelegate
 
         using (DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(BuildPagedSql(sql + predicate + orderBy, query))))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(cmd, query.Name);
             BindPaging(cmd, query);
 
@@ -498,7 +498,7 @@ public partial class StdAdoDelegate
         if (query.IncludeTotalCount)
         {
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(countSql + predicate));
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(cmd, query.Name);
             totalCount = await SelectCount(cmd, cancellationToken).ConfigureAwait(false);
         }
@@ -545,7 +545,7 @@ public partial class StdAdoDelegate
         if (IsCountOnly(query))
         {
             using DbCommand countCmd = PrepareCommand(conn, ReplaceTablePrefix(countSql + predicate));
-            AddCommandParameter(countCmd, "schedulerName", schedulerName);
+            AddCommandParameter(countCmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(countCmd, query.Name);
 
             return CountOnlyResult<TriggerGroup>(query, await SelectCount(countCmd, cancellationToken).ConfigureAwait(false));
@@ -556,7 +556,7 @@ public partial class StdAdoDelegate
 
         using (DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(BuildPagedSql(sql + predicate + orderBy, query))))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(cmd, query.Name);
             BindPaging(cmd, query);
 
@@ -571,7 +571,7 @@ public partial class StdAdoDelegate
         if (query.IncludeTotalCount)
         {
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(countSql + predicate));
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindGroupName(cmd, query.Name);
             totalCount = await SelectCount(cmd, cancellationToken).ConfigureAwait(false);
         }
@@ -586,7 +586,7 @@ public partial class StdAdoDelegate
     {
         if (groupName is not null)
         {
-            AddCommandParameter(cmd, "groupName", groupName);
+            AddCommandParameter(cmd, SqlParameters.GroupName, groupName);
         }
     }
 
@@ -601,7 +601,7 @@ public partial class StdAdoDelegate
         if (IsCountOnly(query))
         {
             using DbCommand countCmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountCalendarNames + namePredicate));
-            AddCommandParameter(countCmd, "schedulerName", schedulerName);
+            AddCommandParameter(countCmd, SqlParameters.SchedulerName, schedulerName);
             BindCalendarNameFilter(countCmd, nameParameter);
 
             return CountOnlyResult<string>(query, await SelectCount(countCmd, cancellationToken).ConfigureAwait(false));
@@ -612,7 +612,7 @@ public partial class StdAdoDelegate
 
         using (DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(BuildPagedSql(StdAdoConstants.SqlSelectCalendarNames + namePredicate + StdAdoConstants.SqlOrderByCalendarName, query))))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindCalendarNameFilter(cmd, nameParameter);
             BindPaging(cmd, query);
 
@@ -623,7 +623,7 @@ public partial class StdAdoDelegate
         if (query.IncludeTotalCount)
         {
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlCountCalendarNames + namePredicate));
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             BindCalendarNameFilter(cmd, nameParameter);
             totalCount = await SelectCount(cmd, cancellationToken).ConfigureAwait(false);
         }
@@ -639,7 +639,7 @@ public partial class StdAdoDelegate
     {
         if (nameParameter is not null)
         {
-            AddCommandParameter(cmd, "calendarName", nameParameter);
+            AddCommandParameter(cmd, SqlParameters.CalendarName, nameParameter);
         }
     }
 
@@ -737,7 +737,7 @@ public partial class StdAdoDelegate
     /// </summary>
     private void BindFireInstanceFilters(DbCommand cmd, List<KeyValuePair<string, object?>> parameters)
     {
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         foreach (KeyValuePair<string, object?> parameter in parameters)
         {
             AddCommandParameter(cmd, parameter.Key, parameter.Value);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Schedulers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Schedulers.cs
@@ -15,10 +15,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertSchedulerState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "instanceName", instanceId);
-        AddCommandParameter(cmd, "lastCheckinTime", GetDbDateTimeValue(checkInTime));
-        AddCommandParameter(cmd, "checkinInterval", GetDbTimeSpanValue(interval));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.InstanceName, instanceId);
+        AddCommandParameter(cmd, SqlParameters.LastCheckinTime, GetDbDateTimeValue(checkInTime));
+        AddCommandParameter(cmd, SqlParameters.CheckinInterval, GetDbTimeSpanValue(interval));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -30,8 +30,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteSchedulerState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "instanceName", instanceId);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.InstanceName, instanceId);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -44,9 +44,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateSchedulerState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "lastCheckinTime", GetDbDateTimeValue(checkInTime));
-        AddCommandParameter(cmd, "instanceName", instanceId);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.LastCheckinTime, GetDbDateTimeValue(checkInTime));
+        AddCommandParameter(cmd, SqlParameters.InstanceName, instanceId);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -60,14 +60,14 @@ public partial class StdAdoDelegate
         if (instanceId is not null)
         {
             cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectSchedulerState));
-            AddCommandParameter(cmd, "instanceName", instanceId);
+            AddCommandParameter(cmd, SqlParameters.InstanceName, instanceId);
         }
         else
         {
             cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectSchedulerStates));
         }
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -84,10 +84,33 @@ public partial class StdAdoDelegate
         return list;
     }
 
+    /// <summary>
+    /// The count a caller passes when it wants every row, rather than a batch of them.
+    /// </summary>
+    internal const int NoRowLimit = -1;
+
+    /// <summary>
+    /// Where this dialect's row-limiting clause goes, and what it says. The one thing a dialect has
+    /// to declare in order to limit a row-limited statement: both statements that carry a limit ask
+    /// here, so a dialect says it once and neither statement is rewritten by hand.
+    /// </summary>
+    /// <remarks>
+    /// The default limits nothing, because there is no ANSI way to. The sentinel that asks for no
+    /// limit at all is dealt with before this is called, so an override never sees it.
+    /// </remarks>
+    /// <param name="count">The most rows the statement may return, always at least one.</param>
+    protected virtual SqlRowLimit GetRowLimit(int count) => SqlRowLimit.Unlimited;
+
+    /// <summary>
+    /// The row limit for a batch size, with <see cref="NoRowLimit" /> taken out of every dialect's
+    /// hands: an unlimited statement is unlimited on every database, and each dialect used to spell
+    /// that check for itself.
+    /// </summary>
+    private SqlRowLimit RowLimitFor(int count) => count == NoRowLimit ? SqlRowLimit.Unlimited : GetRowLimit(count);
+
     protected virtual string GetSelectMisfiredTriggersToRecoverSql(int count)
     {
-        // by default we don't support limits, this is db specific
-        return StdAdoConstants.SqlSelectMisfiredTriggersToRecover;
+        return StdAdoConstants.BuildSqlSelectMisfiredTriggersToRecover(RowLimitFor(count));
     }
 
     /// <inheritdoc />
@@ -1350,8 +1373,7 @@ public partial class StdAdoDelegate
 
     protected virtual string GetSelectNextTriggerToAcquireSql(TriggerAcquisitionSqlShape shape)
     {
-        // by default we don't support limits, this is db specific
-        return StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(shape.ExcludedJobTypeBucket);
+        return StdAdoConstants.BuildSqlSelectNextTriggerToAcquire(shape.ExcludedJobTypeBucket, RowLimitFor(shape.MaxCount));
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -62,8 +62,8 @@ public partial class StdAdoDelegate
         List<StoredTriggerState> states = DistinctStates(oldStates, nameof(oldStates));
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerStatesFromOtherStatesPrefix + AdoUtil.BuildTriggerStatePredicate(states.Count)));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
         AddOldStateParameters(cmd, states);
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -72,8 +72,8 @@ public partial class StdAdoDelegate
     public virtual async ValueTask<List<TriggerKey>> SelectTriggersInState(ConnectionAndTransactionHolder conn, StoredTriggerState state, CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggersInState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "state", state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<TriggerKey> list = [];
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -121,9 +121,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(GetCountMisfiredTriggersInStateSql()));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(misfireTime));
-        AddCommandParameter(cmd, "state", state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(misfireTime));
+        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
 
         return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
     }
@@ -140,9 +140,9 @@ public partial class StdAdoDelegate
 
         using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectInstancesRecoverableFiredTriggers)))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "instanceName", instanceId);
-            AddCommandParameter(cmd, "requestsRecovery", GetDbBooleanValue(true));
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+            AddCommandParameter(cmd, SqlParameters.InstanceName, instanceId);
+            AddCommandParameter(cmd, SqlParameters.RequestsRecovery, GetDbBooleanValue(true));
 
             using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -226,23 +226,23 @@ public partial class StdAdoDelegate
     /// </summary>
     private void BindFiredTriggerQuery(DbCommand cmd, FiredTriggerQuery query)
     {
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
         if (query.Trigger is not null)
         {
-            AddCommandParameter(cmd, "triggerName", query.Trigger.Name);
-            AddCommandParameter(cmd, "triggerGroup", query.Trigger.Group);
+            AddCommandParameter(cmd, SqlParameters.TriggerName, query.Trigger.Name);
+            AddCommandParameter(cmd, SqlParameters.TriggerGroup, query.Trigger.Group);
         }
 
         if (query.Job is not null)
         {
-            AddCommandParameter(cmd, "jobName", query.Job.Name);
-            AddCommandParameter(cmd, "jobGroup", query.Job.Group);
+            AddCommandParameter(cmd, SqlParameters.JobName, query.Job.Name);
+            AddCommandParameter(cmd, SqlParameters.JobGroup, query.Job.Group);
         }
 
         if (query.InstanceId is not null)
         {
-            AddCommandParameter(cmd, "instanceName", query.InstanceId);
+            AddCommandParameter(cmd, SqlParameters.InstanceName, query.InstanceId);
         }
     }
 
@@ -264,10 +264,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectCountExecutingFiredTriggersOfJob));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
-        AddCommandParameter(cmd, "executingState", StoredTriggerState.Executing.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.ExecutingState, StoredTriggerState.Executing.ToStoredValue());
 
         object? result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
         return Convert.ToInt32(result) > 0;
@@ -284,15 +284,15 @@ public partial class StdAdoDelegate
         var jobData = SerializeJobData(trigger.JobDataMap);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-        AddCommandParameter(cmd, "triggerJobName", trigger.JobKey.Name);
-        AddCommandParameter(cmd, "triggerJobGroup", trigger.JobKey.Group);
-        AddCommandParameter(cmd, "triggerDescription", trigger.Description);
-        AddCommandParameter(cmd, "triggerNextFireTime", GetDbDateTimeValue(trigger.NextFireTimeUtc));
-        AddCommandParameter(cmd, "triggerPreviousFireTime", GetDbDateTimeValue(trigger.PreviousFireTimeUtc));
-        AddCommandParameter(cmd, "triggerState", state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.TriggerJobName, trigger.JobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerJobGroup, trigger.JobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.TriggerDescription, trigger.Description);
+        AddCommandParameter(cmd, SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerState, state.ToStoredValue());
 
         var tDel = FindTriggerPersistenceDelegate(trigger);
         string type = AdoConstants.TriggerTypeBlob;
@@ -301,21 +301,21 @@ public partial class StdAdoDelegate
             type = tDel.GetHandledTriggerTypeDiscriminator();
         }
 
-        AddCommandParameter(cmd, "triggerType", type);
-        AddCommandParameter(cmd, "triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc));
-        AddCommandParameter(cmd, "triggerEndTime", GetDbDateTimeValue(trigger.EndTimeUtc));
-        AddCommandParameter(cmd, "triggerCalendarName", trigger.CalendarName);
-        AddCommandParameter(cmd, "triggerMisfireInstruction", trigger.MisfireInstructionCode);
-        AddCommandParameter(cmd, "triggerJobJobDataMap", jobData, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.TriggerType, type);
+        AddCommandParameter(cmd, SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerEndTime, GetDbDateTimeValue(trigger.EndTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerCalendarName, trigger.CalendarName);
+        AddCommandParameter(cmd, SqlParameters.TriggerMisfireInstruction, trigger.MisfireInstructionCode);
+        AddCommandParameter(cmd, SqlParameters.TriggerJobJobDataMap, jobData, DbProvider.Metadata.BinaryParameterType);
 
-        AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
+        AddCommandParameter(cmd, SqlParameters.TriggerPriority, trigger.Priority);
 
         string? execGroup = trigger.ExecutionGroup;
-        AddCommandParameter(cmd, "triggerExecutionGroup", (object?) execGroup ?? DBNull.Value);
+        AddCommandParameter(cmd, SqlParameters.TriggerExecutionGroup, (object?) execGroup ?? DBNull.Value);
 
         PreferredNode preferredNode = trigger.PreferredNode;
-        AddCommandParameter(cmd, "triggerPreferredNode", (object?) preferredNode.StoredNode ?? DBNull.Value);
-        AddCommandParameter(cmd, "triggerPreferredNodeAuto", GetDbBooleanValue(preferredNode.StoredAutomatic));
+        AddCommandParameter(cmd, SqlParameters.TriggerPreferredNode, (object?) preferredNode.StoredNode ?? DBNull.Value);
+        AddCommandParameter(cmd, SqlParameters.TriggerPreferredNodeAuto, GetDbBooleanValue(preferredNode.StoredAutomatic));
 
         int insertResult = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
@@ -340,10 +340,10 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertBlobTrigger));
         // update the blob
         byte[]? buf = SerializeObject(trigger);
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-        AddCommandParameter(cmd, "blob", buf, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.Blob, buf, DbProvider.Metadata.BinaryParameterType);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -443,37 +443,37 @@ public partial class StdAdoDelegate
     {
         List<SqlStatementParameter> parameters =
         [
-            new("schedulerName", schedulerName),
-            new("triggerJobName", trigger.JobKey.Name),
-            new("triggerJobGroup", trigger.JobKey.Group),
-            new("triggerDescription", trigger.Description),
-            new("triggerNextFireTime", GetDbDateTimeValue(trigger.NextFireTimeUtc)),
-            new("triggerPreviousFireTime", GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
-            new("triggerState", state.ToStoredValue()),
-            new("triggerType", type),
-            new("triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc)),
-            new("triggerEndTime", GetDbDateTimeValue(trigger.EndTimeUtc)),
-            new("triggerCalendarName", trigger.CalendarName),
-            new("triggerMisfireInstruction", trigger.MisfireInstructionCode),
-            new("triggerPriority", trigger.Priority)
+            new(SqlParameters.SchedulerName, schedulerName),
+            new(SqlParameters.TriggerJobName, trigger.JobKey.Name),
+            new(SqlParameters.TriggerJobGroup, trigger.JobKey.Group),
+            new(SqlParameters.TriggerDescription, trigger.Description),
+            new(SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
+            new(SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
+            new(SqlParameters.TriggerState, state.ToStoredValue()),
+            new(SqlParameters.TriggerType, type),
+            new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc)),
+            new(SqlParameters.TriggerEndTime, GetDbDateTimeValue(trigger.EndTimeUtc)),
+            new(SqlParameters.TriggerCalendarName, trigger.CalendarName),
+            new(SqlParameters.TriggerMisfireInstruction, trigger.MisfireInstructionCode),
+            new(SqlParameters.TriggerPriority, trigger.Priority)
         ];
 
         if (updateJobData)
         {
-            parameters.Add(new SqlStatementParameter("triggerJobJobDataMap", SerializeJobData(trigger.JobDataMap), DbProvider.Metadata.BinaryParameterType));
+            parameters.Add(new SqlStatementParameter(SqlParameters.TriggerJobJobDataMap, SerializeJobData(trigger.JobDataMap), DbProvider.Metadata.BinaryParameterType));
         }
 
-        parameters.Add(new SqlStatementParameter("triggerExecutionGroup", (object?) trigger.ExecutionGroup ?? DBNull.Value));
+        parameters.Add(new SqlStatementParameter(SqlParameters.TriggerExecutionGroup, (object?) trigger.ExecutionGroup ?? DBNull.Value));
 
         if (writePreferredNode)
         {
             PreferredNode preferredNode = trigger.PreferredNode;
-            parameters.Add(new SqlStatementParameter("triggerPreferredNode", (object?) preferredNode.StoredNode ?? DBNull.Value));
-            parameters.Add(new SqlStatementParameter("triggerPreferredNodeAuto", GetDbBooleanValue(preferredNode.StoredAutomatic)));
+            parameters.Add(new SqlStatementParameter(SqlParameters.TriggerPreferredNode, (object?) preferredNode.StoredNode ?? DBNull.Value));
+            parameters.Add(new SqlStatementParameter(SqlParameters.TriggerPreferredNodeAuto, GetDbBooleanValue(preferredNode.StoredAutomatic)));
         }
 
-        parameters.Add(new SqlStatementParameter("triggerName", trigger.Key.Name));
-        parameters.Add(new SqlStatementParameter("triggerGroup", trigger.Key.Group));
+        parameters.Add(new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name));
+        parameters.Add(new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group));
 
         return parameters;
     }
@@ -545,10 +545,10 @@ public partial class StdAdoDelegate
         // update the blob
         byte[]? os = SerializeObject(trigger);
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "blob", os, DbProvider.Metadata.BinaryParameterType);
-        AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.Blob, os, DbProvider.Metadata.BinaryParameterType);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -561,10 +561,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "state", state.ToStoredValue());
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -580,10 +580,10 @@ public partial class StdAdoDelegate
         List<StoredTriggerState> states = DistinctStates(oldStates, nameof(oldStates));
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerStateFromStatesPrefix + AdoUtil.BuildTriggerStatePredicate(states.Count)));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
         AddOldStateParameters(cmd, states);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -601,9 +601,9 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlUpdateTriggerGroupStateFromStatesEqualsPrefix, StdAdoConstants.SqlUpdateTriggerGroupStateFromStatesLikePrefix);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql + AdoUtil.BuildTriggerStatePredicate(states.Count)));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
-        AddCommandParameter(cmd, "groupName", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.GroupName, parameter);
         AddOldStateParameters(cmd, states);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -618,11 +618,11 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerStateFromState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
-        AddCommandParameter(cmd, "oldState", oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -637,12 +637,12 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerStateFromStateWithNextFireTime));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
-        AddCommandParameter(cmd, "oldState", oldState.ToStoredValue());
-        AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(nextFireTime));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(nextFireTime));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -658,10 +658,10 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlUpdateTriggerGroupStateFromStateEquals, StdAdoConstants.SqlUpdateTriggerGroupStateFromStateLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "newState", newState.ToStoredValue());
-        AddCommandParameter(cmd, "triggerGroup", parameter);
-        AddCommandParameter(cmd, "oldState", oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, parameter);
+        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -674,10 +674,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobTriggerStates));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "state", state.ToStoredValue());
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -691,11 +691,11 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobTriggerStatesFromOtherState));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "state", newState.ToStoredValue());
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
-        AddCommandParameter(cmd, "oldState", oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.State, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -728,11 +728,11 @@ public partial class StdAdoDelegate
             TriggerStateTransition transition = transitions[i];
             into.Add(new SqlStatement(sql,
             [
-                new SqlStatementParameter("schedulerName", schedulerName),
-                new SqlStatementParameter("state", transition.To.ToStoredValue()),
-                new SqlStatementParameter("jobName", jobKey.Name),
-                new SqlStatementParameter("jobGroup", jobKey.Group),
-                new SqlStatementParameter("oldState", transition.From.ToStoredValue())
+                new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),
+                new SqlStatementParameter(SqlParameters.State, transition.To.ToStoredValue()),
+                new SqlStatementParameter(SqlParameters.JobName, jobKey.Name),
+                new SqlStatementParameter(SqlParameters.JobGroup, jobKey.Group),
+                new SqlStatementParameter(SqlParameters.OldState, transition.From.ToStoredValue())
             ]));
         }
     }
@@ -761,27 +761,27 @@ public partial class StdAdoDelegate
 
         statements.Add(new SqlStatement(ReplaceTablePrefix(StdAdoConstants.SqlUpdateFiredTrigger),
         [
-            new SqlStatementParameter("schedulerName", schedulerName),
-            new SqlStatementParameter("instanceName", instanceId),
-            new SqlStatementParameter("firedTime", GetDbDateTimeValue(timeProvider.GetUtcNow())),
-            new SqlStatementParameter("scheduledTime", GetDbDateTimeValue(update.ScheduledFireTimeUtc)),
-            new SqlStatementParameter("entryState", StoredTriggerState.Executing.ToStoredValue()),
-            new SqlStatementParameter("jobName", trigger.JobKey.Name),
-            new SqlStatementParameter("jobGroup", trigger.JobKey.Group),
-            new SqlStatementParameter("isNonConcurrent", GetDbBooleanValue(update.JobDetail.ConcurrentExecutionDisallowed)),
-            new SqlStatementParameter("requestsRecover", GetDbBooleanValue(update.JobDetail.RequestsRecovery)),
-            new SqlStatementParameter("executionGroup", (object?) trigger.ExecutionGroup ?? DBNull.Value),
-            new SqlStatementParameter("entryId", trigger.FireInstanceId)
+            new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),
+            new SqlStatementParameter(SqlParameters.InstanceName, instanceId),
+            new SqlStatementParameter(SqlParameters.FiredTime, GetDbDateTimeValue(timeProvider.GetUtcNow())),
+            new SqlStatementParameter(SqlParameters.ScheduledTime, GetDbDateTimeValue(update.ScheduledFireTimeUtc)),
+            new SqlStatementParameter(SqlParameters.EntryState, StoredTriggerState.Executing.ToStoredValue()),
+            new SqlStatementParameter(SqlParameters.JobName, trigger.JobKey.Name),
+            new SqlStatementParameter(SqlParameters.JobGroup, trigger.JobKey.Group),
+            new SqlStatementParameter(SqlParameters.IsNonConcurrent, GetDbBooleanValue(update.JobDetail.ConcurrentExecutionDisallowed)),
+            new SqlStatementParameter(SqlParameters.RequestsRecover, GetDbBooleanValue(update.JobDetail.RequestsRecovery)),
+            new SqlStatementParameter(SqlParameters.ExecutionGroup, (object?) trigger.ExecutionGroup ?? DBNull.Value),
+            new SqlStatementParameter(SqlParameters.EntryId, trigger.FireInstanceId)
         ]));
 
         if (update.ClearMisfireOriginalFireTime)
         {
             statements.Add(new SqlStatement(ReplaceTablePrefix(StdAdoConstants.SqlUpdateMisfireOrigFireTime),
             [
-                new SqlStatementParameter("schedulerName", schedulerName),
-                new SqlStatementParameter("triggerName", trigger.Key.Name),
-                new SqlStatementParameter("triggerGroup", trigger.Key.Group),
-                new SqlStatementParameter("misfireOrigFireTime", null)
+                new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),
+                new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name),
+                new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group),
+                new SqlStatementParameter(SqlParameters.MisfireOrigFireTime, null)
             ]));
         }
 
@@ -821,9 +821,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteBlobTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -837,9 +837,9 @@ public partial class StdAdoDelegate
         await DeleteTriggerExtension(conn, triggerKey, cancellationToken).ConfigureAwait(false);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -1096,9 +1096,9 @@ public partial class StdAdoDelegate
 
         using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTrigger)))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-            AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+            AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+            AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
             using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1169,9 +1169,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         return await rs.ReadAsync(cancellationToken).ConfigureAwait(false);
@@ -1184,9 +1184,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerData));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(System.Data.CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1209,9 +1209,9 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerState));
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         var state = (string?) await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
@@ -1227,9 +1227,9 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerStateWithExecuting));
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1251,9 +1251,9 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerHeader));
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (!await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -1280,9 +1280,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerType));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1298,8 +1298,8 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlSelectTriggerGroupsEquals, StdAdoConstants.SqlSelectTriggerGroupsLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerGroup", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, parameter);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<string> list = [];
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1316,8 +1316,8 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlSelectTriggersInGroup, StdAdoConstants.SqlSelectTriggersInGroupLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerGroup", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, parameter);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<TriggerKey> keys = [];
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1335,8 +1335,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertPausedTriggerGroup));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerGroup", groupName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, groupName);
         int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
         return rows;
@@ -1351,8 +1351,8 @@ public partial class StdAdoDelegate
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlDeletePausedTriggerGroupEquals, StdAdoConstants.SqlDeletePausedTriggerGroupLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerGroup", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, parameter);
         int rows = await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
         return rows;
@@ -1365,8 +1365,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectPausedTriggerGroup));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerGroup", groupName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, groupName);
 
         return await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
     }
@@ -1388,9 +1388,9 @@ public partial class StdAdoDelegate
     /// </param>
     protected void AddPreferredNodeParameters(DbCommand cmd, DateTimeOffset liveNodeCutoff)
     {
-        AddCommandParameter(cmd, "instanceId", instanceId);
-        AddCommandParameter(cmd, "autoPinSentinel", StdAdoConstants.AutoPinSentinel);
-        AddCommandParameter(cmd, "liveNodeCutoff", GetDbDateTimeValue(liveNodeCutoff));
+        AddCommandParameter(cmd, SqlParameters.InstanceId, instanceId);
+        AddCommandParameter(cmd, SqlParameters.AutoPinSentinel, StdAdoConstants.AutoPinSentinel);
+        AddCommandParameter(cmd, SqlParameters.LiveNodeCutoff, GetDbDateTimeValue(liveNodeCutoff));
     }
 
     /// <inheritdoc />
@@ -1406,13 +1406,13 @@ public partial class StdAdoDelegate
         // Parameters are added in SQL token order for providers with positional binding.
         // The expected pin is compared with '=', so a transition expecting PreferredNode.None matches
         // no row: SQL equality against NULL is never true. The claim paths never expect one.
-        AddCommandParameter(cmd, "triggerPreferredNode", transition.New.StoredNode);
-        AddCommandParameter(cmd, "triggerPreferredNodeAuto", GetDbBooleanValue(transition.New.StoredAutomatic));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
-        AddCommandParameter(cmd, "expectedPreferredNode", transition.Expected.StoredNode);
-        AddCommandParameter(cmd, "expectedPreferredNodeAuto", GetDbBooleanValue(transition.Expected.StoredAutomatic));
+        AddCommandParameter(cmd, SqlParameters.TriggerPreferredNode, transition.New.StoredNode);
+        AddCommandParameter(cmd, SqlParameters.TriggerPreferredNodeAuto, GetDbBooleanValue(transition.New.StoredAutomatic));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.ExpectedPreferredNode, transition.Expected.StoredNode);
+        AddCommandParameter(cmd, SqlParameters.ExpectedPreferredNodeAuto, GetDbBooleanValue(transition.Expected.StoredAutomatic));
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -1426,11 +1426,11 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlRepinTriggersFromDeadNode));
         // Parameters are added in SQL token order for providers with positional binding.
         // Only auto-claimed pins are released; the reset value ("*") is not itself auto-claimed.
-        AddCommandParameter(cmd, "newPreferredNode", newPreferredNode);
-        AddCommandParameter(cmd, "newPreferredNodeAuto", GetDbBooleanValue(false));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "oldPreferredNode", oldPreferredNode);
-        AddCommandParameter(cmd, "oldPreferredNodeAuto", GetDbBooleanValue(true));
+        AddCommandParameter(cmd, SqlParameters.NewPreferredNode, newPreferredNode);
+        AddCommandParameter(cmd, SqlParameters.NewPreferredNodeAuto, GetDbBooleanValue(false));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.OldPreferredNode, oldPreferredNode);
+        AddCommandParameter(cmd, SqlParameters.OldPreferredNodeAuto, GetDbBooleanValue(true));
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -1460,10 +1460,10 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, sql);
         List<TriggerAcquireResult> nextTriggers = new();
 
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "state", StoredTriggerState.Waiting.ToStoredValue());
-        AddCommandParameter(cmd, "noLaterThan", GetDbDateTimeValue(criteria.NoLaterThan));
-        AddCommandParameter(cmd, "noEarlierThan", GetDbDateTimeValue(criteria.NoEarlierThan));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerState.Waiting.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NoLaterThan, GetDbDateTimeValue(criteria.NoLaterThan));
+        AddCommandParameter(cmd, SqlParameters.NoEarlierThan, GetDbDateTimeValue(criteria.NoEarlierThan));
         AddPreferredNodeParameters(cmd, criteria.LiveNodeCutoff);
 
         if (excludedJobTypeNames is not null)
@@ -1538,7 +1538,7 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectExecutionGroupsInFlight));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
         List<ExecutionGroupInFlight> counts = [];
 
@@ -1566,31 +1566,31 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlInsertFiredTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerEntryId", trigger.FireInstanceId);
-        AddCommandParameter(cmd, "triggerName", trigger.Key.Name);
-        AddCommandParameter(cmd, "triggerGroup", trigger.Key.Group);
-        AddCommandParameter(cmd, "triggerInstanceName", instanceId);
-        AddCommandParameter(cmd, "triggerFireTime", GetDbDateTimeValue(timeProvider.GetUtcNow()));
-        AddCommandParameter(cmd, "triggerScheduledTime", GetDbDateTimeValue(trigger.NextFireTimeUtc));
-        AddCommandParameter(cmd, "triggerState", state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerEntryId, trigger.FireInstanceId);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+        AddCommandParameter(cmd, SqlParameters.TriggerInstanceName, instanceId);
+        AddCommandParameter(cmd, SqlParameters.TriggerFireTime, GetDbDateTimeValue(timeProvider.GetUtcNow()));
+        AddCommandParameter(cmd, SqlParameters.TriggerScheduledTime, GetDbDateTimeValue(trigger.NextFireTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerState, state.ToStoredValue());
         if (job is not null)
         {
-            AddCommandParameter(cmd, "triggerJobName", trigger.JobKey.Name);
-            AddCommandParameter(cmd, "triggerJobGroup", trigger.JobKey.Group);
-            AddCommandParameter(cmd, "triggerJobStateful", GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
-            AddCommandParameter(cmd, "triggerJobRequestsRecovery", GetDbBooleanValue(job.RequestsRecovery));
+            AddCommandParameter(cmd, SqlParameters.TriggerJobName, trigger.JobKey.Name);
+            AddCommandParameter(cmd, SqlParameters.TriggerJobGroup, trigger.JobKey.Group);
+            AddCommandParameter(cmd, SqlParameters.TriggerJobStateful, GetDbBooleanValue(job.ConcurrentExecutionDisallowed));
+            AddCommandParameter(cmd, SqlParameters.TriggerJobRequestsRecovery, GetDbBooleanValue(job.RequestsRecovery));
         }
         else
         {
-            AddCommandParameter(cmd, "triggerJobName", null);
-            AddCommandParameter(cmd, "triggerJobGroup", null);
-            AddCommandParameter(cmd, "triggerJobStateful", GetDbBooleanValue(false));
-            AddCommandParameter(cmd, "triggerJobRequestsRecovery", GetDbBooleanValue(false));
+            AddCommandParameter(cmd, SqlParameters.TriggerJobName, null);
+            AddCommandParameter(cmd, SqlParameters.TriggerJobGroup, null);
+            AddCommandParameter(cmd, SqlParameters.TriggerJobStateful, GetDbBooleanValue(false));
+            AddCommandParameter(cmd, SqlParameters.TriggerJobRequestsRecovery, GetDbBooleanValue(false));
         }
 
-        AddCommandParameter(cmd, "triggerPriority", trigger.Priority);
-        AddCommandParameter(cmd, "triggerExecutionGroup", (object?) trigger.ExecutionGroup ?? DBNull.Value);
+        AddCommandParameter(cmd, SqlParameters.TriggerPriority, trigger.Priority);
+        AddCommandParameter(cmd, SqlParameters.TriggerExecutionGroup, (object?) trigger.ExecutionGroup ?? DBNull.Value);
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -1681,7 +1681,7 @@ public partial class StdAdoDelegate
     {
         List<string> instanceNames = [];
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectFiredTriggerInstanceNames));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -1698,8 +1698,8 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlDeleteFiredTrigger));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerEntryId", entryId);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerEntryId, entryId);
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -1756,9 +1756,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggerExistence));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
         using var dr = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         if (await dr.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1775,9 +1775,9 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectNumTriggersForJob));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobName", jobKey.Name);
-        AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
 
         return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
     }
@@ -1790,9 +1790,9 @@ public partial class StdAdoDelegate
 
         using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggersForJob)))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "jobName", jobKey.Name);
-            AddCommandParameter(cmd, "jobGroup", jobKey.Group);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+            AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
+            AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
 
             using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -1821,8 +1821,8 @@ public partial class StdAdoDelegate
         List<TriggerKey> keys = [];
         using (var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggersForCalendar)))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "calendarName", calendarName);
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+            AddCommandParameter(cmd, SqlParameters.CalendarName, calendarName);
             using (var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
             {
                 while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1852,10 +1852,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateMisfireOrigFireTime));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
-        AddCommandParameter(cmd, "misfireOrigFireTime", GetDbDateTimeValue(fireTime));
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.MisfireOrigFireTime, GetDbDateTimeValue(fireTime));
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -1866,10 +1866,10 @@ public partial class StdAdoDelegate
         CancellationToken cancellationToken = default)
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateMisfireOrigFireTime));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "triggerName", triggerKey.Name);
-        AddCommandParameter(cmd, "triggerGroup", triggerKey.Group);
-        AddCommandParameter(cmd, "misfireOrigFireTime", null);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+        AddCommandParameter(cmd, SqlParameters.MisfireOrigFireTime, null);
         await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -1917,9 +1917,9 @@ public partial class StdAdoDelegate
 
         using (var cmd = PrepareCommand(conn, sql))
         {
-            AddCommandParameter(cmd, "schedulerName", schedulerName);
-            AddCommandParameter(cmd, "nextFireTime", GetDbDateTimeValue(misfireTime));
-            AddCommandParameter(cmd, "state", state.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+            AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(misfireTime));
+            AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
 
             using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             TriggerRowOrdinals? ordinals = null;
@@ -2110,7 +2110,7 @@ public partial class StdAdoDelegate
     {
         var paddedCount = AdoUtil.RoundUpTriggerKeyCount(length);
         var cmd = PrepareCommand(conn, ReplaceTablePrefix(sqlPrefix + AdoUtil.BuildTriggerKeyPredicate(paddedCount, qualified)));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
 
         for (var i = 0; i < paddedCount; i++)
         {
@@ -2224,20 +2224,20 @@ public partial class StdAdoDelegate
 
         List<SqlStatementParameter> parameters =
         [
-            new("schedulerName", schedulerName),
-            new("triggerNextFireTime", GetDbDateTimeValue(trigger.NextFireTimeUtc)),
-            new("triggerPreviousFireTime", GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
-            new("triggerState", update.NewState.ToStoredValue()),
-            new("triggerStartTime", GetDbDateTimeValue(trigger.StartTimeUtc))
+            new(SqlParameters.SchedulerName, schedulerName),
+            new(SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
+            new(SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
+            new(SqlParameters.TriggerState, update.NewState.ToStoredValue()),
+            new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc))
         ];
 
         if (writeMisfireOrigFireTime)
         {
-            parameters.Add(new SqlStatementParameter("triggerMisfireOrigFireTime", GetDbDateTimeValue(update.MisfireOriginalFireTime)));
+            parameters.Add(new SqlStatementParameter(SqlParameters.TriggerMisfireOrigFireTime, GetDbDateTimeValue(update.MisfireOriginalFireTime)));
         }
 
-        parameters.Add(new SqlStatementParameter("triggerName", trigger.Key.Name));
-        parameters.Add(new SqlStatementParameter("triggerGroup", trigger.Key.Group));
+        parameters.Add(new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name));
+        parameters.Add(new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group));
 
         into.Add(new SqlStatement(
             ReplaceTablePrefix(writeMisfireOrigFireTime ? StdAdoConstants.SqlUpdateTriggerMisfireWithOrigFireTime : StdAdoConstants.SqlUpdateTriggerMisfire),
@@ -2252,12 +2252,12 @@ public partial class StdAdoDelegate
         {
             into.Add(new SqlStatement(ReplaceTablePrefix(StdAdoConstants.SqlUpdateSimpleTrigger),
             [
-                new SqlStatementParameter("schedulerName", schedulerName),
-                new SqlStatementParameter("triggerRepeatCount", simpleTrigger.RepeatCount),
-                new SqlStatementParameter("triggerRepeatInterval", GetDbTimeSpanValue(simpleTrigger.RepeatInterval)),
-                new SqlStatementParameter("triggerTimesTriggered", simpleTrigger.TimesTriggered),
-                new SqlStatementParameter("triggerName", trigger.Key.Name),
-                new SqlStatementParameter("triggerGroup", trigger.Key.Group)
+                new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),
+                new SqlStatementParameter(SqlParameters.TriggerRepeatCount, simpleTrigger.RepeatCount),
+                new SqlStatementParameter(SqlParameters.TriggerRepeatInterval, GetDbTimeSpanValue(simpleTrigger.RepeatInterval)),
+                new SqlStatementParameter(SqlParameters.TriggerTimesTriggered, simpleTrigger.TimesTriggered),
+                new SqlStatementParameter(SqlParameters.TriggerName, trigger.Key.Name),
+                new SqlStatementParameter(SqlParameters.TriggerGroup, trigger.Key.Group)
             ]));
         }
         else if (persistenceDelegate is null)

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -188,7 +188,7 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
         List<SqlStatement> statements = new(clearDataStatements.Length);
         foreach (string sql in clearDataStatements)
         {
-            statements.Add(new SqlStatement(ReplaceTablePrefix(sql), [new SqlStatementParameter("schedulerName", schedulerName)]));
+            statements.Add(new SqlStatement(ReplaceTablePrefix(sql), [new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName)]));
         }
 
         return ExecuteStatements(conn, statements, cancellationToken);
@@ -380,8 +380,8 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
         (string sql, string parameter) = MatchGroup(matcher, StdAdoConstants.SqlSelectJobsInGroup, StdAdoConstants.SqlSelectJobsInGroupLike);
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
-        AddCommandParameter(cmd, "schedulerName", schedulerName);
-        AddCommandParameter(cmd, "jobGroup", parameter);
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.JobGroup, parameter);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         var list = new List<JobKey>();


### PR DESCRIPTION
Three things in the SQL layer were held together by convention. Each becomes a structure, and the
wire is proved unchanged where it was meant to be.

## The row limit is a slot

There is no ANSI row limit, so each of the six dialects built its own row-limited statement by editing
finished SQL. `SqlServerDelegate` cut the first six characters off and pasted `SELECT TOP n` back on —
correct only while the statement began with exactly `SELECT`, which nothing enforced; `OracleDelegate`
wrapped the whole thing; the rest appended `LIMIT n` or `ROWS n`. Two statements carry a limit
(acquisition and the misfire scan), so that was twelve overrides, three assumptions about a statement
none of them owns, and a `count == -1` test written out six times.

A new `SqlRowLimit` names the three placements, and one member says which a dialect wants:

```csharp
protected virtual SqlRowLimit GetRowLimit(int count) => SqlRowLimit.Unlimited;

// SqlServerDelegate
protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.InProjection("TOP", count);
// PostgreSQLDelegate, MySQLDelegate, SQLiteDelegate
protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("LIMIT", count);
// FirebirdDelegate
protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.AtStatementEnd("ROWS", count);
// OracleDelegate
protected override SqlRowLimit GetRowLimit(int count) => SqlRowLimit.InEnclosingSelect("rownum", count);
```

Two of the three placements are slots the statement template carries — `AfterSelect` right after the
`SELECT` keyword and `AtEnd` after the last clause, both empty by default so an unlimited statement is
the text it always was. The third, `Enclose`, wraps a finished statement and assumes nothing about it
beyond its being one. The `-1` that means "every row" is turned into `SqlRowLimit.Unlimited` before the
member is called, so an override never tests for it.

Five of the six dialect delegates now override nothing else. `FirebirdDelegate` is four lines.
`MySQLDelegate` keeps its two overrides, for the `FORCE INDEX` hint a row limit cannot express.

### The wire-identity proof

`AcquisitionSqlTest` already snapshotted the acquisition statement per dialect. The first commit adds
the same for the misfire scan, in both its limited and unlimited forms, **before** anything changed —
so the fourteen statements are recorded as they were and the refactoring commit has to leave them
alone. It does, with one deliberate exception, which is the entire diff of that verified file:

```diff
             FROM
-                {0}TRIGGERS t
+                {0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)
```

**A reviewer should decide about this one.** MySQL's misfire scan used to lose its index hint when the
recovery batch was unlimited, because the hint and the row limit shared an early return — an artefact,
not a decision. Which index the sweep reads does not depend on how many rows come back, and the
unlimited sweep is the one that reads the most, so the hint is applied unconditionally now.
`MySQLDelegateTest.GetSelectMisfiredTriggersToRecoverSql_WithMinusOne_*` changed with it. Say the word
and I will restore the old behaviour instead.

## Nine statements name their columns

`SELECT *` over `SIMPROP_TRIGGERS`, `CRON_TRIGGERS`, `SIMPLE_TRIGGERS`, `FIRED_TRIGGERS` and
`SCHEDULER_STATE` meant a column added by a user or by a migration changed what came back, and the
fired-trigger read was fetching `EXECUTION_GROUP` for a record that has no such field. The tenth —
`SimplePropertiesTriggerPersistenceDelegateBase`'s single-key lookup, the twin of the batch form in the
list — is folded in rather than left starred beside its named sibling.

| Statement | Columns |
|---|---|
| `SqlSelectCronTriggers` | `CRON_EXPRESSION, TIME_ZONE_ID` |
| `SqlSelectCronTriggersByKeysPrefix` | the same, plus `TRIGGER_NAME, TRIGGER_GROUP` |
| `SqlSelectSimpleTrigger` | `REPEAT_COUNT, REPEAT_INTERVAL, TIMES_TRIGGERED` |
| `SqlSelectSimpleTriggersByKeysPrefix` | the same, plus the key columns |
| `SqlSelectSimpropTriggersByKeysPrefix` | the twelve `*_PROP_*` columns and `TIME_ZONE_ID`, plus the key columns |
| `SelectSimplePropsTrigger` (the single-key twin) | the same twelve |
| `SqlSelectFiredTriggers` | the twelve `ReadFiredTriggerRecord` reads — `EXECUTION_GROUP` is on the row and is not one of them |
| `SqlSelectInstancesRecoverableFiredTriggers` | the seven the recovery trigger is built from |
| `SqlSelectSchedulerState` / `…States` | `INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL` |

Each list is a named constant shared by the single-key and batch forms of the same read, so the two
cannot drift apart.

`SelectColumnListTest` is what makes "the list is what the reader reads" a test rather than a comment.
It takes each statement's projection **from the statement text**, builds a `DbDataReader` that knows
only those columns, and drives the real reader against it. A column the reader wants and the statement
does not project throws from `GetOrdinal`, the way it would against a database; a column the statement
projects and nothing reads is left over at the end. Both directions were confirmed by mutation:

```
The statement does not project 'TIMES_TRIGGERED'. It projects: REPEAT_COUNT, REPEAT_INTERVAL
Expected reader.Unread to be empty ... but found at least one item {"SCHED_NAME"}.
```

## `GetParameterName` caches

It was `ParameterNamePrefix + parameterName`, called once per parameter bound — seven for an
acquisition, fifteen for a trigger write. The spelling is remembered per name now, in the
`ConditionalWeakTable` the record already uses for its derived state, so that two descriptions saying
the same thing about a driver still compare equal after one of them has been used. A description with
no prefix hands back the name it was given and needs no cache at all.

The cache is capped at 4096 entries, because the method is public: Quartz's own names are bounded
(about eighty-five fixed, four hundred trigger-key, five hundred job-key, eleven state, at most a
thousand job-type exclusions), but a delegate naming a parameter after its data would otherwise grow it
without bound. Past the cap it simply stops adding.

The assertion is an allocation one — `GC.GetAllocatedBytesForCurrentThread()` around a second pass over
an acquisition's seven names, which must be zero. Reverted to the concatenation, it reports the 360
bytes that were there.

## A parameter name is one constant

Eighty-six names were each written twice: `@triggerName` in the statement, `"triggerName"` in the
binder — forty times over for that one. A misspelling on either side compiled, and surfaced as a
provider complaining about an unbound parameter, or, on a provider that adapts named parameters
positionally, as a value bound to the wrong column.

`SqlParameters` holds each name once. The statement interpolates it (`@{SqlParameters.TriggerName}`)
and the binder passes it (`AddCommandParameter(cmd, SqlParameters.TriggerName, …)`), so a name that
does not exist is a build error. The four statement sites built by concatenation rather than
interpolation — the three `ApplyPaging` clauses and the simple-properties statements — splice it as
`" = @" + SqlParameters.TriggerName` instead.

All 860 sites were rewritten mechanically, and the result was proved back: substituting each constant
for the literal it stands for reproduces all thirteen files exactly, so no statement's text moved. A
guard test also reflects over every statement and fails one holding the literal text `SqlParameters` —
which is what an interpolation hole landing in a plain string looks like — and one carrying a
placeholder no constant declares.

Two things the constants make visible rather than fix, both on the wire and neither worth a statement
change: the fired-trigger `UPDATE` spells `REQUESTS_RECOVERY` as `@requestsRecover`, a syllable short of
the `@requestsRecovery` every other statement uses; and the preferred-node names are prefixes of their
`*Auto` siblings. `AdoUtil`'s placeholder rewrite is greedy so neither is a live bug, but they are now
next to each other instead of a letter apart in two unrelated strings.

## Public API

`SqlRowLimit` is new and `StdAdoDelegate.GetRowLimit` is new; five dialect delegates stopped overriding
`GetSelectNextTriggerToAcquireSql` and `GetSelectMisfiredTriggersToRecoverSql`. The baseline was
re-accepted through Verify, and the migration guide carries the delta — a new *Row limiting is a slot,
not a splice* section and two rows in the breaking-changes table. Both hooks stay `protected virtual`,
so a dialect delegate that splices its own clause keeps working; it just spells the same thing twice.
`docs/documentation/quartz-4.x/how-tos/dialect-delegate.md` and its sample say the new shape.

## Verification

| | |
|---|---|
| `dotnet build Quartz.slnx` | succeeded, 0 warnings |
| `dotnet test src/Quartz.Tests.Unit` | 3563 passed, 4 skipped |
| `dotnet test src/Quartz.Tests.AspNetCore` | 527 passed |
| integration `basic` | 329 passed |
| integration `postgres` | 149 passed |
| integration `sqlserver` | 141 passed |
| integration `mysql` | 84 passed |
| integration `sqlite` | 12 passed |
| integration `firebird` | 84 passed |
| integration `oracle` | 83 passed |
| `dotnet fallout VerifyDocsSnippets` | up to date, 93 markdown files |
| `dotnet fallout PublishTrimmed` | canary passed, including its SQLite store round-trip |
| `node docs/.vuepress/check-links.mjs` | 214 pages, 843 links, 494 fragments, no dead anchors |

Oracle, Firebird and SQLite were run because this touches their delegates. The `IntegrationTest`
fallout target is gated to GitHub Actions on Linux, so each leg was run as the target runs it —
`QUARTZ_TEST_DATABASE=<db> dotnet test … --filter TestCategory=db-<db>` — against a local Docker
daemon.

Closes #3427
