### PR TITLE
Clustering's instance ids, clock skew, lock handlers and three untested dialects get tests

### DIFF
--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -185,6 +185,13 @@ A node whose clock runs ahead of a peer's by more than the slack in that compari
 peer, releases its acquired triggers and re-runs its recovery-requesting jobs — while it is still
 executing them.
 
+**The database's clock plays no part in this.** `LAST_CHECKIN_TIME` holds the writing node's reading of
+its own clock, and nothing in the store ever asks the server what time it is — there is no `GETDATE()`,
+`now()` or `SYSDATE` anywhere in the SQL. So a database server whose clock disagrees with the whole
+cluster's changes nothing at all, and setting its clock is not a fix for this. Only the nodes' clocks
+agreeing with *each other* matters, and the slack they have to agree within is the failed node's own
+stored check-in interval plus the deciding node's check-in misfire threshold.
+
 **Resolution:** run a time-synchronisation service on every node; that is the fix, and ordinary NTP is
 orders of magnitude inside the requirement. Where you cannot guarantee it — or cannot guarantee that the
 process gets CPU promptly, which produces the same symptom with a perfect clock — widen the window with

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceFirebirdTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceFirebirdTest.cs
@@ -1,0 +1,17 @@
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two contending nodes against Firebird. Until now the Firebird leg ran the smoke test — with
+/// clustering off — the paging test and the schema test, so nothing anywhere said whether a Firebird
+/// store hands each due trigger to one node.
+/// </summary>
+[Category("db-firebird")]
+[NonParallelizable]
+public sealed class ClusteredExactlyOnceFirebirdTest : ClusteredExactlyOnceTestBase
+{
+    public ClusteredExactlyOnceFirebirdTest() : base(DataSourceOptions.Providers.Firebird)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceMySqlTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceMySqlTest.cs
@@ -1,0 +1,18 @@
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two contending nodes against MySQL, whose store locks with <c>SELECT … FOR UPDATE</c> through
+/// <see cref="Quartz.Impl.AdoJobStore.SelectForUpdateLockHandler" /> and pages with
+/// <c>MySQLDelegate</c>'s own <c>LIMIT</c>. Until now the MySQL leg ran the smoke test, the paging test
+/// and the schema test, and nothing that put two nodes on one database at once.
+/// </summary>
+[Category("db-mysql")]
+[NonParallelizable]
+public sealed class ClusteredExactlyOnceMySqlTest : ClusteredExactlyOnceTestBase
+{
+    public ClusteredExactlyOnceMySqlTest() : base(DataSourceOptions.Providers.MySqlConnector)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceOracleTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceOracleTest.cs
@@ -1,0 +1,19 @@
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two contending nodes against Oracle, whose store locks with <c>SELECT … FOR UPDATE</c> through
+/// <see cref="Quartz.Impl.AdoJobStore.SelectForUpdateLockHandler" /> and whose driver is the only one
+/// here that binds parameters with <c>:</c> rather than <c>@</c>. Until now the Oracle leg ran the
+/// smoke test, the paging test and the schema test, and nothing that put two nodes on one database at
+/// once.
+/// </summary>
+[Category("db-oracle")]
+[NonParallelizable]
+public sealed class ClusteredExactlyOnceOracleTest : ClusteredExactlyOnceTestBase
+{
+    public ClusteredExactlyOnceOracleTest() : base(DataSourceOptions.Providers.Oracle)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredExactlyOnceTestBase.cs
@@ -1,0 +1,168 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Globalization;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The property a clustered job store exists to provide, and the only one every engine has to be shown
+/// to hold: two nodes, one set of due triggers, every trigger fired exactly once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It is a base of its own rather than part of <see cref="ClusteredHardeningTestBase" /> because of
+/// what the two need from an engine. This case is all product code — two configured schedulers racing
+/// for rows the store wrote — so it runs anywhere there is a fixture. The hardening cases write a dead
+/// node's residue by hand, which means the fixture itself has to spell a boolean and a timestamp the
+/// way each engine stores them, and they are carried on the two engines where that is written.
+/// </para>
+/// <para>
+/// The split also decides what a ten-minute CI leg pays for. MySQL, Oracle and Firebird carry this one
+/// case; PostgreSQL and SQL Server carry it and the residue cases both.
+/// </para>
+/// </remarks>
+public abstract class ClusteredExactlyOnceTestBase : ClusteredJobStoreTestBase
+{
+    private const string Group = "clusterExactlyOnce";
+
+    protected ClusteredExactlyOnceTestBase(string provider) : base(provider)
+    {
+    }
+
+    protected override string SchedulerName => "ClusterExactlyOnceTest";
+
+    [SetUp]
+    public void ResetFirings() => FiringRecordingJob.Reset();
+
+    /// <summary>
+    /// The property the clustered job store exists to provide: two nodes, one set of triggers, every
+    /// trigger fired exactly once.
+    /// </summary>
+    [Test]
+    public Task TwoNodes_EveryOneShotTriggerFiresExactlyOnce()
+    {
+        return AssertNoDoubleFire(configure: null);
+    }
+
+    /// <summary>
+    /// Starts two contending nodes, schedules thirty one-shot triggers due at the same instant, and
+    /// asserts each fired exactly once. Both nodes acquire in batches so they genuinely reach for
+    /// overlapping sets of rows rather than politely taking turns, which is the only arrangement in
+    /// which a broken lock or a lost <c>WHERE TRIGGER_STATE = 'WAITING'</c> guard shows up at all.
+    /// </summary>
+    protected async Task AssertNoDoubleFire(Action<NameValueCollection> configure)
+    {
+        const int TriggerCount = 30;
+
+        void ConfigureNode(NameValueCollection properties)
+        {
+            // A node that acquires ten at a time reaches for overlapping sets of rows rather than
+            // politely taking one each; the thread pool has to grow with it, because the scheduler
+            // refuses a batch larger than the number of threads that could run it.
+            properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = "10";
+            properties["quartz.threadPool.maxConcurrency"] = "10";
+            configure?.Invoke(properties);
+        }
+
+        IScheduler nodeA = await CreateScheduler("nodeA", configure: ConfigureNode);
+        IScheduler nodeB = await CreateScheduler("nodeB", configure: ConfigureNode);
+
+        try
+        {
+            await nodeA.Start();
+            await nodeB.Start();
+
+            IJobDetail job = JobBuilder.Create<FiringRecordingJob>()
+                .WithIdentity("noDoubleFireJob", Group)
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, new AddJobOptions { Replace = true });
+
+            // Far enough out that every trigger is stored before any of them is due, so all thirty
+            // become eligible at the same instant with both nodes awake to see them.
+            DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(5);
+            string[] expected = new string[TriggerCount];
+            for (int i = 0; i < TriggerCount; i++)
+            {
+                expected[i] = "oneShot-" + i.ToString(CultureInfo.InvariantCulture);
+                await nodeA.ScheduleJob(TriggerBuilder.Create()
+                    .WithIdentity(expected[i], Group)
+                    .ForJob(job)
+                    .StartAt(start)
+                    .Build());
+            }
+
+            await WaitForCondition(
+                () => Task.FromResult(FiringRecordingJob.Firings.Count >= TriggerCount),
+                timeoutMs: 90_000,
+                async () =>
+                {
+                    string[] missing = expected.Except(FiredTriggerNames()).ToArray();
+                    return $"all {TriggerCount} one-shot triggers to fire; {missing.Length} never did "
+                           + $"([{string.Join(", ", missing)}]). State:\n{await DumpDatabaseState()}";
+                });
+
+            // Absence cannot be polled for, only waited out: a duplicate acquisition that lost the race by
+            // a few hundred milliseconds arrives after the thirtieth firing, not before it.
+            await SettleForRepeatFirings();
+
+            TestContext.Out.WriteLine("Firings per node: " + string.Join(", ", FiringRecordingJob.Firings
+                .GroupBy(x => x.InstanceId)
+                .OrderBy(x => x.Key, StringComparer.Ordinal)
+                .Select(x => $"{x.Key}={x.Count()}")));
+
+            FiredTriggerNames().Should().BeEquivalentTo(expected,
+                "a clustered store hands each one-shot trigger to exactly one node — a repeated name means "
+                + "two nodes acquired the same row, and a missing one means a row was acquired and dropped");
+        }
+        finally
+        {
+            await nodeA.Shutdown(waitForJobsToComplete: false);
+            await nodeB.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    protected static string[] FiredTriggerNames() => FiringRecordingJob.Firings.Select(x => x.TriggerKey.Name).ToArray();
+
+    protected Task WaitForFirings(int count, int timeoutMs, string what)
+    {
+        return WaitForCondition(
+            () => Task.FromResult(FiringRecordingJob.Firings.Count >= count),
+            timeoutMs,
+            async () => $"{what}. State:\n{await DumpDatabaseState()}");
+    }
+
+    /// <summary>
+    /// Gives a repeat firing time to arrive before the caller asserts there was none. Recovery is driven
+    /// by the check-in loop, so a recovery that failed to clean up after itself would run again on the
+    /// next check-in — three of those, at this fixture's one-second interval, pass inside this wait.
+    /// </summary>
+    protected static Task SettleForRepeatFirings() => Task.Delay(3000);
+
+    protected sealed record FiringRecord(TriggerKey TriggerKey, string InstanceId, string OriginalTriggerName);
+
+    /// <summary>
+    /// Records the trigger, the node, and — for a recovered firing — the trigger whose firing is being
+    /// replayed. Concurrent by design: the exactly-once property under test belongs to trigger
+    /// acquisition, and <c>[DisallowConcurrentExecution]</c> would hide it behind a queue.
+    /// </summary>
+    protected sealed class FiringRecordingJob : IJob
+    {
+        private static volatile ConcurrentQueue<FiringRecord> firings = new();
+
+        public static ConcurrentQueue<FiringRecord> Firings => firings;
+
+        public static void Reset() => Interlocked.Exchange(ref firings, new ConcurrentQueue<FiringRecord>());
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            JobDataMap map = context.MergedJobDataMap;
+            string originalTriggerName = map.ContainsKey(SchedulerConstants.FailedJobOriginalTriggerName)
+                ? map.GetString(SchedulerConstants.FailedJobOriginalTriggerName)
+                : null;
+
+            Firings.Enqueue(new FiringRecord(context.Trigger.Key, context.Scheduler.SchedulerInstanceId, originalTriggerName));
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredHardeningTestBase.cs
@@ -1,21 +1,22 @@
-using System.Collections.Concurrent;
-using System.Collections.Specialized;
-using System.Globalization;
-
 namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 
 /// <summary>
 /// The clustered failures nobody can produce by shutting a scheduler down politely: a node that died
-/// mid-flight and left its rows behind, and two live nodes racing for the same due triggers.
+/// mid-flight and left its rows behind, and a live node that a peer decided was dead.
 /// <para>
-/// These run against every engine that has a fixture, because the interesting code is the SQL — the row
-/// locking that stops two nodes acquiring the same trigger, and the recovery statements that undo a
-/// dead node's residue — and that SQL differs per engine. PostgreSQL locks with
-/// <c>SELECT ... FOR UPDATE</c>, SQL Server with an <c>(UPDLOCK,ROWLOCK)</c> hint; only running both
-/// says the store works on both.
+/// These run on PostgreSQL and SQL Server, because the interesting code is the SQL — the row locking
+/// that stops two nodes acquiring the same trigger, and the recovery statements that undo a dead node's
+/// residue — and that SQL differs per engine. PostgreSQL locks with <c>SELECT ... FOR UPDATE</c>, SQL
+/// Server with an <c>(UPDLOCK,ROWLOCK)</c> hint; only running both says the store works on both.
+/// </para>
+/// <para>
+/// The exactly-once case these inherit from <see cref="ClusteredExactlyOnceTestBase" /> runs on three
+/// more engines besides. What keeps the cases below off those is that they write a dead node's residue
+/// by hand, so the fixture has to spell a boolean and a timestamp the way each engine stores them —
+/// which is fixture work rather than coverage of the store.
 /// </para>
 /// </summary>
-public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
+public abstract class ClusteredHardeningTestBase : ClusteredExactlyOnceTestBase
 {
     private const string Group = "clusterHardening";
 
@@ -30,9 +31,6 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
     }
 
     protected override string SchedulerName => "ClusterHardeningTest";
-
-    [SetUp]
-    public void ResetFirings() => FiringRecordingJob.Reset();
 
     /// <summary>
     /// A node killed while it held an acquired trigger leaves the trigger row in ACQUIRED and a
@@ -336,111 +334,6 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
     }
 
     /// <summary>
-    /// The property the clustered job store exists to provide: two nodes, one set of triggers, every
-    /// trigger fired exactly once.
-    /// </summary>
-    [Test]
-    public Task TwoNodes_EveryOneShotTriggerFiresExactlyOnce()
-    {
-        return AssertNoDoubleFire(configure: null);
-    }
-
-    /// <summary>
-    /// Starts two contending nodes, schedules thirty one-shot triggers due at the same instant, and
-    /// asserts each fired exactly once. Both nodes acquire in batches so they genuinely reach for
-    /// overlapping sets of rows rather than politely taking turns, which is the only arrangement in
-    /// which a broken lock or a lost <c>WHERE TRIGGER_STATE = 'WAITING'</c> guard shows up at all.
-    /// </summary>
-    protected async Task AssertNoDoubleFire(Action<NameValueCollection> configure)
-    {
-        const int TriggerCount = 30;
-
-        void ConfigureNode(NameValueCollection properties)
-        {
-            // A node that acquires ten at a time reaches for overlapping sets of rows rather than
-            // politely taking one each; the thread pool has to grow with it, because the scheduler
-            // refuses a batch larger than the number of threads that could run it.
-            properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = "10";
-            properties["quartz.threadPool.maxConcurrency"] = "10";
-            configure?.Invoke(properties);
-        }
-
-        IScheduler nodeA = await CreateScheduler("nodeA", configure: ConfigureNode);
-        IScheduler nodeB = await CreateScheduler("nodeB", configure: ConfigureNode);
-
-        try
-        {
-            await nodeA.Start();
-            await nodeB.Start();
-
-            IJobDetail job = JobBuilder.Create<FiringRecordingJob>()
-                .WithIdentity("noDoubleFireJob", Group)
-                .StoreDurably()
-                .Build();
-            await nodeA.AddJob(job, new AddJobOptions { Replace = true });
-
-            // Far enough out that every trigger is stored before any of them is due, so all thirty
-            // become eligible at the same instant with both nodes awake to see them.
-            DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(5);
-            string[] expected = new string[TriggerCount];
-            for (int i = 0; i < TriggerCount; i++)
-            {
-                expected[i] = "oneShot-" + i.ToString(CultureInfo.InvariantCulture);
-                await nodeA.ScheduleJob(TriggerBuilder.Create()
-                    .WithIdentity(expected[i], Group)
-                    .ForJob(job)
-                    .StartAt(start)
-                    .Build());
-            }
-
-            await WaitForCondition(
-                () => Task.FromResult(FiringRecordingJob.Firings.Count >= TriggerCount),
-                timeoutMs: 90_000,
-                async () =>
-                {
-                    string[] missing = expected.Except(FiredTriggerNames()).ToArray();
-                    return $"all {TriggerCount} one-shot triggers to fire; {missing.Length} never did "
-                           + $"([{string.Join(", ", missing)}]). State:\n{await DumpDatabaseState()}";
-                });
-
-            // Absence cannot be polled for, only waited out: a duplicate acquisition that lost the race by
-            // a few hundred milliseconds arrives after the thirtieth firing, not before it.
-            await SettleForRepeatFirings();
-
-            TestContext.Out.WriteLine("Firings per node: " + string.Join(", ", FiringRecordingJob.Firings
-                .GroupBy(x => x.InstanceId)
-                .OrderBy(x => x.Key, StringComparer.Ordinal)
-                .Select(x => $"{x.Key}={x.Count()}")));
-
-            FiredTriggerNames().Should().BeEquivalentTo(expected,
-                "a clustered store hands each one-shot trigger to exactly one node — a repeated name means "
-                + "two nodes acquired the same row, and a missing one means a row was acquired and dropped");
-        }
-        finally
-        {
-            await nodeA.Shutdown(waitForJobsToComplete: false);
-            await nodeB.Shutdown(waitForJobsToComplete: false);
-        }
-    }
-
-    private static string[] FiredTriggerNames() => FiringRecordingJob.Firings.Select(x => x.TriggerKey.Name).ToArray();
-
-    private Task WaitForFirings(int count, int timeoutMs, string what)
-    {
-        return WaitForCondition(
-            () => Task.FromResult(FiringRecordingJob.Firings.Count >= count),
-            timeoutMs,
-            async () => $"{what}. State:\n{await DumpDatabaseState()}");
-    }
-
-    /// <summary>
-    /// Gives a repeat firing time to arrive before the caller asserts there was none. Recovery is driven
-    /// by the check-in loop, so a recovery that failed to clean up after itself would run again on the
-    /// next check-in — three of those, at this fixture's one-second interval, pass inside this wait.
-    /// </summary>
-    private static Task SettleForRepeatFirings() => Task.Delay(3000);
-
-    /// <summary>
     /// Writes the SCHEDULER_STATE row a node leaves behind, then ages it past the failure threshold. The
     /// row is inserted at the current time and backdated rather than written already stale, so that the
     /// helper the staleness waits use is also what makes this node look dead.
@@ -504,32 +397,5 @@ public abstract class ClusteredHardeningTestBase : ClusteredJobStoreTestBase
             $"SELECT COUNT(*) FROM {table} WHERE SCHED_NAME = @schedulerName AND INSTANCE_NAME = @instanceName",
             ("schedulerName", SchedulerName),
             ("instanceName", instanceName));
-    }
-
-    private sealed record FiringRecord(TriggerKey TriggerKey, string InstanceId, string OriginalTriggerName);
-
-    /// <summary>
-    /// Records the trigger, the node, and — for a recovered firing — the trigger whose firing is being
-    /// replayed. Concurrent by design: the exactly-once property under test belongs to trigger
-    /// acquisition, and <c>[DisallowConcurrentExecution]</c> would hide it behind a queue.
-    /// </summary>
-    private sealed class FiringRecordingJob : IJob
-    {
-        private static volatile ConcurrentQueue<FiringRecord> firings = new();
-
-        public static ConcurrentQueue<FiringRecord> Firings => firings;
-
-        public static void Reset() => Interlocked.Exchange(ref firings, new ConcurrentQueue<FiringRecord>());
-
-        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
-        {
-            JobDataMap map = context.MergedJobDataMap;
-            string originalTriggerName = map.ContainsKey(SchedulerConstants.FailedJobOriginalTriggerName)
-                ? map.GetString(SchedulerConstants.FailedJobOriginalTriggerName)
-                : null;
-
-            Firings.Enqueue(new FiringRecord(context.Trigger.Key, context.Scheduler.SchedulerInstanceId, originalTriggerName));
-            return default;
-        }
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -55,17 +55,23 @@ public abstract class ClusteredJobStoreTestBase
         // SCHEDULER_STATE row survives Shutdown (it is only deleted by another node's
         // ClusterRecover), and scheduler.Clear() does not touch it either. Remove all
         // rows for this fixture's scheduler so later tests start against a clean cluster.
-        await ExecuteNonQuery(
-            "DELETE FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_SIMPLE_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_CRON_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_SIMPROP_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_BLOB_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_JOB_DETAILS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_CALENDARS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = @schedulerName;" +
-            "DELETE FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName;",
+        //
+        // One statement per round trip rather than one semicolon-separated batch: Oracle has no
+        // statement separator outside a PL/SQL block and Firebird's driver takes one statement per
+        // command, so a batch here would work on three engines and fail on two.
+        await ExecuteStatements(
+            [
+                "DELETE FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SIMPLE_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_CRON_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SIMPROP_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_BLOB_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_JOB_DETAILS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_CALENDARS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName",
+            ],
             ("schedulerName", SchedulerName));
     }
 
@@ -162,7 +168,7 @@ public abstract class ClusteredJobStoreTestBase
     }
 
     /// <summary>
-    /// Runs a statement (or a batch of them) against the store's own tables.
+    /// Runs a statement against the store's own tables.
     /// </summary>
     protected async Task<int> ExecuteNonQuery(string sql, params (string Name, object Value)[] parameters)
     {
@@ -170,6 +176,22 @@ public abstract class ClusteredJobStoreTestBase
         await connection.OpenAsync();
         using DbCommand command = CreateCommand(connection, sql, parameters);
         return await command.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>
+    /// Runs several statements, each on its own command, over one connection. Statements that a
+    /// fixture wants run together but that no single command can carry on every engine.
+    /// </summary>
+    protected async Task ExecuteStatements(IReadOnlyList<string> statements, params (string Name, object Value)[] parameters)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+
+        foreach (string sql in statements)
+        {
+            using DbCommand command = CreateCommand(connection, sql, parameters);
+            await command.ExecuteNonQueryAsync();
+        }
     }
 
     /// <summary>
@@ -184,9 +206,27 @@ public abstract class ClusteredJobStoreTestBase
         return Convert.ToInt32(result, CultureInfo.InvariantCulture);
     }
 
-    private static DbCommand CreateCommand(DbConnection connection, string sql, (string Name, object Value)[] parameters)
+    /// <summary>
+    /// Prepares a fixture's statement for this engine's driver, rewriting the <c>@name</c> placeholders
+    /// every fixture writes into whatever the driver spells them with.
+    /// </summary>
+    /// <remarks>
+    /// The longest names go first, so that a rewrite cannot chop the head off a longer placeholder that
+    /// happens to start with a shorter one's name.
+    /// </remarks>
+    private DbCommand CreateCommand(DbConnection connection, string sql, (string Name, object Value)[] parameters)
     {
         DbCommand command = connection.CreateCommand();
+
+        string prefix = Database.ParameterPrefix;
+        if (prefix != "@")
+        {
+            foreach ((string name, _) in parameters.OrderByDescending(x => x.Name.Length))
+            {
+                sql = sql.Replace("@" + name, prefix + name, StringComparison.Ordinal);
+            }
+        }
+
         command.CommandText = sql;
         foreach ((string name, object value) in parameters)
         {
@@ -214,11 +254,11 @@ public abstract class ClusteredJobStoreTestBase
             "SELECT TRIGGER_NAME, TRIGGER_STATE, PREFERRED_NODE, PREFERRED_NODE_AUTO, EXECUTION_GROUP, NEXT_FIRE_TIME "
             + "FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName",
             reader => $"TRIGGER: {reader.GetString(0)} state={reader.GetString(1)} "
-                      + $"pin={Text(reader, 2)} auto={reader.GetBoolean(3)} group={Text(reader, 4)} next={Number(reader, 5)}");
+                      + $"pin={Text(reader, 2)} auto={Text(reader, 3)} group={Text(reader, 4)} next={Number(reader, 5)}");
 
         await AppendRows(
             "SELECT INSTANCE_NAME, LAST_CHECKIN_TIME, CHECKIN_INTERVAL FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName",
-            reader => $"STATE: {reader.GetString(0)} lastCheckin={reader.GetInt64(1)} interval={reader.GetInt64(2)}");
+            reader => $"STATE: {reader.GetString(0)} lastCheckin={Number(reader, 1)} interval={Number(reader, 2)}");
 
         await AppendRows(
             "SELECT TRIGGER_NAME, INSTANCE_NAME, STATE, ENTRY_ID FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
@@ -236,9 +276,15 @@ public abstract class ClusteredJobStoreTestBase
             }
         }
 
