### PR TITLE
A job listener that throws synchronously loses its firing, not the schedule

### DIFF
--- a/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
@@ -1,0 +1,359 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Core;
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What a job listener's failure costs the firing it failed on, and what it must not cost anybody else.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A listener can fail in either of two shapes, and until #3502 they were not handled alike. An
+/// <c>async</c> listener hands back a faulted task; a listener whose guard clause throws before it
+/// returns anything fails while the scheduler is still evaluating the call. Only the first was wrapped
+/// in the exception <see cref="JobRunShell" /> catches, so the second escaped the run shell entirely and
+/// the firing was never handed back to the store — leaving a job that forbids concurrent execution
+/// blocked behind a firing that had already been abandoned. Every case here therefore runs twice, once
+/// per shape, and the two shapes must be indistinguishable.
+/// </para>
+/// <para>
+/// The scheduler's own record of what is executing rides along with the same fault: it used to be kept
+/// by the listener loop, so a listener that stopped the loop stopped the bookkeeping too and left the
+/// firing listed as executing for as long as the process lived.
+/// </para>
+/// <para>
+/// Nothing here waits for a length of time or measures one. The store records a firing after it has
+/// acted on it, so a test that waits for a record and then asks a question is asking a store that has
+/// already settled.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public sealed class JobListenerFailureTest
+{
+    private const string Group = "job-listener-failure";
+
+    /// <summary>
+    /// How long a test is willing to wait for a firing to reach the store before declaring the
+    /// scheduler stuck. Long enough that a loaded build agent never trips it, and never used as a
+    /// measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The two ways a listener can fail, which the scheduler has to treat as one.
+    /// </summary>
+    public enum FailureShape
+    {
+        /// <summary>Throws before handing anything back, as a guard clause in a method that is not <c>async</c> does.</summary>
+        Synchronous,
+
+        /// <summary>Hands back a faulted task, as an <c>async</c> method does.</summary>
+        Asynchronous,
+    }
+
+    /// <summary>
+    /// Which side of the job the listener fails on.
+    /// </summary>
+    public enum FailureSide
+    {
+        /// <summary><see cref="IJobListener.JobToBeExecuted" />, which stops the job running.</summary>
+        BeforeTheJob,
+
+        /// <summary><see cref="IJobListener.JobWasExecuted" />, which is too late to stop anything.</summary>
+        AfterTheJob,
+    }
+
+    /// <summary>
+    /// The wedge #3502 reported: the firing is abandoned, and the job's other trigger has to be let go
+    /// of anyway — which only happens if the abandoned firing is completed at the store.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous)]
+    [TestCase(FailureShape.Asynchronous)]
+    public async Task AListenerFailingBeforeTheJobStillCompletesTheFiringAndLetsTheSiblingTriggerFire(FailureShape shape)
+    {
+        TriggerKey wedgedKey = new TriggerKey("wedged", Group);
+        CallLog<TriggerKey> runs = new();
+
+        // Fails only for the first trigger's firing, so that the second one running the job is the
+        // scheduler carrying on rather than this listener having lost interest.
+        FailingJobListener listener = new(shape, FailureSide.BeforeTheJob, context => context.Trigger.Key.Equals(wedgedKey));
+
+        (IScheduler scheduler, CompletionRecordingJobStore store) = await BuildScheduler($"listener-wedge-{shape}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            // Two triggers of one job that forbids concurrent execution, both already due and the
+            // wedged one due first. Committing its firing blocks the sibling, and completing that
+            // firing is the only thing that lets the sibling go again.
+            DateTimeOffset due = DateTimeOffset.UtcNow;
+
+            ITrigger wedged = Repeating(wedgedKey, job, due);
+            ITrigger sibling = Repeating(new TriggerKey("sibling", Group), job, due.AddMilliseconds(1));
+
+            await scheduler.ScheduleJob(job, [wedged, sibling]);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "a firing a listener abandoned still has to be reported to the store, or the trigger is never "
+                + "handed back and every trigger of a job that forbids concurrent execution stays blocked behind it");
+
+            store.Completions.Entries[0].Should().Be(
+                new CompletedFiring(wedgedKey, job.Key, SchedulerInstruction.NoInstruction),
+                "a firing that never happened settles nothing about the schedule");
+
+            store.Releases.Entries.Should().BeEmpty(
+                "the firing was already committed, so it is completed rather than released - releasing does "
+                + "not unblock the job's other triggers");
+
+            await ShouldObserve(store.Completions.Reaches(2),
+                "the sibling was blocked by a firing that has now been completed, so it is free to fire");
+
+            store.Completions.Entries[1].Should().Be(
+                new CompletedFiring(sibling.Key, job.Key, SchedulerInstruction.NoInstruction),
+                "the sibling's own firing is an ordinary one");
+
+            runs.Entries.Should().Equal([sibling.Key],
+                "the job ran exactly once, for the trigger whose firing no listener stopped - which is what "
+                + "says the wedged firing neither ran the job nor kept the job to itself");
+
+            (await scheduler.GetTriggerState(wedgedKey)).Should().Be(TriggerState.Normal,
+                "the wedged trigger has firings ahead of it, and a failed listener does not take them away");
+            (await scheduler.GetTriggerState(sibling.Key)).Should().Be(TriggerState.Normal,
+                "a trigger that has fired and finished is waiting for its next turn, not blocked");
+
+            ExecutingJobs(scheduler).Should().BeEmpty(
+                "both firings are over, so nothing is executing");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// The phantom entry #3502 reported: the scheduler's record of what it is running is its own, and a
+    /// user listener cannot be what keeps it honest.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Synchronous, FailureSide.AfterTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.AfterTheJob)]
+    public async Task AFailedListenerLeavesNothingListedAsExecuting(FailureShape shape, FailureSide side)
+    {
+        CallLog<TriggerKey> runs = new();
+        FailingJobListener listener = new(shape, side, _ => true);
+
+        (IScheduler scheduler, CompletionRecordingJobStore store) = await BuildScheduler($"listener-phantom-{shape}-{side}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            TriggerKey triggerKey = new TriggerKey("once", Group);
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the firing has to be over before what is executing means anything");
+
+            runs.Entries.Should().HaveCount(side == FailureSide.BeforeTheJob ? 0 : 1,
+                "a listener that fails on the way in stops the job running, and one that fails afterwards is too late to");
+
+            ExecutingJobs(scheduler).Should().BeEmpty(
+                "the firing is over, and an operator reading the list of executing jobs must not be shown one "
+                + "that a listener's failure stranded there");
+
+            (await scheduler.GetMetadata()).LocalExecutingJobs.Should().Be(0,
+                "the count the metadata reports is the same record, and it is what a dashboard shows");
+
+            (await scheduler.GetMetadata()).JobsExecuted.Should().Be(1,
+                "the firing was dispatched, which is what this counts - a listener stopping it does not unfire it");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// A scheduler whose in-memory store records every firing it is handed back.
+    /// </summary>
+    private static async Task<(IScheduler Scheduler, CompletionRecordingJobStore Store)> BuildScheduler(string instanceName)
+    {
+        CompletionRecordingJobStore store = null;
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = instanceName)
+            .UseJobStore(provider =>
+            {
+                store = new CompletionRecordingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                return store;
+            })
+            .BuildScheduler();
+
+        return (scheduler, store);
+    }
+
+    private static ITrigger Repeating(TriggerKey key, IJobDetail job, DateTimeOffset startAt)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(key)
+            .ForJob(job)
+            .StartAt(startAt)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+    }
+
+    /// <summary>
+    /// The firings the scheduler is running, which is what an operator is shown.
+    /// </summary>
+    private static List<IJobExecutionContext> ExecutingJobs(IScheduler scheduler)
+    {
+        return ((StdScheduler) scheduler).scheduler.GetCurrentlyExecutingJobs();
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// A job that records which trigger fired it, through a log handed to it in its data map so that
+    /// nothing here is static.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentRecordingJob : IJob
+    {
+        public const string RunLogKey = "run log";
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((CallLog<TriggerKey>) context.MergedJobDataMap[RunLogKey]).Record(context.Trigger.Key);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Fails on one side of the job, in whichever of the two shapes it was built for, for the firings it
+    /// was told to fail for and no others.
+    /// </summary>
+    private sealed class FailingJobListener : IJobListener
+    {
+        private readonly FailureShape shape;
+        private readonly FailureSide side;
+        private readonly Func<IJobExecutionContext, bool> failFor;
+
+        public FailingJobListener(FailureShape shape, FailureSide side, Func<IJobExecutionContext, bool> failFor)
+        {
+            this.shape = shape;
+            this.side = side;
+            this.failFor = failFor;
+        }
+
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return side == FailureSide.BeforeTheJob && failFor(context)
+                ? Fail("the listener could not prepare for this job")
+                : default;
+        }
+
+        public ValueTask JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            return side == FailureSide.AfterTheJob && failFor(context)
+                ? Fail("the listener could not record this job")
+                : default;
+        }
+
+        private ValueTask Fail(string message)
+        {
+            if (shape == FailureShape.Synchronous)
+            {
+                // What a guard clause in a method that is not async does: the caller is handed an
+                // exception where it expected a ValueTask, before there is anything to await.
+                throw new InvalidOperationException(message);
+            }
+
+            // What an async method does: the exception arrives in the task the caller was handed.
+            return ValueTask.FromException(new InvalidOperationException(message));
+        }
+    }
+
+    /// <summary>
+    /// Records each firing the scheduler handed back, after the real store has acted on it — so a test
+    /// that waits for a record and then asks the store a question is asking a store that has settled.
+    /// </summary>
+    private sealed class CompletionRecordingJobStore : DelegatingJobStore
+    {
+        public CompletionRecordingJobStore(IJobStore jobStore) : base(jobStore)
+        {
+        }
+
+        /// <summary>The completions the scheduler reported, instruction included.</summary>
+        public CallLog<CompletedFiring> Completions { get; } = new();
+
+        /// <summary>The triggers handed back through <see cref="ReleaseAcquiredTrigger" />.</summary>
+        public CallLog<TriggerKey> Releases { get; } = new();
+
+        public override async ValueTask TriggeredJobComplete(
+            IOperableTrigger trigger,
+            IJobDetail jobDetail,
+            SchedulerInstruction triggerInstructionCode,
+            CancellationToken cancellationToken = default)
+        {
+            await base.TriggeredJobComplete(trigger, jobDetail, triggerInstructionCode, cancellationToken).ConfigureAwait(false);
+            Completions.Record(new CompletedFiring(trigger.Key, jobDetail.Key, triggerInstructionCode));
+        }
+
+        public override async ValueTask ReleaseAcquiredTrigger(IOperableTrigger trigger, CancellationToken cancellationToken = default)
+        {
+            await base.ReleaseAcquiredTrigger(trigger, cancellationToken).ConfigureAwait(false);
+            Releases.Record(trigger.Key);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
@@ -219,6 +219,54 @@ public sealed class JobListenerFailureTest
     }
 
     /// <summary>
+    /// A trigger with nothing left to fire is finished whether its last firing ran or a listener
+    /// abandoned it, and the scheduler listeners hear so either way.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Synchronous, FailureSide.AfterTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.AfterTheJob)]
+    public async Task AFailedListenerDoesNotSwallowTheTriggersFinalizedNotification(FailureShape shape, FailureSide side)
+    {
+        CallLog<TriggerKey> runs = new();
+        FailingJobListener listener = new(shape, side, _ => true);
+        FinalizedRecordingSchedulerListener finalized = new();
+
+        (IScheduler scheduler, _) = await BuildScheduler($"listener-finalized-{shape}-{side}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+            scheduler.ListenerManager.AddSchedulerListener(finalized);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            TriggerKey triggerKey = new TriggerKey("once", Group);
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            await ShouldObserve(finalized.Finalized.Reaches(1),
+                "the trigger had one firing in it and it is spent, so the scheduler listeners have to be told "
+                + "it will never fire again - the listener's failure is not theirs to inherit");
+
+            finalized.Finalized.Entries.Should().Equal([triggerKey]);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
     /// A scheduler whose in-memory store records every firing it is handed back.
     /// </summary>
     private static async Task<(IScheduler Scheduler, CompletionRecordingJobStore Store)> BuildScheduler(string instanceName)
@@ -321,6 +369,17 @@ public sealed class JobListenerFailureTest
 
             // What an async method does: the exception arrives in the task the caller was handed.
             return ValueTask.FromException(new InvalidOperationException(message));
+        }
+    }
+
+    private sealed class FinalizedRecordingSchedulerListener : ISchedulerListener
+    {
+        public CallLog<TriggerKey> Finalized { get; } = new();
+
+        public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            Finalized.Record(trigger.Key);
+            return default;
         }
     }
 

--- a/src/Quartz/Core/ExecutingJobsManager.cs
+++ b/src/Quartz/Core/ExecutingJobsManager.cs
@@ -6,8 +6,18 @@ using Quartz.Extensibility;
 namespace Quartz.Core;
 
 /// <summary>
-/// ExecutingJobsManager - Job Listener Class.
+/// The scheduler's own record of the firings it is running: what
+/// <see cref="QuartzScheduler.GetCurrentlyExecutingJobs" /> lists and
+/// <see cref="QuartzScheduler.NumberOfJobsExecutingHere" /> counts.
 /// </summary>
+/// <remarks>
+/// It is the scheduler's built-in job listener, and it is told about the same two moments a user
+/// listener is — but directly, rather than through the loop that notifies them. A user listener that
+/// throws abandons that loop, and bookkeeping carried along with it would leave a firing listed as
+/// executing for as long as the process lived (#3502). <see cref="FiringStarted" /> and
+/// <see cref="FiringEnded" /> are the members the scheduler calls, and they are synchronous because
+/// there has never been anything in them to await.
+/// </remarks>
 internal sealed class ExecutingJobsManager : IJobListener
 {
     private readonly ConcurrentDictionary<string, IJobExecutionContext> executingJobs = new ConcurrentDictionary<string, IJobExecutionContext>();
@@ -65,12 +75,33 @@ internal sealed class ExecutingJobsManager : IJobListener
         return executingJobs.TryGetValue(fireInstanceId, out context);
     }
 
+    /// <summary>
+    /// Records that a firing has begun. It is listed as executing, and counted as fired, until
+    /// <see cref="FiringEnded" /> is called for it.
+    /// </summary>
+    public void FiringStarted(IJobExecutionContext context)
+    {
+        Interlocked.Increment(ref numJobsFired);
+        executingJobs[((IOperableTrigger) context.Trigger).FireInstanceId] = context;
+    }
+
+    /// <summary>
+    /// Records that a firing is over, whether the job ran or a listener stopped it on the way in.
+    /// </summary>
+    /// <remarks>
+    /// The count of jobs fired is deliberately not taken back: it counts the firings this scheduler
+    /// dispatched, which a firing a listener then abandoned still is.
+    /// </remarks>
+    public void FiringEnded(IJobExecutionContext context)
+    {
+        executingJobs.TryRemove(((IOperableTrigger) context.Trigger).FireInstanceId, out _);
+    }
+
     public ValueTask JobToBeExecuted(
         IJobExecutionContext context,
         CancellationToken cancellationToken = default)
     {
-        Interlocked.Increment(ref numJobsFired);
-        executingJobs[((IOperableTrigger) context.Trigger).FireInstanceId] = context;
+        FiringStarted(context);
         return default;
     }
 
@@ -78,7 +109,7 @@ internal sealed class ExecutingJobsManager : IJobListener
         JobExecutionException? jobException,
         CancellationToken cancellationToken = default)
     {
-        executingJobs.TryRemove(((IOperableTrigger) context.Trigger).FireInstanceId, out _);
+        FiringEnded(context);
         return default;
     }
 

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -181,6 +181,7 @@ internal sealed class JobRunShell
                 {
                     if (!await NotifyListenersBeginning(context, cancellationToken).ConfigureAwait(false))
                     {
+                        await NotifyFinalizedIfDone(qs, context, cancellationToken).ConfigureAwait(false);
                         await qs.NotifyJobStoreJobComplete(trigger, jobDetail, SchedulerInstruction.NoInstruction, cancellationToken).ConfigureAwait(false);
                         break;
                     }
@@ -290,6 +291,7 @@ internal sealed class JobRunShell
                 // notify all job listeners
                 if (!await NotifyJobListenersComplete(qs, context, jobExEx, cancellationToken).ConfigureAwait(false))
                 {
+                    await NotifyFinalizedIfDone(qs, context, cancellationToken).ConfigureAwait(false);
                     await qs.NotifyJobStoreJobComplete(trigger, jobDetail, instructionCode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
@@ -297,23 +299,7 @@ internal sealed class JobRunShell
                 // notify all trigger listeners
                 if (!await NotifyTriggerListenersComplete(qs, context, instructionCode, cancellationToken).ConfigureAwait(false))
                 {
-                    // Ensure finalized notification is still sent when the trigger has no next fire time,
-                    // even if trigger listener notification failed.
-                    try
-                    {
-                        if (!trigger.MayFireAgain)
-                        {
-                            await qs.NotifySchedulerListenersFinalized(context.Trigger, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        SchedulerException se2 = new SchedulerException("Error notifying scheduler listeners of finalized trigger.", e);
-                        await qs.NotifySchedulerListenersError(
-                            ErrorFor(context, "Error notifying scheduler listeners of finalized trigger.", se2),
-                            cancellationToken).ConfigureAwait(false);
-                    }
-
+                    await NotifyFinalizedIfDone(qs, context, cancellationToken).ConfigureAwait(false);
                     await qs.NotifyJobStoreJobComplete(trigger, jobDetail, instructionCode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
@@ -492,6 +478,39 @@ internal sealed class JobRunShell
             string msg = $"Unable to notify TriggerListener(s) of Job that was executed: (error will be ignored). trigger= {ctx.Trigger.Key} job= {ctx.JobDetail.Key}";
             await qs.NotifySchedulerListenersError(ErrorFor(ctx, msg, se), cancellationToken).ConfigureAwait(false);
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Announces that the trigger has fired for the last time, when it has.
+    /// </summary>
+    /// <remarks>
+    /// Every way out of a firing has to do this, the ones a failed listener cut short included: a
+    /// trigger whose last firing was abandoned is as finished as one whose last firing ran, and a
+    /// scheduler listener told only about the tidy paths would go on believing the trigger is still
+    /// there. The veto path says it in its own words, because the message it reports a failure with
+    /// names the veto.
+    /// </remarks>
+    private static async ValueTask NotifyFinalizedIfDone(
+        QuartzScheduler qs,
+        JobExecutionContextImpl ctx,
+        CancellationToken cancellationToken)
+    {
+        if (ctx.Trigger.MayFireAgain)
+        {
+            return;
+        }
+
+        try
+        {
+            await qs.NotifySchedulerListenersFinalized(ctx.Trigger, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            SchedulerException se = new SchedulerException("Error notifying scheduler listeners of finalized trigger.", e);
+            await qs.NotifySchedulerListenersError(
+                ErrorFor(ctx, "Error notifying scheduler listeners of finalized trigger.", se),
+                cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -2031,10 +2031,39 @@ internal sealed class QuartzScheduler
         IJobExecutionContext context,
         CancellationToken cancellationToken = default)
     {
-        return NotifyJobListeners(static (jl, context, jobExecutionException, cancellationToken) => jl.JobToBeExecuted(context, cancellationToken),
+        // The scheduler's own record of the firing is kept outside the listener loop below, because a
+        // listener that throws abandons that loop. JobRunShell then completes the firing without the
+        // job having run and without anyone being told it was executed, so a record kept inside the
+        // loop would list the firing as executing for as long as the process lived (#3502).
+        jobMgr.FiringStarted(context);
+
+        ValueTask notification = NotifyJobListeners(
+            static (jl, context, jobExecutionException, cancellationToken) => jl.JobToBeExecuted(context, cancellationToken),
             context,
             null,
             cancellationToken);
+
+        return notification.IsCompletedSuccessfully
+            ? default
+            : EndFiringIfNotificationFails(notification, jobMgr, context);
+
+        static async ValueTask EndFiringIfNotificationFails(
+            ValueTask notification,
+            ExecutingJobsManager jobMgr,
+            IJobExecutionContext context)
+        {
+            try
+            {
+                await notification.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Nothing further will be notified for this firing, so this is the only place the
+                // record of it can be taken back out.
+                jobMgr.FiringEnded(context);
+                throw;
+            }
+        }
     }
 
     /// <summary>
@@ -2063,6 +2092,11 @@ internal sealed class QuartzScheduler
         JobExecutionException? jobExecutionException,
         CancellationToken cancellationToken = default)
     {
+        // Taken out of the record before the listeners are told, and not by one of them: a listener
+        // that throws here must not leave the firing showing as executing (#3502). It is also what
+        // ShutdownDrainTest pins — the count drops before the job store update the firing ends with.
+        jobMgr.FiringEnded(context);
+
         return NotifyJobListeners(static (jl, context, jobExecutionException, cancellationToken) => jl.JobWasExecuted(context, jobExecutionException, cancellationToken),
             context,
             jobExecutionException,
@@ -2079,42 +2113,18 @@ internal sealed class QuartzScheduler
         var listeners = ListenerManager.GetJobListeners();
         if (listeners.Count == 0)
         {
-            return NotifyExecutingJobManager(notifyAction, context, jobExecutionException, cancellationToken, jobMgr);
+            return default;
         }
 
-        return NotifyAllJobListeners(ListenerManager, jobMgr, listeners, notifyAction, context, jobExecutionException, cancellationToken);
-
-        static ValueTask NotifyExecutingJobManager(Func<IJobListener, IJobExecutionContext, JobExecutionException?, CancellationToken, ValueTask> notifyAction,
-            IJobExecutionContext context,
-            JobExecutionException? jobExecutionException,
-            CancellationToken cancellationToken,
-            ExecutingJobsManager jobsManager)
-        {
-            var task = notifyAction(jobsManager, context, jobExecutionException, cancellationToken);
-            return task.IsCompletedSuccessfully ? default : NotifySingle(task, jobsManager, context);
-        }
-
-        static ValueTask NotifyAllJobListeners(IListenerManager listenerManager,
-            ExecutingJobsManager jobManager,
-            IReadOnlyList<IJobListener> listeners,
-            Func<IJobListener, IJobExecutionContext, JobExecutionException?, CancellationToken, ValueTask> notifyAction,
-            IJobExecutionContext context,
-            JobExecutionException? jobExecutionException,
-            CancellationToken cancellationToken)
-        {
-            return NotifyAwaited(listenerManager, jobManager, listeners, notifyAction, context, jobExecutionException, cancellationToken);
-        }
+        return NotifyAwaited(ListenerManager, listeners, notifyAction, context, jobExecutionException, cancellationToken);
 
         static async ValueTask NotifyAwaited(IListenerManager listenerManager,
-            ExecutingJobsManager jobManager,
             IReadOnlyList<IJobListener> listeners,
             Func<IJobListener, IJobExecutionContext, JobExecutionException?, CancellationToken, ValueTask> notifyAction,
             IJobExecutionContext context,
             JobExecutionException? jobExecutionException,
             CancellationToken cancellationToken)
         {
-            await NotifySingle(notifyAction(jobManager, context, jobExecutionException, cancellationToken), jobManager, context).ConfigureAwait(false);
-
             foreach (var jl in listeners)
             {
                 if (!MatchJobListener(listenerManager, jl, context.JobDetail.Key))
@@ -2122,19 +2132,19 @@ internal sealed class QuartzScheduler
                     continue;
                 }
 
-                await NotifySingle(notifyAction(jl, context, jobExecutionException, cancellationToken), jl, context).ConfigureAwait(false);
-            }
-        }
-
-        static async ValueTask NotifySingle(ValueTask t, IJobListener jl, IJobExecutionContext context)
-        {
-            try
-            {
-                await t.ConfigureAwait(false);
-            }
-            catch (Exception e)
-            {
-                throw new JobExecutionProcessException(jl, context, e);
+                // The call to the listener is inside the guard, not an argument to it, so a listener
+                // that throws before it hands anything back — a guard clause in a method that is not
+                // async — is wrapped in the same exception as one that hands back a faulted task.
+                // JobRunShell catches SchedulerException, and a raw exception escaping it left the
+                // firing stranded and the job's other triggers blocked behind it (#3502).
+                try
+                {
+                    await notifyAction(jl, context, jobExecutionException, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new JobExecutionProcessException(jl, context, e);
+                }
             }
         }
     }


### PR DESCRIPTION
A job listener whose guard clause throws — before it hands back a `ValueTask`, which
is what a method that is not `async` does — used to wedge the firing it threw on.
`QuartzScheduler.NotifyJobListeners` evaluated the listener call as an *argument* to
the guarded region, so the exception escaped as itself rather than as the
`JobExecutionProcessException` that `JobRunShell` catches. The run shell never reached
`TriggeredJobComplete`: the trigger stayed acquired and, for a
`[DisallowConcurrentExecution]` job, every sibling trigger stayed blocked behind a
firing that had already been abandoned — permanently.

Closes #3502. Found live by #3501's listener tests, which deliberately used only the
asynchronous shape and reported the synchronous hole rather than papering over it.

### 1. The call is evaluated inside the guard

`NotifyJobListeners` now calls the listener inside the `try` in its notification loop,
so a synchronous throw is wrapped exactly as a faulted task is, and the firing settles
the way an asynchronous failure already did — completed at the store with
`SchedulerInstruction.NoInstruction`.

Two notes for a reviewer:

- The issue says the run shell "completes the firing with `SetAllJobTriggersError` as
  it does for any other listener failure". That is not what the tree does and not what
  #3501's merged-soon test asserts: the begin-notification abort path completes with
  `NoInstruction`, because a firing that never happened settles nothing about the
  schedule. This PR makes the synchronous shape match the asynchronous one, which is
  what the sentence before it asks for; it does not change the instruction.
- The private `NotifySingle` local function is gone rather than being given the
  `notifyAction` to invoke. The loop that called it was already an `async` method, so
  the guard is a plain `try`/`catch` around the `await` — the same shape the trigger
  listener notifications a few lines up already have. That also drops one state machine
  allocation per listener per notification, since `await NotifySingle(...)` allocated
  one every time.

### 2. The scheduler's bookkeeping left the user-listener loop

**Chosen: notify `ExecutingJobsManager` outside the loop, on both ends** — the first of
the two options the issue offers.

The manager used to be notified as the first entry of the same loop, so a user listener
that stopped the loop stopped the bookkeeping with it: `JobWasExecuted` never ran for
anyone, nothing removed the entry, and `NumberOfJobsExecutingHere` read 1 after the
store had already been told the firing was over. That is the phantom an operator sees
in the dashboard's "currently executing".

`NotifyJobListenersToBeExecuted` now records the firing before the loop and takes the
record back if the loop fails; `NotifyJobListenersWasExecuted` removes it before the
loop. The manager keeps `IJobListener` — it is still the scheduler's built-in job
listener — but the two members that do the recording are synchronous, because there
was never anything in them to await.

Why not the second option (deliver `JobWasExecuted`, with the failure, to every
listener that received `JobToBeExecuted`): it changes what user listeners observe. A
listener would start seeing a `JobWasExecuted` for a job that never ran, on a firing
another listener aborted, and `JobChainingJobListener` and anything else that treats
that call as "the job finished" would act on it. The bookkeeping fix needs none of
that, and it keeps the manager's count honest by construction rather than by every
listener behaving.

`NumberOfJobsExecuted` is deliberately *not* taken back on the failure path: it counts
the firings this scheduler dispatched, and a firing a listener abandoned is still one
of those.

### 3. `NotifySchedulerListenersFinalized` across the abort paths

It reached the scheduler listeners from the veto path and from the
trigger-listener-completion path, but from neither of the paths a job listener's
failure takes. A trigger with one firing left in it was therefore spent in silence: the
run shell completed the firing, the store dropped the trigger, and a listener watching
for the end of a schedule never heard. The three abort paths now share one member,
which is the block the trigger-listener path already carried — the veto path keeps its
own wording, because the error it reports when the announcement itself fails names the
veto.

### Tests

`src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs`, ten cases, every one run in
both failure shapes so the two cannot drift apart again. They sit beside #3501's
`ThrowingJobListenerTest` and `VetoedFiringTest` and overlap none of their assertions:
those pin what the store is told and what the scheduler listeners are told, these pin
that the schedule keeps moving.

- a synchronously throwing `JobToBeExecuted` on a `[DisallowConcurrentExecution]` job
  with two due triggers: the firing is completed with `NoInstruction`, never released,
  and the sibling trigger goes on to fire and run the job — the job runs exactly once,
  for the trigger no listener stopped;
- nothing is left listed as executing, and `LocalExecutingJobs` reads 0, after a
  failure on either side of the job;
- the trigger's finalized notification survives a failure on either side.

**Failing first, verified**: with the two product commits reverted and restored
byte-for-byte (`git hash-object` checked before and after), 9 of the 10 cases fail —
six by timing out at the 30s deadline waiting for a firing that never reaches the
store, three on the phantom entry. The tenth,
`AFailedListenerLeavesNothingListedAsExecuting(Asynchronous, AfterTheJob)`, passes on
the unfixed tree: that is the one arrangement that already worked, and it is here as a
regression pin.

Nothing waits for a length of time or measures one. The store double records a firing
*after* the real store has acted on it, so a test that waits for a record and then asks
a question is asking a store that has already settled.

### Verification

```
dotnet build Quartz.slnx                      Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit             Passed! Failed: 0, Passed: 3609, Skipped: 4 (run twice)
dotnet test src/Quartz.Tests.AspNetCore       Passed! Failed: 0, Passed: 547
integration, 'basic' leg                      Passed! Failed: 0, Passed: 329
```

No public API moves; the baselines are untouched and `PublicApiTest` is green.
