### PR TITLE
A trigger written as a plain object graph keeps its time zone

### DIFF
--- a/src/Quartz.Serialization.Json/Converters/TimeZoneInfoConverter.cs
+++ b/src/Quartz.Serialization.Json/Converters/TimeZoneInfoConverter.cs
@@ -1,0 +1,75 @@
+using System;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Quartz.Util;
+
+namespace Quartz.Converters;
+
+/// <summary>
+/// A time zone travels as its id, which is the only part of a <see cref="TimeZoneInfo" /> that means
+/// anything to another process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, a trigger written as a plain object graph - which is what
+/// <see cref="NewtonsoftJsonSerializerOptions.RegisterTriggerConverters" /> being off means, and off is
+/// the default - lost its zone outright. Json.NET's default contract writes a
+/// <see cref="TimeZoneInfo" /> as its public properties, every one of which is read-only, so reading
+/// the object back populated the zone the getter already held and set nothing at all. A trigger stored
+/// under Tokyo came back running on whichever zone the reading machine happened to be in, and nothing
+/// said so.
+/// </para>
+/// <para>
+/// Both forms are read. The object form is what is sitting in job store blobs written before this
+/// converter existed, and it carries the id under <c>Id</c>; the string form is what is written from
+/// now on, and it is the same spelling the trigger and calendar serializers have always used for a
+/// zone. Reading the object form is not optional even after the fix, because a typed member in a blob
+/// written before it still carries one.
+/// </para>
+/// <para>
+/// <see cref="QuartzContractResolver" /> attaches this per property, to members typed as a
+/// <see cref="TimeZoneInfo" />, and it is deliberately <em>not</em> in the serializer's converter list:
+/// that list is consulted for a value's runtime type wherever the value appears, so a zone held as an
+/// <see cref="object" /> - a job data map value - would be written as a bare string and lose the
+/// <c>$type</c> that path carries. Scoped to typed members, this reaches every trigger's
+/// <c>TimeZone</c> and nothing else.
+/// </para>
+/// </remarks>
+internal sealed class TimeZoneInfoConverter : JsonConverter
+{
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        writer.WriteValue(((TimeZoneInfo) value!).Id);
+    }
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+                return null;
+
+            case JsonToken.String:
+                return TimeZoneUtil.FindTimeZoneById((string) reader.Value!);
+
+            case JsonToken.StartObject:
+                // The shape Json.NET's default contract used to write: every public property of a
+                // TimeZoneInfo, of which only the id is portable.
+                JObject source = JObject.Load(reader);
+                string? id = source.Value<string>("Id");
+                if (string.IsNullOrEmpty(id))
+                {
+                    throw new JsonSerializationException($"Could not read a time zone from {source.ToString(Formatting.None)}: no Id");
+                }
+
+                return TimeZoneUtil.FindTimeZoneById(id!);
+
+            default:
+                throw new JsonSerializationException($"Could not read a time zone from a {reader.TokenType} token");
+        }
+    }
+
+    public override bool CanConvert(Type objectType) => objectType == typeof(TimeZoneInfo);
+}

--- a/src/Quartz.Serialization.Json/QuartzContractResolver.cs
+++ b/src/Quartz.Serialization.Json/QuartzContractResolver.cs
@@ -5,6 +5,8 @@ using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
+using Quartz.Converters;
+
 namespace Quartz;
 
 /// <summary>
@@ -21,13 +23,27 @@ namespace Quartz;
 /// firing every day.
 /// </para>
 /// <para>
+/// <b>A property typed as a <see cref="TimeZoneInfo" /> travels as its id.</b> The default contract
+/// writes a zone as its whole public surface, every member of which is read-only, so reading one back
+/// populated the instance the getter already held and set nothing - and the owning trigger's getter
+/// falls back to <see cref="TimeZoneInfo.Local" />, so a trigger stored under Tokyo fired on whichever
+/// zone the reading machine was in. <see cref="TimeZoneInfoConverter" /> is attached here, per property,
+/// rather than registered on the serializer, because the serializer's converter list is consulted for a
+/// value's runtime type wherever it appears: a <see cref="TimeZoneInfo" /> sitting in a job data map
+/// would be written as a bare string and read back as one, losing the <c>$type</c> that path carries.
+/// Scoped to typed members, the change reaches every trigger's <c>TimeZone</c> and leaves
+/// <see cref="object" />-typed slots exactly as they were.
+/// </para>
+/// <para>
 /// This is a resolver rather than a <see cref="JsonConverter" /> on purpose: a converter registered
 /// on the serializer is not consulted for a value whose type came from a <c>$type</c> property - a