-        static string Text(DbDataReader reader, int ordinal) => reader.IsDBNull(ordinal) ? "<null>" : reader.GetString(ordinal);
+        // Read through the boxed value rather than a typed accessor: a boolean is a `bit` on SQL Server,
+        // a `boolean` on MySQL, a `VARCHAR2(1)` on Oracle and a `SMALLINT` on Firebird, and a big number
+        // is `BIGINT` on four engines and `NUMBER` — which comes back a decimal — on Oracle. This is a
+        // diagnostic, and one that threw while explaining a failure would replace the explanation.
+        static string Text(DbDataReader reader, int ordinal)
+            => reader.IsDBNull(ordinal) ? "<null>" : Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
 
-        static string Number(DbDataReader reader, int ordinal) => reader.IsDBNull(ordinal) ? "<null>" : reader.GetInt64(ordinal).ToString(CultureInfo.InvariantCulture);
+        static string Number(DbDataReader reader, int ordinal)
+            => reader.IsDBNull(ordinal) ? "<null>" : Convert.ToInt64(reader.GetValue(ordinal), CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
     }
 
     protected static async Task WaitForTriggerCompletion(

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredTestDatabase.cs
@@ -1,9 +1,16 @@
 using System.Data.Common;
 
+using FirebirdSql.Data.FirebirdClient;
+
 using Microsoft.Data.SqlClient;
+
+using MySqlConnector;
 
 using Npgsql;
 
+using Oracle.ManagedDataAccess.Client;
+
+using Quartz.Configuration;
 using Quartz.Impl.AdoJobStore;
 
 namespace Quartz.Tests.Integration.Impl.AdoJobStore;
@@ -27,6 +34,21 @@ public abstract class ClusteredTestDatabase
     public static ClusteredTestDatabase SqlServer { get; } = new SqlServerTestDatabase();
 
     /// <summary>
+    /// The assembly-wide MySQL database.
+    /// </summary>
+    public static ClusteredTestDatabase MySql { get; } = new MySqlTestDatabase();
+
+    /// <summary>
+    /// The assembly-wide Oracle database.
+    /// </summary>
+    public static ClusteredTestDatabase Oracle { get; } = new OracleTestDatabase();
+
+    /// <summary>
+    /// The assembly-wide Firebird database.
+    /// </summary>
+    public static ClusteredTestDatabase Firebird { get; } = new FirebirdTestDatabase();
+
+    /// <summary>
     /// Resolves the database for a <c>quartz.dataSource.default.provider</c> value, which is what an
     /// NUnit <c>[TestFixture]</c> argument can carry — attribute arguments have to be constants, and
     /// the provider names already are.
@@ -35,8 +57,44 @@ public abstract class ClusteredTestDatabase
     {
         TestConstants.PostgresProvider => Postgres,
         TestConstants.DefaultSqlServerProvider => SqlServer,
+        DataSourceOptions.Providers.MySqlConnector => MySql,
+        DataSourceOptions.Providers.Oracle => Oracle,
+        DataSourceOptions.Providers.Firebird => Firebird,
         _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "no clustered test database for this provider")
     };
