### PR TITLE
The trigger indexes are measured, and neither candidate earns its place

### DIFF
--- a/docs/documentation/quartz-4.x/db/index.md
+++ b/docs/documentation/quartz-4.x/db/index.md
@@ -84,3 +84,55 @@ trigger that does not exist. The stored states map onto it: `WAITING` and `ACQUI
 `PAUSED_BLOCKED` reads as `Paused`, and `DELETED` reads as `None`. A trigger whose job is running reads as
 `Executing`, unless the row says it is deleted, in error or paused — those are reported as they stand.
 `TriggerStateResolver.Resolve` is that mapping, should you need it in code of your own.
+
+### Indexes, and the two columns that have none
+
+Four indexes ship on `QRTZ_TRIGGERS`, five on SQL Server, MySQL, Oracle and Firebird. Three are lookups
+by key — `(SCHED_NAME, JOB_NAME, JOB_GROUP)`, `(SCHED_NAME, TRIGGER_GROUP, TRIGGER_NAME)` and
+`(SCHED_NAME, CALENDAR_NAME)`. The fourth, `IDX_QRTZ_T_NFT_ST` over
+`(SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME)`, is the one acquisition runs on. The fifth,
+`IDX_QRTZ_T_NFT_ST_MISFIRE`, serves the misfire sweep; PostgreSQL and SQLite omit it because
+`IDX_QRTZ_T_NFT_ST` already covers that predicate.
+
+Two columns the scheduler reads on hot paths are in none of them: `PRIORITY`, the acquisition
+statement's second `ORDER BY` key, and `PREFERRED_NODE`, which node affinity filters and re-pins on.
+Whether either is worth covering was measured on PostgreSQL 15, SQL Server 2022 and MySQL 8.0 against
+100,000 triggers ([#3426](https://github.com/quartznet/quartznet/issues/3426)); the harness is
+[`AcquisitionIndexBenchmark`](https://github.com/quartznet/quartznet/blob/main/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs),
+which prints the plans again on demand. **The schema is unchanged as a result, and these are the numbers
+that say why.**
+
+**Appending `PRIORITY` to the acquisition index changes nothing.** The plan comes back operator for
+operator on all three engines — PostgreSQL still runs its incremental sort, SQL Server still reads 4,319
+pages of `QRTZ_TRIGGERS`, MySQL still sorts 5,000 rows — because the statement orders by
+`NEXT_FIRE_TIME ASC, PRIORITY DESC`, and an ascending trailing column cannot deliver two directions. The
+obvious index costs four bytes an entry and buys nothing.
+
+**Declaring that column `PRIORITY DESC` is a different matter, and it is a large win.** With the two
+directions matching, the engine takes the first index entry rather than materialising every candidate
+and sorting: SQL Server goes from 4,319 logical reads to 8, MySQL from a 5,000-row sort at 39 ms to a
+one-row read at 0.1 ms, PostgreSQL from 371 buffers at 0.52 ms to 7 at 0.15 ms. It is not adopted here,
+for two reasons worth knowing before you add it by hand:
+
+- Firebird cannot express it. Its indexes are ascending or descending as a whole, with no per-column
+  direction, so the one schema in the set that cannot take it is also the one with no workaround. MySQL
+  before 8.0 and MariaDB before 10.8 parse `DESC` in an index definition and ignore it, which is
+  harmless but silently buys nothing.
+- The plan it produces is a seek from the oldest waiting trigger, and the statement's lower bound on
+  `NEXT_FIRE_TIME` sits inside an `OR` with `MISFIRE_INSTR`, so it cannot narrow that seek. A backlog of
+  misfired triggers therefore sits in front of every acquisition: against a 5,000-row backlog on SQL
+  Server the descending index read 20,410 pages where the shipped one read 4,319. Backlogs drain, but
+  the index wants that predicate made sargable beside it.
+
+**An index on `PREFERRED_NODE` does nothing for acquisition.** The node-affinity filter is a
+disjunction — unpinned, *or* pinned here, *or* pinned to a node that has stopped checking in — and no
+B-tree serves an `OR`. The plan is unchanged on all three engines with the index in place. What it does
+change is the failover re-pin, the one `UPDATE` `ClusterRecover` issues per dead node: from a full scan
+(PostgreSQL 8.4 ms, SQL Server 4,319 logical reads, MySQL around 88 ms) to a seek of two or three pages.
+That statement runs once per node failure, so a permanent write cost on the busiest table in the schema
+is not a trade the shipped schema makes.
+
+**If you add one anyway**, `(SCHED_NAME, PREFERRED_NODE, PREFERRED_NODE_AUTO)` is the shape the re-pin
+wants, and a cluster that fails over often enough for a multi-second recovery to hurt is the case for
+it. Measure your own schema first: none of this is visible below a few thousand triggers, where every
+plan reads a handful of pages whatever the indexes are.

--- a/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
+++ b/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
@@ -1,0 +1,518 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The shape of the acquisition index the arm under measurement puts on <c>QRTZ_TRIGGERS</c>.
+/// </summary>
+/// <remarks>
+/// Every arm redefines the shipped index under its shipped name rather than adding a second one beside
+/// it, because <c>MySQLDelegate</c> pins the acquisition statement to that name with
+/// <c>FORCE INDEX (IDX_*_T_NFT_ST)</c>: on MySQL an index under any other name cannot be reached by
+/// the statement at all, so redefining the named one is the only change MySQL could ever adopt.
+/// </remarks>
+public enum AcquisitionIndexShape
+{
+    /// <summary>What <c>database/tables/</c> ships: <c>(SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME)</c>.</summary>
+    Shipped,
+
+    /// <summary><c>PRIORITY</c> appended ascending, which is the change the issue proposes.</summary>
+    TrailingPriority,
+
+    /// <summary>
+    /// <c>PRIORITY</c> appended descending. The acquisition statement orders by
+    /// <c>NEXT_FIRE_TIME ASC, PRIORITY DESC</c>, and only an index whose columns are sorted the same
+    /// two ways can deliver that order without a sort — an ascending trailing column cannot, on any of
+    /// these engines. If appending <c>PRIORITY</c> is ever going to pay, this is the form that does it.
+    /// </summary>
+    TrailingPriorityDescending,
+
+    /// <summary>
+    /// The shipped acquisition index, plus <c>(SCHED_NAME, PREFERRED_NODE, PREFERRED_NODE_AUTO)</c> for
+    /// the node-affinity paths.
+    /// </summary>
+    PreferredNode,
+}
+
+/// <summary>
+/// What the trigger indexes cost the acquisition round trip on a populated schema: the candidate select
+/// under each candidate index shape, and the failover re-pin that <c>ClusterRecover</c> issues for every
+/// node it finds dead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the harness for the index audit in issue #3426. Two columns the shipped indexes do not
+/// mention are read on hot paths — <c>PRIORITY</c>, the second <c>ORDER BY</c> key of the acquisition
+/// statement, and <c>PREFERRED_NODE</c>, which node affinity filters and re-pins on — and the question
+/// is whether covering either of them is worth the write cost an index puts on the table every firing
+/// updates. An index that does not pay for itself is not free, so the answer has to be measured.
+/// </para>
+/// <para>
+/// <b>Running it.</b> Start the databases yourself and point the benchmark at them — a container per
+/// benchmark case is not a thing BenchmarkDotNet's process-per-case model can give you:
+/// </para>
+/// <code>
+/// docker run -d --name quartz-bench-pg -p 55432:5432 \
+///   -e POSTGRES_DB=quartznet -e POSTGRES_USER=quartznet -e POSTGRES_PASSWORD=quartznet postgres:15.1
+/// docker run -d --name quartz-bench-mssql -p 51433:1433 \
+///   -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD='Quartz!DockerP4ss' \
+///   mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04
+/// docker run -d --name quartz-bench-mysql -p 53306:3306 \
+///   -e MYSQL_DATABASE=quartznet -e MYSQL_ROOT_PASSWORD=quartznet mysql:8.0
+///
+/// QUARTZ_BENCHMARK_POSTGRES='Host=localhost;Port=55432;Database=quartznet;Username=quartznet;Password=quartznet'
+/// QUARTZ_BENCHMARK_SQLSERVER='Server=localhost,51433;User ID=sa;Password=Quartz!DockerP4ss;TrustServerCertificate=true'
+/// QUARTZ_BENCHMARK_MYSQL='Server=localhost;Port=53306;Database=quartznet;User ID=root;Password=quartznet'
+///
+/// dotnet run -c Release --project src/Quartz.Benchmark -- --filter '*AcquisitionIndex*'
+/// </code>
+/// <para>
+/// Setting <c>QUARTZ_BENCHMARK_EXPLAIN=1</c> makes each parameter set print three things before
+/// measuring anything: the statement it is about to measure, the engine's executed plan for it, and a
+/// thousand acquisitions timed one at a time as percentiles. The plan is the other half of the answer —
+/// a round trip that did not move because the plan did not change is a different finding from one that
+/// did not move because the sort was already cheap — and the percentiles are the half BenchmarkDotNet
+/// cannot report, because what it summarises is the distribution of iteration averages rather than the
+/// spread of a single round trip.
+/// </para>
+/// <para>
+/// <b>The population.</b> A hundred thousand triggers over two hundred groups and a thousand jobs,
+/// which is a large cluster's schedule rather than a toy one. Most are <c>WAITING</c> with a fire time
+/// spread over the coming day; the rest sit in the states a live scheduler always has some rows in, so
+/// that the <c>(SCHED_NAME, TRIGGER_STATE)</c> prefix has real work to do. Five per cent carry a
+/// <c>PREFERRED_NODE</c> pin, half of them to nodes that are still checking in and half to nodes that
+/// are not, so the correlated liveness subquery in the acquisition filter is not vacuous.
+/// </para>
+/// <para>
+/// <b><see cref="Candidates" />.</b> How many rows satisfy the whole acquisition predicate, which is
+/// what the <c>ORDER BY</c> has to order and therefore the only thing that decides whether an index
+/// could retire a sort. It is varied by moving the window's upper bound rather than by reseeding, so
+/// one population serves every parameter set and a sweep is minutes rather than hours; the statement
+/// only ever sees the bound, so narrowing the window and thinning the data are the same question asked
+/// twice.
+/// </para>
+/// <para>
+/// The candidates arrive in groups of a hundred sharing one fire time, because that is the shape a
+/// schedule actually has: cron triggers on the same expression become due at the same instant, to the
+/// tick. Ties are the whole reason <c>PRIORITY</c> is in the <c>ORDER BY</c>, and they are the case
+/// where an index that cannot deliver the ordering has the most to sort — so this is the sharp end of
+/// the question rather than the average one.
+/// </para>
+/// <para>
+/// <b>The clock.</b> Fire times and the acquisition window are both anchored to a fixed instant rather
+/// than to <c>now</c>, so the same seed is valid in the next process and the numbers repeat.
+/// </para>
+/// <para>
+/// <b><see cref="RepinFromDeadNode" />.</b> The statement <c>ClusterRecover</c> runs once per dead node
+/// to release its auto-claimed pins. It is measured in the state it is overwhelmingly in — a node whose
+/// pins have already been released, so nothing matches — which is deliberately the case most flattering
+/// to an index: proving that no row matches is all a seek has to do, while a scan still reads the
+/// table. If an index cannot win here it cannot win anywhere on this path.
+/// </para>
+/// </remarks>
+[SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
+[BenchmarkCategory(BenchmarkCategories.RequiresDatabase, BenchmarkCategories.LongRunning)]
+public class AcquisitionIndexBenchmark
+{
+    private const string SchedulerName = "BenchmarkScheduler";
+    private const string InstanceId = "NODE-01";
+    private const string TablePrefix = "QRTZ_";
+
+    private const string AcquisitionIndexName = "IDX_QRTZ_T_NFT_ST";
+    private const string PreferredNodeIndexName = "IDX_QRTZ_T_PN";
+
+    private const int TotalTriggers = 100_000;
+    private const int TriggerGroups = 200;
+    private const int Jobs = 1_000;
+
+    /// <summary>Triggers carrying a <c>PREFERRED_NODE</c> pin, spread over ten node names.</summary>
+    private const int PinnedTriggers = 5_000;
+
+    private const int PinNodes = 10;
+
+    /// <summary>How many of <see cref="PinNodes" /> are still checking in.</summary>
+    private const int LiveNodes = 5;
+
+    /// <summary>A batch size a cluster tuned for throughput runs with; the shipped default is one.</summary>
+    private const int BatchSize = 20;
+
+    /// <summary>Triggers seeded inside the acquisition window, in <see cref="TiedCandidates" />-sized ties.</summary>
+    private const int DueTriggers = 5_000;
+
+    /// <summary>How many triggers share one fire time, as a cron expression's worth of them does.</summary>
+    private const int TiedCandidates = 100;
+
+    /// <summary>
+    /// Everything the seed and the acquisition window are measured from. A constant rather than
+    /// <c>now</c>, so that a seed written by one benchmark process is still the right seed for the next
+    /// one and the numbers are comparable across a sweep.
+    /// </summary>
+    private static readonly DateTimeOffset seedEpoch = new(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The first, and already slightly late, of the due fire times.</summary>
+    private static readonly DateTimeOffset dueBandStart = seedEpoch.AddSeconds(-10);
+
+    /// <summary>The default misfire threshold, which is how far back a misfiring trigger is still acquirable.</summary>
+    private static readonly DateTimeOffset noEarlierThan = seedEpoch.AddSeconds(-60);
+
+    private static readonly DateTimeOffset liveNodeCutoff = seedEpoch.AddSeconds(-30);
+
+    [Params(BenchmarkDialect.Postgres, BenchmarkDialect.SqlServer, BenchmarkDialect.MySql)]
+    public BenchmarkDialect Dialect { get; set; } = BenchmarkDialect.Postgres;
+
+    [Params(
+        AcquisitionIndexShape.Shipped,
+        AcquisitionIndexShape.TrailingPriority,
+        AcquisitionIndexShape.TrailingPriorityDescending,
+        AcquisitionIndexShape.PreferredNode)]
+    public AcquisitionIndexShape Index { get; set; } = AcquisitionIndexShape.Shipped;
+
+    /// <summary>Rows satisfying the whole acquisition predicate, and so the size of the sort's input.</summary>
+    [Params(TiedCandidates, DueTriggers)]
+    public int Candidates { get; set; }
+
+    /// <summary>The upper bound that admits exactly <see cref="Candidates" /> of the seeded rows.</summary>
+    private DateTimeOffset NoLaterThan => FireTime(Candidates - 1);
+
+    /// <summary>Where the seed puts the <paramref name="index" />th due trigger's fire time.</summary>
+    private static DateTimeOffset FireTime(int index) => dueBandStart.AddSeconds(index / TiedCandidates);
+
+    private BenchmarkDatabase database = null!;
+    private StdAdoDelegate driverDelegate = null!;
+    private TriggerAcquisitionCriteria singleCriteria = null!;
+    private TriggerAcquisitionCriteria batchCriteria = null!;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        database = await BenchmarkDatabase.Open(Dialect).ConfigureAwait(false);
+        driverDelegate = database.CreateDelegate(SchedulerName, InstanceId, TablePrefix);
+
+        await Seed().ConfigureAwait(false);
+        await ApplyIndexes().ConfigureAwait(false);
+
+        singleCriteria = new TriggerAcquisitionCriteria
+        {
+            NoLaterThan = NoLaterThan,
+            NoEarlierThan = noEarlierThan,
+            MaxCount = 1,
+            LiveNodeCutoff = liveNodeCutoff,
+        };
+        batchCriteria = singleCriteria with { MaxCount = BatchSize };
+
+        if (Environment.GetEnvironmentVariable("QUARTZ_BENCHMARK_EXPLAIN") is { Length: > 0 })
+        {
+            await Explain().ConfigureAwait(false);
+            await Percentiles().ConfigureAwait(false);
+        }
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await database.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // No baseline is declared. BenchmarkDotNet's ratio column compares methods within a parameter set,
+    // and these three are different statements rather than three ways of doing one thing; the
+    // comparison that matters is one method across the Index parameter, which the ratio column cannot
+    // express. Reading the Mean column down an Index sweep is the whole of it.
+
+    /// <summary>One acquisition attempt at the shipped batch size of one, where a sort is worst placed.</summary>
+    [Benchmark]
+    public async Task<int> Acquire()
+    {
+        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(database.Holder, singleCriteria).ConfigureAwait(false);
+        return results.Count;
+    }
+
+    /// <summary>The same at a batch of twenty, which is what a cluster tuned for throughput asks for.</summary>
+    [Benchmark]
+    public async Task<int> AcquireBatch()
+    {
+        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(database.Holder, batchCriteria).ConfigureAwait(false);
+        return results.Count;
+    }
+
+    /// <summary>The failover re-pin, in the state it spends nearly all of its life in.</summary>
+    [Benchmark]
+    public async Task<int> RepinFromDeadNode()
+    {
+        return await driverDelegate.RepinTriggersFromDeadNode(database.Holder, "NODE-NOT-PINNED", PreferredNode.AutoSentinel).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Prints the statement about to be measured and the engine's plan for it. Runs once per parameter
+    /// set, before anything is measured.
+    /// </summary>
+    private async Task Explain()
+    {
+        string acquisitionSql = ((IAcquisitionSqlSource) driverDelegate).AcquisitionSql(1);
+
+        Console.WriteLine($"=== {Dialect} / {Index} / candidates={Candidates} ===");
+        Console.WriteLine(acquisitionSql);
+
+        Dictionary<string, object?> parameters = new(StringComparer.Ordinal)
+        {
+            ["schedulerName"] = SchedulerName,
+            ["state"] = StoredTriggerState.Waiting.ToStoredValue(),
+            ["noLaterThan"] = NoLaterThan.UtcTicks,
+            ["noEarlierThan"] = noEarlierThan.UtcTicks,
+            ["instanceId"] = InstanceId,
+            ["autoPinSentinel"] = PreferredNode.AutoSentinel,
+            ["liveNodeCutoff"] = liveNodeCutoff.UtcTicks,
+        };
+
+        Console.WriteLine("--- acquisition plan ---");
+        foreach (string line in await database.Explain(acquisitionSql, parameters).ConfigureAwait(false))
+        {
+            Console.WriteLine(line);
+        }
+
+        Console.WriteLine("--- re-pin plan ---");
+        Dictionary<string, object?> repinParameters = new(StringComparer.Ordinal)
+        {
+            ["newPreferredNode"] = PreferredNode.AutoSentinel,
+            ["newPreferredNodeAuto"] = false,
+            ["schedulerName"] = SchedulerName,
+            ["oldPreferredNode"] = "NODE-NOT-PINNED",
+            ["oldPreferredNodeAuto"] = true,
+        };
+
+        string repinSql = StdAdoConstants.SqlRepinTriggersFromDeadNode.Replace("{0}", TablePrefix);
+        foreach (string line in await database.Explain(repinSql, repinParameters).ConfigureAwait(false))
+        {
+            Console.WriteLine(line);
+        }
+
+        Console.WriteLine("=== end plans ===");
+    }
+
+    /// <summary>
+    /// A thousand acquisitions timed one at a time, reported as percentiles of the single round trip.
+    /// </summary>
+    /// <remarks>
+    /// The tail is the interesting half of an index question. A plan that reads one page and a plan that
+    /// reads the whole table have means a millisecond of transport apart on a loopback database and
+    /// ninety-fifth percentiles that are nothing like each other, and it is the tail a scheduler thread
+    /// waits on. BenchmarkDotNet cannot say this: an iteration there is however many operations fit in
+    /// its target time, so what it summarises is the spread of iteration averages.
+    /// </remarks>
+    private async Task Percentiles()
+    {
+        const int Warmup = 50;
+        const int Samples = 1_000;
+
+        for (int i = 0; i < Warmup; i++)
+        {
+            await driverDelegate.SelectTriggersToAcquire(database.Holder, singleCriteria).ConfigureAwait(false);
+        }
+
+        double[] microseconds = new double[Samples];
+        for (int i = 0; i < Samples; i++)
+        {
+            long started = Stopwatch.GetTimestamp();
+            await driverDelegate.SelectTriggersToAcquire(database.Holder, singleCriteria).ConfigureAwait(false);
+            microseconds[i] = Stopwatch.GetElapsedTime(started).TotalMicroseconds;
+        }
+
+        Array.Sort(microseconds);
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture,
+            $"--- {Samples} acquisitions, us: p50={Percentile(microseconds, 0.50):F1} p90={Percentile(microseconds, 0.90):F1} p95={Percentile(microseconds, 0.95):F1} p99={Percentile(microseconds, 0.99):F1} max={microseconds[^1]:F1}"));
+    }
+
+    private static double Percentile(double[] sorted, double fraction)
+    {
+        return sorted[Math.Clamp((int) (sorted.Length * fraction), 0, sorted.Length - 1)];
+    }
+
+    /// <summary>
+    /// Puts the acquisition index into the shape this arm asks for. Always dropped and recreated, so a
+    /// process inherits nothing from the one before it, and the statistics are refreshed afterwards
+    /// because a plan chosen from a freshly indexed table with no statistics is not the plan a
+    /// deployment gets.
+    /// </summary>
+    private async Task ApplyIndexes()
+    {
+        await DropIndex(AcquisitionIndexName).ConfigureAwait(false);
+        await DropIndex(PreferredNodeIndexName).ConfigureAwait(false);
+
+        string acquisitionColumns = Index switch
+        {
+            AcquisitionIndexShape.TrailingPriority => "SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME, PRIORITY",
+            AcquisitionIndexShape.TrailingPriorityDescending => "SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME ASC, PRIORITY DESC",
+            _ => "SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME",
+        };
+
+        await database.Execute($"CREATE INDEX {AcquisitionIndexName} ON {TablePrefix}TRIGGERS ({acquisitionColumns})").ConfigureAwait(false);
+
+        if (Index == AcquisitionIndexShape.PreferredNode)
+        {
+            await database.Execute($"CREATE INDEX {PreferredNodeIndexName} ON {TablePrefix}TRIGGERS (SCHED_NAME, PREFERRED_NODE, PREFERRED_NODE_AUTO)").ConfigureAwait(false);
+        }
+
+        await database.UpdateStatistics(TablePrefix + "TRIGGERS").ConfigureAwait(false);
+    }
+
+    private async Task DropIndex(string name)
+    {
+        if (Dialect == BenchmarkDialect.MySql)
+        {
+            // MySQL has no DROP INDEX ... IF EXISTS outside a stored program.
+            long exists = await database.Scalar(
+                "SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '"
+                + TablePrefix + "TRIGGERS' AND INDEX_NAME = '" + name + "'").ConfigureAwait(false);
+
+            if (exists > 0)
+            {
+                await database.Execute($"DROP INDEX {name} ON {TablePrefix}TRIGGERS").ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        await database.Execute(Dialect == BenchmarkDialect.Postgres
+            ? $"DROP INDEX IF EXISTS {name}"
+            : $"DROP INDEX IF EXISTS {name} ON {TablePrefix}TRIGGERS").ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Writes the population, unless it is already there. The seed does not depend on any parameter, so
+    /// it is written once per database and every later process finds it and moves on; the check is exact
+    /// because the seed is anchored to a constant instant rather than to <c>now</c>.
+    /// </summary>
+    private async Task Seed()
+    {
+        if (await database.Scalar($"SELECT COUNT(*) FROM {TablePrefix}TRIGGERS").ConfigureAwait(false) == TotalTriggers
+            && await database.Scalar(string.Create(CultureInfo.InvariantCulture,
+                $"SELECT COUNT(*) FROM {TablePrefix}TRIGGERS WHERE TRIGGER_STATE = 'WAITING' AND NEXT_FIRE_TIME <= {FireTime(DueTriggers - 1).UtcTicks}")).ConfigureAwait(false) == DueTriggers)
+        {
+            return;
+        }
+
+        foreach (string table in new[] { "SIMPLE_TRIGGERS", "SIMPROP_TRIGGERS", "CRON_TRIGGERS", "BLOB_TRIGGERS", "TRIGGERS", "JOB_DETAILS", "SCHEDULER_STATE", "FIRED_TRIGGERS" })
+        {
+            await database.Execute("DELETE FROM " + TablePrefix + table).ConfigureAwait(false);
+        }
+
+        await SeedJobs().ConfigureAwait(false);
+        await SeedSchedulerState().ConfigureAwait(false);
+        await SeedTriggers().ConfigureAwait(false);
+        await database.UpdateStatistics(TablePrefix + "JOB_DETAILS").ConfigureAwait(false);
+    }
+
+    private async Task SeedJobs()
+    {
+        List<string> rows = new(Jobs);
+        for (int i = 0; i < Jobs; i++)
+        {
+            rows.Add($"('{SchedulerName}', 'job{i}', 'jobs', 'Quartz.Job.NoOpJob, Quartz', {database.True}, {database.False}, {database.False}, {database.False})");
+        }
+
+        await InsertRows(
+            $"INSERT INTO {TablePrefix}JOB_DETAILS (SCHED_NAME, JOB_NAME, JOB_GROUP, JOB_CLASS_NAME, IS_DURABLE, IS_NONCONCURRENT, IS_UPDATE_DATA, REQUESTS_RECOVERY) VALUES ",
+            rows).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Half the pin targets are checking in and half are not, so the liveness subquery in the
+    /// acquisition filter both matches and fails to match on real data.
+    /// </summary>
+    private async Task SeedSchedulerState()
+    {
+        List<string> rows = new(PinNodes + 1);
+        rows.Add(string.Create(CultureInfo.InvariantCulture,
+            $"('{SchedulerName}', '{InstanceId}', {seedEpoch.UtcTicks}, 15000)"));
+
+        for (int i = 0; i < PinNodes; i++)
+        {
+            long checkin = i < LiveNodes ? seedEpoch.UtcTicks : seedEpoch.AddHours(-1).UtcTicks;
+            rows.Add(string.Create(CultureInfo.InvariantCulture, $"('{SchedulerName}', 'PIN-{i}', {checkin}, 15000)"));
+        }
+
+        await InsertRows(
+            $"INSERT INTO {TablePrefix}SCHEDULER_STATE (SCHED_NAME, INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL) VALUES ",
+            rows).ConfigureAwait(false);
+    }
+
+    private async Task SeedTriggers()
+    {
+        List<string> rows = new(TotalTriggers);
+        for (int i = 0; i < TotalTriggers; i++)
+        {
+            bool due = i < DueTriggers;
+
+            // The due band starts before the epoch and runs past it, so a window over it holds triggers
+            // that are already late beside triggers that are not yet due, as a waking node's does. Rows
+            // outside the band are a day's schedule, well past any window measured here.
+            long nextFireTime = due
+                ? FireTime(i).UtcTicks
+                : seedEpoch.AddMinutes(2).UtcTicks + (long) (i % 86_400) * TimeSpan.TicksPerSecond;
+
+            string state = due ? "WAITING" : NotDueState(i);
+
+            // Priorities vary within each tie group, so the DESC tie-break on PRIORITY decides which row
+            // a batch of one comes back with, rather than being a column that happens to hold one value.
+            int priority = due ? 1 + i % 10 : 5;
+
+            string preferredNode = i % (TotalTriggers / PinnedTriggers) == 0
+                ? $"'PIN-{i % PinNodes}'"
+                : "NULL";
+            string preferredNodeAuto = preferredNode == "NULL" ? database.False : database.True;
+
+            rows.Add(string.Create(CultureInfo.InvariantCulture,
+                $"('{SchedulerName}', 'trigger{i}', 'group{i % TriggerGroups}', 'job{i % Jobs}', 'jobs', '{state}', 'SIMPLE', {seedEpoch.UtcTicks}, {nextFireTime}, {priority}, 0, {preferredNode}, {preferredNodeAuto})"));
+        }
+
+        await InsertRows(
+            $"INSERT INTO {TablePrefix}TRIGGERS (SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, JOB_NAME, JOB_GROUP, TRIGGER_STATE, TRIGGER_TYPE, START_TIME, NEXT_FIRE_TIME, PRIORITY, MISFIRE_INSTR, PREFERRED_NODE, PREFERRED_NODE_AUTO) VALUES ",
+            rows).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The states a live scheduler always has some rows in, in roughly the proportions it has them, so
+    /// that <c>TRIGGER_STATE</c> is a column worth indexing rather than a constant.
+    /// </summary>
+    private static string NotDueState(int i)
+    {
+        return (i % 100) switch
+        {
+            < 85 => "WAITING",
+            < 93 => "ACQUIRED",
+            < 98 => "PAUSED",
+            _ => "BLOCKED",
+        };
+    }
+
+    /// <summary>
+    /// Sends the rows as multi-row <c>INSERT</c> statements. A hundred thousand single-row statements is
+    /// most of a sweep's runtime; five hundred rows to a statement is inside SQL Server's thousand-row
+    /// limit on a <c>VALUES</c> list and turns that into a few seconds.
+    /// </summary>
+    private async Task InsertRows(string prefix, List<string> rows)
+    {
+        const int RowsPerStatement = 500;
+
+        List<string> statements = new(rows.Count / RowsPerStatement + 1);
+        StringBuilder statement = new();
+        for (int i = 0; i < rows.Count; i++)
+        {
+            statement.Append(statement.Length == 0 ? prefix : ", ").Append(rows[i]);
+            if ((i + 1) % RowsPerStatement == 0 || i == rows.Count - 1)
+            {
+                statements.Add(statement.ToString());
+                statement.Clear();
+            }
+        }
+
+        await database.ExecuteBatched(statements, chunkSize: 1).ConfigureAwait(false);
+    }
+}

--- a/src/Quartz.Benchmark/BenchmarkDatabase.cs
+++ b/src/Quartz.Benchmark/BenchmarkDatabase.cs
@@ -1,0 +1,473 @@
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using System.Xml.Linq;
+
+using Microsoft.Data.SqlClient;
+
+using MySqlConnector;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The databases a real-database benchmark can be pointed at.
+/// </summary>
+public enum BenchmarkDialect
+{
+    Postgres,
+    SqlServer,
+    MySql,
+}
+
+/// <summary>
+/// Hands out the acquisition statement a delegate will actually run.
+/// </summary>
+/// <remarks>
+/// The statement is assembled by <c>GetSelectNextTriggerToAcquireSql</c>, which each dialect overrides
+/// to add its row limit and, on MySQL, an index hint. A plan captured for anything else would be a plan
+/// for a copy kept in step by eye, so the delegates the benchmarks use expose the real one.
+/// </remarks>
+internal interface IAcquisitionSqlSource
+{
+    string AcquisitionSql(int maxCount);
+}
+
+/// <summary>
+/// One open connection to a real database, with the schema from <c>database/tables/</c> applied and
+/// the handful of dialect differences a benchmark has to know about answered in one place.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The databases are started outside the process and named by an environment variable, because
+/// BenchmarkDotNet runs a process per benchmark case and a container owned by a benchmark would be
+/// started and thrown away once per case. See the remarks on <see cref="ExecutionCeilingBenchmark" />
+/// and <see cref="AcquisitionIndexBenchmark" /> for the commands.
+/// </para>
+/// <para>
+/// One connection is opened per parameter set and reused: pool acquisition is the same on both sides
+/// of every question these benchmarks ask, and would only add variance.
+/// </para>
+/// </remarks>
+internal sealed class BenchmarkDatabase : IAsyncDisposable
+{
+    private const string DatabaseName = "quartznet";
+
+    private BenchmarkDatabase(BenchmarkDialect dialect, DbProvider provider, DbConnection connection)
+    {
+        Dialect = dialect;
+        Provider = provider;
+        Connection = connection;
+        Holder = new ConnectionAndTransactionHolder(connection, null);
+    }
+
+    public BenchmarkDialect Dialect { get; }
+
+    public DbProvider Provider { get; }
+
+    public DbConnection Connection { get; }
+
+    /// <summary>The holder the driver delegates take, wrapping <see cref="Connection" /> with no transaction.</summary>
+    public ConnectionAndTransactionHolder Holder { get; }
+
+    /// <summary>The boolean literal this dialect accepts in an <c>INSERT</c>.</summary>
+    public string True => Dialect == BenchmarkDialect.Postgres ? "TRUE" : "1";
+
+    /// <inheritdoc cref="True" />
+    public string False => Dialect == BenchmarkDialect.Postgres ? "FALSE" : "0";
+
+    public static async Task<BenchmarkDatabase> Open(BenchmarkDialect dialect)
+    {
+        string variable = dialect switch
+        {
+            BenchmarkDialect.Postgres => "QUARTZ_BENCHMARK_POSTGRES",
+            BenchmarkDialect.SqlServer => "QUARTZ_BENCHMARK_SQLSERVER",
+            _ => "QUARTZ_BENCHMARK_MYSQL",
+        };
+
+        string connectionString = Environment.GetEnvironmentVariable(variable)
+            ?? throw new InvalidOperationException($"{variable} is not set; see the remarks on {nameof(BenchmarkDatabase)} for how to start the databases.");
+
+        connectionString = dialect switch
+        {
+            // A fresh SQL Server container has only the system databases, and the table script's USE has
+            // to land somewhere.
+            BenchmarkDialect.SqlServer => await EnsureSqlServerDatabase(connectionString).ConfigureAwait(false),
+
+            // The MySQL table script switches on a @DropDb user variable, which MySqlConnector reads as a
+            // parameter placeholder unless the connection asks for user variables.
+            BenchmarkDialect.MySql => new MySqlConnectionStringBuilder(connectionString) { AllowUserVariables = true }.ConnectionString,
+
+            _ => connectionString,
+        };
+
+        string providerName = dialect switch
+        {
+            BenchmarkDialect.Postgres => "Npgsql",
+            BenchmarkDialect.SqlServer => "SqlServer",
+            _ => "MySqlConnector",
+        };
+
+        DbProvider provider = new(providerName, connectionString);
+        DbConnection connection = provider.CreateConnection();
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        BenchmarkDatabase database = new(dialect, provider, connection);
+        await database.EnsureSchema().ConfigureAwait(false);
+        return database;
+    }
+
+    /// <summary>
+    /// A driver delegate for this dialect, initialized against the connection this instance holds.
+    /// </summary>
+    public StdAdoDelegate CreateDelegate(string schedulerName, string instanceId, string tablePrefix)
+    {
+        StdAdoDelegate driverDelegate = Dialect switch
+        {
+            BenchmarkDialect.Postgres => new BenchmarkPostgreSQLDelegate(),
+            BenchmarkDialect.SqlServer => new BenchmarkSqlServerDelegate(),
+            _ => new BenchmarkMySQLDelegate(),
+        };
+
+        driverDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = tablePrefix,
+            SchedulerName = schedulerName,
+            InstanceId = instanceId,
+            TypeLoader = new SimpleTypeLoader(),
+            DbProvider = Provider,
+        });
+
+        return driverDelegate;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Holder.Dispose();
+        await Connection.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public async Task Execute(string sql)
+    {
+        using DbCommand command = Connection.CreateCommand();
+        command.CommandText = sql;
+        command.CommandTimeout = 300;
+        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs a list of statements in chunks, so that seeding a hundred thousand rows does not arrive as
+    /// one multi-megabyte command.
+    /// </summary>
+    public async Task ExecuteBatched(IReadOnlyList<string> statements, int chunkSize = 500)
+    {
+        StringBuilder chunk = new();
+        for (int i = 0; i < statements.Count; i++)
+        {
+            chunk.Append(statements[i]).Append(";\n");
+            if ((i + 1) % chunkSize == 0 || i == statements.Count - 1)
+            {
+                await Execute(chunk.ToString()).ConfigureAwait(false);
+                chunk.Clear();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs a scalar query, answering -1 when the statement fails — which is how <see cref="EnsureSchema" />
+    /// discovers that the tables are not there yet.
+    /// </summary>
+    public async Task<long> Scalar(string sql)
+    {
+        try
+        {
+            using DbCommand command = Connection.CreateCommand();
+            command.CommandText = sql;
+            command.CommandTimeout = 300;
+            object? value = await command.ExecuteScalarAsync().ConfigureAwait(false);
+            return value is null or DBNull ? -1 : Convert.ToInt64(value, CultureInfo.InvariantCulture);
+        }
+        catch (DbException)
+        {
+            return -1;
+        }
+    }
+
+    /// <summary>
+    /// The engine's plan for a statement, as lines fit to paste into an issue.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every dialect here is asked for an <em>executed</em> plan rather than an estimated one, because
+    /// the question an index audit asks — did the access path change, is there still a sort, how much
+    /// was read — is only answered by row counts the engine actually saw. PostgreSQL and MySQL run the
+    /// statement to produce one and SQL Server's <c>STATISTICS XML</c> is a by-product of running it, so
+    /// this must not be pointed at a statement whose effects matter.
+    /// </para>
+    /// <para>
+    /// A diagnostic degrades rather than takes the run down with it: anything thrown here comes back as
+    /// the line it would have printed.
+    /// </para>
+    /// </remarks>
+    public async Task<List<string>> Explain(string sql, IReadOnlyDictionary<string, object?> parameters)
+    {
+        try
+        {
+            if (Dialect == BenchmarkDialect.SqlServer)
+            {
+                return await ExplainSqlServer(sql, parameters).ConfigureAwait(false);
+            }
+
+            bool select = sql.TrimStart().StartsWith("SELECT", StringComparison.OrdinalIgnoreCase);
+            string prefix = Dialect switch
+            {
+                BenchmarkDialect.Postgres => "EXPLAIN (ANALYZE, BUFFERS) ",
+
+                // MySQL 8.0 takes EXPLAIN ANALYZE for SELECT only; an UPDATE gets the estimated plan,
+                // which still names the access path and the rows examined.
+                _ => select ? "EXPLAIN ANALYZE " : "EXPLAIN ",
+            };
+
+            return await ReadRows(prefix + sql, parameters).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            return ["<plan unavailable: " + exception.Message.Replace('\n', ' ') + ">"];
+        }
+    }
+
+    /// <summary>
+    /// SQL Server's actual plan, condensed to one line per operator, beside the logical reads
+    /// <c>STATISTICS IO</c> reports. The raw showplan is tens of kilobytes of XML; what an index audit
+    /// wants out of it is which object each operator touched, whether a sort survived, and how many rows
+    /// really went through.
+    /// </summary>
+    private async Task<List<string>> ExplainSqlServer(string sql, IReadOnlyDictionary<string, object?> parameters)
+    {
+        SqlConnection sqlConnection = (SqlConnection) Connection;
+        List<string> io = [];
+        void OnInfoMessage(object sender, SqlInfoMessageEventArgs e) => io.Add(e.Message.Replace('\n', ' ').Trim());
+
+        sqlConnection.InfoMessage += OnInfoMessage;
+        try
+        {
+            await Execute("SET STATISTICS IO ON").ConfigureAwait(false);
+            await Execute("SET STATISTICS XML ON").ConfigureAwait(false);
+
+            List<string> raw = await ReadAllResults(sql, parameters).ConfigureAwait(false);
+            List<string> lines = [];
+            foreach (string candidate in raw)
+            {
+                if (candidate.StartsWith("<ShowPlanXML", StringComparison.Ordinal))
+                {
+                    lines.AddRange(CondenseShowPlan(candidate));
+                }
+            }
+
+            lines.AddRange(io);
+            return lines;
+        }
+        finally
+        {
+            sqlConnection.InfoMessage -= OnInfoMessage;
+            await Execute("SET STATISTICS XML OFF").ConfigureAwait(false);
+            await Execute("SET STATISTICS IO OFF").ConfigureAwait(false);
+        }
+    }
+
+    private static IEnumerable<string> CondenseShowPlan(string xml)
+    {
+        XNamespace showplan = "http://schemas.microsoft.com/sqlserver/2004/07/showplan";
+        foreach (XElement relOp in XDocument.Parse(xml).Descendants(showplan + "RelOp"))
+        {
+            int depth = relOp.Ancestors(showplan + "RelOp").Count();
+            string? index = relOp.Descendants(showplan + "Object").FirstOrDefault()?.Attribute("Index")?.Value;
+            string? actual = relOp.Descendants(showplan + "RunTimeCountersPerThread").FirstOrDefault()?.Attribute("ActualRows")?.Value;
+
+            yield return string.Create(CultureInfo.InvariantCulture,
+                $"{new string(' ', depth * 2)}{relOp.Attribute("PhysicalOp")?.Value}{(index is null ? "" : " " + index)} est={relOp.Attribute("EstimateRows")?.Value} act={actual ?? "?"}");
+        }
+    }
+
+    private async Task<List<string>> ReadRows(string sql, IReadOnlyDictionary<string, object?> parameters)
+    {
+        using DbCommand command = CreateCommand(sql, parameters);
+        List<string> rows = [];
+        await using DbDataReader reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            rows.Add(RowText(reader));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// The same across every result set, which is where SQL Server puts the showplan it was asked for.
+    /// </summary>
+    private async Task<List<string>> ReadAllResults(string sql, IReadOnlyDictionary<string, object?> parameters)
+    {
+        using DbCommand command = CreateCommand(sql, parameters);
+        List<string> rows = [];
+        await using DbDataReader reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        do
+        {
+            while (await reader.ReadAsync().ConfigureAwait(false))
+            {
+                rows.Add(RowText(reader));
+            }
+        }
+        while (await reader.NextResultAsync().ConfigureAwait(false));
+
+        return rows;
+    }
+
+    private static string RowText(DbDataReader reader)
+    {
+        string[] fields = new string[reader.FieldCount];
+        for (int i = 0; i < reader.FieldCount; i++)
+        {
+            fields[i] = reader.IsDBNull(i) ? "" : Convert.ToString(reader.GetValue(i), CultureInfo.InvariantCulture) ?? "";
+        }
+
+        return string.Join(" | ", fields);
+    }
+
+    private DbCommand CreateCommand(string sql, IReadOnlyDictionary<string, object?> parameters)
+    {
+        DbCommand command = Connection.CreateCommand();
+        command.CommandText = sql;
+        command.CommandTimeout = 300;
+
+        foreach (KeyValuePair<string, object?> parameter in parameters)
+        {
+            DbParameter bound = command.CreateParameter();
+            bound.ParameterName = "@" + parameter.Key;
+            bound.Value = parameter.Value ?? DBNull.Value;
+            command.Parameters.Add(bound);
+        }
+
+        return command;
+    }
+
+    /// <summary>
+    /// Refreshes the optimizer's statistics for a table. A freshly seeded and freshly indexed table has
+    /// none worth the name on any of these engines, and a plan chosen from nothing is not the plan a
+    /// deployment gets.
+    /// </summary>
+    public Task UpdateStatistics(string table)
+    {
+        return Execute(Dialect switch
+        {
+            BenchmarkDialect.Postgres => "ANALYZE " + table,
+            BenchmarkDialect.SqlServer => "UPDATE STATISTICS " + table + " WITH FULLSCAN",
+            _ => "ANALYZE TABLE " + table,
+        });
+    }
+
+    /// <summary>Applies <c>database/tables/</c> when the tables are not there yet.</summary>
+    private async Task EnsureSchema()
+    {
+        if (await Scalar("SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS").ConfigureAwait(false) >= 0)
+        {
+            return;
+        }
+
+        string script = ReadScript(Dialect switch
+        {
+            BenchmarkDialect.Postgres => "tables_postgres.sql",
+            BenchmarkDialect.SqlServer => "tables_sqlServer.sql",
+            _ => "tables_mysql_innodb.sql",
+        });
+
+        foreach (string batch in Batches(script))
+        {
+            await Execute(batch).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Creates the <c>quartznet</c> database if the server has not got one, and returns a connection
+    /// string that names it.
+    /// </summary>
+    private static async Task<string> EnsureSqlServerDatabase(string connectionString)
+    {
+        SqlConnectionStringBuilder builder = new(connectionString) { TrustServerCertificate = true };
+        string master = new SqlConnectionStringBuilder(builder.ConnectionString) { InitialCatalog = "master" }.ConnectionString;
+
+        await using (SqlConnection connection = new(master))
+        {
+            await connection.OpenAsync().ConfigureAwait(false);
+            await using SqlCommand command = connection.CreateCommand();
+            command.CommandText = $"IF DB_ID('{DatabaseName}') IS NULL CREATE DATABASE {DatabaseName}";
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        builder.InitialCatalog = DatabaseName;
+        return builder.ConnectionString;
+    }
+
+    /// <summary>
+    /// Splits a script on the <c>GO</c> separators SQL Server's tooling uses; the PostgreSQL and MySQL
+    /// scripts have none and come back whole.
+    /// </summary>
+    private static IEnumerable<string> Batches(string script)
+    {
+        StringBuilder batch = new();
+        foreach (string line in script.Split('\n'))
+        {
+            if (line.Trim().TrimEnd('\r').Equals("GO", StringComparison.OrdinalIgnoreCase))
+            {
+                if (batch.Length > 0)
+                {
+                    yield return batch.ToString();
+                    batch.Clear();
+                }
+
+                continue;
+            }
+
+            batch.Append(line.Replace("[enter_db_name_here]", "[" + DatabaseName + "]").Replace("[enter_path_here]", "/tmp")).Append('\n');
+        }
+
+        if (batch.ToString().Trim().Length > 0)
+        {
+            yield return batch.ToString();
+        }
+    }
+
+    private static string ReadScript(string fileName)
+    {
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current.FullName, "database", "tables", fileName);
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate, Encoding.UTF8);
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate the schema script.", fileName);
+    }
+
+    private sealed class BenchmarkPostgreSQLDelegate : PostgreSQLDelegate, IAcquisitionSqlSource
+    {
+        public string AcquisitionSql(int maxCount) => ReplaceTablePrefix(GetSelectNextTriggerToAcquireSql(new TriggerAcquisitionSqlShape(maxCount, 0)));
+    }
+
+    private sealed class BenchmarkSqlServerDelegate : SqlServerDelegate, IAcquisitionSqlSource
+    {
+        public string AcquisitionSql(int maxCount) => ReplaceTablePrefix(GetSelectNextTriggerToAcquireSql(new TriggerAcquisitionSqlShape(maxCount, 0)));
+    }
+
+    private sealed class BenchmarkMySQLDelegate : MySQLDelegate, IAcquisitionSqlSource
+    {
+        public string AcquisitionSql(int maxCount) => ReplaceTablePrefix(GetSelectNextTriggerToAcquireSql(new TriggerAcquisitionSqlShape(maxCount, 0)));
+    }
+}

--- a/src/Quartz.Benchmark/ExecutionCeilingBenchmark.cs
+++ b/src/Quartz.Benchmark/ExecutionCeilingBenchmark.cs
@@ -1,15 +1,9 @@
-using System.Data.Common;
 using System.Globalization;
-using System.Text;
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 
-using Microsoft.Data.SqlClient;
-
-using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
-using Quartz.Impl.AdoJobStore.Common;
 
 namespace Quartz.Benchmark;
 
@@ -41,9 +35,10 @@ namespace Quartz.Benchmark;
 /// QUARTZ_BENCHMARK_SQLSERVER='Server=localhost,51433;User ID=sa;Password=Quartz!DockerP4ss;TrustServerCertificate=true'
 /// </code>
 /// <para>
-/// The schema comes from <c>database/tables/</c> and is applied on first use, so the tables and their
-/// indexes are the ones a real deployment has. Seeding is skipped when the tables already hold what
-/// this parameter set wants, which is what keeps a sweep of this size to minutes rather than hours.
+/// The schema comes from <c>database/tables/</c> and is applied on first use by
+/// <see cref="BenchmarkDatabase" />, so the tables and their indexes are the ones a real deployment
+/// has. Seeding is skipped when the tables already hold what this parameter set wants, which is what
+/// keeps a sweep of this size to minutes rather than hours.
 /// </para>
 /// <para>
 /// <b>Row counts.</b> <c>FIRED_TRIGGERS</c> holds one row per reservation or running execution, so its
@@ -66,10 +61,6 @@ namespace Quartz.Benchmark;
 /// Neither depends on the row count, the group count or the index, so they double as a control: if
 /// they drift between parameter sets, the machine drifted rather than the query.
 /// </para>
-/// <para>
-/// One connection is opened per parameter set and reused, because pool acquisition is the same on both
-/// sides of the question and would only add variance.
-/// </para>
 /// </remarks>
 [MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
@@ -85,8 +76,8 @@ public class ExecutionCeilingBenchmark
 
     private const string CoveringIndexName = "IDX_QRTZ_FT_EG_TG";
 
-    [Params("Postgres", "SqlServer")]
-    public string Dialect { get; set; } = "Postgres";
+    [Params(BenchmarkDialect.Postgres, BenchmarkDialect.SqlServer)]
+    public BenchmarkDialect Dialect { get; set; } = BenchmarkDialect.Postgres;
 
     [Params(10, 100, 1_000, 10_000)]
     public int FiredTriggerRows { get; set; }
@@ -98,42 +89,17 @@ public class ExecutionCeilingBenchmark
     [Params(false, true)]
     public bool Indexed { get; set; }
 
+    private BenchmarkDatabase database = null!;
     private StdAdoDelegate driverDelegate = null!;
-    private DbConnection connection = null!;
-    private ConnectionAndTransactionHolder holder = null!;
     private TriggerAcquisitionCriteria singleCriteria = null!;
     private TriggerAcquisitionCriteria batchCriteria = null!;
-    private bool postgres;
 
     [GlobalSetup]
     public async Task Setup()
     {
-        postgres = Dialect == "Postgres";
-        string variable = postgres ? "QUARTZ_BENCHMARK_POSTGRES" : "QUARTZ_BENCHMARK_SQLSERVER";
-        string connectionString = Environment.GetEnvironmentVariable(variable)
-            ?? throw new InvalidOperationException($"{variable} is not set; see the remarks on {nameof(ExecutionCeilingBenchmark)} for how to start the databases.");
+        database = await BenchmarkDatabase.Open(Dialect).ConfigureAwait(false);
+        driverDelegate = database.CreateDelegate(SchedulerName, InstanceId, TablePrefix);
 
-        if (!postgres)
-        {
-            connectionString = await EnsureSqlServerDatabase(connectionString).ConfigureAwait(false);
-        }
-
-        DbProvider provider = new(postgres ? "Npgsql" : "SqlServer", connectionString);
-        driverDelegate = postgres ? new PostgreSQLDelegate() : new SqlServerDelegate();
-        driverDelegate.Initialize(new DriverDelegateContext
-        {
-            TablePrefix = TablePrefix,
-            SchedulerName = SchedulerName,
-            InstanceId = InstanceId,
-            TypeLoader = new SimpleTypeLoader(),
-            DbProvider = provider,
-        });
-
-        connection = provider.CreateConnection();
-        await connection.OpenAsync().ConfigureAwait(false);
-        holder = new ConnectionAndTransactionHolder(connection, null);
-
-        await EnsureSchema().ConfigureAwait(false);
         await EnsureWaitingTriggers().ConfigureAwait(false);
         await EnsureFiredTriggers().ConfigureAwait(false);
         await ApplyIndex().ConfigureAwait(false);
@@ -152,15 +118,14 @@ public class ExecutionCeilingBenchmark
     [GlobalCleanup]
     public async Task Cleanup()
     {
-        holder.Dispose();
-        await connection.DisposeAsync().ConfigureAwait(false);
+        await database.DisposeAsync().ConfigureAwait(false);
     }
 
     /// <summary>The aggregate the cluster-wide ceiling reads, once per acquisition attempt.</summary>
     [Benchmark]
     public async Task<int> InFlightAggregate()
     {
-        List<ExecutionGroupInFlight> counts = await driverDelegate.SelectExecutionGroupsInFlight(holder).ConfigureAwait(false);
+        List<ExecutionGroupInFlight> counts = await driverDelegate.SelectExecutionGroupsInFlight(database.Holder).ConfigureAwait(false);
         return counts.Count;
     }
 
@@ -168,7 +133,7 @@ public class ExecutionCeilingBenchmark
     [Benchmark]
     public async Task<int> AcquireCandidates()
     {
-        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(holder, singleCriteria).ConfigureAwait(false);
+        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(database.Holder, singleCriteria).ConfigureAwait(false);
         return results.Count;
     }
 
@@ -176,85 +141,20 @@ public class ExecutionCeilingBenchmark
     [Benchmark]
     public async Task<int> AcquireCandidatesBatched()
     {
-        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(holder, batchCriteria).ConfigureAwait(false);
+        List<TriggerAcquireResult> results = await driverDelegate.SelectTriggersToAcquire(database.Holder, batchCriteria).ConfigureAwait(false);
         return results.Count;
-    }
-
-    /// <summary>
-    /// Creates the <c>quartznet</c> database if the server has not got one, and returns a connection
-    /// string that names it. A fresh SQL Server container has only the system databases, and the table
-    /// script's <c>USE</c> has to land somewhere.
-    /// </summary>
-    private static async Task<string> EnsureSqlServerDatabase(string connectionString)
-    {
-        SqlConnectionStringBuilder builder = new(connectionString) { TrustServerCertificate = true };
-        string master = new SqlConnectionStringBuilder(builder.ConnectionString) { InitialCatalog = "master" }.ConnectionString;
-
-        await using (SqlConnection connection = new(master))
-        {
-            await connection.OpenAsync().ConfigureAwait(false);
-            await using SqlCommand command = connection.CreateCommand();
-            command.CommandText = "IF DB_ID('quartznet') IS NULL CREATE DATABASE quartznet";
-            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
-        }
-
-        builder.InitialCatalog = "quartznet";
-        return builder.ConnectionString;
-    }
-
-    private async Task EnsureSchema()
-    {
-        if (await Scalar("SELECT COUNT(*) FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false) >= 0)
-        {
-            return;
-        }
-
-        string script = ReadScript(postgres ? "tables_postgres.sql" : "tables_sqlServer.sql");
-        foreach (string batch in Batches(script))
-        {
-            await Execute(batch).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// Splits a script on the <c>GO</c> separators SQL Server's tooling uses; PostgreSQL's script has
-    /// none and comes back whole.
-    /// </summary>
-    private static IEnumerable<string> Batches(string script)
-    {
-        StringBuilder batch = new();
-        foreach (string line in script.Split('\n'))
-        {
-            if (line.Trim().TrimEnd('\r').Equals("GO", StringComparison.OrdinalIgnoreCase))
-            {
-                if (batch.Length > 0)
-                {
-                    yield return batch.ToString();
-                    batch.Clear();
-                }
-
-                continue;
-            }
-
-            batch.Append(line.Replace("[enter_db_name_here]", "[quartznet]").Replace("[enter_path_here]", "/tmp")).Append('\n');
-        }
-
-        if (batch.ToString().Trim().Length > 0)
-        {
-            yield return batch.ToString();
-        }
     }
 
     private async Task ApplyIndex()
     {
         // Dropped and recreated per parameter set, so the two arms differ in the index and nothing else.
-        await Execute(postgres
+        await database.Execute(Dialect == BenchmarkDialect.Postgres
             ? "DROP INDEX IF EXISTS " + CoveringIndexName
             : "DROP INDEX IF EXISTS " + CoveringIndexName + " ON " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false);
 
         if (Indexed)
         {
-            await Execute("CREATE INDEX " + CoveringIndexName + " ON " + TablePrefix
+            await database.Execute("CREATE INDEX " + CoveringIndexName + " ON " + TablePrefix
                 + "FIRED_TRIGGERS (SCHED_NAME, EXECUTION_GROUP, TRIGGER_GROUP)").ConfigureAwait(false);
         }
     }
@@ -263,23 +163,20 @@ public class ExecutionCeilingBenchmark
     {
         // Re-seeding 5,000 rows in every one of the ninety-odd processes a sweep launches is most of
         // its runtime, so what is already there is left alone.
-        if (await Scalar("SELECT COUNT(*) FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false) == WaitingTriggers
-            && await Scalar("SELECT COUNT(DISTINCT TRIGGER_GROUP) FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false) == ExecutionGroups)
+        if (await database.Scalar("SELECT COUNT(*) FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false) == WaitingTriggers
+            && await database.Scalar("SELECT COUNT(DISTINCT TRIGGER_GROUP) FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false) == ExecutionGroups)
         {
             return;
         }
 
-        await Execute("DELETE FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false);
-        await Execute("DELETE FROM " + TablePrefix + "JOB_DETAILS").ConfigureAwait(false);
-        await Execute("DELETE FROM " + TablePrefix + "SCHEDULER_STATE").ConfigureAwait(false);
+        await database.Execute("DELETE FROM " + TablePrefix + "TRIGGERS").ConfigureAwait(false);
+        await database.Execute("DELETE FROM " + TablePrefix + "JOB_DETAILS").ConfigureAwait(false);
+        await database.Execute("DELETE FROM " + TablePrefix + "SCHEDULER_STATE").ConfigureAwait(false);
 
-        string trueLiteral = postgres ? "TRUE" : "1";
-        string falseLiteral = postgres ? "FALSE" : "0";
+        await database.Execute("INSERT INTO " + TablePrefix + "JOB_DETAILS (SCHED_NAME, JOB_NAME, JOB_GROUP, JOB_CLASS_NAME, IS_DURABLE, IS_NONCONCURRENT, IS_UPDATE_DATA, REQUESTS_RECOVERY) VALUES ('"
+            + SchedulerName + "', 'job', 'jobs', 'Quartz.Job.NoOpJob, Quartz', " + database.True + ", " + database.False + ", " + database.False + ", " + database.False + ")").ConfigureAwait(false);
 
-        await Execute("INSERT INTO " + TablePrefix + "JOB_DETAILS (SCHED_NAME, JOB_NAME, JOB_GROUP, JOB_CLASS_NAME, IS_DURABLE, IS_NONCONCURRENT, IS_UPDATE_DATA, REQUESTS_RECOVERY) VALUES ('"
-            + SchedulerName + "', 'job', 'jobs', 'Quartz.Job.NoOpJob, Quartz', " + trueLiteral + ", " + falseLiteral + ", " + falseLiteral + ", " + falseLiteral + ")").ConfigureAwait(false);
-
-        await Execute(string.Create(CultureInfo.InvariantCulture,
+        await database.Execute(string.Create(CultureInfo.InvariantCulture,
             $"INSERT INTO {TablePrefix}SCHEDULER_STATE (SCHED_NAME, INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL) VALUES ('{SchedulerName}', '{InstanceId}', {TimeProvider.System.GetUtcNow().UtcTicks}, 15000)")).ConfigureAwait(false);
 
         // Fire times spread one second apart, so the candidate select finds a handful inside its window
@@ -289,25 +186,25 @@ public class ExecutionCeilingBenchmark
         for (int i = 0; i < WaitingTriggers; i++)
         {
             inserts.Add(string.Create(CultureInfo.InvariantCulture,
-                $"INSERT INTO {TablePrefix}TRIGGERS (SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, JOB_NAME, JOB_GROUP, TRIGGER_STATE, TRIGGER_TYPE, START_TIME, NEXT_FIRE_TIME, PRIORITY, MISFIRE_INSTR, EXECUTION_GROUP, PREFERRED_NODE_AUTO) VALUES ('{SchedulerName}', 'trigger{i}', 'group{i % ExecutionGroups}', 'job', 'jobs', 'WAITING', 'SIMPLE', {start}, {start + i * TimeSpan.TicksPerSecond}, 5, -1, 'exec{i % ExecutionGroups}', {falseLiteral})"));
+                $"INSERT INTO {TablePrefix}TRIGGERS (SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, JOB_NAME, JOB_GROUP, TRIGGER_STATE, TRIGGER_TYPE, START_TIME, NEXT_FIRE_TIME, PRIORITY, MISFIRE_INSTR, EXECUTION_GROUP, PREFERRED_NODE_AUTO) VALUES ('{SchedulerName}', 'trigger{i}', 'group{i % ExecutionGroups}', 'job', 'jobs', 'WAITING', 'SIMPLE', {start}, {start + i * TimeSpan.TicksPerSecond}, 5, -1, 'exec{i % ExecutionGroups}', {database.False})"));
         }
 
-        await ExecuteBatched(inserts).ConfigureAwait(false);
+        await database.ExecuteBatched(inserts).ConfigureAwait(false);
     }
 
     private async Task EnsureFiredTriggers()
     {
         int wantedGroups = Math.Min(FiredTriggerRows, ExecutionGroups);
-        if (await Scalar("SELECT COUNT(*) FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false) == FiredTriggerRows
-            && await Scalar("SELECT COUNT(DISTINCT TRIGGER_GROUP) FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false) == wantedGroups)
+        if (await database.Scalar("SELECT COUNT(*) FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false) == FiredTriggerRows
+            && await database.Scalar("SELECT COUNT(DISTINCT TRIGGER_GROUP) FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false) == wantedGroups)
         {
             return;
         }
 
-        await Execute("DELETE FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false);
+        await database.Execute("DELETE FROM " + TablePrefix + "FIRED_TRIGGERS").ConfigureAwait(false);
 
         long now = TimeProvider.System.GetUtcNow().UtcTicks;
-        string falseLiterals = postgres ? "FALSE, FALSE" : "0, 0";
+        string falseLiterals = database.False + ", " + database.False;
         List<string> inserts = new(FiredTriggerRows);
         for (int i = 0; i < FiredTriggerRows; i++)
         {
@@ -315,70 +212,7 @@ public class ExecutionCeilingBenchmark
                 $"INSERT INTO {TablePrefix}FIRED_TRIGGERS (SCHED_NAME, ENTRY_ID, TRIGGER_NAME, TRIGGER_GROUP, INSTANCE_NAME, FIRED_TIME, SCHED_TIME, PRIORITY, STATE, JOB_NAME, JOB_GROUP, IS_NONCONCURRENT, REQUESTS_RECOVERY, EXECUTION_GROUP) VALUES ('{SchedulerName}', 'entry{i}', 'trigger{i}', 'group{i % ExecutionGroups}', 'NODE-{i % 10}', {now}, {now}, 5, 'EXECUTING', 'job', 'jobs', {falseLiterals}, 'exec{i % ExecutionGroups}')"));
         }
 
-        await ExecuteBatched(inserts).ConfigureAwait(false);
+        await database.ExecuteBatched(inserts).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Runs a list of statements in chunks, so that seeding ten thousand rows does not arrive as one
-    /// multi-megabyte command.
-    /// </summary>
-    private async Task ExecuteBatched(List<string> statements)
-    {
-        const int ChunkSize = 500;
-        StringBuilder chunk = new();
-        for (int i = 0; i < statements.Count; i++)
-        {
-            chunk.Append(statements[i]).Append(";\n");
-            if ((i + 1) % ChunkSize == 0 || i == statements.Count - 1)
-            {
-                await Execute(chunk.ToString()).ConfigureAwait(false);
-                chunk.Clear();
-            }
-        }
-    }
-
-    private async Task Execute(string sql)
-    {
-        using DbCommand command = connection.CreateCommand();
-        command.CommandText = sql;
-        command.CommandTimeout = 300;
-        await command.ExecuteNonQueryAsync().ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Runs a scalar query, answering -1 when the statement fails — which is how
-    /// <see cref="EnsureSchema" /> discovers that the tables are not there yet.
-    /// </summary>
-    private async Task<int> Scalar(string sql)
-    {
-        try
-        {
-            using DbCommand command = connection.CreateCommand();
-            command.CommandText = sql;
-            command.CommandTimeout = 300;
-            object? value = await command.ExecuteScalarAsync().ConfigureAwait(false);
-            return value is null or DBNull ? -1 : Convert.ToInt32(value, CultureInfo.InvariantCulture);
-        }
-        catch (DbException)
-        {
-            return -1;
-        }
-    }
-
-    private static string ReadScript(string fileName)
-    {
-        DirectoryInfo? current = new(AppContext.BaseDirectory);
-        while (current is not null)
-        {
-            string candidate = Path.Combine(current.FullName, "database", "tables", fileName);
-            if (File.Exists(candidate))
-            {
-                return File.ReadAllText(candidate, Encoding.UTF8);
-            }
-
-            current = current.Parent;
-        }
-
-        throw new FileNotFoundException("Could not locate the schema script.", fileName);
-    }
 }

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -16,14 +16,15 @@
   </ItemGroup>
 
   <!--
-    ExecutionCeilingBenchmark measures statements against a real database, so it needs the two drivers
-    the issue asks for numbers on. The databases themselves are started outside the benchmark and named
-    by environment variables. BenchmarkDotNet runs a process per benchmark case, so a container owned by
-    the benchmark would be started and thrown away ninety-odd times in one sweep. Nothing else here
-    touches a database; every other benchmark runs against stubs.
+    ExecutionCeilingBenchmark and AcquisitionIndexBenchmark measure statements against a real database,
+    so they need the drivers for the dialects the issues ask for numbers on. The databases themselves are
+    started outside the benchmark and named by environment variables. BenchmarkDotNet runs a process per
+    benchmark case, so a container owned by the benchmark would be started and thrown away a hundred-odd
+    times in one sweep. Nothing else here touches a database; every other benchmark runs against stubs.
   -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Npgsql" />
   </ItemGroup>
 


### PR DESCRIPTION
The audit #3426 asked for, measured rather than argued. Two candidate indexes, three engines, a
hundred thousand triggers, and the plans and numbers recorded so nobody has to start over.

**Verdict: neither candidate is adopted, and the schema is unchanged.** But the measurement turned up
something the issue did not anticipate, and it is the interesting half of this PR — see *The finding
the issue did not expect* below, which is the one thing a reviewer has to decide about.

## The harness

`src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs`, carrying `RequiresDatabase` and `LongRunning` so
`BenchmarkSmoke` leaves it out. It sweeps `Dialect` x `Index` x `Candidates` over:

- **100,000 triggers**, 200 trigger groups, 1,000 jobs. 85% `WAITING` with fire times over the coming
  day; the rest `ACQUIRED`, `PAUSED` and `BLOCKED` in the proportions a live scheduler has, so that
  `(SCHED_NAME, TRIGGER_STATE)` has real selectivity work. 5% carry a `PREFERRED_NODE` pin, half to
  nodes still checking in and half to nodes that are not, so the correlated liveness subquery in the
  acquisition filter is not vacuous.
- **`Candidates`** — how many rows satisfy the whole acquisition predicate, which is what the
  `ORDER BY` has to order and so the only thing that decides whether an index can retire a sort. 100
  is a busy steady state; 5,000 is a cron minute's worth of triggers becoming due at once. Candidates
  arrive in ties of a hundred sharing one fire time, because that is what a cron expression produces
  and because ties are the only case where the second `ORDER BY` key decides anything.
- **Four index arms**, each redefining `IDX_QRTZ_T_NFT_ST` under its shipped name. That is not a
  convenience: `MySQLDelegate` pins the statement with `FORCE INDEX (IDX_*_T_NFT_ST)`, so on MySQL an
  index under any other name is unreachable and redefining the named one is the only change MySQL
  could ever adopt.

`QUARTZ_BENCHMARK_EXPLAIN=1` prints the exact statement (taken from the delegate, not a copy), the
engine's **executed** plan for it, and a thousand acquisitions timed one at a time as percentiles.
Percentiles are done by hand because BenchmarkDotNet summarises the spread of iteration averages, not
of a single round trip, and the tail is what a scheduler thread waits on.

The `database/tables/` bootstrap the two real-database benchmarks share is now `BenchmarkDatabase`;
`ExecutionCeilingBenchmark` moved onto it and lost ~130 lines of duplicate.

Ran against PostgreSQL 15.1, SQL Server 2022-CU14 and MySQL 8.0 in Docker on Windows, one connection
per parameter set.

## (a) `PRIORITY` as a trailing column: no change, exactly as expected

Round trip, p50 / p95 in microseconds, 1,000 timed acquisitions at `MaxBatchSize` 1:

| Dialect | Candidates | shipped | + `PRIORITY` | + `PRIORITY DESC` | + `PREFERRED_NODE` |
|---|--:|--:|--:|--:|--:|
| PostgreSQL 15 | 100 | 1552 / 2251 | 1249 / 2076 | **814 / 1264** | 1028 / 1189 |
| PostgreSQL 15 | 5000 | 1089 / 1217 | 1014 / 1154 | **694 / 784** | 1187 / 2634 |
| SQL Server 2022 | 100 | 1527 / 2095 | 1176 / 1328 | **626 / 707** | 1044 / 1262 |
| SQL Server 2022 | 5000 | 18803 / 25817 | 17183 / 23719 | **632 / 758** | 27967 / 40139 |
| MySQL 8.0 | 100 | 1053 / 1343 | 1109 / 1529 | **763 / 888** | 1536 / 3286 |
| MySQL 8.0 | 5000 | 48709 / 92058 | 22294 / 71005 | **839 / 951** | 20851 / 57493 |

The `+ PRIORITY` column moves by up to 45% either way against `shipped`, and **all of it is noise**.
The plans say so: they come back operator for operator identical, at 5,000 candidates:

| Dialect | shipped | + `PRIORITY` |
|---|---|---|
| PostgreSQL | Index Scan on `idx_qrtz_t_nft_st` -> Incremental Sort (`Presorted Key: next_fire_time`, top-N heapsort over 85 rows), 374 buffers, 0.523 ms | identical, 399 buffers, 0.445 ms |
| SQL Server | Clustered Index Seek on `PK_QRTZ_TRIGGERS` emitting 5,000 rows -> Sort, **4,319 logical reads on QRTZ_TRIGGERS** | identical, 4,319 logical reads |
| MySQL | index range scan on `IDX_QRTZ_T_NFT_ST` reading 5,000 rows -> `Sort: t.NEXT_FIRE_TIME, t.PRIORITY DESC`, 39.2 ms | identical, 5,000 rows, 14.0 ms |

The reason is structural, not statistical. The statement orders by `NEXT_FIRE_TIME ASC, PRIORITY DESC`,
and an ascending trailing column cannot deliver two directions on any of these engines. **The index the
issue proposes costs four bytes an entry and buys nothing. Not adopted.**

## (b) An index on `PREFERRED_NODE`: nothing for acquisition, a lot for a statement that runs once per failure

**Acquisition: unchanged on all three engines.** The `+ PREFERRED_NODE` column above is the shipped
acquisition index plus `(SCHED_NAME, PREFERRED_NODE, PREFERRED_NODE_AUTO)`, and its plans are byte for
byte the `shipped` plans. That is structural too: the node-affinity filter is a disjunction —
`PREFERRED_NODE IS NULL OR = @instanceId OR = '*' OR NOT IN (live nodes)` — and no B-tree serves an
`OR`, least of all one whose last arm is a correlated subquery.

**The failover re-pin is a different story.** `SqlRepinTriggersFromDeadNode` is sargable
(`SCHED_NAME = ? AND PREFERRED_NODE = ? AND PREFERRED_NODE_AUTO = ?`) and the index turns a full scan
into a seek. Measured in the state it is nearly always in — a node whose pins have already been
released, so nothing matches, which is the case *most* flattering to an index:

| Dialect | shipped | + `(SCHED_NAME, PREFERRED_NODE, PREFERRED_NODE_AUTO)` |
|---|---|---|
| PostgreSQL | Seq Scan, 100,000 rows filtered, 3,448 buffers, 8.42 ms | Index Scan on `idx_qrtz_t_pn`, 2 buffers, 0.084 ms |
| SQL Server | 4,319 logical reads; 48-73 ms round trip | Index Seek, 3 logical reads; 0.53-0.94 ms |
| MySQL | `key=PRIMARY`, `rows~58,000`; 88-122 ms round trip | `key=IDX_QRTZ_T_PN`, `rows=1`; 0.61-0.68 ms |

100x to 180x, and a plan that stops scanning. **Still not adopted**, because
`AdoJobStoreBase.Cluster.cs:570` runs it once per dead node found and then deletes the state row, so it
does not repeat for that node. A permanent write cost on the busiest table in the schema, to save
90 ms once per node failure, is the textbook index that does not pay for itself. The number and the
shape are written down in the docs for anyone whose failover rate says otherwise.

## The finding the issue did not expect

**`PRIORITY DESC` — the same column, the other direction — is a very large win, and it is the one thing
here a reviewer has to decide about.** With both directions matching, the engine takes the first index
entry rather than materialising every candidate and sorting:

| Dialect | shipped | + `PRIORITY DESC` |
|---|---|---|
| PostgreSQL | Incremental Sort, 374 buffers, 0.523 ms | Index Scan, **no sort node**, 7 buffers, 0.154 ms |
| SQL Server | Clustered Index Seek + Sort, **4,319 logical reads** | Index Seek on `IDX_QRTZ_T_NFT_ST` + one key lookup, **8 logical reads** |
| MySQL | 5,000-row range scan + filesort, 39.2 ms | **one-row** range scan, no sort, 0.115 ms |

Round trip at 5,000 candidates: SQL Server p50 18,803 -> 632 us (**30x**), MySQL 48,709 -> 839 us
(**58x**), PostgreSQL 1,089 -> 694 us (36%). At 100 candidates it is still 41% on SQL Server and 28%
on MySQL. On SQL Server and MySQL the shipped schema is **reading the whole trigger table on every
acquisition attempt** once the candidate set is large, which is a scaling wall rather than a tuning
detail.

Two robustness checks, both on SQL Server against the same 100,000 rows:

- **Not an artefact of the ties.** Re-run with the due band given distinct fire times 10 ms apart:
  shipped 4,319 logical reads, `PRIORITY DESC` **13**. The win survives, because SQL Server cannot know
  `NEXT_FIRE_TIME` is unique and so sorts either way.
- **It has a bad case.** The plan is a seek from the *oldest* waiting trigger, and the statement's lower
  bound on `NEXT_FIRE_TIME` sits inside an `OR` with `MISFIRE_INSTR`, so it cannot narrow the seek.
  Against a 5,000-row misfire backlog the descending index read **20,410** pages where the shipped one
  read 4,319 — 4.7x worse. Break-even is around 1,400 backlogged rows at this table size. Backlogs
  drain, and the shipped index is only immune because the optimizer abandons the seek for a full scan,
  but it is real.

**I did not adopt it, and I want that decision made deliberately rather than by me:**

1. It is not the index the issue authorised. `PRIORITY` appended and `PRIORITY DESC` appended are
   different changes with different portability, and the issue asked about the first.
2. **Firebird cannot express it.** Its indexes are ascending or descending as a whole, with no
   per-column direction — so the "every migration ships a file for every dialect" rule would have to
   take an exception, which is a maintainer's call. (MySQL below 8.0 and MariaDB below 10.8 parse
   `DESC` and ignore it: harmless, but silently no benefit.)
3. Its payoff and its bad case both hinge on that non-sargable lower bound, which lives in
   `StdAdoConstants.SelectNextTriggerToAcquire` — `src/Quartz/Impl/AdoJobStore/`, explicitly not this
   task's surface, with two other agents in it. Shipping the schema half without the query half means
   shipping a new failure mode.

If you want it, it is worth doing **before 4.0 ships**, while `main` is still unreleased and it costs a
`database/tables/` edit rather than a migration everyone has to run. Happy to open the follow-up issue
with these numbers in it; say the word.

## PR #963 (`DROP_EXISTING = ON`) — the verdict G1 promised

**Superseded; correctly closed.** Confirmed against the current tree rather than taken on trust:

- `database/tables/tables_sqlServer.sql` is a pristine-init script. Everything destructive is inside
  `IF @DropDb = 1` (line 12) and the indexes are created once at the end (lines 379-390) against tables
  that were made moments earlier. There is no drop-then-recreate of a surviving index, so
  `DROP_EXISTING = ON` has nothing to save.
- The case it genuinely pays for — re-creating a clustered index so the non-clustered ones are not
  rebuilt around a new clustering key — does not arise: every clustered index in the schema is a
  `PRIMARY KEY CLUSTERED` constraint, and no script re-creates one.
- The re-runnable index management the PR's author actually needed exists now and is generated:
  `database/migrations/3.20/index_alignment_sqlServer.sql` and section 5 of
  `database/migrations/4.0/schema_30_to_40_upgrade_sqlServer.sql`, both guarded
  `CREATE INDEX` / `DROP INDEX`.

Nothing to reopen. If a deployment does hit rebuild cost against those migrations, that is an issue
with numbers, not this PR.

## Verification

```
dotnet build Quartz.slnx                    Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit           Passed! Failed: 0, Passed: 3599, Skipped: 4, Total: 3603
dotnet fallout BenchmarkSmoke               Succeeded, 249 benchmarks executed
                                            (AcquisitionIndexBenchmark excluded, as its categories ask)