-/// trigger stored as a blob, say - and the rule here applies on every path.
+/// trigger stored as a blob, say - and the rules here apply on every path.
 /// </para>
 /// </remarks>
 internal sealed class QuartzContractResolver : DefaultContractResolver
 {
+    private static readonly TimeZoneInfoConverter timeZoneInfoConverter = new TimeZoneInfoConverter();
+
     public QuartzContractResolver()
     {
         IgnoreSerializableInterface = true;
@@ -40,6 +56,11 @@ internal sealed class QuartzContractResolver : DefaultContractResolver
         if (property.Writable && IsReadOnlyCollection(property.PropertyType))
         {
             property.ObjectCreationHandling = ObjectCreationHandling.Replace;
+        }
+
+        if (property.PropertyType == typeof(TimeZoneInfo))
+        {
+            property.Converter = timeZoneInfoConverter;
         }
 
         return property;

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerTimeZoneTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerTimeZoneTest.cs
@@ -1,0 +1,390 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Newtonsoft.Json.Linq;
+
+using NUnit.Framework;
+
+using Quartz.Impl.Triggers;
+using Quartz.Simpl;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A trigger's time zone has to survive being written and read again, whichever of the two shapes the
+/// Newtonsoft serializer is set to write. With <c>RegisterTriggerConverters</c> on - which is not the
+/// default - a trigger goes out through its <c>ITriggerSerializer</c>; with it off it is written
+/// property by property as a plain object graph, and that is the path #3494 was about: Json.NET's
+/// default contract wrote a <see cref="TimeZoneInfo" /> as its whole public surface, every member of
+/// which is read-only, so reading it back set nothing and the trigger's getter fell through to
+/// <see cref="TimeZoneInfo.Local" />.
+/// </summary>
+/// <remarks>
+/// Every zone here is one the test machine is not in, so a trigger whose zone was dropped comes back
+/// visibly wrong rather than accidentally right.
+/// </remarks>
+public class NewtonsoftTriggerTimeZoneTest
+{
+    private static readonly DateTimeOffset startTime = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>
+    /// Tokyo unless the test is running there, which is the only case the fallback exists for.
+    /// </summary>
+    internal static readonly TimeZoneInfo NonLocalZone = PickNonLocalZone();
+
+    private static TimeZoneInfo PickNonLocalZone()
+    {
+        TimeZoneInfo tokyo = TimeZoneUtil.FindTimeZoneById("Tokyo Standard Time");
+        return tokyo.Equals(TimeZoneInfo.Local) ? TimeZoneUtil.FindTimeZoneById("Eastern Standard Time") : tokyo;
+    }
+
+    internal static JsonObjectSerializer CreateSerializer(bool registerTriggerConverters)
+    {
+        JsonObjectSerializer serializer = new JsonObjectSerializer { RegisterTriggerConverters = registerTriggerConverters };
+        serializer.Initialize();
+        return serializer;
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CalendarIntervalTriggerKeepsItsTimeZone(bool registerTriggerConverters)
+    {
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            Key = new TriggerKey("calendarInterval", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            RepeatInterval = 3,
+            RepeatIntervalUnit = IntervalUnit.Hour,
+            TimeZone = NonLocalZone,
+            StartTimeUtc = startTime
+        };
+
+        CalendarIntervalTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters);
+
+        restored.RepeatInterval.Should().Be(3, "the rest of the trigger has to read as it always did");
+        restored.RepeatIntervalUnit.Should().Be(IntervalUnit.Hour);
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "a day or month interval is counted in the stored zone, so reading it back as the machine's own zone reschedules the job");
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void RecurrenceTriggerKeepsItsTimeZone(bool registerTriggerConverters)
+    {
+        RecurrenceTriggerImpl trigger = new RecurrenceTriggerImpl
+        {
+            Key = new TriggerKey("recurrence", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            RecurrenceRule = "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+            TimeZone = NonLocalZone,
+            StartTimeUtc = startTime
+        };
+
+        RecurrenceTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters);
+
+        restored.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+            "the rule is the whole schedule, so a trigger that loses it fires on nothing");
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "the rule is evaluated in the stored zone, so a lost zone is a silently rewritten schedule");
+    }
+
+    /// <summary>
+    /// The cron trigger escaped this bug on 4.x, because its zone rides along on a serialized
+    /// <c>CronExpression</c>, which has always had a converter. Here it does not: 3.x writes only
+    /// <c>CronExpressionString</c>, and a bare cron string carries no zone, so before the converter the
+    /// zone went the same way every other trigger's did.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void CronTriggerKeepsItsTimeZone(bool registerTriggerConverters)
+    {
+        CronTriggerImpl trigger = new CronTriggerImpl
+        {
+            Key = new TriggerKey("cron", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            CronExpressionString = "0/5 * * * * ?",
+            TimeZone = NonLocalZone,
+            StartTimeUtc = startTime
+        };
+
+        CronTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters);
+
+        restored.CronExpressionString.Should().Be("0/5 * * * * ?");
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "a cron expression is resolved in the stored zone, the string form does not carry one, and this getter reads through to the rebuilt expression - so it is also the assertion that the expression got the zone");
+    }
+
+    /// <summary>
+    /// The daily trigger's write side is asserted on its own because its read side cannot be reached
+    /// with the trigger converters off - see
+    /// <see cref="ReadingADailyTimeIntervalTriggerAsAPlainObjectGraphFailsOnItsTimeOfDay" />.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DailyTimeIntervalTriggerWritesItsTimeZoneAsAnId(bool registerTriggerConverters)
+    {
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger();
+
+        JObject written = Write(trigger, registerTriggerConverters);
+
+        written["TimeZone"].Type.Should().Be(JTokenType.String,
+            "the id is the only part of a zone another process can use; the object form the default contract wrote was unreadable");
+        written["TimeZone"].Value<string>().Should().Be(NonLocalZone.Id,
+            "the spelling of a resolved zone's id belongs to the platform and the tz database, so it is compared against the zone in hand");
+    }
+
+    [Test]
+    public void DailyTimeIntervalTriggerKeepsItsTimeZone()
+    {
+        DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger();
+
+        DailyTimeIntervalTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters: true);
+
+        restored.StartTimeOfDay.Should().Be(new TimeOfDay(3, 30), "the rest of the trigger has to read as it always did");
+        restored.EndTimeOfDay.Should().Be(new TimeOfDay(4, 40));
+        restored.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday });
+        restored.TimeZone.Should().Be(NonLocalZone,
+            "the daily window is wall-clock time in the stored zone, so a lost zone moves every firing");
+    }
+
+    /// <summary>
+    /// A defect of the same family as #3494 and deliberately not fixed here: with the trigger
+    /// converters off a <see cref="DailyTimeIntervalTriggerImpl" /> cannot be read back at all, because
+    /// <see cref="TimeOfDay" /> has two public constructors and no parameterless one, so Json.NET has
+    /// nothing to build <c>EndTimeOfDay</c> with. It has nothing to do with the time zone - the zone is
+    /// written correctly, as
+    /// <see cref="DailyTimeIntervalTriggerWritesItsTimeZoneAsAnId" /> shows - and repairing it needs a
+    /// converter of its own, so it is recorded here rather than quietly folded in.
+    /// </summary>
+    /// <remarks>
+    /// This is a loud failure rather than a silent one, which is why it is the lesser bug: nothing
+    /// comes back wrong, the read throws. <c>StartTimeOfDay</c> is the silent half of it - its getter
+    /// hands out a default <c>00:00:00</c> for Json.NET to populate, and every member of a
+    /// <see cref="TimeOfDay" /> is read-only.
+    /// </remarks>
+    [Test]
+    public void ReadingADailyTimeIntervalTriggerAsAPlainObjectGraphFailsOnItsTimeOfDay()
+    {
+        JsonObjectSerializer serializer = CreateSerializer(registerTriggerConverters: false);
+        byte[] bytes = serializer.Serialize(CreateDailyTimeIntervalTrigger());
+
+        Action read = () => serializer.DeSerialize<DailyTimeIntervalTriggerImpl>(bytes);
+
+        read.Should().Throw<Newtonsoft.Json.JsonSerializationException>()
+            .WithInnerException<Newtonsoft.Json.JsonSerializationException>()
+            .WithMessage("*Quartz.TimeOfDay*",
+                "the read fails on the time of day and not on the zone, which is what makes this a separate defect");
+    }
+
+    private static DailyTimeIntervalTriggerImpl CreateDailyTimeIntervalTrigger()
+    {
+        return new DailyTimeIntervalTriggerImpl
+        {
+            Key = new TriggerKey("dailyTimeInterval", "group"),
+            JobKey = new JobKey("job", "jobGroup"),
+            RepeatInterval = 42,
+            RepeatIntervalUnit = IntervalUnit.Second,
+            StartTimeOfDay = new TimeOfDay(3, 30),
+            EndTimeOfDay = new TimeOfDay(4, 40),
+            DaysOfWeek = new HashSet<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Wednesday },
+            TimeZone = NonLocalZone,
+            StartTimeUtc = startTime
+        };
+    }
+
+    private static JObject Write<T>(T trigger, bool registerTriggerConverters) where T : class
+    {
+        JsonObjectSerializer serializer = CreateSerializer(registerTriggerConverters);
+        return JObject.Parse(Encoding.UTF8.GetString(serializer.Serialize(trigger)));
+    }
+
+    private static T RoundTrip<T>(T trigger, bool registerTriggerConverters) where T : class, ITrigger
+    {
+        JsonObjectSerializer serializer = CreateSerializer(registerTriggerConverters);
+        T restored = serializer.DeSerialize<T>(serializer.Serialize(trigger));
+
+        restored.Should().NotBeNull();
+        restored.Key.Should().Be(trigger.Key);
+        restored.JobKey.Should().Be(trigger.JobKey);
+        restored.StartTimeUtc.Should().Be(trigger.StartTimeUtc);
+        return restored;
+    }
+}
+
+/// <summary>
+/// The plain object graph as it was written before #3494 was fixed, with the whole
+/// <see cref="TimeZoneInfo" /> spelled out. Blobs in this shape are in job store columns now, so the
+/// converter that writes the id from here on has to keep reading them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The literals are verbatim output of the code at <c>1ce49f80b</c> - <c>JsonObjectSerializer</c> with
+/// its default settings, serializing a trigger whose zone was Tokyo - captured before the converter was
+/// written and pasted in unedited, so "it still reads" is a fact about those bytes rather than a
+/// reconstruction of them. The display and standard names are the Windows spellings the capturing
+/// machine had; only <c>Id</c> is ever read, which is exactly why the rest of the object was worthless.
+/// </para>
+/// <para>
+/// Nothing here carries a framework-qualified <c>$type</c>, so the same literals read on
+/// <c>net472</c> and <c>net10.0</c> alike.
+/// </para>
+/// </remarks>
+public class NewtonsoftLegacyTimeZonePayloadTest
+{
+    private const string LegacyCalendarIntervalTrigger =
+        """{"$type":"Quartz.Impl.Triggers.CalendarIntervalTriggerImpl, Quartz","StartTimeUtc":"2024-07-01T00:00:00+00:00","HasMillisecondPrecision":true,"RepeatIntervalUnit":3,"RepeatInterval":3,"TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"PreserveHourOfDayAcrossDaylightSavings":false,"SkipDayIfHourDoesNotExist":false,"TimesTriggered":0,"Name":"calendarInterval","Group":"group","JobName":"job","JobGroup":"jobGroup","FullName":"group.calendarInterval","Key":{"Name":"calendarInterval","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"FullJobName":"jobGroup.job","IsPreferredNodeAuto":false,"JobDataMap":{},"MisfireInstruction":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private const string LegacyRecurrenceTrigger =
+        """{"$type":"Quartz.Impl.Triggers.RecurrenceTriggerImpl, Quartz","RecurrenceRule":"FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR","TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"TimesTriggered":3,"StartTimeUtc":"2024-07-01T00:00:00+00:00","HasMillisecondPrecision":false,"Name":"recurrence","Group":"group","JobName":"job","JobGroup":"jobGroup","FullName":"group.recurrence","Key":{"Name":"recurrence","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"FullJobName":"jobGroup.job","IsPreferredNodeAuto":false,"JobDataMap":{},"MisfireInstruction":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private const string LegacyCronTrigger =
+        """{"$type":"Quartz.Impl.Triggers.CronTriggerImpl, Quartz","CronExpressionString":"0/5 * * * * ?","StartTimeUtc":"2024-07-01T00:00:00+00:00","TimeZone":{"Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false},"HasMillisecondPrecision":false,"Name":"cron","Group":"group","JobName":"job","JobGroup":"jobGroup","FullName":"group.cron","Key":{"Name":"cron","Group":"group"},"JobKey":{"Name":"job","Group":"jobGroup"},"FullJobName":"jobGroup.job","IsPreferredNodeAuto":false,"JobDataMap":{},"MisfireInstruction":0,"Priority":5,"HasAdditionalProperties":false}""";
+
+    private static TimeZoneInfo Tokyo => TimeZoneUtil.FindTimeZoneById("Tokyo Standard Time");
+
+    [Test]
+    public void CalendarIntervalTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        CalendarIntervalTriggerImpl trigger = Deserialize<CalendarIntervalTriggerImpl>(LegacyCalendarIntervalTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.RepeatInterval.Should().Be(3, "the rest of the payload has to read as it always did");
+        trigger.RepeatIntervalUnit.Should().Be(IntervalUnit.Hour);
+    }
+
+    [Test]
+    public void RecurrenceTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        RecurrenceTriggerImpl trigger = Deserialize<RecurrenceTriggerImpl>(LegacyRecurrenceTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo);
+        trigger.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR");
+    }
+
+    [Test]
+    public void CronTriggerReadsTheTimeZoneObjectItUsedToBeWrittenWith()
+    {
+        CronTriggerImpl trigger = Deserialize<CronTriggerImpl>(LegacyCronTrigger);
+
+        trigger.TimeZone.Should().Be(Tokyo,
+            "the getter reads through to the expression once one exists, so this is also the assertion that the rebuilt expression carries the zone");
+        trigger.CronExpressionString.Should().Be("0/5 * * * * ?");
+    }
+
+    private static T Deserialize<T>(string json) where T : class
+    {
+        // The default settings, which is what wrote these payloads.
+        JsonObjectSerializer serializer = new JsonObjectSerializer();
+        serializer.Initialize();
+        return serializer.DeSerialize<T>(Encoding.UTF8.GetBytes(json));
+    }
+}
+
+/// <summary>
+/// The converter is attached to typed <see cref="TimeZoneInfo" /> members by
+/// <c>QuartzContractResolver</c>, not registered on the serializer, and this is the difference that
+/// makes: a trigger's <c>TimeZone</c> property is written as its id, while a zone sitting in a job data
+/// map - where the slot is typed <see cref="object" /> - is written exactly as it always was.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Scoping is what keeps that true: a converter on the serializer's list is consulted for a value's
+/// runtime type wherever it appears, so a global one would have written the zone as a bare string and
+/// dropped the <c>$type</c> that the object-typed path carries - changing the shape of every payload
+/// already sitting in a job data column.
+/// </para>
+/// <para>
+/// The written shape is asserted member by member rather than against a captured string, because most
+/// of what Json.NET writes for a zone is the running OS's own text: Windows says
+/// <c>"(UTC+09:00) Osaka, Sapporo, Tokyo"</c> where Linux says
+/// <c>"(UTC+09:00) Japan Standard Time (Tokyo)"</c>, and the standard and daylight names differ with
+/// them. Which members are written differs by target framework too - <c>HasIanaId</c> is .NET 6 and
+/// later. Only <c>$type</c> and <c>Id</c> mean the same thing everywhere, and even the <c>$type</c>
+/// names <c>System.Private.CoreLib</c> on <c>net10.0</c> and <c>mscorlib</c> on <c>net472</c>.
+/// </para>
+/// </remarks>
+public class NewtonsoftJobDataTimeZoneTest
+{
+    [Test]
+    public void AZoneInAJobDataMapIsWrittenAsItAlwaysWas()
+    {
+        JsonObjectSerializer serializer = NewtonsoftTriggerTimeZoneTest.CreateSerializer(registerTriggerConverters: false);
+        TimeZoneInfo tokyo = TimeZoneUtil.FindTimeZoneById("Tokyo Standard Time");
+        JobDataMap map = new JobDataMap();
+        map.Put("zone", tokyo);
+
+        JObject written = JObject.Parse(Encoding.UTF8.GetString(serializer.Serialize(map)));
+        JToken zone = written["zone"];
+
+        zone.Type.Should().Be(JTokenType.Object,
+            "the converter is scoped to typed members, so an object-typed slot is left alone - a global one would have collapsed the zone to a bare string");
+        zone["$type"].Value<string>().Should().StartWith("System.TimeZoneInfo,",
+            "the $type is what every payload already in a job data column carries, and losing it would change the shape of a stored blob");
+        zone["Id"].Value<string>().Should().Be(tokyo.Id,
+            "the id is the one member of a written zone that means the same thing on every platform");
+    }
+
+    [Test]
+    public void ATriggerWritesItsZoneAsTheIdInstead()
+    {
+        JsonObjectSerializer serializer = NewtonsoftTriggerTimeZoneTest.CreateSerializer(registerTriggerConverters: false);
+        TimeZoneInfo tokyo = TimeZoneUtil.FindTimeZoneById("Tokyo Standard Time");
+        CalendarIntervalTriggerImpl trigger = new CalendarIntervalTriggerImpl
+        {
+            Key = new TriggerKey("calendarInterval", "group"),
+            RepeatIntervalUnit = IntervalUnit.Hour,
+            TimeZone = tokyo,
+            StartTimeUtc = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+
+        JObject written = JObject.Parse(Encoding.UTF8.GetString(serializer.Serialize(trigger)));
+        JToken zone = written["TimeZone"];
+
+        zone.Type.Should().Be(JTokenType.String,
+            "a typed member is where the converter applies, so the whole object collapses to one value");
+        zone.Value<string>().Should().Be(tokyo.Id,
+            "the id is the only part of a zone another process can use, and its spelling is the resolving platform's own");
+    }
+
+    /// <summary>
+    /// Reading that job data payload back has never worked: <c>IgnoreSerializableInterface</c> keeps
+    /// Json.NET off <see cref="TimeZoneInfo" />'s <c>ISerializable</c> implementation, and every public
+    /// member it writes instead is read-only, so there is nothing to construct the zone from. Recorded
+    /// here because it is a limitation this change deliberately neither introduces nor repairs - the
+    /// scoping is what proves it unchanged, and a job that needs a zone in its data should store the id.
+    /// </summary>
+    [Test]
+    public void ReadingThatZoneBackHasNeverWorked()
+    {
+        JsonObjectSerializer serializer = NewtonsoftTriggerTimeZoneTest.CreateSerializer(registerTriggerConverters: false);
+        JobDataMap map = new JobDataMap();
+        map.Put("zone", TimeZoneUtil.FindTimeZoneById("Tokyo Standard Time"));
+        byte[] bytes = serializer.Serialize(map);
+
+        Action read = () => serializer.DeSerialize<JobDataMap>(bytes);
+
+        read.Should().Throw<Newtonsoft.Json.JsonSerializationException>(
+            "a TimeZoneInfo has no constructor Json.NET can call, which is why a job data map should hold the id and not the zone");
+    }
+}

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -65,17 +65,6 @@ public class CalendarIntervalTriggerImpl : AbstractTrigger, ICalendarIntervalTri
     private int repeatInterval;
     internal TimeZoneInfo? timeZone;
 
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value == null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
-
     /// <summary>
     /// Create a <see cref="ICalendarIntervalTrigger" /> with no settings.
     /// </summary>

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -185,22 +185,11 @@ public class CronTriggerImpl : AbstractTrigger, ICronTrigger
     private DateTimeOffset? nextFireTimeUtc;
     private DateTimeOffset? previousFireTimeUtc;
 
+    // With binary serialization the time zone does not need serializing, since it is part of the
+    // CronExpression. With JSON serialization the cron expression is written as a string only, so the
+    // zone is written separately - as its id, by TimeZoneInfoConverter with the trigger converters off
+    // and by CronTriggerSerializer with them on.
     [NonSerialized] private TimeZoneInfo? timeZone;
-
-    // With binary serialization, the timeZone doesn't need serialized since it is part of the CronExpression.
-    // With json serialization, however, the cron expression is only serialized as a string (CronExpressionString),
-    // so the TimeZone needs serialized separately.
-    //
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value == null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
 
     /// <summary>
     /// Create a <see cref="CronTriggerImpl" /> with no settings.

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -98,17 +98,6 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
     private int repeatCount = RepeatIndefinitely;
     internal TimeZoneInfo? timeZone;
 
-    // Serializing TimeZones is tricky in .NET Core. This helper will ensure that we get the same timezone on a given platform,
-    // but there's not yet a good method of serializing/deserializing timezones cross-platform since Windows timezone IDs don't
-    // match IANA tz IDs (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). This feature is coming, but depending
-    // on timelines, it may be worth doign the mapping here.
-    // More info: https://github.com/dotnet/corefx/issues/7757
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value == null ? null : TimeZoneInfo.FindSystemTimeZoneById(value);
-    }
-
     /// <summary>
     /// Create a  <see cref="IDailyTimeIntervalTrigger"/> with no settings.
     /// </summary>