+
+    /// <summary>
+    /// What this engine's driver spells a parameter placeholder with in statement text. Every fixture
+    /// writes <c>@name</c>, which is what all but one of them use;
+    /// <see cref="ClusteredJobStoreTestBase.ExecuteNonQuery" /> rewrites it for the one that does not.
+    /// </summary>
+    /// <remarks>
+    /// This is the test side of what <c>AdoUtil.AddCommandParameter</c> does for the store's own
+    /// statements. It is a property of the driver rather than of the SQL, which is why the fixtures do
+    /// not each have to know about it.
+    /// </remarks>
+    public virtual string ParameterPrefix => "@";
+
+    /// <summary>
+    /// The connection string the container this assembly started published, read from the environment
+    /// variable it publishes it in.
+    /// </summary>
+    /// <remarks>
+    /// Read rather than defaulted: a container is the only supported way to get a <c>db-*</c> leg going,
+    /// so an empty value means the container never started, and saying that is worth more than timing
+    /// out against whatever else happens to be on localhost.
+    /// </remarks>
+    protected static string ContainerConnectionString(string variableName)
+    {
+        string connectionString = Environment.GetEnvironmentVariable(variableName);
+
+        connectionString.Should().NotBeNullOrWhiteSpace(
+            "{0} is set by the container this assembly starts, so an empty one means the container for "
+            + "this leg never started — run the fixture through its own QUARTZ_TEST_DATABASE leg",
+            variableName);
+
+        return connectionString;
+    }
 
     /// <summary>
     /// The ADO.NET provider name, as <c>quartz.dataSource.default.provider</c> spells it.
@@ -93,5 +151,49 @@ public abstract class ClusteredTestDatabase
         public override IDriverDelegate CreateDriverDelegate() => new SqlServerDelegate();
 
         public override DbConnection CreateConnection() => new SqlConnection(ConnectionString);
