### PR TITLE
The cron and scheduling numbers are measured on main, not quoted from 3.14

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,6 +35,7 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="MySqlConnector" Version="2.6.2" />
+    <PackageVersion Include="NCrontab" Version="3.4.0" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="6.2.0" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.7.1" />
     <PackageVersion Include="NUnit" Version="4.6.1" />

--- a/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
+++ b/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
@@ -118,6 +118,7 @@ public enum AcquisitionIndexShape
 /// table. If an index cannot win here it cannot win anywhere on this path.
 /// </para>
 /// </remarks>
+[MemoryDiagnoser]
 [SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
 [BenchmarkCategory(BenchmarkCategories.RequiresDatabase, BenchmarkCategories.LongRunning)]
 public class AcquisitionIndexBenchmark

--- a/src/Quartz.Benchmark/CronExpressionComparisonBenchmark.cs
+++ b/src/Quartz.Benchmark/CronExpressionComparisonBenchmark.cs
@@ -1,0 +1,160 @@
+using BenchmarkDotNet.Attributes;
+
+using NCrontab;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The cron cases a published cross-library comparison reports Quartz numbers for, measured on this
+/// branch and beside the library it was compared against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// TickerQ's <c>CronExpressionComparison</c> puts <see cref="Quartz.CronExpression.GetNextValidTimeAfter" />
+/// at roughly 1.2 µs and 3 KB a call against NCrontab's 13 ns and nothing, and construction at 3-4 µs
+/// and 9-13 KB. That run was taken against Quartz 3.14, which predates the bitmask cron fields
+/// (#3126-#3129) and 4.0's rebuilt <see cref="Quartz.CronExpression" />, and nobody had re-measured. This
+/// is that measurement, kept deliberately close to the published one so the two tables can be read
+/// against each other: the same three schedules in both dialects, the same fixed instant, the same
+/// operations, and NCrontab running in the same process so both rows come off one table on one machine
+/// rather than off two tables on two.
+/// </para>
+/// <para>
+/// Neither library is handed a time zone, exactly as the published comparison leaves them, so
+/// <see cref="Quartz.CronExpression" /> resolves against the machine's local zone while NCrontab has no
+/// notion of one. Whether that zone observes daylight saving decides whether the interval expressions
+/// take the fall-back pass, so the zone belongs beside any number taken from this;
+/// <c>src/Quartz.Benchmark/README.md</c> records it with the rest of the machine.
+/// </para>
+/// <para>
+/// This measures production code against a reference implementation rather than two arms of ours, so
+/// there is nothing to switch on: the comparison is between the rows of a single run.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class CronExpressionComparisonBenchmark
+{
+    /// <summary>Every five minutes, in NCrontab's five-field form.</summary>
+    private const string SimpleNCrontab = "*/5 * * * *";
+
+    /// <summary>Every five minutes, in Quartz's seven-field form.</summary>
+    private const string SimpleQuartz = "0 0/5 * * * ?";
+
+    /// <summary>On the hour through the working day, Monday to Friday.</summary>
+    private const string ComplexNCrontab = "0 9-17 * * 1-5";
+
+    /// <inheritdoc cref="ComplexNCrontab" />
+    private const string ComplexQuartz = "0 0 9-17 ? * MON-FRI";
+
+    /// <summary>Every thirty seconds, which is the finest resolution either dialect reaches.</summary>
+    private const string SecondLevelNCrontab = "*/30 * * * * *";
+
+    /// <inheritdoc cref="SecondLevelNCrontab" />
+    private const string SecondLevelQuartz = "0/30 * * * * ?";
+
+    /// <summary>
+    /// NCrontab reads a five-field expression by default; the second-level one is six, and says so.
+    /// </summary>
+    private static readonly CrontabSchedule.ParseOptions secondLevelOptions = new CrontabSchedule.ParseOptions { IncludingSeconds = true };
+
+    /// <summary>
+    /// The instant the published comparison searches from. It is a Monday noon, so the weekday
+    /// expression's next fire is later the same day and no case is measuring a walk over a weekend.
+    /// </summary>
+    private static readonly DateTime baseTime = new DateTime(2026, 3, 16, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc cref="baseTime" />
+    private static readonly DateTimeOffset baseTimeOffset = new DateTimeOffset(baseTime, TimeSpan.Zero);
+
+    private CronExpression quartzSimple = null!;
+    private CronExpression quartzComplex = null!;
+    private CronExpression quartzSecondLevel = null!;
+    private CrontabSchedule ncrontabSimple = null!;
+    private CrontabSchedule ncrontabComplex = null!;
+    private CrontabSchedule ncrontabSecondLevel = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        quartzSimple = new CronExpression(SimpleQuartz);
+        quartzComplex = new CronExpression(ComplexQuartz);
+        quartzSecondLevel = new CronExpression(SecondLevelQuartz);
+
+        ncrontabSimple = CrontabSchedule.Parse(SimpleNCrontab);
+        ncrontabComplex = CrontabSchedule.Parse(ComplexNCrontab);
+        ncrontabSecondLevel = CrontabSchedule.Parse(SecondLevelNCrontab, secondLevelOptions);
+    }
+
+    [Benchmark]
+    public CronExpression Parse_Simple() => new CronExpression(SimpleQuartz);
+
+    [Benchmark]
+    public CrontabSchedule Parse_Simple_NCrontab() => CrontabSchedule.Parse(SimpleNCrontab);
+
+    [Benchmark]
+    public CronExpression Parse_Complex() => new CronExpression(ComplexQuartz);
+
+    [Benchmark]
+    public CrontabSchedule Parse_Complex_NCrontab() => CrontabSchedule.Parse(ComplexNCrontab);
+
+    [Benchmark]
+    public CronExpression Parse_SecondLevel() => new CronExpression(SecondLevelQuartz);
+
+    [Benchmark]
+    public CrontabSchedule Parse_SecondLevel_NCrontab() => CrontabSchedule.Parse(SecondLevelNCrontab, secondLevelOptions);
+
+    [Benchmark]
+    public DateTimeOffset? Next_Simple() => quartzSimple.GetNextValidTimeAfter(baseTimeOffset);
+
+    [Benchmark]
+    public DateTime Next_Simple_NCrontab() => ncrontabSimple.GetNextOccurrence(baseTime);
+
+    [Benchmark]
+    public DateTimeOffset? Next_Complex() => quartzComplex.GetNextValidTimeAfter(baseTimeOffset);
+
+    [Benchmark]
+    public DateTime Next_Complex_NCrontab() => ncrontabComplex.GetNextOccurrence(baseTime);
+
+    [Benchmark]
+    public DateTimeOffset? Next_SecondLevel() => quartzSecondLevel.GetNextValidTimeAfter(baseTimeOffset);
+
+    [Benchmark]
+    public DateTime Next_SecondLevel_NCrontab() => ncrontabSecondLevel.GetNextOccurrence(baseTime);
+
+    /// <summary>
+    /// A hundred fires chained off each other, which is the shape a running trigger has and the case
+    /// where a per-call allocation shows up as something an application would notice.
+    /// </summary>
+    [Benchmark]
+    public DateTimeOffset? Next100()
+    {
+        DateTimeOffset current = baseTimeOffset;
+
+        for (int i = 0; i < 100; i++)
+        {
+            DateTimeOffset? next = quartzSimple.GetNextValidTimeAfter(current);
+            if (next is null)
+            {
+                return null;
+            }
+
+            current = next.Value;
+        }
+
+        return current;
+    }
+
+    /// <inheritdoc cref="Next100" />
+    [Benchmark]
+    public DateTime Next100_NCrontab()
+    {
+        DateTime current = baseTime;
+
+        for (int i = 0; i < 100; i++)
+        {
+            current = ncrontabSimple.GetNextOccurrence(current);
+        }
+
+        return current;
+    }
+}

--- a/src/Quartz.Benchmark/JobAndTriggerBuilderBenchmark.cs
+++ b/src/Quartz.Benchmark/JobAndTriggerBuilderBenchmark.cs
@@ -1,0 +1,66 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// Building a job detail and a trigger, without storing either.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These are the halves of <see cref="ScheduleJobBenchmark" />'s cases that happen before the
+/// scheduler is called at all, and they are here rather than beside them because that class empties
+/// its store between iterations and these are nanosecond-scale: a per-iteration setup would be most of
+/// what they measured.
+/// </para>
+/// <para>
+/// The pair is worth having because the published comparison's simple-versus-cron gap is mostly
+/// decided here. A cron trigger parses its expression while it is being built and computes a first
+/// fire time from it; a simple one does neither. Reading <see cref="BuildCronTrigger" /> against
+/// <see cref="BuildSimpleTrigger" /> says how much of the gap the schedule costs, and what is left
+/// belongs to the scheduler and the store.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class JobAndTriggerBuilderBenchmark
+{
+    /// <summary>Every five minutes, the schedule the published comparison uses.</summary>
+    private const string CronSchedule = "0 0/5 * * * ?";
+
+    private const string Group = "bench";
+
+    [Benchmark]
+    public IJobDetail BuildJobDetail()
+    {
+        return JobBuilder.Create<NoOpJob>()
+            .WithIdentity("job-build", Group)
+            .UsingJobData("message", "hello")
+            .UsingJobData("count", 42)
+            .Build();
+    }
+
+    [Benchmark]
+    public ITrigger BuildSimpleTrigger()
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("trigger-build", Group)
+            .StartAt(DateTimeOffset.UtcNow.AddSeconds(30))
+            .Build();
+    }
+
+    [Benchmark]
+    public ITrigger BuildCronTrigger()
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("trigger-build", Group)
+            .WithCronSchedule(CronSchedule)
+            .Build();
+    }
+
+    private sealed class NoOpJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -16,6 +16,16 @@
   </ItemGroup>
 
   <!--
