### PR TITLE
Four stale statements are corrected and TimeZones drops its logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,11 @@ binds this repository.
   `src/Quartz/ILLink.Suppressions.xml`, which the worker example's trimmed publish applies; ILCompiler takes no
   such file, so a native AOT publish still reports them). A warning in a type not listed there means new
   reflection — fix it rather than adding a line; that file explains the order to try fixes in. Neither file
-  ships, so consumers still see every warning. The package does **not** say `IsAotCompatible`, and
-  `src/Quartz/Quartz.csproj` says why. Tracked on #3341.
+  ships, so consumers still see every warning. The package **does** say `IsAotCompatible`, and the claim is
+  narrow: Quartz produces no `IL3050` at all, so nothing it does needs code generated at run time, while the
+  `IL2xxx` that remain are the string-named paths #3341 tracks and are unaffected by it. The property lands
+  in the assembly as `[AssemblyMetadata("IsAotCompatible", "True")]` and puts nothing in the nuspec, so its
+  audience is the analyzers and a reader of `src/Quartz/Quartz.csproj`, which spells all of this out.
 - **Allman brace style** — braces on new lines for methods, types, control blocks, properties, accessors, lambdas.
 - **No `DateTime.Now`/`DateTimeOffset.Now`** — banned via Roslyn analyzer (`BannedSymbols.txt`). Use `TimeProvider` instead.
 - **No implicit `DateTime` → `DateTimeOffset` cast** — also banned.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -695,17 +695,18 @@ If you implement `IJobStore` or `ISchedulerPlugin` yourself, they take their col
 constructors now instead of being handed them afterwards.
 
 `IJobStore` loses `InstanceId`, `InstanceName`, `ThreadPoolSize` and `TimeProvider`, and `Initialize`
-loses its parameters:
+takes the scheduler's identity in place of its collaborators:
 
 ```diff
 - ValueTask Initialize(ITypeLoadHelper loadHelper, ISchedulerSignaler signaler, CancellationToken cancellationToken = default);
-+ ValueTask Initialize(CancellationToken cancellationToken = default);
++ ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default);
 ```
 
 Take what you need — `ISchedulerSignaler`, `ITypeLoader`, `TimeProvider`,