--- a/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/RecurrenceTriggerImpl.cs
@@ -32,13 +32,6 @@ public sealed class RecurrenceTriggerImpl : AbstractTrigger, IRecurrenceTrigger
     [NonSerialized]
     private volatile RRule? parsedRule;
 
-    // For binary serialization — uses TimeZoneUtil for cross-platform ID resolution
-    private string? timeZoneInfoId
-    {
-        get => timeZone?.Id;
-        set => timeZone = value == null ? null : TimeZoneUtil.FindTimeZoneById(value);
-    }
-
     /// <summary>
     /// Create a <see cref="RecurrenceTriggerImpl"/> with no settings.
     /// </summary>


### PR DESCRIPTION
The `3.x` companion of #3494. Based on `1ce49f80b2761fc558069a3b605da36210745f2c` (`origin/3.x` at the
time of writing).

Companion of #3494 on 4.x (#3498).

## The fix

`UseNewtonsoftJsonSerializer` leaves `RegisterTriggerConverters` off by default here too, and with it
off a trigger is written property by property. Json.NET's default contract wrote a `TimeZoneInfo` as
its whole public surface — `Id`, `DisplayName`, `BaseUtcOffset`, all read-only — so reading the object
back populated the instance the getter already held and set nothing, and the trigger's getter fell
through to `TimeZoneInfo.Local`. A trigger stored under Tokyo fired on whichever zone the reading
machine was in, silently. Measured on this branch before touching anything:

```
CalendarIntervalTriggerImpl   stored Tokyo Standard Time -> read back FLE Standard Time
RecurrenceTriggerImpl         stored Tokyo Standard Time -> read back FLE Standard Time
CronTriggerImpl               stored Tokyo Standard Time -> read back FLE Standard Time
```

`TimeZoneInfoConverter` (internal, `Quartz.Converters`) writes the id and reads both the id and the
old object form. `QuartzContractResolver` attaches it per property to members *typed* as a
`TimeZoneInfo`; it is deliberately not on the serializer's converter list, because that list is
consulted for a value's runtime type wherever it appears, so a zone held in an `object`-typed slot — a
job data map value — would have been written as a bare string and lost the `$type` that path carries.
Scoped this way it reaches every trigger's `TimeZone` and nothing else.

The four private `timeZoneInfoId` helpers are gone. They were meant for exactly this and never worked,
because `DefaultContractResolver` does not serialize private members. They are *computed* properties
rather than auto-properties, so there is no `<timeZoneInfoId>k__BackingField` to lose and a
`BLOB_TRIGGERS` payload written by `BinaryObjectSerializer` is unaffected — `BinaryFormatter` matches
by field name and there was never a field.

## Differences from #3498

Four of them, three of which that PR predicted and one it could not have.