+    NCrontab is the cron library the published third-party comparison measures Quartz against, and
+    CronExpressionComparisonBenchmark runs it in the same process so the two are read off one table
+    rather than off two machines. It is a benchmark-only reference row: nothing under src/Quartz uses
+    it, and it is dependency-free, so it costs the restore one small assembly.
+  -->
+  <ItemGroup>
+    <PackageReference Include="NCrontab" />
+  </ItemGroup>
+
+  <!--
     ExecutionCeilingBenchmark and AcquisitionIndexBenchmark measure statements against a real database,
     so they need the drivers for the dialects the issues ask for numbers on. The databases themselves are
     started outside the benchmark and named by environment variables. BenchmarkDotNet runs a process per

--- a/src/Quartz.Benchmark/README.md
+++ b/src/Quartz.Benchmark/README.md
@@ -1,0 +1,198 @@
+# Quartz.Benchmark
+
+The BenchmarkDotNet suites for Quartz.NET. Nothing here ships — the project sets `IsPackable` to
+`false`, and it exists so that a change to a hot path can be argued with numbers instead of opinion.
+
+## Running
+
+One suite, measured properly:
+
+```shell
+dotnet run -c Release --project src/Quartz.Benchmark -- --filter "*CronExpressionBenchmark*"
+```
+
+Everything, executed once with nothing measured — the liveness check that the `BenchmarkSmoke` build
+target runs on every pull request, and what to run by hand after touching a benchmark:
+
+```shell
+dotnet run -c Release --project src/Quartz.Benchmark -- --smoke
+```
+
+`--smoke` is a whole run rather than a modifier, so it takes no other arguments. It covers every
+benchmark in the assembly except the two categories in `BenchmarkCategories`: `RequiresDatabase`,
+which needs a database pointed at by an environment variable, and `LongRunning`, whose single dry
+iteration is minutes. A benchmark written tomorrow is in the smoke run without anybody adding it to a
+list, which is the property that makes the target worth having; see `Program.cs` for the rest.
+
+Release is not optional. BenchmarkDotNet refuses a non-optimized assembly, and a smoke run of one
+would prove nothing.
+
+## Cron and RAMJobStore reference numbers (2026-08-30, AMD Ryzen 9 5950X)
+
+Taken on `a620fc632` to answer #3538. TickerQ publishes a comparison putting
+`CronExpression.GetNextValidTimeAfter` at ~1.2 µs and ~3 KB a call against NCrontab's 13 ns and
+nothing, and `ScheduleJob` into `RAMJobStore` at 4.4 µs (simple trigger) and 31 µs / 38.7 KB (cron
+trigger). Those runs pinned **Quartz 3.14**, which predates the bitmask cron fields (#3126-#3129) and
+4.0's rebuilt `CronExpression`, so they had never been checked against this branch.
+
+`CronExpressionComparisonBenchmark`, `JobAndTriggerBuilderBenchmark` and `ScheduleJobBenchmark` are
+the reproduction. They use the published comparison's own expressions, its fixed search instant and
+its operations, and they run NCrontab in the same process, so the reference row and the Quartz row
+come off one table on one machine rather than off two tables on two.
+
+**Machine and runtime.** BenchmarkDotNet v0.15.8; Windows 11 (10.0.26200.9168/25H2); AMD Ryzen 9
+5950X 3.40 GHz, 1 CPU, 32 logical and 16 physical cores; .NET SDK 10.0.400; host and job
+.NET 10.0.11 (10.0.1126.37416), X64 RyuJIT x86-64-v3. The machine's local time zone is
+`FLE Standard Time` (UTC+02:00 Helsinki), which observes daylight saving — neither library is given a
+time zone in these cases, exactly as the published comparison leaves them, so `CronExpression`
+resolves against that zone and the interval expressions do reach the fall-back check.
+
+**Read the Error column.** The machine had other work on it throughout, so the means carry more
+spread than a quiet box would give. It does not touch the conclusions: the allocation column is exact
+whatever the load, and the effects below are multiples rather than percentages.
+
+### Cron parsing and next-fire-time
+
+`CronExpressionComparisonBenchmark`, default job capped at 20 iterations
+(`--maxIterationCount 20`; uncapped, BenchmarkDotNet's noise-driven extension made the suite a
+~35-minute run on this machine).
+
+| Method                     | Mean         | Error      | Allocated |
+|--------------------------- |-------------:|-----------:|----------:|
+| Parse_Simple               |    307.17 ns |  19.514 ns |     576 B |
+| Parse_Simple_NCrontab      |    514.65 ns |  45.301 ns |    1816 B |
+| Parse_Complex              |    337.66 ns |  32.430 ns |     656 B |
+| Parse_Complex_NCrontab     |    391.74 ns |  12.117 ns |    1880 B |
+| Parse_SecondLevel          |    236.21 ns |  15.722 ns |     688 B |
+| Parse_SecondLevel_NCrontab |    404.46 ns |  27.500 ns |    2152 B |
+| Next_Simple                |    362.27 ns |   4.275 ns |         - |
+| Next_Simple_NCrontab       |     25.23 ns |   0.394 ns |         - |
+| Next_Complex               |    372.61 ns |   5.579 ns |         - |
+| Next_Complex_NCrontab      |     23.28 ns |   2.020 ns |         - |
+| Next_SecondLevel           |    314.53 ns |  18.761 ns |         - |
+| Next_SecondLevel_NCrontab  |     54.94 ns |  11.393 ns |         - |
+| Next100                    | 38,434.24 ns | 748.355 ns |         - |
+| Next100_NCrontab           |  2,799.70 ns |  26.359 ns |         - |
+
+Against the published 3.14 table, per operation:
+
+| Operation              | Quartz 3.14 (published) | Quartz 4.0 (here) | NCrontab (here) |
+|----------------------- |------------------------:|------------------:|----------------:|
+| Parse simple           |     3,835 ns / 10.8 KB   |   307 ns / 576 B  |  515 ns / 1816 B |
+| Parse complex          |     3,017 ns / 8.7 KB    |   338 ns / 656 B  |  392 ns / 1880 B |
+| Parse second-level     |     4,598 ns / 12.9 KB   |   236 ns / 688 B  |  404 ns / 2152 B |
+| Next occurrence simple |     1,292 ns / 3.2 KB    |   362 ns / **0 B**|   25 ns / 0 B    |
+| Next occurrence complex|     1,119 ns / 3.1 KB    |   373 ns / **0 B**|   23 ns / 0 B    |
+| Next occurrence second |     1,318 ns / 2.7 KB    |   315 ns / **0 B**|   55 ns / 0 B    |
+| 100 next occurrences   |   128,580 ns / 314 KB    | 38,434 ns / **0 B** | 2,800 ns / 0 B |
+
+### Building a job detail and a trigger
+
+`JobAndTriggerBuilderBenchmark`, same job.
+
+| Method             | Mean        | Error      | Allocated |
+|------------------- |------------:|-----------:|----------:|
+| BuildJobDetail     |    95.85 ns |   5.708 ns |     672 B |
+| BuildSimpleTrigger |    97.52 ns |   4.141 ns |     616 B |
+| BuildCronTrigger   | 1,023.56 ns | 144.541 ns |    1824 B |
+
+### Scheduling into RAMJobStore
+
+`ScheduleJobBenchmark`, BenchmarkDotNet's default job. One invocation is 50,000 schedules into a
+store that started empty, each under a fresh identity, through a scheduler that has been started.
+
+| Method                    | Mean      | Error     | Allocated |
+|-------------------------- |----------:|----------:|----------:|
+| ScheduleJob_SimpleTrigger |  4.610 us | 0.1630 us |   3.06 KB |
+| ScheduleJob_CronTrigger   | 10.479 us | 0.7597 us |      5 KB |
+
+Against the published 3.14 table: simple 4.4 µs / 2.3 KB, cron 31 µs / 38.7 KB.
+
+### The repository's own cron suite
+
+`CronExpressionBenchmark` over all fourteen expression shapes it carries, `--job Short`. Three
+iterations on a loaded machine is enough to place a mean but not to split two of them, so read the
+Error column here as "same order of magnitude" and nothing finer. The `Allocated` column is exact
+regardless, and it is the point: **every** `NextOccurrence` and `NextOccurrences100` row is `-`,
+including the `L`, `L-2`, `LW`, `6#3` and `6L` shapes whose day-of-month work used to be the
+expensive one.
+
+| Method             | CronExpression       | Mean         | Error         | Allocated |
+|------------------- |--------------------- |-------------:|--------------:|----------:|
+| Parse              | 0 0 12 * * ?         |     245.0 ns |     274.62 ns |     576 B |
+| NextOccurrence     | 0 0 12 * * ?         |     501.4 ns |     278.06 ns |         - |
+| NextOccurrences100 | 0 0 12 * * ?         |  45,163.9 ns |  50,338.57 ns |         - |
+| Parse              | 0 0 8-18 ? * MON-FRI |     338.8 ns |     494.27 ns |     656 B |
+| NextOccurrence     | 0 0 8-18 ? * MON-FRI |     462.5 ns |      49.64 ns |         - |
+| NextOccurrences100 | 0 0 8-18 ? * MON-FRI |  40,397.3 ns |  12,458.01 ns |         - |
+| Parse              | 0 0-30 9-17 * * ?    |     314.9 ns |      43.40 ns |     800 B |
+| NextOccurrence     | 0 0-30 9-17 * * ?    |     373.8 ns |      46.31 ns |         - |
+| NextOccurrences100 | 0 0-30 9-17 * * ?    |  31,134.5 ns |   5,861.73 ns |         - |
+| Parse              | 0 0,1(...)* * ? [26] |     367.2 ns |     994.21 ns |     576 B |
+| NextOccurrence     | 0 0,1(...)* * ? [26] |     509.0 ns |      57.06 ns |         - |
+| NextOccurrences100 | 0 0,1(...)* * ? [26] |  46,529.6 ns |  79,803.42 ns |         - |
+| Parse              | 0 0/5 * * * ?        |     271.9 ns |     690.19 ns |     576 B |
+| NextOccurrence     | 0 0/5 * * * ?        |     531.6 ns |   1,065.92 ns |         - |
+| NextOccurrences100 | 0 0/5 * * * ?        |  56,734.7 ns |  60,939.11 ns |         - |
+| Parse              | 0 15 10 ? * 6#3 *    |     398.3 ns |     450.21 ns |     504 B |
+| NextOccurrence     | 0 15 10 ? * 6#3 *    |   1,049.1 ns |     975.28 ns |         - |
+| NextOccurrences100 | 0 15 10 ? * 6#3 *    | 137,298.6 ns | 178,941.86 ns |         - |
+| Parse              | 0 15 10 ? * 6L       |     362.1 ns |     390.62 ns |     504 B |
+| NextOccurrence     | 0 15 10 ? * 6L       |   1,133.3 ns |     419.70 ns |         - |
+| NextOccurrences100 | 0 15 10 ? * 6L       | 149,851.9 ns | 100,250.02 ns |         - |
+| Parse              | 0 15 10 * * ?        |     267.0 ns |     161.66 ns |     576 B |
+| NextOccurrence     | 0 15 10 * * ?        |     558.3 ns |     483.28 ns |         - |
+| NextOccurrences100 | 0 15 10 * * ?        |  54,941.0 ns |   1,490.88 ns |         - |
+| Parse              | 0 15 (...)-2025 [23] |     673.4 ns |   1,331.95 ns |    1720 B |
+| NextOccurrence     | 0 15 (...)-2025 [23] |     449.1 ns |      55.71 ns |         - |
+| NextOccurrences100 | 0 15 (...)-2025 [23] |  46,769.5 ns |  17,380.83 ns |         - |
+| Parse              | 0 15 (...)* ? * [35] |     385.1 ns |     445.59 ns |     576 B |
+| NextOccurrence     | 0 15 (...)* ? * [35] |     583.5 ns |      88.37 ns |         - |
+| NextOccurrences100 | 0 15 (...)* ? * [35] |  79,317.9 ns |  85,571.17 ns |         - |
+| Parse              | 0 15 10 L * ?        |     288.7 ns |     532.19 ns |     632 B |
+| NextOccurrence     | 0 15 10 L * ?        |     915.6 ns |   1,367.75 ns |         - |
+| NextOccurrences100 | 0 15 10 L * ?        |  98,619.6 ns |  78,363.64 ns |         - |
+| Parse              | 0 15 10 L-2 * ?      |     394.8 ns |     355.85 ns |     752 B |
+| NextOccurrence     | 0 15 10 L-2 * ?      |   1,098.9 ns |     491.07 ns |         - |
+| NextOccurrences100 | 0 15 10 L-2 * ?      | 133,915.8 ns | 101,947.05 ns |         - |
+| Parse              | 0 15 10 LW * ?       |     379.8 ns |     678.10 ns |     640 B |
+| NextOccurrence     | 0 15 10 LW * ?       |     991.0 ns |     553.20 ns |         - |
+| NextOccurrences100 | 0 15 10 LW * ?       | 109,018.2 ns |  30,428.74 ns |         - |
+| Parse              | 0/15 * * * * ?       |     288.8 ns |     145.36 ns |     688 B |
+| NextOccurrence     | 0/15 * * * * ?       |     299.9 ns |      18.89 ns |         - |
+| NextOccurrences100 | 0/15 * * * * ?       |  43,571.4 ns | 173,050.96 ns |         - |
+
+### Verdict
+
+The Quartz 3.14 numbers no longer describe `main`: `GetNextValidTimeAfter` now allocates nothing at
+all rather than ~3 KB a call and runs in 315-373 ns rather than ~1.2 µs, constructing a
+`CronExpression` costs 236-338 ns and 576-688 B rather than 3-4.6 µs and 8.7-12.9 KB — which makes
+Quartz's parse now faster than NCrontab's — and scheduling a cron-triggered job into `RAMJobStore`
+costs 10.5 µs and 5 KB rather than 31 µs and 38.7 KB; the one claim that survives is that NCrontab
+computes a next occurrence about 14× faster than Quartz (25 ns against 362 ns), which is a real gap
+but not the 88× the published table reports.
+
+### What the remaining numbers are made of
+
+Recorded rather than acted on — #3538 asks for the measurement, not for an optimisation.
+
+- **`GetNextValidTimeAfter` allocates nothing.** The `Allocated` column is `-` for every
+  next-fire-time case, including the hundred-call one that the published table puts at 314 KB.
+  `CronExpression.GetTimeAfter` walks with a `readonly record struct NextFireTimeCursor` and the
+  field progressors are called directly rather than through a delegate array, so the ~3 KB a call is
+  gone. There is no allocation left to hunt, and no follow-up issue is owed for one.
+- **`WithCronSchedule(string)` parses the expression twice.** `CronScheduleBuilder.Create(string)`
+  calls `CronExpression.ValidateExpression(cronExpression)` — whose whole body is
+  `var _ = new CronExpression(cronExpression);` — and then hands the same string to
+  `CronScheduleNoParseException`, which constructs a second one. Two parses at 307 ns and 576 B each
+  account for most of `BuildCronTrigger`'s 1,024 ns and 1,824 B, against `BuildSimpleTrigger`'s 98 ns
+  and 616 B. `CronTriggerImpl.GetScheduleBuilder()` goes down the same path.
+- **Most of the cron/simple gap in `ScheduleJob` is not cron.** The two cases differ by 5.9 µs, of
+  which the build accounts for 0.9 µs. The rest is a property of the fixtures rather than of cron
+  parsing: every one of the 50,000 cron triggers in an invocation is `0 0/5 * * * ?`, so they all
+  land on the *same* next fire time, while the simple triggers get `UtcNow + 30 s` and so are
+  distinct and increasing. `TriggerTimeComparator` returns on the `DateTimeOffset` comparison for the
+  simple ones; for the cron ones it falls through equal times and equal priorities to
+  `trig1.Key.CompareTo(trig2.Key)`, which ends in `StringComparer.Ordinal.Compare` on the trigger
+  name — a string comparison per level of the store's `SortedSet` on every insert. The published
+  comparison uses the same single cron expression, so its 31 µs carries the same effect.

--- a/src/Quartz.Benchmark/ScheduleJobBenchmark.cs
+++ b/src/Quartz.Benchmark/ScheduleJobBenchmark.cs
@@ -1,0 +1,145 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// What it costs to put one new job and one new trigger into a running scheduler backed by
+/// <c>RAMJobStore</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// TickerQ's <c>JobCreationComparison</c> puts this at 4.4 µs and 2.3 KB for a simple trigger and
+/// 31 µs and 38.7 KB for a cron one — a seven-fold gap between two calls that differ only in which
+/// schedule the trigger carries. That run was taken against Quartz 3.14, before the bitmask cron
+/// fields (#3126-#3129) and before 4.0's rebuilt <see cref="Quartz.CronExpression" />, which is what
+/// the gap was largely made of, so it says nothing about this branch. This reproduces the shape of
+/// their measurement: a scheduler that has been started, a fresh identity for every schedule, and the
+/// whole <see cref="IScheduler.ScheduleJob(IJobDetail, ITrigger, CancellationToken)" /> call rather
+/// than the store write inside it.
+/// </para>
+/// <para>
+/// <b>Why a loop and a cleared store.</b> Scheduling under a fresh identity every time means the store
+/// only grows, and left to a default run it reaches millions of entries — which measures a dictionary
+/// and a sorted set growing rather than the call. Clearing it in <see cref="IterationSetup" /> caps
+/// that, but BenchmarkDotNet answers an iteration setup by dropping to one invocation an iteration,
+/// which would time a single cold call. So the operations are counted here instead, the way
+/// <see cref="RAMJobStoreBenchmark" /> counts its own: one invocation is
+/// <see cref="SchedulesPerInvocation" /> schedules into a store that started empty, which is long
+/// enough to measure and small enough to stay a plausible scheduler.
+/// </para>
+/// <para>
+/// The scheduler is started, as the published comparison starts theirs, so the signal each schedule
+/// sends the scheduler thread and that thread's answering acquisition round are inside the number.
+/// Nothing fires during a run: every trigger's first fire is at least half a minute out, and no
+/// iteration lasts that long.
+/// </para>
+/// <para>
+/// The two cases that build a job and a trigger without storing either are in
+/// <see cref="JobAndTriggerBuilderBenchmark" />, because they are nanosecond-scale and do not want any
+/// of this.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ScheduleJobBenchmark
+{
+    /// <summary>Every five minutes, the schedule the published comparison uses.</summary>
+    private const string CronSchedule = "0 0/5 * * * ?";
+
+    private const string Group = "bench";
+
+    /// <summary>
+    /// How many jobs one measured invocation schedules. Enough that an iteration is a couple of
+    /// hundred milliseconds rather than the microsecond BenchmarkDotNet warns about, and few enough
+    /// that the store it fills stays a size a real scheduler reaches.
+    /// </summary>
+    private const int SchedulesPerInvocation = 50_000;
+
+    /// <summary>
+    /// How far out the simple trigger's single fire is. Long enough that nothing fires while an
+    /// iteration is running, and the value the published comparison uses.
+    /// </summary>
+    private static readonly TimeSpan simpleTriggerDelay = TimeSpan.FromSeconds(30);
+
+    private IScheduler scheduler = null!;
+    private int counter;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        scheduler = QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options =>
+            {
+                // Named for this benchmark because the smoke run puts every benchmark in the assembly
+                // in one process, and the scheduler repository refuses a second scheduler that shares
+                // a name and an instance id with one already bound.
+                options.InstanceName = nameof(ScheduleJobBenchmark);
+                options.InstanceId = nameof(ScheduleJobBenchmark);
+            })
+            .UseInMemoryStore()
+            .BuildScheduler()
+            .GetAwaiter().GetResult();
+
+        scheduler.Start().GetAwaiter().GetResult();
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        scheduler.Shutdown(waitForJobsToComplete: false).GetAwaiter().GetResult();
+    }
+
+    [IterationSetup]
+    public void IterationSetup()
+    {
+        scheduler.Clear().GetAwaiter().GetResult();
+    }
+
+    [Benchmark(OperationsPerInvoke = SchedulesPerInvocation)]
+    public void ScheduleJob_SimpleTrigger()
+    {
+        for (int i = 0; i < SchedulesPerInvocation; i++)
+        {
+            int id = Interlocked.Increment(ref counter);
+
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity($"simple-job-{id}", Group)
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity($"simple-trigger-{id}", Group)
+                .StartAt(DateTimeOffset.UtcNow.Add(simpleTriggerDelay))
+                .Build();
+
+            scheduler.ScheduleJob(job, trigger).GetAwaiter().GetResult();
+        }
+    }
+
+    [Benchmark(OperationsPerInvoke = SchedulesPerInvocation)]
+    public void ScheduleJob_CronTrigger()
+    {
+        for (int i = 0; i < SchedulesPerInvocation; i++)
+        {
+            int id = Interlocked.Increment(ref counter);
+
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity($"cron-job-{id}", Group)
+                .UsingJobData("message", "hello")
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity($"cron-trigger-{id}", Group)
+                .WithCronSchedule(CronSchedule)
+                .Build();
+
+            scheduler.ScheduleJob(job, trigger).GetAwaiter().GetResult();
+        }
+    }
+
+    private sealed class NoOpJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Benchmark/StringOperatorBenchmark.cs
+++ b/src/Quartz.Benchmark/StringOperatorBenchmark.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Quartz.Benchmark;
 