dotnet fallout VerifyMigrations             All generated migration scripts are up to date
dotnet fallout VerifyDocsSnippets           Documentation snippets are up to date (93 files)
npm run docs:check-links                    214 pages, 851 internal links, 502 fragments; no dead links
```

No migration is generated and no schema file is touched, so `MigrationScriptTest` has nothing new to
assert; `VerifyMigrations` is green on the unchanged generator. Docker was available and all three
benchmark databases ran in it. `Quartz.Tests.Integration`, `Quartz.Tests.AspNetCore` and
`Quartz.Tests.AOT` were not run: no production code changed, and the whole solution compiles.

## Deviations from the brief

- **The brief named `IDX_QRTZ_T_NFT_ST_MISFIRE` as the acquisition index.** It is not — the acquisition
  statement runs on `IDX_QRTZ_T_NFT_ST`, which `MySQLDelegate.GetSelectNextTriggerToAcquireSql`
  confirms by `FORCE INDEX`-ing exactly that name. The misfire index serves the misfire sweep. The
  benchmark measures the right one.
- **The brief's docs path, `docs/documentation/quartz-4.x/database/`, does not exist.** The index
  guidance went to `docs/documentation/quartz-4.x/db/index.md`, the schema reference page, which had no
  index section at all and is where someone asking "should I add an index?" would look.
- **`ExecutionCeilingBenchmark` was refactored**, which the brief did not ask for. Its `Dialect`
  parameter changed from `string` to the shared `BenchmarkDialect` enum and its schema bootstrap moved
  to `BenchmarkDatabase`. Adding a third dialect to the project without that would have meant a second
  copy of 130 lines of DDL plumbing.
- **A fifth arm was added to the experiment**: `PRIORITY DESC`. Without it the audit would have
  reported "no change" and been wrong about why.

Closes #3426