-`IOptions<QuartzSchedulerOptions>` — through your constructor. What remains in `Initialize` is work
-that has to happen before the scheduler runs and cannot be done while constructing, such as verifying
-a database schema.
+`IOptions<QuartzSchedulerOptions>` — through your constructor. The identity is the one thing a constructor
+cannot carry, for the reason [If you implement `IJobStore`](#if-you-implement-ijobstore) gives. What
+remains in `Initialize` is work that has to happen before the scheduler runs and cannot be done while
+constructing, such as verifying a database schema.
 
 Options arrive as the scheduler's own, whichever of the three interfaces you ask for.
 `IOptionsMonitor<QuartzSchedulerOptions>` and `IOptionsSnapshot<QuartzSchedulerOptions>` work as well
@@ -4156,12 +4157,12 @@ The scheduler body's `statistics` object gained `localExecutingJobs`, mirroring 
 
 Three members. `QueryFireInstances(FireInstanceQuery, CancellationToken)` is the listing, abstract like
 the rest of the query family; `QueryClusterNodes(CancellationToken)` is the node listing described in
-[The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing). And `Initialize` now
-takes a `SchedulerIdentity`:
+[The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing). And `Initialize` takes a
+`SchedulerIdentity`, which is the whole of what it takes — see
+[SPI changes](#spi-changes) for what its 3.x parameters became:
 
-```diff
-- ValueTask Initialize(CancellationToken cancellationToken = default);
-+ ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default);
+```csharp
+ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default);
 ```
 
 The identity — the scheduler's name and this node's instance id — could not be a constructor argument,

--- a/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
@@ -42,6 +42,30 @@ JobStore implementation for Quartz.NET scheduler using MongoDb.
 
 Autofac integration package for Quartz.Net.
 
+## Dashboards
+
+### [CrystalQuartz](https://github.com/guryanovev/CrystalQuartz)
+
+A pluggable web UI for Quartz.NET, hosted inside the application whose scheduler it watches.
+
+### [SilkierQuartz](https://github.com/MaiKeBing/SilkierQuartz)
+
+Web management tools for Quartz.NET, with an execution-history plugin of its own and EF Core stores to
+keep that history in.
+
+::: warning Neither has a Quartz.NET 4.0 release yet
+As with everything else on this page, 4.0 support is theirs to state — and when this page was last
+checked, on 2026-08-30, neither had published a release built against it: SilkierQuartz 10.0.0 depends on
+`Quartz` 3.18.0, and CrystalQuartz 7.3.0's Quartz 3 adapter is compiled against the 3.x interface. Both
+read `IScheduler.GetMetaData()`, `IScheduler.GetCurrentlyExecutingJobs()` and the `IsStarted` /
+`InStandbyMode` / `IsShutdown` triple, every one of which 4.0 renamed or removed — the
+[appendix to the migration guide](../migration-guide.md#appendix-what-happened-to-a-name) says what each
+became. Both bind to whichever `Quartz` assembly the host loaded rather than to one of their own, so the
+mismatch shows itself when the dashboard is served, not when the application compiles.
+
+[`Quartz.Dashboard`](dashboard.md), which ships from this repository, is built against 4.0.
+:::
+
 ## Schedules
 
 ### [NaturalCron.Quartz](https://github.com/hugoj0s3/NaturalCron)

--- a/src/Quartz.Tests.Unit/TimeZonesTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZonesTest.cs
@@ -330,6 +330,39 @@ public class TimeZonesTest
     }
 
     [Test]
+    public void NotFoundMessage_NamesTheAliasThatWasTriedToo()
+    {
+        string message = TimeZones.NotFoundMessage("CET", attemptedAlias: "Central European Standard Time");
+
+        message.Should().Contain("CET").And.Contain("Central European Standard Time",
+            "an alias lookup that fails used to be logged, and the message is the only place that signal "
+            + "can live now that TimeZones carries no logger - without it a reader of the failure cannot "
+            + "tell that a second id was tried");
+    }
+
+    [Test]
+    public void NotFoundMessage_WithNoAliasTried_NamesOnlyTheIdAsked()
+    {
+        string message = TimeZones.NotFoundMessage("Quartz/Test-Unknown-Zone", attemptedAlias: null);
+
+        message.Should().Contain("Quartz/Test-Unknown-Zone").And.NotContain("alias",
+            "an id the alias table does not know was never looked up under a second name, so there is no "
+            + "second id to report");
+    }
+
+    [Test]
+    public void TimeZones_CarriesNoLoggingDependency()
+    {
+        // TimeZones is reached from CronExpression and from trigger deserialization, neither of which
+        // needs a scheduler; keeping it on the BCL alone is what lets that code be split into a package
+        // of its own later without taking Microsoft.Extensions.Logging along.
+        string source = File.ReadAllText(Path.Combine(RepositoryRoot.Find().FullName, "src", "Quartz", "TimeZones.cs"));
+
+        source.Should().NotContain("Microsoft.Extensions.Logging").And.NotContain("LogProvider").And.NotContain("ILogger",
+            "TimeZones.cs is deliberately free of any tie to logging, and one call site is all it takes to put it back");
+    }
+
+    [Test]
     public void AddResolver_MostRecentlyAddedWins_AndDisposalUnregisters()
     {
         const string id = "Quartz/Test-Resolver-Ordering";

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -390,8 +390,6 @@
     "Deleting trigger: {Key}"
 5100  Warning  UtilityLog.MisfireInstructionFromAnotherFamily
     "Misfire instruction '{MisfireInstruction}' is not one of the {Family} trigger names. It resolves to code {Code}, which for this trigger means {Policy}; spell it '{Canonical}'"
-5101  Error  UtilityLog.TimeZoneAliasNotFound
-    "Could not find time zone using alias id {AliasId}"
 5102  Warning  UtilityLog.TypeFoundUnderNewName
     "Type '{OldName}' was found as '{NewName}'; the type moved in Quartz 4.0. Update the configuration, as this fallback will not last forever."
 5103  Warning  UtilityLog.UnrecognizedCronMisfirePolicy

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -19,9 +19,6 @@
 
 #endregion
 
-using Microsoft.Extensions.Logging;
-
-using Quartz.Diagnostics;
 using Quartz.Util;
 
 namespace Quartz;
@@ -364,13 +361,14 @@ public static class TimeZones
     public static TimeZoneInfo FindById(string id)
     {
         TimeZoneInfo? info = null;
+        string? attemptedAlias = null;
         try
         {
             info = TimeZoneInfo.FindSystemTimeZoneById(id);
         }
         catch (TimeZoneNotFoundException ex)
         {
-            if (timeZoneIdAliases.TryGetValue(id, out var aliasedId))
+            if (timeZoneIdAliases.TryGetValue(id, out string? aliasedId))
             {
                 try
                 {
@@ -378,8 +376,10 @@ public static class TimeZones
                 }
                 catch
                 {
-                    var logger = LogProvider.CreateLogger(nameof(TimeZones));
-                    logger.TimeZoneAliasNotFound(aliasedId);
+                    // Not logged: this file depends on the BCL alone, so that the time zone and cron
+                    // code can be split into a package of its own without dragging logging with it.
+                    // The alias travels in the message of the failure below instead.
+                    attemptedAlias = aliasedId;
                 }
             }
 
@@ -425,12 +425,22 @@ public static class TimeZones
             if (info is null)
             {
                 // we tried our best
-                throw new TimeZoneNotFoundException(
-                    $"Could not find time zone with id {id}, consider using Quartz.Plugins.TimeZoneConverter for resolving more time zones ids",
-                    ex);
+                throw new TimeZoneNotFoundException(NotFoundMessage(id, attemptedAlias), ex);
             }
         }
 
         return info;
+    }
+
+    /// <summary>
+    /// The message a lookup that ran out of fallbacks carries. <paramref name="attemptedAlias" /> is the
+    /// other spelling this id is known by, when one was tried and did not resolve either: it is the
+    /// second id the search gave up on, and naming it is the only trace left that the alias table was
+    /// consulted at all.
+    /// </summary>
+    internal static string NotFoundMessage(string id, string? attemptedAlias)
+    {
+        string alsoTried = attemptedAlias is null ? "" : $" (nor under its alias {attemptedAlias})";
+        return $"Could not find time zone with id {id}{alsoTried}, consider using Quartz.Plugins.TimeZoneConverter for resolving more time zones ids";
     }
 }

--- a/src/Quartz/Util/UtilityLog.cs
+++ b/src/Quartz/Util/UtilityLog.cs
@@ -50,9 +50,6 @@ internal static partial class UtilityLog
         string policy,
         string canonical);
 
-    [LoggerMessage(EventId = 5101, Level = LogLevel.Error, Message = "Could not find time zone using alias id {AliasId}")]
-    public static partial void TimeZoneAliasNotFound(this ILogger logger, string aliasId);
-
     [LoggerMessage(EventId = 5102, Level = LogLevel.Warning, Message = "Type '{OldName}' was found as '{NewName}'; the type moved in Quartz 4.0. Update the configuration, as this fallback will not last forever.")]
     public static partial void TypeFoundUnderNewName(this ILogger logger, string oldName, string newName);
 


### PR DESCRIPTION
Four corrections that share nothing but a milestone. Each is one commit and stands on its own.

**1. `AGENTS.md` said the package does not claim `IsAotCompatible`.** `src/Quartz/Quartz.csproj:47` has set
`<IsAotCompatible>true</IsAotCompatible>` since #3476, and the csproj comment above it argues the claim
rather than its absence — as do `migration-guide.md` ("`Quartz` also declares **`IsAotCompatible`** on 4.0,
which 3.x does not") and `how-tos/trimming-and-native-aot.md:12`. The sentence now carries what the claim is
worth, since that is the part worth reading: no `IL3050` anywhere, the remaining `IL2xxx` being the
string-named paths #3341 tracks, and the property landing in assembly metadata and nothing in the nuspec.
`TrimAnalysisBaseline.cs` guidance and the #3341 reference around it are untouched. `AGENTS.md` is 21.3 kB
against `AgentInstructionsTest`'s 32,768.

**2. The migration guide stated a superseded `IJobStore.Initialize`.** `:702` showed
`Initialize(CancellationToken cancellationToken = default)`; the shipped member is
`Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default)`
(`src/Quartz/Extensibility/IJobStore.cs:80`, baseline `PublicApiTest_Quartz.verified.txt:1899`). The guide
already got it right at `:4159-4165`, so the two halves disagreed and whichever one a reader met first
decided whether their store compiled.

The SPI section now shows the shipped signature and points at the later section for why an identity cannot
be a constructor argument. The later section drops its `diff` block, whose `-` line was a 4.0-preview
signature no reader migrating from 3.x has ever seen, and points back at the SPI section for what the 3.x
parameters became. Those two are the only stale mentions: `grep` finds `Initialize(CancellationToken)`
elsewhere only for `IThreadPool` (correct — `src/Quartz/Extensibility/IThreadPool.cs:58`), and
`how-tos/custom-job-store.md:116` already had the identity form.

**3. `TimeZones.cs` no longer reaches for a logger.** One call site — an alias lookup that failed —
was the whole of what tied a BCL-only file to `Microsoft.Extensions.Logging`. Removing it now is free
insurance for the `Quartz.Cron` split, which is not alpha.4's business; a one-line comment where the call
was says so. `UtilityLog.TimeZoneAliasNotFound` had no other caller and goes with it, and the
`LogEventCatalogTest_Quartz` baseline was re-accepted through Verify (`.received` → `.verified`, the diff
being exactly those two lines). Event id 5101 is retired rather than reused.

**A reviewer should decide one thing here.** The issue says "the alias miss is already reflected in the
return value", which is not what the code does: `FindById` returns a non-nullable `TimeZoneInfo` and
**throws** on a total miss, and its message named only the id the caller asked for — never the alias the
search also gave up on. So the log was the only trace that a second id had been tried. I kept that signal
by putting the alias in the exception message, which is where a caller can act on it, rather than dropping
it. This also fixes a smaller wart: the old call logged at **Error** level even when the alias miss was
followed by a successful resolution through the BCL conversion or a registered resolver.

The message composition is tested directly (`NotFoundMessage_*`), because the branch that produces a
non-null alias needs a platform that ships *neither* spelling of an aliased pair and so cannot be reached
deterministically from `FindById` — `FindById_ResolvesAliasPairsOnAnyPlatform` covers every pair the table
holds. `TimeZones_CarriesNoLoggingDependency` is the guard that keeps the file logger-free; it fails on the
tree as it stood.

**4. A Dashboards section on the third-party page.** The page listed Migrations, Database Implementations,
Dependency Injection and Schedules, and mentioned neither CrystalQuartz nor SilkierQuartz — so the first
thing a 4.0 adopter learned about them was a run-time failure. Quartzmin is not listed. What the note claims
was checked rather than assumed:

* SilkierQuartz 10.0.0's nuspec depends on `Quartz` 3.18.0; `Controllers/SchedulerController.cs` calls
  `GetMetaData()`, `GetCurrentlyExecutingJobs()` and `IsShutdown`.
* CrystalQuartz 7.3.0's `CrystalQuartz.Core.Quartz3/Quartz3SchedulerClerk.cs` calls `GetMetaData()`,
  `GetCurrentlyExecutingJobs()`, `IsShutdown`, `InStandbyMode`, `IsStarted` and `SchedulerMetaData.InStandbyMode`.
* None of those members is in `PublicApiTest_Quartz.verified.txt`.

`CheckExists`, which the brief also listed, is **not** called by either project's current source, so the
note does not claim it. The claim is dated in the page text, because it is a fact about a moment, and 4.0
support stays theirs to state.

## Verification

```
dotnet build Quartz.slnx                                     Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                            Passed! Failed: 0, Passed: 3763, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore                      Passed! Failed: 0, Passed: 549, Skipped: 0
dotnet fallout VerifyDocsSnippets                            Succeeded (93 markdown files checked)
cd docs && npm ci && npm run docs:check-links                214 pages, 899 internal links, 545 fragments,
                                                             no dead links or anchors
```

`Quartz.Tests.Integration` was not run: nothing here touches a store, a delegate or a dialect.
No public API moved — `PublicApiTest` is part of the unit run above and `NotFoundMessage` is `internal` —
so there is no migration-guide API delta to carry beyond item 2's correction.

Part of milestone 4.0.0-alpha.4.

Closes #3539.