+[MemoryDiagnoser]
 public class StringOperatorBenchmark
 {
     [Benchmark]


### PR DESCRIPTION
Part of milestone 4.0.0-alpha.4. Closes #3538.

TickerQ publishes a comparison pinning **Quartz 3.14** — before the bitmask cron fields (#3126–#3129) and before 4.0's rebuilt `CronExpression`. Nobody had re-measured on `main`, so neither the claim nor any rebuttal was true or false. Now measured, on `a620fc632`.

## Headline numbers

BenchmarkDotNet v0.15.8; Windows 11 (10.0.26200.9168/25H2); **AMD Ryzen 9 5950X** 3.40 GHz, 1 CPU, 32 logical / 16 physical cores; **.NET SDK 10.0.400**, host and job **.NET 10.0.11** (10.0.1126.37416), X64 RyuJIT x86-64-v3.

| Operation | Quartz 3.14 (published) | **Quartz 4.0 (measured here)** | NCrontab (measured here) |
|---|---:|---:|---:|
| Parse simple `0 0/5 * * * ?` | 3,835 ns / 10.8 KB | **307 ns / 576 B** | 515 ns / 1,816 B |
| Parse complex `0 0 9-17 ? * MON-FRI` | 3,017 ns / 8.7 KB | **338 ns / 656 B** | 392 ns / 1,880 B |
| Parse second-level `0/30 * * * * ?` | 4,598 ns / 12.9 KB | **236 ns / 688 B** | 404 ns / 2,152 B |
| `GetNextValidTimeAfter` simple | 1,292 ns / 3.2 KB | **362 ns / 0 B** | 25 ns / 0 B |
| `GetNextValidTimeAfter` complex | 1,119 ns / 3.1 KB | **373 ns / 0 B** | 23 ns / 0 B |
| `GetNextValidTimeAfter` second-level | 1,318 ns / 2.7 KB | **315 ns / 0 B** | 55 ns / 0 B |
| 100 next occurrences | 128,580 ns / 314 KB | **38,434 ns / 0 B** | 2,800 ns / 0 B |
| `ScheduleJob` + simple trigger | 4,400 ns / 2.3 KB | **4,610 ns / 3.06 KB** | — |
| `ScheduleJob` + cron trigger | 31,037 ns / 38.7 KB | **10,479 ns / 5 KB** | — |

## Verdict

> The Quartz 3.14 numbers no longer describe `main`: `GetNextValidTimeAfter` now allocates nothing at all rather than ~3 KB a call and runs in 315–373 ns rather than ~1.2 µs, constructing a `CronExpression` costs 236–338 ns and 576–688 B rather than 3–4.6 µs and 8.7–12.9 KB — which makes Quartz's parse now faster than NCrontab's — and scheduling a cron-triggered job into `RAMJobStore` costs 10.5 µs and 5 KB rather than 31 µs and 38.7 KB; the one claim that survives is that NCrontab computes a next occurrence about 14× faster than Quartz (25 ns against 362 ns), which is a real gap but not the 88× the published table reports.

## What changed

Three new suites in `src/Quartz.Benchmark/`, all in the smoke run (no category excludes them):

- **`CronExpressionComparisonBenchmark`** — TickerQ's own three schedules in both dialects, their fixed instant (`2026-03-16T12:00:00Z`), their operations, with **NCrontab running in the same process** so the reference row and ours come off one table on one machine.
- **`ScheduleJobBenchmark`** — the scheduler-level case the issue says is missing: `IScheduler.ScheduleJob(jobDetail, trigger)` into `RAMJobStore` through a started scheduler, fresh identity per schedule, simple and cron.
- **`JobAndTriggerBuilderBenchmark`** — the build-only cases, split out because they are nanosecond-scale and cannot share the cleared store the scheduler suite needs.

`[MemoryDiagnoser]` added to `StringOperatorBenchmark` and `AcquisitionIndexBenchmark`, the only two suites that lacked it (the issue's correction is right that `CronExpressionBenchmark` and `RAMJobStoreBenchmark` already had it — those are untouched).

`src/Quartz.Benchmark/README.md` is new. It did not exist; it now documents how to run a suite and what `--smoke` covers, and carries the dated **"Cron and RAMJobStore reference numbers (2026-08-30, AMD Ryzen 9 5950X)"** section with all four tables, including all 42 rows of `CronExpressionBenchmark`.

## Findings — recorded, not acted on

The issue asks for measurement, not optimisation, so nothing here is optimised.

1. **`GetNextValidTimeAfter` allocates nothing, so no follow-up issue is owed.** Done-means item 4 is answered in the negative: the `Allocated` column is `-` for every next-fire-time row across all **fourteen** expression shapes in `CronExpressionBenchmark`, including the `L`, `L-2`, `LW`, `6#3` and `6L` shapes. `GetTimeAfter` walks with a `readonly record struct NextFireTimeCursor` and calls the field progressors directly rather than through a delegate array.

2. **`WithCronSchedule(string)` parses the expression twice.** `CronScheduleBuilder.Create(string)` calls `CronExpression.ValidateExpression(cronExpression)` — whose entire body is `var _ = new CronExpression(cronExpression);` — and then hands the same string to `CronScheduleNoParseException`, which constructs a second one. Two parses at 307 ns / 576 B each account for most of `BuildCronTrigger`'s 1,024 ns / 1,824 B against `BuildSimpleTrigger`'s 98 ns / 616 B. `CronTriggerImpl.GetScheduleBuilder()` takes the same path.

3. **Most of the cron-vs-simple gap in `ScheduleJob` is not cron.** The two cases differ by 5.9 µs, of which the build accounts for 0.9 µs. The rest is a property of the fixture: all 50,000 cron triggers in an invocation are `0 0/5 * * * ?`, so they land on the *same* next fire time, while the simple triggers get `UtcNow + 30 s` and are distinct and increasing. `TriggerTimeComparator` returns on the `DateTimeOffset` comparison for the simple ones; for the cron ones it falls through equal times and equal priorities to `trig1.Key.CompareTo(trig2.Key)`, ending in `StringComparer.Ordinal.Compare` on the trigger name — a string comparison per `SortedSet` level on every insert. TickerQ's benchmark uses the same single expression, so its 31 µs carries the same effect.

## For a reviewer to decide

- **NCrontab as a `PackageReference`.** The issue's "not in scope" rules out a Hangfire or TickerQ reference; NCrontab is neither, and the work item explicitly allowed it if it added trivially — it did (dependency-free, one `PackageVersion` line, restore unchanged). It is the whole reason the comparison rows are commensurable. Say the word and I will drop it and the six reference rows with it.
- **`--maxIterationCount 20` on the cron suite.** Uncapped, BenchmarkDotNet's noise-driven extension ran to ~100 iterations per case on a machine that had concurrent load, making the suite a ~35-minute run. The cap is recorded in the README beside the table. `ScheduleJobBenchmark` used the plain default job; `CronExpressionBenchmark`'s 42 cases used `--job Short`, and its Error column is wide enough that it places a mean but does not split two.
- **`ScheduleJobBenchmark` clears the store between iterations** and counts 50,000 operations per invocation. TickerQ's lets the store grow without bound, which measures a growing dictionary; this bounds it so every iteration starts from the same state. It makes our number the more favourable of the two, and it is worth agreeing that is the right call.

## Verification

- `dotnet build Quartz.slnx` — **Build succeeded, 0 Warning(s), 0 Error(s)** (`TreatWarningsAsErrors` on).
- `dotnet test src/Quartz.Tests.Unit` — **Failed: 0, Passed: 3760, Skipped: 0, Total: 3760**.
- `dotnet run -c Release --project src/Quartz.Benchmark -- --smoke` — **exit 0**, `Global total time: 00:00:28 (28.4 sec), executed benchmarks: 280`.

Integration tests were not run: they need a Docker daemon and nothing here touches that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