1. **Four dead helpers, not three** — `RecurrenceTriggerImpl` has one here as well. All four removed.
2. **`CronTriggerImpl` was affected here, and is fixed.** On `main` it escaped, because its zone rides
   along on a serialized `CronExpression`, which has always had a converter. On this branch
   `CronTriggerImpl.CronExpression` is *set-only*, so the plain object graph carries
   `CronExpressionString` alone and a bare cron string has no zone in it. That makes four affected
   trigger types here against three there.
3. **Names and namespaces** — `Quartz.Serialization.Json` rather than `Quartz.Serialization.Newtonsoft`;
   `JsonObjectSerializer` rather than `NewtonsoftJsonObjectSerializer`; the converter lands in
   `Quartz.Converters`; `TimeZoneUtil.FindTimeZoneById` rather than `TimeZones.FindById`; the exception
   is `Newtonsoft.Json.JsonSerializationException`, since `Quartz.JsonSerializationException` lives in
   `Quartz.Serialization.SystemTextJson` and this package does not reference it.
4. **`3.x` source files are mixed on the BOM**, not uniformly BOM'd as #3498's note said. The two files
   this branch adds are neighbours of `QuartzContractResolver.cs` and the other converters, none of
   which carry one, so the new files do not either. Nothing on this branch checks; `main`'s
   `SourceEncodingTest` has no counterpart here.