+    }
+
+    private sealed class MySqlTestDatabase : ClusteredTestDatabase
+    {
+        public override string Provider => DataSourceOptions.Providers.MySqlConnector;
+
+        public override string ConnectionString => ContainerConnectionString("MYSQL_CONNECTION_STRING");
+
+        public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.MySQLDelegate, Quartz";
+
+        public override IDriverDelegate CreateDriverDelegate() => new MySQLDelegate();
+
+        public override DbConnection CreateConnection() => new MySqlConnection(ConnectionString);
+    }
+
+    private sealed class OracleTestDatabase : ClusteredTestDatabase
+    {
+        public override string Provider => DataSourceOptions.Providers.Oracle;
+
+        public override string ConnectionString => ContainerConnectionString("ORACLE_CONNECTION_STRING");
+
+        public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.OracleDelegate, Quartz";
+
+        /// <summary>
+        /// The one driver here that does not spell a placeholder <c>@name</c>.
+        /// </summary>
+        public override string ParameterPrefix => ":";
+
+        public override IDriverDelegate CreateDriverDelegate() => new OracleDelegate();
+
+        public override DbConnection CreateConnection() => new OracleConnection(ConnectionString);
+    }
+
+    private sealed class FirebirdTestDatabase : ClusteredTestDatabase
+    {
+        public override string Provider => DataSourceOptions.Providers.Firebird;
+
+        public override string ConnectionString => ContainerConnectionString("FIREBIRD_CONNECTION_STRING");
+
+        public override string DriverDelegateType => "Quartz.Impl.AdoJobStore.FirebirdDelegate, Quartz";
+
+        public override IDriverDelegate CreateDriverDelegate() => new FirebirdDelegate();
+
+        public override DbConnection CreateConnection() => new FbConnection(ConnectionString);
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionPostgresTest.cs
@@ -1,0 +1,17 @@
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Lock contention against PostgreSQL, whose store locks with <c>SELECT … FOR UPDATE</c> through
+/// <see cref="PostgreSqlSelectForUpdateLockHandler" />.
+/// </summary>
+[Category("db-postgres")]
+public sealed class DbLockHandlerContentionPostgresTest : DbLockHandlerContentionTestBase
+{
+    public DbLockHandlerContentionPostgresTest() : base(TestConstants.PostgresProvider)
+    {
+    }
+
+    protected override Type ExpectedLockHandler => typeof(PostgreSqlSelectForUpdateLockHandler);
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionSqlServerTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionSqlServerTest.cs
@@ -1,0 +1,19 @@
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Lock contention against SQL Server, whose store locks through
+/// <see cref="SelectForUpdateLockHandler" /> carrying the <c>(UPDLOCK,ROWLOCK)</c> statement the store
+/// defaults it to — a different statement from PostgreSQL's <c>SELECT … FOR UPDATE</c>, and the reason
+/// the fixture runs on both.
+/// </summary>
+[Category("db-sqlserver")]
+public sealed class DbLockHandlerContentionSqlServerTest : DbLockHandlerContentionTestBase
+{
+    public DbLockHandlerContentionSqlServerTest() : base(TestConstants.DefaultSqlServerProvider)
+    {
+    }
+
+    protected override Type ExpectedLockHandler => typeof(SelectForUpdateLockHandler);
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/DbLockHandlerContentionTestBase.cs
@@ -1,0 +1,306 @@
+using System.Collections.Concurrent;
+using System.Data;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Globalization;
+
+using Quartz.Extensibility;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Tests;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The cluster-wide lock itself, under contention, against a real database. Everything a clustered
+/// store serializes it serializes through this one row, and until now the only coverage the row-lock
+/// handlers had was retry behaviour in front of a faked provider — which proves the handler tries
+/// again, and nothing at all about whether the statement it issues excludes anybody.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The handler under test is not constructed here. It is read off a real store that has been
+/// initialized with clustering on, so this fixture exercises whichever handler and whichever statement
+/// the store picks for the dialect — <c>SELECT … FOR UPDATE</c> on PostgreSQL, <c>(UPDLOCK,ROWLOCK)</c>
+/// on SQL Server — rather than a second copy of that decision that could drift from it.
+/// </para>
+/// <para>
+/// Exclusion here belongs to the transaction, not to the handler: <c>ReleaseLock</c> only forgets the
+/// in-process record of ownership, and the row stays locked until the transaction commits. So each
+/// contender below leaves the critical section, releases, and only then commits — which is the order
+/// the job store uses, and the order that makes "one holder at a time" mean anything.
+/// </para>
+/// <para>
+/// The <c>TRIGGER_ACCESS</c> row exists before any contender starts. The other race — two nodes
+/// reaching for a lock row that does not exist yet, both falling through to the <c>INSERT</c> — is what
+/// <see cref="PostgreSQLLockTest" /> covers and what
+/// <see cref="Quartz.Impl.AdoJobStore.PostgreSqlSelectForUpdateLockHandler" /> exists for; this fixture
+/// is about the steady state, where the row is there and two nodes want it.
+/// </para>
+/// </remarks>
+public abstract class DbLockHandlerContentionTestBase
+{
+    /// <summary>
+    /// How many callers reach for the lock at once, spread over the two nodes. Enough that a handler
+    /// which excluded nobody would have several of them inside at the same instant, because they are
+    /// all released from the same gate.
+    /// </summary>
+    private const int Contenders = 8;
+
+    /// <summary>
+    /// How long the holder in <see cref="ANodeBlocksWhileAnotherHoldsTheRow" /> keeps the row before
+    /// committing. An absence cannot be polled for, only waited out — and the wait is given teeth by
+    /// the assertion that follows it, which requires the handover after the commit to take less time
+    /// than this window did.
+    /// </summary>
+    private static readonly TimeSpan HoldWindow = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// When an awaited handover is reported as a hang instead of hanging the run. Not a timing
+    /// assertion.
+    /// </summary>
+    private static readonly TimeSpan GiveUpAfter = TimeSpan.FromSeconds(60);
+
+    protected DbLockHandlerContentionTestBase(string provider)
+    {
+        Database = ClusteredTestDatabase.For(provider);
+    }
+
+    protected ClusteredTestDatabase Database { get; }
+
+    /// <summary>
+    /// The scheduler name whose lock row this fixture contends for. Derived from the fixture's own type
+    /// name, because the lock statement filters by it and two dialect fixtures sharing a name in one
+    /// database would be contending with each other.
+    /// </summary>
+    private string SchedulerName => "DbLockContention_" + GetType().Name;
+
+    /// <summary>
+    /// The handler this dialect's store picks for itself, named by the subclass so that each leg says
+    /// which statement it is the coverage for. Asserted rather than assumed: a store that quietly
+    /// started handing out a different handler would otherwise leave this fixture testing something
+    /// else under the same name.
+    /// </summary>
+    protected abstract Type ExpectedLockHandler { get; }
+
+    [SetUp]
+    public async Task GiveTheLockRowAKnownStartingPoint()
+    {
+        await ExecuteNonQuery("DELETE FROM QRTZ_LOCKS WHERE SCHED_NAME = @schedulerName", ("schedulerName", SchedulerName));
+        await ExecuteNonQuery(
+            "INSERT INTO QRTZ_LOCKS (SCHED_NAME, LOCK_NAME) VALUES (@schedulerName, @lockName)",
+            ("schedulerName", SchedulerName),
+            ("lockName", "TRIGGER_ACCESS"));
+    }
+
+    [TearDown]
+    public Task RemoveTheLockRow()
+    {
+        return ExecuteNonQuery("DELETE FROM QRTZ_LOCKS WHERE SCHED_NAME = @schedulerName", ("schedulerName", SchedulerName));
+    }
+
+    /// <summary>
+    /// Two nodes, one lock name, eight callers released together: every one is served, no two are
+    /// inside at once, and the run finishes — which is the whole of what a clustered store asks of the
+    /// row.
+    /// </summary>
+    [Test]
+    public async Task TwoNodesContendingForOneLockAreServedOneAtATime()
+    {
+        ILockHandler nodeA = await NodeLockHandler("nodeA");
+        ILockHandler nodeB = await NodeLockHandler("nodeB");
+
+        TaskCompletionSource gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConcurrentBag<int> occupancyOnEntry = [];
+        ConcurrentBag<string> order = [];
+        int inside = 0;
+
+        async Task Contend(int index)
+        {
+            ILockHandler lockHandler = index % 2 == 0 ? nodeA : nodeB;
+            Guid requestorId = Guid.NewGuid();
+
+            await using DbConnection connection = Database.CreateConnection();
+            await connection.OpenAsync();
+            await using DbTransaction transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+
+            // Owns nothing: the transaction is committed below, by the caller, after the lock has been
+            // given back — which is the sequence the row lock's lifetime actually depends on.
+            using ConnectionAndTransactionHolder holder = new(connection, transaction, ownsResources: false);
+
+            // Everyone opens a connection and begins a transaction first, so that what is being timed
+            // when the gate opens is the reach for the row rather than the connection pool.
+            await gate.Task;
+
+            bool taken = await lockHandler.AcquireLock(requestorId, holder, SchedulerLock.TriggerAccess);
+            taken.Should().BeTrue("a caller that does not hold the lock has no business proceeding");
+
+            occupancyOnEntry.Add(Interlocked.Increment(ref inside));
+            order.Add(index.ToString(CultureInfo.InvariantCulture));
+
+            // A real round trip inside the section: a contender queued on the row in the server is
+            // released the instant the holder commits, so any failure to exclude shows up as two of
+            // them counted here rather than as a race this has to be lucky to catch.
+            await ReadLockRowCount(holder);
+
+            Interlocked.Decrement(ref inside);
+
+            await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
+            await transaction.CommitAsync();
+        }
+
+        Task all = Task.WhenAll(Enumerable.Range(0, Contenders).Select(index => Task.Run(() => Contend(index))));
+        gate.SetResult();
+
+        await all.WaitAsync(GiveUpAfter);
+
+        order.Should().HaveCount(Contenders,
+            "a caller that never reaches the row is a node that stops writing; waiting is fine, starving is not");
+        occupancyOnEntry.Should().OnlyContain(count => count == 1,
+            "the row is the only thing standing between two nodes writing the same trigger rows, so two "
+            + "callers counted inside it at once is a clustered store with no mutual exclusion at all");
+
+        // Nothing was left holding: a lock that survives its owner's commit blocks the cluster for good,
+        // and the only way to see that is to ask for it again.
+        ILockHandler after = await NodeLockHandler("nodeC");
+        await using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+        await using DbTransaction transaction = await connection.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+        using ConnectionAndTransactionHolder holder = new(connection, transaction, ownsResources: false);
+
+        Task<bool> free = after.AcquireLock(Guid.NewGuid(), holder, SchedulerLock.TriggerAccess).AsTask();
+        (await free.WaitAsync(GiveUpAfter)).Should().BeTrue(
+            "every contender committed, so the row is free — a hang here is the deadlock this whole "
+            + "arrangement is watched for");
+
+        await transaction.CommitAsync();
+
+        (await CountRows("SELECT COUNT(*) FROM QRTZ_LOCKS WHERE SCHED_NAME = @schedulerName", ("schedulerName", SchedulerName)))
+            .Should().Be(1, "eight contenders share one lock row; a handler that inserted one of its own per "
+                            + "caller would be locking eight different rows and excluding nobody");
+    }
+
+    /// <summary>
+    /// The exclusion seen from the waiting side: while one node holds the row, the other's request does
+    /// not come back at all. It is the same property the occupancy count asserts, observed as a caller
+    /// genuinely parked in the database rather than as a count that happened never to reach two.
+    /// </summary>
+    /// <remarks>
+    /// The negative is waited out rather than polled for, and the assertion after it is what makes the
+    /// wait mean something: once the holder commits, the handover has to take less time than the window
+    /// in which it demonstrably did not happen. A window too short to have caught anything fails that
+    /// comparison instead of passing quietly.
+    /// </remarks>
+    [Test]
+    public async Task ANodeBlocksWhileAnotherHoldsTheRow()
+    {
+        ILockHandler holderNode = await NodeLockHandler("holder");
+        ILockHandler waitingNode = await NodeLockHandler("waiter");
+
+        await using DbConnection holderConnection = Database.CreateConnection();
+        await holderConnection.OpenAsync();
+        await using DbTransaction holderTransaction = await holderConnection.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+        using ConnectionAndTransactionHolder holderHolder = new(holderConnection, holderTransaction, ownsResources: false);
+
+        (await holderNode.AcquireLock(Guid.NewGuid(), holderHolder, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        await using DbConnection waiterConnection = Database.CreateConnection();
+        await waiterConnection.OpenAsync();
+        await using DbTransaction waiterTransaction = await waiterConnection.BeginTransactionAsync(IsolationLevel.ReadCommitted);
+        using ConnectionAndTransactionHolder waiterHolder = new(waiterConnection, waiterTransaction, ownsResources: false);
+
+        Task<bool> queued = waitingNode.AcquireLock(Guid.NewGuid(), waiterHolder, SchedulerLock.TriggerAccess).AsTask();
+
+        await Task.Delay(HoldWindow);
+
+        queued.IsCompleted.Should().BeFalse(
+            "the other node holds the row and has not committed, so this request is parked in the "
+            + "database — a request that came back here is one the store would act on while a peer was "
+            + "still writing");
+
+        long handoverStarted = Stopwatch.GetTimestamp();
+        await holderTransaction.CommitAsync();
+
+        (await queued.WaitAsync(GiveUpAfter)).Should().BeTrue("committing releases the row to whoever was waiting on it");
+
+        TimeSpan handover = Stopwatch.GetElapsedTime(handoverStarted);
+        handover.Should().BeLessThan(HoldWindow,
+            "the handover took less time than the window the request spent not completing, so that window "
+            + "was long enough to have caught a lock that excluded nobody");
+
+        await waiterTransaction.CommitAsync();
+    }
+
+    /// <summary>
+    /// The lock handler a store of this dialect builds for itself, taken off a real store rather than
+    /// constructed here. Each call builds a separate store, which is what makes two of them two nodes:
+    /// a handler remembers in memory which requestors it has given the lock to, so one handler shared
+    /// between the two would be answering out of that memory rather than out of the database.
+    /// </summary>
+    private async ValueTask<ILockHandler> NodeLockHandler(string instanceId)
+    {
+        IDbProvider dbProvider = new DbProvider(Database.Provider, Database.ConnectionString);
+
+        AdoJobStoreDependencies dependencies = TestJobStores.Dependencies(
+            schedulerOptions: TestJobStores.SchedulerOptions(SchedulerName, instanceId),
+            storeOptions: TestJobStores.StoreOptions("lock-contention"),
+            clusteringOptions: TestJobStores.ClusteringOptions(options => options.Enabled = true),
+            dbProvider: dbProvider,
+            driverDelegate: Database.CreateDriverDelegate()) with
+        {
+            LockHandler = null,
+        };
+
+        LocalTransactionJobStore store = new(dependencies);
+        await store.Initialize(new SchedulerIdentity { SchedulerName = SchedulerName, InstanceId = instanceId });
+
+        store.LockHandler.Should().BeOfType(ExpectedLockHandler,
+            "this fixture is the coverage for the statement that handler issues, so it has to be the one "
+            + "a clustered store of this dialect actually ends up with");
+        store.LockHandler.RequiresConnection.Should().BeTrue("a row lock is taken on the caller's own unit of work");
+
+        return store.LockHandler;
+    }
+
+    /// <summary>
+    /// One statement inside the critical section, on the contender's own connection and transaction, so
+    /// that the section is a real unit of work rather than two adjacent method calls.
+    /// </summary>
+    private static async Task ReadLockRowCount(ConnectionAndTransactionHolder holder)
+    {
+        using DbCommand command = holder.Connection.CreateCommand();
+        holder.Attach(command);
+        command.CommandText = "SELECT COUNT(*) FROM QRTZ_LOCKS";
+        await command.ExecuteScalarAsync();
+    }
+
+    private async Task<int> ExecuteNonQuery(string sql, params (string Name, object Value)[] parameters)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+        using DbCommand command = CreateCommand(connection, sql, parameters);
+        return await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<int> CountRows(string sql, params (string Name, object Value)[] parameters)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+        using DbCommand command = CreateCommand(connection, sql, parameters);
+        return Convert.ToInt32(await command.ExecuteScalarAsync(), CultureInfo.InvariantCulture);
+    }
+
+    private static DbCommand CreateCommand(DbConnection connection, string sql, (string Name, object Value)[] parameters)
+    {
+        DbCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+        foreach ((string name, object value) in parameters)
+        {
+            DbParameter parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value;
+            command.Parameters.Add(parameter);
+        }
+        return command;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -2405,6 +2405,158 @@ public class AdoJobStoreBaseTest
 
     #endregion
 
+    #region Clock skew
+
+    /// <summary>
+    /// Where the cluster's clock actually lives, which is not where discussion #2248 assumes. Nothing in
+    /// the store ever asks the database what time it is: <c>LAST_CHECKIN_TIME</c> holds the writer's own
+    /// <see cref="TimeProvider" /> reading, and the reader compares it against its own. So a database
+    /// whose clock disagrees with every node's changes nothing at all, and this whole node judging on a
+    /// clock five years out reaches exactly the verdicts the real-time fixture does.
+    /// </summary>
+    [Test]
+    public async Task ClockSkew_TheDatabasesOwnClockNeverEntersTheArithmetic()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+
+        // Far enough from any plausible database clock that a store reading one would be wrong by years.
+        DateTimeOffset elsewhere = ClusterNow.AddYears(5);
+
+        GivenStoppedClock(elsewhere);
+        jobStoreSupport.SetFirstCheckIn(false);
+        jobStoreSupport.LastCheckin = elsewhere;
+
+        A.CallTo(() => driverDelegate.UpdateSchedulerState(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<string>.Ignored,
+                A<DateTimeOffset>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<int>(1));
+
+        GivenSchedulerStates(
+            new SchedulerStateRecord(OwnInstanceId, elsewhere, CheckinInterval),
+            new SchedulerStateRecord("alive-node", elsewhere - TimeSpan.FromSeconds(5), CheckinInterval),
+            new SchedulerStateRecord(DeadInstanceId, elsewhere - TimeSpan.FromSeconds(60), CheckinInterval));
+
+        List<SchedulerStateRecord> failed = await jobStoreSupport.CallClusterCheckIn(conn);
+
+        failed.Select(x => x.SchedulerInstanceId).Should().Equal([DeadInstanceId],
+            "the whole predicate is arithmetic between this node's clock and stamps other nodes wrote "
+            + "from theirs, so a cluster agreeing with itself is judged the same wherever its clocks "
+            + "stand relative to the database's");
+
+        A.CallTo(() => driverDelegate.UpdateSchedulerState(conn, OwnInstanceId, elsewhere, A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// How far a peer's clock may sit from this node's before the peer is written off: its own check-in
+    /// interval plus this node's misfire threshold, which for this fixture's ten-second interval and the
+    /// default 7.5s threshold is 17.5s. The boundary is asserted from both sides, because "roughly a
+    /// check-in interval" is what an operator would guess and it is short by the threshold.
+    /// </summary>
+    [Test]
+    public async Task ClockSkew_APeerIsToleratedUpToItsCheckInIntervalPlusTheMisfireThreshold()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.SetFirstCheckIn(false);
+
+        // This node is checking in punctually, so CalcFailedIfAfter has no outage of its own to allow
+        // for and the record's interval sets the deadline.
+        jobStoreSupport.LastCheckin = ClusterNow;
+
+        TimeSpan tolerance = CheckinInterval + jobStoreSupport.ClusterCheckinMisfireThreshold;
+
+        // Both peers checked in on the instant by their own clocks. What differs is how far those clocks
+        // sit from this one's, which is what makes their stamps look old here.
+        GivenSchedulerStates(
+            new SchedulerStateRecord(OwnInstanceId, ClusterNow, CheckinInterval),
+            new SchedulerStateRecord("skew-at-the-limit", ClusterNow - tolerance, CheckinInterval),
+            new SchedulerStateRecord("skew-past-the-limit", ClusterNow - tolerance - TimeSpan.FromMilliseconds(1), CheckinInterval));
+
+        List<SchedulerStateRecord> failed = await jobStoreSupport.CallFindFailedInstances(conn);
+
+        failed.Select(x => x.SchedulerInstanceId).Should().Equal(["skew-past-the-limit"],
+            "a stamp landing exactly on the deadline is not past it -- the predicate is a strict "
+            + "comparison -- so the tolerance is the interval plus the threshold inclusive, and one "
+            + "millisecond more is a peer this node takes the work of");
+    }
+
+    /// <summary>
+    /// The limitation this leaves, stated rather than fixed: a node whose clock runs more than that
+    /// tolerance ahead of its peers' declares healthy peers failed and takes their work over. Changing
+    /// the predicate is out of scope for #3436 — what is in scope is that the behaviour is pinned, so
+    /// that a later change to it is a change to this test rather than a surprise in production.
+    /// </summary>
+    /// <remarks>
+    /// The same arrangement read from the other end is the other half of the report: a node checking in
+    /// punctually on a clock that lags the cluster by more than the tolerance leaves stamps its peers
+    /// read as stale, and is recovered while it is still running. One row, one comparison, two ways to
+    /// arrive at it — which is why there is one test.
+    /// </remarks>
+    [Test]
+    public async Task ClockSkew_ANodeWhoseClockRunsAheadOfTheClusterDeclaresHealthyPeersFailed()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.SetFirstCheckIn(false);
+        jobStoreSupport.LastCheckin = ClusterNow;
+
+        // A minute, against a 17.5s tolerance: enough that no amount of check-in jitter accounts for it.
+        TimeSpan skew = TimeSpan.FromMinutes(1);
+
+        GivenSchedulerStates(
+            new SchedulerStateRecord(OwnInstanceId, ClusterNow, CheckinInterval),
+            new SchedulerStateRecord("healthy-peer", ClusterNow - skew, CheckinInterval));
+
+        List<SchedulerStateRecord> failed = await jobStoreSupport.CallFindFailedInstances(conn);
+
+        failed.Should().ContainSingle(
+                "the peer wrote that stamp a moment ago by its own clock, and this node cannot tell a "
+                + "clock a minute behind its own from a process that stopped a minute ago")
+            .Which.SchedulerInstanceId.Should().Be("healthy-peer");
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        StateOf(nodes, "healthy-peer").Should().Be(ClusterNodeState.Failed,
+            "the listing an operator reads is the same predicate, so it agrees with the sweep — which is "
+            + "what makes the skew diagnosable from QueryClusterNodes at all");
+    }
+
+    /// <summary>
+    /// The safe half of the same skew: a node whose clock lags the cluster reads every peer's stamp as
+    /// being in its own future, and a stamp in the future is never past a deadline built by adding to
+    /// it. A slow clock therefore costs the cluster nothing except this node's own rows looking stale to
+    /// everyone else.
+    /// </summary>
+    [Test]
+    public async Task ClockSkew_ANodeWhoseClockLagsTheClusterNeverDeclaresAPeerFailed()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+        jobStoreSupport.SetFirstCheckIn(false);
+        jobStoreSupport.LastCheckin = ClusterNow;
+
+        TimeSpan skew = TimeSpan.FromMinutes(1);
+
+        GivenSchedulerStates(
+            new SchedulerStateRecord(OwnInstanceId, ClusterNow, CheckinInterval),
+            new SchedulerStateRecord("healthy-peer", ClusterNow + skew, CheckinInterval));
+
+        List<SchedulerStateRecord> failed = await jobStoreSupport.CallFindFailedInstances(conn);
+
+        failed.Should().BeEmpty(
+            "the peer's stamp is a minute ahead of this node's now, so the deadline built from it is "
+            + "further ahead still; nothing a lagging node reads can look overdue to it");
+
+        List<ClusterNode> nodes = await jobStoreSupport.CallQueryClusterNodes(conn);
+
+        StateOf(nodes, "healthy-peer").Should().Be(ClusterNodeState.Alive);
+    }
+
+    #endregion
+
     #region ClusterCheckIn
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/InProcessLockHandlerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/InProcessLockHandlerTest.cs
@@ -1,0 +1,262 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.Logging;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Tests.Unit.Plugin.History;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// What <see cref="InProcessLockHandler" /> promises the job store, which until now was described only
+/// by a benchmark. It is the handler a single-node ADO store uses, so everything the store serializes —
+/// every write to a job, a trigger or a calendar, and every acquisition — is serialized by this and
+/// nothing else.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here waits on wall time. A lock that is held makes the next request's task incomplete
+/// synchronously, so "the second caller is queued" is asserted by looking at the task rather than by
+/// sleeping and hoping; the deadlines that do appear are give-up deadlines on an awaited handover, not
+/// timing assertions.
+/// </para>
+/// <para>
+/// <b>Ordering is deliberately not asserted.</b> The handler queues on
+/// <see cref="SemaphoreSlim" />, whose documentation promises no order among waiters, so a test that
+/// pinned first-in-first-out would be pinning an implementation detail of the BCL. What is asserted
+/// instead is the property the store actually needs: every waiter is eventually served, and never two
+/// at once.
+/// </para>
+/// </remarks>
+public class InProcessLockHandlerTest
+{
+    /// <summary>
+    /// How long an awaited handover may take before the test gives up. Not a timing assertion — the
+    /// handover is a semaphore release on the same thread pool, so this only decides when a hang is
+    /// reported as a failure instead of hanging the run.
+    /// </summary>
+    private static readonly TimeSpan GiveUpAfter = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The warning <see cref="InProcessLockHandler.ReleaseLock" /> raises for a caller returning a lock
+    /// it does not hold, spelled out rather than read from <c>LockHandlerLog</c>: an id is what an
+    /// operator filters on, so a test reading the same constant the product logs from would let a
+    /// renumbering through.
+    /// </summary>
+    private const int ReturnedByNonOwnerEvent = 3704;
+
+    [Test]
+    public async Task OnlyOneOwnerHoldsALockAtATime()
+    {
+        InProcessLockHandler lockHandler = new();
+        Guid holder = Guid.NewGuid();
+        Guid waiter = Guid.NewGuid();
+
+        bool held = await lockHandler.AcquireLock(holder, conn: null, SchedulerLock.TriggerAccess);
+        held.Should().BeTrue("nothing held the lock, so the first caller takes it");
+
+        Task<bool> queued = lockHandler.AcquireLock(waiter, conn: null, SchedulerLock.TriggerAccess).AsTask();
+
+        queued.IsCompleted.Should().BeFalse(
+            "the lock is held, so the second caller has to wait for it — a handler that answered here "
+            + "would be letting two callers write the same trigger rows at once");
+
+        await lockHandler.ReleaseLock(holder, SchedulerLock.TriggerAccess);
+
+        (await queued.WaitAsync(GiveUpAfter)).Should().BeTrue(
+            "releasing hands the lock to whoever was waiting for it");
+    }
+
+    /// <summary>
+    /// Re-entrancy, which is the reason the handler asks who owns a lock before waiting for it: the job
+    /// store takes <c>TRIGGER_ACCESS</c> around an operation that may itself take <c>TRIGGER_ACCESS</c>,
+    /// and a handler that queued would deadlock against itself.
+    /// </summary>
+    /// <remarks>
+    /// The <see langword="false" /> is not a refusal. It is the store's release protocol: the answer
+    /// means "you now hold this and are the one who must give it back", so the inner caller releases
+    /// nothing and the outer one's single release is what frees the lock.
+    /// </remarks>
+    [Test]
+    public async Task AnOwnerAskingAgainIsAnsweredWithoutWaitingAndWithoutTakingASecondHold()
+    {
+        InProcessLockHandler lockHandler = new();
+        Guid owner = Guid.NewGuid();
+        Guid other = Guid.NewGuid();
+
+        (await lockHandler.AcquireLock(owner, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        Task<bool> again = lockHandler.AcquireLock(owner, conn: null, SchedulerLock.TriggerAccess).AsTask();
+
+        again.IsCompleted.Should().BeTrue("an owner that had to wait for its own lock would never be released");
+        (await again).Should().BeFalse(
+            "the answer says who has to release, and it is the outer caller; a nested caller that "
+            + "released on a true would drop a lock its outer caller still needs");
+
+        await lockHandler.ReleaseLock(owner, SchedulerLock.TriggerAccess);
+
+        (await lockHandler.AcquireLock(other, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue(
+            "one release is enough, because the nested acquisition never took a second hold to give back");
+    }
+
+    /// <summary>
+    /// Returning a lock somebody else holds. It must not free the lock — that would hand the holder's
+    /// rows to the next waiter while the holder is still writing them — and it must say so, because a
+    /// store that does it is broken and the log is the only place that shows up.
+    /// </summary>
+    [Test]
+    public async Task ReturningALockThisCallerNeverTookLeavesTheHolderHoldingIt()
+    {
+        RecordingLoggerProvider log = new();
+        using LoggerFactory factory = new();
+        factory.AddProvider(log);
+
+        InProcessLockHandler lockHandler = new();
+        lockHandler.Initialize(Context(factory));
+
+        Guid holder = Guid.NewGuid();
+        Guid stranger = Guid.NewGuid();
+
+        (await lockHandler.AcquireLock(holder, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        await lockHandler.ReleaseLock(stranger, SchedulerLock.TriggerAccess);
+
+        Task<bool> queued = lockHandler.AcquireLock(stranger, conn: null, SchedulerLock.TriggerAccess).AsTask();
+
+        queued.IsCompleted.Should().BeFalse(
+            "the lock is still the holder's; a release by a non-owner that freed it would let the next "
+            + "caller in while the holder was still working");
+
+        log.Entries.Should().ContainSingle(entry => entry.EventId.Id == ReturnedByNonOwnerEvent)
+            .Which.Level.Should().Be(LogLevel.Warning,
+                "a caller returning a lock it never took is a bug in the caller, and nothing else reports it");
+
+        await lockHandler.ReleaseLock(holder, SchedulerLock.TriggerAccess);
+        (await queued.WaitAsync(GiveUpAfter)).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A waiter whose token is cancelled while it is queued. It reports that it took nothing rather than
+    /// throwing, which is what lets the store's <c>finally</c> release only what it actually holds — and
+    /// it must leave the queue without consuming the handover, or the lock would be lost to a caller
+    /// that has already given up.
+    /// </summary>
+    [Test]
+    public async Task AWaiterCancelledWhileQueuedTakesNothingAndLeavesTheLockWhereItWas()
+    {
+        InProcessLockHandler lockHandler = new();
+        Guid holder = Guid.NewGuid();
+        Guid abandoning = Guid.NewGuid();
+        Guid patient = Guid.NewGuid();
+
+        (await lockHandler.AcquireLock(holder, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        using CancellationTokenSource cancellation = new();
+        Task<bool> abandoned = lockHandler.AcquireLock(abandoning, conn: null, SchedulerLock.TriggerAccess, cancellation.Token).AsTask();
+        abandoned.IsCompleted.Should().BeFalse();
+
+        await cancellation.CancelAsync();
+
+        (await abandoned.WaitAsync(GiveUpAfter)).Should().BeFalse(
+            "a cancelled wait answers 'I do not hold this' rather than throwing, so the caller's cleanup "
+            + "does not go on to release a lock it never took");
+
+        Task<bool> queued = lockHandler.AcquireLock(patient, conn: null, SchedulerLock.TriggerAccess).AsTask();
+        queued.IsCompleted.Should().BeFalse("the lock is still the holder's, cancellation notwithstanding");
+
+        await lockHandler.ReleaseLock(holder, SchedulerLock.TriggerAccess);
+
+        (await queued.WaitAsync(GiveUpAfter)).Should().BeTrue(
+            "the abandoned waiter left the queue without consuming the handover; had it taken the lock on "
+            + "its way out, this release would have gone to a caller that no longer exists and the store "
+            + "would be stuck");
+    }
+
+    [Test]
+    public async Task TheTwoLocksAreHeldIndependently()
+    {
+        InProcessLockHandler lockHandler = new();
+        Guid owner = Guid.NewGuid();
+
+        (await lockHandler.AcquireLock(owner, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        Task<bool> stateAccess = lockHandler.AcquireLock(owner, conn: null, SchedulerLock.StateAccess).AsTask();
+
+        stateAccess.IsCompleted.Should().BeTrue(
+            "the cluster check-in runs on a transaction of its own so that it cannot queue behind trigger "
+            + "work, and one handler holding both locks as one would put it right back in that queue");
+        (await stateAccess).Should().BeTrue("STATE_ACCESS was free; this caller now holds it too");
+    }
+
+    /// <summary>
+    /// Sixteen callers, one lock: every one of them is served, and no two are inside it together. The
+    /// order they are served in is <see cref="SemaphoreSlim" />'s business and is not asserted — see the
+    /// note on the fixture.
+    /// </summary>
+    [Test]
+    public async Task EveryContenderIsServedAndNoTwoAreInsideTheLockTogether()
+    {
+        const int Contenders = 16;
+
+        InProcessLockHandler lockHandler = new();
+        ConcurrentBag<int> occupancyOnEntry = [];
+        int inside = 0;
+        int served = 0;
+
+        async Task Contend()
+        {
+            Guid requestorId = Guid.NewGuid();
+
+            (await lockHandler.AcquireLock(requestorId, conn: null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+            occupancyOnEntry.Add(Interlocked.Increment(ref inside));
+            Interlocked.Increment(ref served);
+
+            // Hands the thread back while holding, so that a handler which let two callers in would be
+            // caught with both of them counted rather than passing on how fast the body is.
+            await Task.Yield();
+
+            Interlocked.Decrement(ref inside);
+            await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
+        }
+
+        await Task.WhenAll(Enumerable.Range(0, Contenders).Select(_ => Task.Run(Contend)))
+            .WaitAsync(GiveUpAfter);
+
+        served.Should().Be(Contenders,
+            "a waiter that is never handed the lock is a scheduler that stops writing, and it is the "
+            + "queue rather than the order that has to hold");
+        occupancyOnEntry.Should().OnlyContain(count => count == 1,
+            "the lock is what serializes every write the store makes; two callers counted inside it at "
+            + "once is that serialization gone");
+    }
+
+    private static LockHandlerContext Context(ILoggerFactory loggerFactory) => new()
+    {
+        SchedulerName = "TESTSCHED",
+        InstanceId = "node-1",
+        TablePrefix = AdoConstants.DefaultTablePrefix,
+        LoggerFactory = loggerFactory,
+    };
+}

--- a/src/Quartz.Tests.Unit/Simpl/AutoInstanceIdTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/AutoInstanceIdTest.cs
@@ -1,0 +1,124 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+
+using Quartz.Configuration;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// The one property <c>quartz.scheduler.instanceId = AUTO</c> exists to provide: two nodes of one
+/// cluster end up with ids that differ. A cluster whose nodes share an id is not a cluster — each of
+/// them reads the others' fired triggers as its own, and the one <c>SCHEDULER_STATE</c> row they all
+/// write over says only that somebody checked in.
+/// </summary>
+/// <remarks>
+/// Every generation here happens on one machine, which is exactly the arrangement the reports are
+/// about: replicas of one container image all report the same host name, so a generator that leans on
+/// the host name alone hands every replica the same id. Nothing in this fixture assumes a particular
+/// host name — it asserts that the ids differ, and that what they differ in is not the host part.
+/// </remarks>
+public class AutoInstanceIdTest
+{
+    /// <summary>
+    /// How many ids the loop asks for. <see cref="SimpleInstanceIdGenerator" /> appends
+    /// <see cref="TimeProvider.GetTimestamp" /> — the high-resolution counter, which no
+    /// <see cref="TimeProvider" /> a test can inject reaches — so distinctness cannot be driven from a
+    /// fake clock and is asserted over a run of back-to-back generations instead. Back-to-back is the
+    /// hard case: two nodes starting out of one process, or one image, are as close together as ids
+    /// ever get, and a generator that repeats at all repeats here.
+    /// </summary>
+    private const int Generations = 200;
+
+    [Test]
+    public async Task TheGeneratorBehindAutoNeverHandsOutOneIdTwice()
+    {
+        SimpleInstanceIdGenerator generator = new();
+
+        List<string> ids = [];
+        for (int i = 0; i < Generations; i++)
+        {
+            ids.Add(await generator.GenerateInstanceId());
+        }
+
+        ids.Should().OnlyHaveUniqueItems(
+            "every one of these was generated on one host, which is what every replica of a container "
+            + "image is, and two cluster nodes sharing an id read each other's fired triggers as their own");
+    }
+
+    [Test]
+    public async Task TheGeneratorBehindAutoDoesNotRelyOnTheHostNameToTellNodesApart()
+    {
+        SimpleInstanceIdGenerator generator = new();
+
+        string first = await generator.GenerateInstanceId();
+        string second = await generator.GenerateInstanceId();
+
+        HostPart(first).Should().Be(HostPart(second),
+            "both ran on this machine, so the host name in them is the same host name — the state every "
+            + "replica of a container image is in");
+        first.Should().NotBe(second,
+            "with the host part identical, the whole of the difference has to come from what is appended "
+            + "to it; a generator that appended nothing would hand every replica one id");
+    }
+
+    /// <summary>
+    /// The same question asked of a whole scheduler, because <c>AUTO</c> is a configuration key rather
+    /// than a type name and the wiring behind it is what an application actually gets.
+    /// </summary>
+    /// <remarks>
+    /// Both nodes are built here in one process and share a scheduler name, which is what a cluster is.
+    /// Each <see cref="QuartzSchedulerBuilder" /> owns its own container and its own repository, so this
+    /// really is two nodes rather than one looked up twice.
+    /// </remarks>
+    [Test]
+    public async Task TwoNodesConfiguredAutoGetDistinctInstanceIds()
+    {
+        NameValueCollection properties = new()
+        {
+            ["quartz.scheduler.instanceName"] = "AutoInstanceIdCluster",
+            ["quartz.scheduler.instanceId"] = "AUTO",
+            ["quartz.threadPool.maxConcurrency"] = "1",
+        };
+
+        await using StandaloneSchedulerFactory firstNode = ClusteredNodeBuilder.Build(properties);
+        await using StandaloneSchedulerFactory secondNode = ClusteredNodeBuilder.Build(properties);
+
+        IScheduler first = await firstNode.GetScheduler();
+        IScheduler second = await secondNode.GetScheduler();
+
+        first.SchedulerInstanceId.Should().NotBe(QuartzSchedulerOptions.DefaultInstanceId,
+            "AUTO over a clustered store means 'generate one', and NON_CLUSTERED is the placeholder for a "
+            + "scheduler that shares its database with nobody");
+        first.SchedulerInstanceId.Should().NotBe(second.SchedulerInstanceId,
+            "two nodes of one cluster that agree on their id are indistinguishable in every table the "
+            + "store writes");
+    }
+
+    /// <summary>
+    /// The digits <see cref="SimpleInstanceIdGenerator" /> appends, removed. A host name that itself
+    /// ends in a digit loses that too, which costs nothing here: both ids lose the same characters, so
+    /// what is left is still the same string for both whenever the host name is.
+    /// </summary>
+    private static string HostPart(string instanceId) => instanceId.TrimEnd('0', '1', '2', '3', '4', '5', '6', '7', '8', '9');
+}

--- a/src/Quartz.Tests.Unit/Simpl/ClusteredNodeBuilder.cs
+++ b/src/Quartz.Tests.Unit/Simpl/ClusteredNodeBuilder.cs
@@ -1,0 +1,75 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// Builds a scheduler whose job store reports itself clustered, which is the only condition under
+/// which an instance id is generated at all: <c>DefaultSchedulerFactory.GenerateInstanceId</c> hands
+/// back <see cref="QuartzSchedulerOptions.DefaultInstanceId" /> without asking the generator anything
+/// when the store shares its database with nobody.
+/// </summary>
+/// <remarks>
+/// The store is in-memory and merely says it is clustered. That is all an instance-id test needs — the
+/// id is settled before the store is asked to do anything — and it is why these tests need no database,
+/// which is what the <c>TODO</c> in <see cref="SystemPropertyInstanceIdGeneratorTest" /> was waiting
+/// for.
+/// </remarks>
+internal static class ClusteredNodeBuilder
+{
+    /// <summary>
+    /// Builds a node's factory. The caller owns it: disposing the factory disposes the container it
+    /// built and shuts the scheduler down.
+    /// </summary>
+    public static StandaloneSchedulerFactory Build(NameValueCollection properties = null)
+    {
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
+
+        if (properties is not null)
+        {
+            builder = builder.UseProperties(properties);
+        }
+
+        return builder
+            .UseJobStore(provider => new ClusteredInMemoryJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider)))
+            .Build();
+    }
+
+    /// <summary>
+    /// An in-memory store that answers <see cref="IJobStore.Clustered" /> the way a database-backed
+    /// store configured for a cluster does, and behaves in every other respect like the store it wraps.
+    /// </summary>
+    private sealed class ClusteredInMemoryJobStore : DelegatingJobStore
+    {
+        public ClusteredInMemoryJobStore(IJobStore jobStore) : base(jobStore)
+        {
+        }
+
+        public override bool Clustered => true;
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/SystemPropertyInstanceIdGeneratorTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SystemPropertyInstanceIdGeneratorTest.cs
@@ -21,14 +21,19 @@
 
 using System.Collections.Specialized;
 
+using Quartz.Configuration;
 using Quartz.Impl;
-using Quartz.Impl.AdoJobStore;
 
 namespace Quartz.Tests.Unit.Simpl;
 
 /// <summary>
 /// Unit test for SystemPropertyInstanceIdGenerator.
 /// </summary>
+/// <remarks>
+/// Not parallelizable: the setup writes environment variables, which belong to the process rather than
+/// to this fixture, and one of the tests holds them across building a whole scheduler.
+/// </remarks>
+[NonParallelizable]
 public class SystemPropertyInstanceIdGeneratorTest
 {
     [SetUp]
@@ -93,13 +98,21 @@ public class SystemPropertyInstanceIdGeneratorTest
         Assert.That(instId, Is.EqualTo("goo"));
     }
 
+    /// <summary>
+    /// The generator reached through configuration rather than constructed: the type, the variable it
+    /// reads and the prefix and suffix around it all arrive as strings, and nothing else asserts that
+    /// those four keys land on the object the container builds.
+    /// </summary>
+    /// <remarks>
+    /// The store is in-memory and merely reports itself clustered — see
+    /// <see cref="ClusteredNodeBuilder" /> — because that is the whole of what the id path needs. A
+    /// scheduler whose store is not clustered never asks the generator anything; it takes
+    /// <see cref="QuartzSchedulerOptions.DefaultInstanceId" />. The database the <c>TODO</c> that stood
+    /// here was waiting for would have bought nothing beyond saying <c>true</c>.
+    /// </remarks>
     [Test]
-    [Ignore("Work in progress")]
     public async Task TestGeneratorThroughSchedulerInstantiation()
     {
-        // TODO
-        //JdbcQuartzTestUtilities.createDatabase("MeSchedulerDatabase");
-
         NameValueCollection config = new NameValueCollection();
         config["quartz.scheduler.instanceName"] = "MeScheduler";
         config["quartz.scheduler.instanceId"] = "AUTO";
@@ -107,14 +120,15 @@ public class SystemPropertyInstanceIdGeneratorTest
         config["quartz.scheduler.instanceIdGenerator.prepend"] = "1";
         config["quartz.scheduler.instanceIdGenerator.postpend"] = "2";
         config["quartz.scheduler.instanceIdGenerator.systemPropertyName"] = "blah.blah";
-        config["quartz.threadPool.threadCount"] = "1";
+        config["quartz.threadPool.maxConcurrency"] = "1";
         config["quartz.threadPool.type"] = typeof(DefaultThreadPool).AssemblyQualifiedName;
-        config["quartz.jobStore.type"] = typeof(LocalTransactionJobStore).AssemblyQualifiedName;
-        config["quartz.jobStore.clustered"] = "true";
-        config["quartz.jobStore.dataSource"] = "MeSchedulerDatabase";
 
-        IScheduler scheduler = await QuartzSchedulerBuilder.Create().UseProperties(config).BuildScheduler();
+        await using StandaloneSchedulerFactory factory = ClusteredNodeBuilder.Build(config);
+        IScheduler scheduler = await factory.GetScheduler();
 
-        Assert.That(scheduler.SchedulerInstanceId, Is.EqualTo("1goo2"));
+        scheduler.SchedulerInstanceId.Should().Be("1goo2",
+            "the id is the value of the variable systemPropertyName named, wrapped in the prepend and "
+            + "postpend keys — all four settings arrive as strings and are applied to the generator after "
+            + "the container has constructed it");
     }
 }


### PR DESCRIPTION
Five clustering paths had no test at all. Nothing here changes clustering behaviour; the one
product-adjacent edit is a paragraph of documentation correcting what the issue's clock-skew bullet
assumes.

## What each fixture proves

**`AutoInstanceIdTest`** — `quartz.scheduler.instanceId = AUTO` had no test that the ids it produces
differ, which is the only thing it is for. Two hundred back-to-back generations from
`SimpleInstanceIdGenerator` are all distinct, and a pair of them is shown to share its host part and
differ only in what follows — everything here is generated on one machine, which is the reported
failure's arrangement, so the assertion is about the suffix rather than about a host name the test
would have to guess. Then the same question of two whole schedulers: two nodes sharing a scheduler
name, each with its own container, come out with different `SchedulerInstanceId`s and neither is
`NON_CLUSTERED`.

`SystemPropertyInstanceIdGeneratorTest.TestGeneratorThroughSchedulerInstantiation` loses its
`[Ignore("Work in progress")]` and its `TODO` body. The database the `TODO` was waiting for was never
the point: `DefaultSchedulerFactory.GenerateInstanceId` asks the generator for an id only when the
store reports itself clustered, so an in-memory store that reports so is the whole of what the path
needs. `ClusteredNodeBuilder` is that store, and the test now asserts what it always meant to —
`1goo2`, the environment variable `systemPropertyName` names wrapped in the `prepend` and `postpend`
keys, all four of them arriving as strings and applied after the container has constructed the
generator. The fixture is `[NonParallelizable]` now, because its setup writes environment variables
and one of its tests holds them across building a scheduler.

**`AdoJobStoreBaseTest`, `#region Clock skew`** — four tests on the faked delegate and a
`FakeTimeProvider`: the verdicts a store reaches are unchanged by its clock standing five years from
real time as long as the cluster agrees with itself; a peer is tolerated up to its own stored check-in
interval plus this node's misfire threshold, inclusive, and one millisecond past that is recovered; a
node whose clock runs ahead of the cluster declares healthy peers failed, and its listing agrees with
its sweep; a node whose clock lags never declares a peer failed at all.

**`InProcessLockHandlerTest`** — six tests for the handler that serializes every write a single-node
ADO store makes, and which had a benchmark and nothing else. One holder at a time; an owner asking
again answered without waiting and without a second hold to give back; a release by a non-owner that
leaves the holder holding it and logs `3704` at warning; a waiter cancelled while queued that takes
nothing, does not throw, and leaves the handover intact for the next caller; the two lock kinds held
apart; sixteen contenders all served with never two inside at once. Nothing sleeps: a held lock makes
the next request's task incomplete synchronously, so "queued" is asserted by looking at the task.
Ordering among waiters is deliberately not asserted, and the fixture says why — the queue is a
`SemaphoreSlim`, which promises none.

**`DbLockHandlerContentionTestBase`** (PostgreSQL, SQL Server) — eight callers spread over two stores,
released together against a real database: every one served, no two counted inside the row at once,
the run finishes, one lock row left. A second test watches the same property from the waiting side —
a request parked in the server while the holder has not committed — and gives the wait teeth by
requiring the handover after the commit to be quicker than the window in which it demonstrably did
not happen. The handler is read off a real store initialized with clustering on rather than
constructed in the fixture, so each leg exercises the statement its dialect actually gets, and the
type is asserted so that a store which started picking a different handler fails here rather than
leaving the fixture testing something else under the same name.

Checked for teeth: with the `AcquireLock` call taken out, the occupancy assertion fails with
`{2, 4, 3, 2}`.

**`ClusteredExactlyOnceMySqlTest` / `…OracleTest` / `…FirebirdTest`** — the thirty-trigger
exactly-once case on the three engines that had no clustered test at all. All three fire it across
both nodes: 19/11 on MySQL, 11/19 on Oracle, 10/20 on Firebird, so the property is being contended
for rather than one node quietly doing all the work.

## For a reviewer to decide

**The new fixtures derive from a new `ClusteredExactlyOnceTestBase` rather than from
`ClusteredHardeningTestBase` directly.** The issue asks for the thirty-trigger case on three engines;
a subclass of the hardening base would have brought the four residue cases with it, and those write a
dead node's rows by hand — which would make each new fixture spell a boolean (`bit`, `boolean`,
`VARCHAR2(1)`, `SMALLINT`) and a timestamp the way its engine stores them. That is fixture work rather
than coverage of the store, and it would have taken each new leg from ~13 s to ~32 s inside a
ten-minute budget that has an Oracle container in it. `ClusteredHardeningTestBase` now derives from
the new base, so PostgreSQL and SQL Server run exactly what they ran before.

**Firebird now runs clustered, where `AdoJobStoreSmokeTest.TestFirebird` passes `clustered: false`.**
Nothing in the repository says why the smoke test opts out, and the thirty-trigger case passes on
Firebird with work genuinely split across the two nodes. If that opt-out records a known problem
rather than an accident, this fixture should hear about it.

## The defect this pins and does not fix

A node whose clock runs more than *(the peer's stored check-in interval + this node's misfire
threshold)* ahead of a peer's declares that healthy peer failed and takes its work over; the same
comparison read from the other end is a punctual node on a lagging clock being recovered while it
runs. #3436 puts the failure predicate out of scope, so the behaviour is pinned by
`ClockSkew_ANodeWhoseClockRunsAheadOfTheClusterDeclaresHealthyPeersFailed` rather than changed.

## Premises corrected

- **"Clock skew" is not about the database's clock.** The issue and discussion #2248 read as though a
  database server whose clock disagrees with the nodes could cause false failovers. It cannot:
  `LAST_CHECKIN_TIME` holds the *writing node's* reading of its own `TimeProvider`, and no statement
  in the store asks the server what time it is — there is no `GETDATE()`, `now()` or `SYSDATE`
  anywhere in the SQL. Only the nodes' clocks agreeing with each other matters.
  `troubleshooting.md`'s "Clock Skew Between Nodes" now says so, because setting the database
  server's clock is a fix people will otherwise reach for.
- **The self-failed-out bullet is already covered**, by #3512 —
  `ClusteredHardeningTestBase.NodeFailedOutByAPeer_RegistersItselfAgainAndDoesNotReplayItsOwnWork`
  plus the unit tests in `#region Self-failed-out`. Nothing was added for it.
- **`DbSemaphore` contention was not entirely untested, but nearly.** `DbLockHandlerRetryTest` and
  `DbLockHandlerSubclassContractTest` exist; both run in front of a faked provider, so they prove a
  handler retries and can be subclassed, and nothing about whether its statement excludes anybody.
  `RedisLockHandlerTest` covers the Redis handler against a real Redis, and `SqliteLockHandlerTest`
  exists too. `InProcessLockHandler` had only the benchmark, as the issue says.
- **The generator behind `AUTO` does not in fact collide on identical host names.**
  `SimpleInstanceIdGenerator` appends `TimeProvider.GetTimestamp()`, so the container case the issue
  describes is survived — which is what the new tests establish, rather than a bug they fix.
  `HostNameInstanceIdGenerator`, which is the host name and nothing else, is a different generator
  and a deliberate one.

## Verification

```
dotnet build Quartz.slnx                                   0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit  (run 1)                 3711 passed, 0 failed, 0 skipped (55 s)
dotnet test src/Quartz.Tests.Unit  (run 2)                 3711 passed, 0 failed, 0 skipped (51 s)
dotnet test src/Quartz.Tests.AspNetCore                    547 passed, 0 failed
dotnet fallout VerifyDocsSnippets                          up to date (93 markdown files checked)
```

Integration legs, run as `QUARTZ_TEST_DATABASE=<db>` with `--filter TestCategory=db-<db>`. Wall clock
is for the whole leg on this machine with the container image already pulled:

| Leg | Result | Leg wall clock | Added case |
|---|---|---|---|
| postgres | 154 passed, 0 failed | 2 m 51 s | lock contention, 3 s |
| sqlserver | 146 passed, 0 failed | 3 m 17 s | lock contention, 3 s |
| mysql | 87 passed, 0 failed | 1 m 36 s | exactly-once, 9–12 s |
| oracle | 86 passed, 0 failed | 2 m 16 s | exactly-once, 13–14 s |
| firebird | 87 passed, 0 failed | 1 m 56 s | exactly-once, 9 s |
| basic | 335 passed, 0 failed | 1 m 46 s | — |

Every leg is inside the ten-minute budget with room to spare: the three new exactly-once cases add
9–14 s each and the two lock-contention fixtures 3 s each. There is no `Quartz.Tests.AOT` project on
this branch. `npm run docs:check-links` was not run — the docs edit adds no link and no heading, and
`node_modules` is not installed in this worktree.

Closes #3436