The `JsonObjectSerializerTest_*.verified.txt` snapshots did not move, as predicted — they are all
taken with `RegisterTriggerConverters = true`, so they were already the id form.

The #3495 `System.Text.Json` half of #3498 is not ported; it does not apply here.

## Fixture provenance

The payloads in `NewtonsoftLegacyTimeZonePayloadTest` are verbatim output of `JsonObjectSerializer`
with its default settings at `1ce49f80b`, serializing triggers whose zone was `Tokyo Standard Time`.
They were dumped to disk by a throwaway test on the unmodified base tree, before the converter existed,
and pasted in unedited — Windows display names and all. "It still reads" is therefore a fact about
those bytes rather than a reconstruction of what they probably were. Only `Id` is ever read, which is
precisely why the rest of the object was worthless.

Nothing in those three literals carries a framework-qualified `$type`, so they read identically on
`net472` and `net10.0`. Where a written payload *is* compared, the assertions parse the JSON and touch
only what means the same thing on every OS and target framework — that the slot is an object rather
than a bare string, that `$type` starts with `System.TimeZoneInfo,`, and that `Id` matches the zone the
test itself resolved. Nothing reads `DisplayName`, `StandardName`, `DaylightName` or `BaseUtcOffset`:
those are the running OS's own text, and `HasIanaId` is not even written on `net472`.

## What the tests prove

`NewtonsoftTriggerTimeZoneTest`, `NewtonsoftLegacyTimeZonePayloadTest` and
`NewtonsoftJobDataTimeZoneTest`, 16 tests in one file. **Eight of them fail on the unfixed tree** — the
three affected triggers' converters-off round trips, the daily trigger's converters-off write, the
three legacy reads, and the "a trigger writes its zone as the id" contrast case. The other eight pin
behaviour the change must *not* move, and pass either way.

## A reviewer decision: `DailyTimeIntervalTriggerImpl` cannot be read back at all with the converters off

Found while writing the tests the brief asked for, and **not** fixed here.

```
Newtonsoft.Json.JsonSerializationException: Unable to find a constructor to use for type
Quartz.TimeOfDay. A class should either have a default constructor, one constructor with
arguments or a constructor marked with the JsonConstructor attribute. Path 'EndTimeOfDay.Hour'
```

`TimeOfDay` has two public constructors and no parameterless one, and `EndTimeOfDay`'s getter hands
back `null` before anything is set, so Json.NET has to construct one and cannot. `StartTimeOfDay` is
the silent half of the same thing — its getter defaults to `00:00:00` for Json.NET to populate, and
every member of a `TimeOfDay` is read-only, so it comes back as midnight.

This is the same *family* of defect as #3494 — a read-only object graph — but it is not the time zone,
it predates this branch, and repairing it needs a converter of its own (attached per property in the
same place, for exactly the same `object`-slot reason). It fails loudly rather than silently, and the
ADO store reaches this path only for a trigger it serializes as a blob, so a shipped
`DailyTimeIntervalTrigger` does not go through it. I have recorded it as
`ReadingADailyTimeIntervalTriggerAsAPlainObjectGraphFailsOnItsTimeOfDay`, with the reason string saying
which member the read dies on, and asserted the daily trigger's zone on the **write** side, where this
fix is observable. Say the word and it becomes either its own issue or a second commit here.

## Verification

Run on Windows against a live Docker daemon (29.5.3).

| | |
|---|---|
| `dotnet build Quartz.slnx` | Build succeeded, **0 Warning(s), 0 Error(s)** |
| `dotnet test src/Quartz.Tests.Unit` `-f net10.0` | **Failed: 0, Passed: 1859, Skipped: 4, Total: 1863** |
| `dotnet test src/Quartz.Tests.Unit` `-f net472` | **Failed: 0, Passed: 1848, Skipped: 5, Total: 1853** |
| `dotnet test src/Quartz.Tests.AspNetCore` | **Failed: 0, Passed: 122** |
| integration, `postgres` leg | **Failed: 0, Passed: 54** (`AdoSchedulerTest` runs both serializers) |
| integration, `sqlite` leg | **Failed: 0, Passed: 15** |
| integration, `basic` leg | **Failed: 0, Passed: 25** |
| the 16 new tests, unfixed tree | **Failed: 8**, which is the point of them |

The public API baselines did not move — `PublicApiTest` rides along in the `net10.0` unit run above and
is green. The converter is `internal`, the resolver is `internal`, and the four removed members were
`private`.

On the brief's "`basic` leg that exercises Newtonsoft against SQLite": there is no such leg here.
`basic` is defined in `build/Build.cs` as *every* database category excluded, SQLite among them, and
`AdoSchedulerTest` — the only integration fixture parameterised on `JsonObjectSerializer` — is
registered for SQL Server and Postgres only. I ran `postgres` for the serializer coverage and `sqlite`
and `basic` besides, all three green.

No release-notes line: `3.x` notes live on the GitHub release.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BkLsBbZGK3h4VWiWKEwWL
