### PR TITLE
A job can declare the type of its input

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1570,6 +1570,69 @@ It does **not** replace `ConfigureJobScope`. The execution context takes the job
 not exist while the job is being constructed: anything that needs the tenant *at construction time*
 still gets it from the hook.
 
+## A job can take a typed input
+
+New in 4.0, and purely additive: `IJob<TInput>` lets a job declare the type of the payload it is
+scheduled with, instead of digging it out of a stringly `JobDataMap`. 3.x had no such thing, so every
+framework that embedded Quartz wrote the same adapter job and payload-carrying context by hand.
+
+```diff
+- public sealed class SendEmailJob : IJob
+- {
+-     public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+-     {
+-         SendEmail input = JsonSerializer.Deserialize<SendEmail>(context.MergedJobDataMap.GetString("payload")!)!;
+-         // ...
+-     }
+- }
+- trigger.UsingJobData("payload", JsonSerializer.Serialize(new SendEmail(to, subject)));
++ public sealed class SendEmailJob : IJob<SendEmail>
++ {
++     public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
++     {
++         // ...
++     }
++ }
++ trigger.UsingInput(new SendEmail(to, subject));
+```
+
+The whole of the dispatch is `IJob<TInput>`'s default implementation of `IJob.Execute`, so the job
+factory, `JobRunShell` and the listeners still see an `IJob` and nothing closes a generic method over a
+runtime type — which is what keeps this working in a trimmed or native-AOT publish.
+
+**The API added.** In `Quartz`: `IJob<TInput>`;
+`SchedulerConstants.JobInput` (`"QRTZ_JOB_INPUT"`);
+`JobExecutionContextInputExtensions.GetInput<TInput>(this IJobExecutionContext)`;
+and `JobInputBuilderExtensions.UsingInput<TJob, TInput>` on `JobBuilder<TJob>`, `TriggerBuilder<TJob>`,
+`IJobConfigurator<TJob>` and `ITriggerConfigurator<TJob>`. In `Quartz.Extensibility`:
+`IJobInputSerializer`. In `Quartz.Impl`: `SystemTextJsonJobInputSerializer`, and a fourth optional
+`IJobInputSerializer? inputSerializer = null` parameter on the `JobExecutionContextImpl` constructor —
+the one existing signature that moved, and source-compatible because it is optional.
+
+**Where the payload lives.** The value goes into the ordinary `JobDataMap` under
+`SchedulerConstants.JobInput`, and the scheduler serializes it to a **string** as the job or trigger is
+stored — so it survives `StoreJobDataAsStrings`, the System.Text.Json write gate, the Newtonsoft
+serializer, the binary blob column and the HTTP wire without any of them knowing about it. A trigger's
+input overrides a job's, which is the `MergedJobDataMap` rule everything else follows.
+
+`UsingInput` is offered only on a builder for a job that declares an input; it is an extension method
+rather than a builder member because a method cannot constrain its own type's type parameter (CS0699).
+`GetInput<TInput>()` is an extension on `IJobExecutionContext` rather than a member for the same kind of
+reason: a member would break every hand-written context in the wild.
+
+**Two things to know.** The input type is inferred from the argument's static type, so pass the type
+argument explicitly — `UsingInput<SendEmailJob, SendEmail>(payload)` — when the payload is held as a
+base type. And a `[PersistJobDataAfterExecution]` job whose *detail* carries the input writes it back
+after every firing; that is harmless, since it is already the string it will be read as, but an input
+that differs per firing belongs on the trigger.
+
+**Serialization.** `IJobInputSerializer` is registered per scheduler, keyed by name like every other
+component, and defaults to `SystemTextJsonJobInputSerializer` built from the same
+`SystemTextJsonSerializerRegistry` as the store's `IObjectSerializer`. An application published trimmed
+or natively declares its payload types with `SystemTextJsonSerializerRegistry.AddTypeInfoResolver`,
+exactly as it declares a job data value type — there is no second registration to learn. See
+[Job Data](tutorial/job-data-map.md#a-typed-input-the-third-read-side).
+
 ## A component of your own is chosen the same way a shipped one is
 
 Three seams that had no code-first spelling at all, and one that only worked through a type-name string:

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -258,6 +258,71 @@ default.
 `UsingJobData(j => j.LookbackDays, 30)` is the write side of exactly this: name the property, get the
 key for free.
 
+## A typed input: the third read side
+
+A job whose data is really *one payload* — a message, a command, an event — can say so. `IJob<TInput>`
+declares the type, and the payload arrives as a parameter:
+
+<!-- snippet: sample_job_data_map_typed_input -->
+```csharp
+public sealed record SendEmail(string To, string Subject);
+
+public sealed class SendEmailJob : IJob<SendEmail>
+{
+    public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
+    {
+        // input.To, input.Subject - no keys, no accessors, no casts
+        return default;
+    }
+}
+
+public static class TypedInputScheduling
+{
+    public static async ValueTask Schedule(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>()
+                .WithIdentity("welcome", "email")
+                .Build(),
+            TriggerBuilder.Create<SendEmailJob>()
+                .WithIdentity("welcome-3401", "email")
+                .StartNow()
+                .UsingInput(new SendEmail("someone@example.org", "Welcome"))
+                .Build(),
+            cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+`UsingInput` is available on `JobBuilder<TJob>`, `TriggerBuilder<TJob>` and the two configurators
+`AddJob` and `AddTrigger` hand you, and it is only offered for a job that declares an input — putting
+one on a job that takes none is a compile error. The value lands in the ordinary `JobDataMap` under the
+reserved key `SchedulerConstants.JobInput` (`QRTZ_JOB_INPUT`), serialized to a **string** by the
+scheduler as the job or trigger is stored, so it survives `StoreJobDataAsStrings`, the JSON write gate
+above, the blob column and the HTTP API alike. Precedence is the ordinary one: an input on the trigger
+overrides an input on the job.
+
+A job that is not an `IJob<TInput>` can read the same payload with `context.GetInput<SendEmail>()`,
+which answers `null` when there is none. An `IJob<TInput>` whose input is missing fails the firing with
+a `SchedulerException` naming the key, rather than running on a default payload.
+
+Two things worth knowing:
+
+- **The input type is inferred from the argument.** `UsingInput(payload)` where `payload` is held as a
+  base type stores and reads it as that base type; pass the type argument explicitly —
+  `UsingInput<SendEmailJob, SendEmail>(payload)` — when the static type is not the one you mean.
+- **Put a per-firing input on the trigger.** A `[PersistJobDataAfterExecution]` job re-stores its own
+  map after every firing, so an input on the *job* is written back each time. That is harmless — it is
+  already the string it will be read as — but the trigger is where an input that differs per firing
+  belongs, and it is where one trigger per payload puts it anyway.
+
+The payload is written by the scheduler's `IJobInputSerializer`, which defaults to
+`SystemTextJsonJobInputSerializer` and is built from the same registry as the store's serializer — see
+[JSON Serialization](../packages/system-text-json.md). A trimmed or native-AOT application declares its
+payload types with `SystemTextJsonSerializerRegistry.AddTypeInfoResolver`, exactly as it declares a job
+data value type.
+
 ## Persisting changes across fires
 
 By default a job's stored map is written once and read many times. `[PersistJobDataAfterExecution]`

--- a/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobDataMapSamples.cs
@@ -135,6 +135,38 @@ public static class JobDataMapSamples
     }
 }
 
+#region sample_job_data_map_typed_input
+
+public sealed record SendEmail(string To, string Subject);
+
+public sealed class SendEmailJob : IJob<SendEmail>
+{
+    public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
+    {
+        // input.To, input.Subject - no keys, no accessors, no casts
+        return default;
+    }
+}
+
+public static class TypedInputScheduling
+{
+    public static async ValueTask Schedule(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>()
+                .WithIdentity("welcome", "email")
+                .Build(),
+            TriggerBuilder.Create<SendEmailJob>()
+                .WithIdentity("welcome-3401", "email")
+                .StartNow()
+                .UsingInput(new SendEmail("someone@example.org", "Welcome"))
+                .Build(),
+            cancellationToken);
+    }
+}
+
+#endregion
+
 #region sample_job_data_map_persist_across_fires
 
 [PersistJobDataAfterExecution]

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -22,6 +22,7 @@
 using AwesomeAssertions.Execution;
 
 using Quartz.Extensibility;
+using Quartz.Impl;
 using Quartz.Impl.Calendar;
 using Quartz.Impl.Triggers;
 
@@ -1949,6 +1950,62 @@ public abstract class JobStoreContractTest
         refired.JobDataMap["count"].Should().Be(1,
             "every firing of such a job starts from the same stored map");
     }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // A typed job's input
+    //
+    // The input is a string under a reserved key, chosen precisely so that no store has to know
+    // anything about it. That is a claim about every store, so it is asserted against every store:
+    // both maps come back holding what was put in them, and the firing hands the job the trigger's
+    // value rather than the job's.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task ATypedJobsInputSurvivesTheStoreAndTheTriggersWins()
+    {
+        IJobDetail job = CreateJob<ContractTestJob>("typed-input", JobGroupA, new JobDataMap
+        {
+            [SchedulerConstants.JobInput] = JobInputPayload,
+        });
+
+        IOperableTrigger trigger = CreateTrigger("typed-input", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        trigger.JobDataMap[SchedulerConstants.JobInput] = TriggerInputPayload;
+
+        await Store.ScheduleJob(job, trigger);
+
+        (await Store.GetJob(job.Key)).JobDataMap[SchedulerConstants.JobInput].Should().Be(JobInputPayload,
+            "the input is a string exactly so that every store carries it unchanged, whatever its data map format");
+        (await Store.GetTrigger(trigger.Key)).JobDataMap[SchedulerConstants.JobInput].Should().Be(TriggerInputPayload);
+
+        (IOperableTrigger firing, IJobDetail fired) = await FireOnce(trigger);
+
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            new TriggerFiredBundle
+            {
+                JobDetail = fired,
+                Trigger = firing,
+                Recovering = false,
+                FireTimeUtc = DateTimeOffset.UtcNow,
+                ScheduledFireTimeUtc = null,
+                PreviousFireTimeUtc = null,
+                NextFireTimeUtc = null,
+            },
+            new ContractTestJob(),
+            new SystemTextJsonJobInputSerializer());
+
+        context.GetInput<ContractInput>().Should().Be(new ContractInput("trigger"),
+            "a firing reads the input out of the merged map, so the trigger's value overrides the job's on every store");
+    }
+
+    private const string JobInputPayload = """{"Source":"job"}""";
+    private const string TriggerInputPayload = """{"Source":"trigger"}""";
+
+    /// <summary>
+    /// A payload a typed job would declare, small enough that its JSON can be written out above.
+    /// </summary>
+    public sealed record ContractInput(string Source);
 
     /// <summary>
     /// Takes the given trigger through one acquisition and firing, handing back the trigger carrying

--- a/src/Quartz.Tests.Unit/TypedJobInputTest.cs
+++ b/src/Quartz.Tests.Unit/TypedJobInputTest.cs
@@ -1,0 +1,335 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// A job that declares the type of its input gets it as a parameter, whichever end of the schedule put
+/// it there.
+/// </summary>
+[NonParallelizable]
+public sealed class TypedJobInputTest
+{
+    public sealed record SendEmail(string To, string Subject);
+
+    public readonly record struct Reminder(int Id, string Note);
+
+    [Test]
+    public async Task AnInputOnTheJobReachesTheJob()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(AnInputOnTheJobReachesTheJob));
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>()
+                .WithIdentity("email", "typed")
+                .UsingInput(new SendEmail("someone@example.org", "hello"))
+                .Build(),
+            TriggerBuilder.Create().WithIdentity("now", "typed").StartNow().Build());
+
+        object received = await recorder.Received;
+
+        received.Should().Be(new SendEmail("someone@example.org", "hello"),
+            "an IJob<TInput> is handed the payload the job was built with, deserialized back to its own type");
+    }
+
+    [Test]
+    public async Task ATriggerInputOverridesTheJobInput()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(ATriggerInputOverridesTheJobInput));
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>()
+                .WithIdentity("email", "typed")
+                .UsingInput(new SendEmail("job@example.org", "from the job"))
+                .Build(),
+            TriggerBuilder.Create<SendEmailJob>()
+                .WithIdentity("now", "typed")
+                .StartNow()
+                .UsingInput(new SendEmail("trigger@example.org", "from the trigger"))
+                .Build());
+
+        object received = await recorder.Received;
+
+        received.Should().Be(new SendEmail("trigger@example.org", "from the trigger"),
+            "the input follows MergedJobDataMap precedence, so the trigger's value wins over the job's");
+    }
+
+    [Test]
+    public async Task ARecordStructPayloadRoundTrips()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(ARecordStructPayloadRoundTrips));
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<ReminderJob>().WithIdentity("reminder", "typed").Build(),
+            TriggerBuilder.Create<ReminderJob>()
+                .WithIdentity("now", "typed")
+                .StartNow()
+                .UsingInput(new Reminder(42, "stand up"))
+                .Build());
+
+        object received = await recorder.Received;
+
+        received.Should().Be(new Reminder(42, "stand up"),
+            "a value-type payload is serialized and read back like any other, not boxed straight through");
+    }
+
+    [Test]
+    public async Task TheStoredInputIsAString()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(TheStoredInputIsAString), start: false);
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>()
+                .WithIdentity("email", "typed")
+                .UsingInput(new SendEmail("someone@example.org", "hello"))
+                .Build(),
+            TriggerBuilder.Create().WithIdentity("later", "typed").StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+        IJobDetail stored = await harness.Scheduler.GetJobDetail(new JobKey("email", "typed"));
+
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().BeOfType<string>(
+            "the value has to survive StoreJobDataAsStrings, the JSON write gate, the blob path and the wire, and a string survives all of them")
+            .Which.Should().Be("""{"To":"someone@example.org","Subject":"hello"}""");
+    }
+
+    [Test]
+    public async Task GetInputReadsTheInputFromAnUntypedJob()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(GetInputReadsTheInputFromAnUntypedJob));
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<UntypedReadingJob>().WithIdentity("untyped", "typed").Build(),
+            TriggerBuilder.Create()
+                .WithIdentity("now", "typed")
+                .StartNow()
+                .UsingJobData(SchedulerConstants.JobInput, new SendEmail("plain@example.org", "read by hand"))
+                .Build());
+
+        object received = await recorder.Received;
+
+        received.Should().Be(new SendEmail("plain@example.org", "read by hand"),
+            "GetInput<T>() is an extension on the context, so a plain IJob can read a typed input too");
+    }
+
+    [Test]
+    public void GetInputAnswersDefaultWhenNothingWasScheduled()
+    {
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            TestUtil.NewMinimalTriggerFiredBundle(),
+            job: null,
+            new SystemTextJsonJobInputSerializer());
+
+        context.GetInput<SendEmail>().Should().BeNull(
+            "reading an input that was never set is a question with an answer, unlike an IJob<TInput> whose input is missing");
+    }
+
+    [Test]
+    public async Task AMissingInputFailsTheFiringByName()
+    {
+        SendEmailJob job = new(new Recorder());
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            TestUtil.NewMinimalTriggerFiredBundle(),
+            job,
+            new SystemTextJsonJobInputSerializer());
+
+        Func<Task> act = async () => await ((IJob) job).Execute(context);
+
+        await act.Should().ThrowAsync<SchedulerException>()
+            .WithMessage($"*{SchedulerConstants.JobInput}*",
+                "a typed job whose input is missing has to say which key it looked under, not run with a default payload");
+    }
+
+    [Test]
+    public async Task AContextBuiltWithoutASerializerSaysSo()
+    {
+        SendEmailJob job = new(new Recorder());
+        TriggerFiredBundle bundle = TestUtil.NewMinimalTriggerFiredBundle();
+        bundle.Trigger.JobDataMap[SchedulerConstants.JobInput] = """{"To":"someone@example.org","Subject":"hello"}""";
+
+        IJobExecutionContext context = new JobExecutionContextImpl(scheduler: null, bundle, job);
+
+        Func<Task> act = async () => await ((IJob) job).Execute(context);
+
+        await act.Should().ThrowAsync<SchedulerException>()
+            .WithMessage("*IJobInputSerializer*",
+                "a hand-built context names what it is missing rather than reflecting its way to an answer");
+    }
+
+    [Test]
+    public async Task APersistedJobWritesTheInputBackUnchanged()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(APersistedJobWritesTheInputBackUnchanged));
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<PersistingSendEmailJob>()
+                .WithIdentity("persisting", "typed")
+                // Durable, so the completed one-shot trigger does not take the job — and the map this
+                // test is about — with it.
+                .StoreDurably()
+                .UsingInput(new SendEmail("someone@example.org", "hello"))
+                .Build(),
+            TriggerBuilder.Create().WithIdentity("now", "typed").StartNow().Build());
+
+        await recorder.Received;
+
+        // The write-back happens in the same store operation that retires the completed one-shot trigger,
+        // so a trigger that is gone is a job whose data map has already been re-stored.
+        await harness.WaitUntilTriggerIsGone(new TriggerKey("now", "typed"));
+
+        IJobDetail stored = await harness.Scheduler.GetJobDetail(new JobKey("persisting", "typed"));
+
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().Be("""{"To":"someone@example.org","Subject":"hello"}""",
+            "a [PersistJobDataAfterExecution] job re-stores its own map, and the input in it is already the string the reader expects");
+    }
+
+    /// <summary>
+    /// A scheduler over the in-memory store with a recorder in its container, so the job the factory
+    /// builds can report what it was handed.
+    /// </summary>
+    private sealed class SchedulerHarness : IAsyncDisposable
+    {
+        private readonly ServiceProvider container;
+
+        private SchedulerHarness(ServiceProvider container, IScheduler scheduler)
+        {
+            this.container = container;
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        public static async Task<SchedulerHarness> Start(Recorder recorder, string name, bool start = true)
+        {
+            ServiceCollection services = new();
+            services.AddSingleton(recorder);
+            services.AddQuartz(q => q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = name;
+                options.InstanceId = "one";
+            }));
+
+            ServiceProvider container = services.BuildServiceProvider();
+            IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+            if (start)
+            {
+                await scheduler.Start();
+            }
+
+            return new SchedulerHarness(container, scheduler);
+        }
+
+        public async Task WaitUntilTriggerIsGone(TriggerKey key)
+        {
+            DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+            while (await Scheduler.GetTrigger(key) is not null)
+            {
+                DateTimeOffset.UtcNow.Should().BeBefore(deadline, $"trigger '{key}' should have completed and been removed");
+                await Task.Delay(20);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Scheduler.Shutdown(waitForJobsToComplete: false);
+            await container.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Carries what a firing was handed back to the test. Registered in the container, so the job factory
+    /// hands the running job the very instance the test is waiting on.
+    /// </summary>
+    public sealed class Recorder
+    {
+        private readonly TaskCompletionSource<object> completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<object> Received => completion.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        public void Record(object value) => completion.TrySetResult(value);
+    }
+
+    public sealed class SendEmailJob : IJob<SendEmail>
+    {
+        private readonly Recorder recorder;
+
+        public SendEmailJob(Recorder recorder) => this.recorder = recorder;
+
+        public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(input);
+            return default;
+        }
+    }
+
+    [PersistJobDataAfterExecution]
+    public sealed class PersistingSendEmailJob : IJob<SendEmail>
+    {
+        private readonly Recorder recorder;
+
+        public PersistingSendEmailJob(Recorder recorder) => this.recorder = recorder;
+
+        public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(input);
+            return default;
+        }
+    }
+
+    public sealed class ReminderJob : IJob<Reminder>
+    {
+        private readonly Recorder recorder;
+
+        public ReminderJob(Recorder recorder) => this.recorder = recorder;
+
+        public ValueTask Execute(IJobExecutionContext context, Reminder input, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(input);
+            return default;
+        }
+    }
+
+    public sealed class UntypedReadingJob : IJob
+    {
+        private readonly Recorder recorder;
+
+        public UntypedReadingJob(Recorder recorder) => this.recorder = recorder;
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(context.GetInput<SendEmail>());
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -539,6 +539,10 @@ namespace Quartz
         System.Threading.Tasks.ValueTask JobToBeExecuted(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask JobWasExecuted(Quartz.IJobExecutionContext context, Quartz.JobExecutionException? jobException, System.Threading.CancellationToken cancellationToken = default);
     }
+    public interface IJob<TInput> : Quartz.IJob
+    {
+        System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, TInput input, System.Threading.CancellationToken cancellationToken = default);
+    }
     public interface IListenerManager
     {
         void AddJobListener(Quartz.IJobListener jobListener, [System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IReadOnlyCollection<Quartz.IMatcher<Quartz.JobKey>> matchers);
@@ -912,6 +916,10 @@ namespace Quartz
     {
         public static Quartz.JobBuilder<Quartz.IJob> GetJobBuilder(this Quartz.IJobDetail jobDetail) { }
     }
+    public static class JobExecutionContextInputExtensions
+    {
+        public static TInput? GetInput<TInput>(this Quartz.IJobExecutionContext context) { }
+    }
     public sealed class JobExecutionException : Quartz.SchedulerException
     {
         public JobExecutionException() { }
@@ -955,6 +963,17 @@ namespace Quartz
         public Quartz.JobKey Key { get; init; }
         public bool PersistJobDataAfterExecution { get; init; }
         public bool RequestsRecovery { get; init; }
+    }
+    public static class JobInputBuilderExtensions
+    {
+        public static Quartz.IJobConfigurator<TJob> UsingInput<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IJobConfigurator<TJob> configurator, TInput input)
+            where TJob : Quartz.IJob<TInput> { }
+        public static Quartz.ITriggerConfigurator<TJob> UsingInput<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.ITriggerConfigurator<TJob> configurator, TInput input)
+            where TJob : Quartz.IJob<TInput> { }
+        public static Quartz.JobBuilder<TJob> UsingInput<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.JobBuilder<TJob> builder, TInput input)
+            where TJob : Quartz.IJob<TInput> { }
+        public static Quartz.TriggerBuilder<TJob> UsingInput<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.TriggerBuilder<TJob> builder, TInput input)
+            where TJob : Quartz.IJob<TInput> { }
     }
     public sealed class JobInstantiationException : Quartz.SchedulerException
     {
@@ -1455,6 +1474,7 @@ namespace Quartz
         public const string FailedJobOriginalTriggerName = "QRTZ_FAILED_JOB_ORIG_TRIGGER_NAME";
         public const string FailedJobOriginalTriggerScheduledFireTime = "QRTZ_FAILED_JOB_ORIG_TRIGGER_SCHEDULED_FIRETIME_AS_STRING";
         public const string ForceJobDataMapDirty = "QRTZ_FORCE_JOB_DATAMAP_DIRTY";
+        public const string JobInput = "QRTZ_JOB_INPUT";
     }
     public sealed class SchedulerContext : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IDictionary<string, object?>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyDictionary<string, object?>, System.Collections.IEnumerable
     {
@@ -1897,6 +1917,11 @@ namespace Quartz.Extensibility
     {
         System.Threading.Tasks.ValueTask<Quartz.Extensibility.JobScope> CreateJob(Quartz.Extensibility.TriggerFiredBundle bundle, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ReturnJob(Quartz.Extensibility.JobScope scope, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface IJobInputSerializer
+    {
+        TInput? Deserialize<TInput>(string payload);
+        string Serialize(object input);
     }
     public interface IJobStore
     {
@@ -3365,7 +3390,7 @@ namespace Quartz.Impl
     }
     public sealed class JobExecutionContextImpl : Quartz.IJobExecutionContext, System.IDisposable
     {
-        public JobExecutionContextImpl(Quartz.IScheduler scheduler, Quartz.Extensibility.TriggerFiredBundle firedBundle, Quartz.IJob job) { }
+        public JobExecutionContextImpl(Quartz.IScheduler scheduler, Quartz.Extensibility.TriggerFiredBundle firedBundle, Quartz.IJob job, Quartz.Extensibility.IJobInputSerializer? inputSerializer = null) { }
         public Quartz.ICalendar? Calendar { get; }
         public System.Threading.CancellationToken CancellationToken { get; }
         public string FireInstanceId { get; }
@@ -3492,6 +3517,13 @@ namespace Quartz.Impl
         protected Quartz.IJob InstantiateJobCore(Quartz.Extensibility.TriggerFiredBundle bundle) { }
         public virtual System.Threading.Tasks.ValueTask ReturnJob(Quartz.Extensibility.JobScope scope, System.Threading.CancellationToken cancellationToken = default) { }
         protected static System.Threading.Tasks.ValueTask DisposeIfDisposable(object? target, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public sealed class SystemTextJsonJobInputSerializer : Quartz.Extensibility.IJobInputSerializer
+    {
+        public SystemTextJsonJobInputSerializer() { }
+        public SystemTextJsonJobInputSerializer(Quartz.Serialization.SystemTextJson.SystemTextJsonSerializerRegistry registry) { }
+        public TInput? Deserialize<TInput>(string payload) { }
+        public string Serialize(object input) { }
     }
     public class SystemTextJsonObjectSerializer : Quartz.Extensibility.IObjectSerializer
     {

--- a/src/Quartz.Trimming.Canary/StoreCheck.cs
+++ b/src/Quartz.Trimming.Canary/StoreCheck.cs
@@ -20,10 +20,13 @@
 #endregion
 
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 using Microsoft.Data.Sqlite;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Serialization.SystemTextJson;
 
 namespace Quartz.Trimming.Canary;
 
@@ -54,6 +57,13 @@ internal static class StoreCheck
     private static readonly TaskCompletionSource fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
+    /// What the typed job was handed, which is the half of the input round trip that a compile cannot
+    /// stand in for: it is written as <see cref="object" /> and read back as its own type, both through
+    /// metadata the application declared rather than through reflection there is none of.
+    /// </summary>
+    private static readonly TaskCompletionSource<CanaryInput> typedInput = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
     /// Runs the check, returning <see langword="null" /> when it passed and a message when it did not.
     /// </summary>
     public static async Task<string?> Run()
@@ -66,6 +76,14 @@ internal static class StoreCheck
             await CreateSchema(connectionString).ConfigureAwait(false);
 
             ServiceCollection services = new();
+
+            // How an application with no reflection left declares a type of its own — here the typed
+            // job's payload. The same registry answers for job data values, so there is one place to
+            // declare a type and not two.
+            SystemTextJsonSerializerRegistry registry = new();
+            registry.AddTypeInfoResolver(CanaryJsonContext.Default);
+            services.AddSingleton(registry);
+
             services.AddQuartz(q =>
             {
                 q.ConfigureScheduler(options =>
@@ -104,6 +122,19 @@ internal static class StoreCheck
                     .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
                     .Build()).ConfigureAwait(false);
 
+            // A job that declares the type of its input, scheduled with a payload on the trigger. The
+            // payload goes into the database as the string the scheduler's IJobInputSerializer wrote,
+            // and comes back out as a CanaryInput — all of it out of a publish with no reflection.
+            await scheduler.ScheduleJob(
+                JobBuilder.Create<TypedCanaryJob>()
+                    .WithIdentity("typed", "store")
+                    .Build(),
+                TriggerBuilder.Create<TypedCanaryJob>()
+                    .WithIdentity("typed", "store")
+                    .StartNow()
+                    .UsingInput(new CanaryInput("the typed input round-trips out of a trimmed publish", 7))
+                    .Build()).ConfigureAwait(false);
+
             await scheduler.Start().ConfigureAwait(false);
 
             // Signalled by the job itself. A sleep would pass on a machine slow enough to make it
@@ -112,6 +143,19 @@ internal static class StoreCheck
             if (completed != fired.Task)
             {
                 return "FAIL store: the job never fired within a minute, so the store never handed a trigger to the scheduler.";
+            }
+
+            Task typed = await Task.WhenAny(typedInput.Task, Task.Delay(TimeSpan.FromSeconds(60))).ConfigureAwait(false);
+            if (typed != typedInput.Task)
+            {
+                return "FAIL store: the typed-input job never fired within a minute.";
+            }
+
+            CanaryInput received = await typedInput.Task.ConfigureAwait(false);
+            CanaryInput expected = new("the typed input round-trips out of a trimmed publish", 7);
+            if (received != expected)
+            {
+                return $"FAIL store: the typed job was handed '{received}' rather than '{expected}'.";
             }
 
             IJobDetail? job = await scheduler.GetJobDetail(jobKey).ConfigureAwait(false);
@@ -138,7 +182,7 @@ internal static class StoreCheck
 
             await scheduler.Shutdown(waitForJobsToComplete: true).ConfigureAwait(false);
 
-            Console.WriteLine("PASS store: scheduled, fired and read back through a SQLite store reached by its DbProviderFactory.");
+            Console.WriteLine("PASS store: scheduled, fired and read back through a SQLite store reached by its DbProviderFactory, typed job input included.");
             return null;
         }
         catch (Exception e)
@@ -202,4 +246,33 @@ internal static class StoreCheck
             return default;
         }
     }
+
+    /// <summary>
+    /// A job that declares the type of its input, so the payload arrives as a parameter. The dispatch is
+    /// the default implementation of <see cref="IJob{TInput}" />, which is the whole reason there is no
+    /// <c>MakeGenericMethod</c> anywhere in the feature and therefore nothing here for ILCompiler to
+    /// report.
+    /// </summary>
+    public sealed class TypedCanaryJob : IJob<CanaryInput>
+    {
+        public ValueTask Execute(IJobExecutionContext context, CanaryInput input, CancellationToken cancellationToken = default)
+        {
+            typedInput.TrySetResult(input);
+            return default;
+        }
+    }
+
 }
+
+/// <summary>
+/// The typed job's payload: a type Quartz has never heard of, which is the case the input serializer
+/// has to answer for.
+/// </summary>
+public sealed record CanaryInput(string Note, int Attempt);
+
+/// <summary>
+/// The metadata for <see cref="CanaryInput" />, handed to the scheduler's registry. This is what an
+/// application published without reflection writes for its own payload types.
+/// </summary>
+[JsonSerializable(typeof(CanaryInput))]
+internal sealed partial class CanaryJsonContext : JsonSerializerContext;

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -191,6 +191,13 @@ internal static class QuartzServiceRegistration
             return serializer;
         });
 
+        // What a typed job's input is written and read with. Built the same way and from the same
+        // registry as the object serializer above, so an application that declared a payload type for
+        // one has declared it for both. It is not part of IPersistentStoreBuilder: a typed input is
+        // carried by the in-memory store too, which has no serializer of its own.
+        services.TryAddKeyed<IJobInputSerializer>(key, static (provider, key) =>
+            ActivatorUtilities.CreateInstance<SystemTextJsonJobInputSerializer>(Scoped(provider, key)));
+
         services.TryAddKeyed<QuartzSchedulerResources>(key, static (provider, key) =>
         {
             var options = provider.GetSchedulerOptions<QuartzSchedulerOptions>(key);
@@ -209,6 +216,7 @@ internal static class QuartzServiceRegistration
                 TimeProvider = timeProvider,
                 LoggerFactory = provider.GetSchedulerLoggerFactory(),
                 Meters = meters,
+                JobInputSerializer = provider.GetScheduler<IJobInputSerializer>(key),
                 ThreadPool = provider.GetScheduler<IThreadPool>(key),
                 JobStore = Instrument(provider.GetScheduler<IJobStore>(key), meters, timeProvider),
                 JobRunShellFactory = provider.GetScheduler<IJobRunShellFactory>(key),

--- a/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
+++ b/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
@@ -50,6 +50,7 @@ internal sealed class SchedulerScopedServiceProvider
         typeof(AdoJobStoreDependencies),
         typeof(ILockHandler),
         typeof(IObjectSerializer),
+        typeof(IJobInputSerializer),
         typeof(SystemTextJsonSerializerRegistry),
         typeof(IThreadPool),
         typeof(IJobFactory),

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -154,7 +154,7 @@ internal sealed class JobRunShell
         {
             try
             {
-                context = new JobExecutionContextImpl(scheduler, firedTriggerBundle, jobScope.Job);
+                context = new JobExecutionContextImpl(scheduler, firedTriggerBundle, jobScope.Job, qs.resources.JobInputSerializer);
             }
             catch (Exception e)
             {

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -659,6 +659,9 @@ internal sealed class QuartzScheduler
         AdjustSimpleTriggerStartTimeIfInPast(trig);
         trig.Validate();
 
+        NormalizeInput(jobDetail.JobDataMap);
+        NormalizeInput(trig.JobDataMap);
+
         ICalendar? calendar = null;
         if (trigger.CalendarName is not null)
         {
@@ -703,6 +706,8 @@ internal sealed class QuartzScheduler
         IOperableTrigger trig = AsOperableTrigger(trigger);
         AdjustSimpleTriggerStartTimeIfInPast(trig);
         trig.Validate();
+
+        NormalizeInput(trig.JobDataMap);
 
         ICalendar? calendar = null;
         if (trigger.CalendarName is not null)
@@ -751,6 +756,8 @@ internal sealed class QuartzScheduler
         {
             Throw.SchedulerException("Jobs added with no trigger must be durable.");
         }
+
+        NormalizeInput(jobDetail.JobDataMap);
 
         await resources.JobStore.AddJob(jobDetail, options.Replace, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(null);
@@ -835,6 +842,8 @@ internal sealed class QuartzScheduler
             {
                 continue;
             }
+            NormalizeInput(job.JobDataMap);
+
             if (triggers is null) // this is possible because the job may be durable, and not yet be having triggers
             {
                 validated.Add(job, []);
@@ -849,6 +858,8 @@ internal sealed class QuartzScheduler
 
                 AdjustSimpleTriggerStartTimeIfInPast(trigger);
                 trigger.Validate();
+
+                NormalizeInput(trigger.JobDataMap);
 
                 ICalendar? calendar = null;
                 if (trigger.CalendarName is not null)
@@ -1074,6 +1085,26 @@ internal sealed class QuartzScheduler
     /// the implementations of <see cref="ITrigger" /> — so a trigger that implements only the read
     /// model is rejected with a clear error rather than an invalid-cast exception.
     /// </summary>
+    /// <summary>
+    /// Turns a job input that is not yet a string into the string a store can hold, on its way in.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the write half of a typed job's round trip, and it lives here because here is the only
+    /// place the value's <em>runtime</em> type is known — which is what has to be serialized. The read
+    /// half is the default implementation of <see cref="IJob{TInput}" />, where the <em>static</em> type
+    /// is known instead. Neither can do the other's job, which is why they are apart.
+    /// </para>
+    /// <para>
+    /// Every entry point that takes a <see cref="JobDataMap" /> to be stored passes through here, so an
+    /// input reaches a store as a string whichever way it was scheduled.
+    /// </para>
+    /// </remarks>
+    private void NormalizeInput(JobDataMap? map)
+    {
+        JobInput.Normalize(map, resources.JobInputSerializer);
+    }
+
     private static IOperableTrigger AsOperableTrigger(ITrigger trigger)
     {
         if (trigger is not IOperableTrigger operableTrigger)
@@ -1164,6 +1195,7 @@ internal sealed class QuartzScheduler
         trig.ComputeFirstFireTimeUtc(null);
         if (data is not null)
         {
+            NormalizeInput(data);
             trig.JobDataMap = data;
         }
 
@@ -1195,6 +1227,8 @@ internal sealed class QuartzScheduler
         ValidateState();
 
         trigger.ComputeFirstFireTimeUtc(null);
+
+        NormalizeInput(trigger.JobDataMap);
 
         bool collision = true;
         while (collision)

--- a/src/Quartz/Core/QuartzSchedulerResources.cs
+++ b/src/Quartz/Core/QuartzSchedulerResources.cs
@@ -301,5 +301,15 @@ internal sealed class QuartzSchedulerResources
     /// </summary>
     internal Diagnostics.Meters Meters { get; set; } = Diagnostics.Meters.Shared;
 
+    /// <summary>
+    /// What an <see cref="IJob{TInput}" />'s input is written and read with. The container path replaces
+    /// this with the one built from this scheduler's own serializer registry.
+    /// </summary>
+    /// <remarks>
+    /// Scheduler-level rather than store-level, because a typed input is carried by every store — the
+    /// in-memory one has no serializer of its own and still round-trips one.
+    /// </remarks>
+    internal IJobInputSerializer JobInputSerializer { get; set; } = new Impl.SystemTextJsonJobInputSerializer();
+
     internal ISchedulerRepository SchedulerRepository { get; set; }
 }

--- a/src/Quartz/Extensibility/IJobInputSerializer.cs
+++ b/src/Quartz/Extensibility/IJobInputSerializer.cs
@@ -1,0 +1,59 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Extensibility;
+
+/// <summary>
+/// Turns an <see cref="IJob{TInput}" />'s input into the string the scheduler stores under
+/// <see cref="SchedulerConstants.JobInput" />, and back again when the job runs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a different job from <see cref="IObjectSerializer" />'s. That one owns the store's own
+/// shapes — triggers, calendars, the job data map itself — and answers a persistent job store. This one
+/// owns a single application-defined payload, is asked for it by the scheduler on the way in and by the
+/// job on the way out, and is used whichever store the scheduler runs on, including the in-memory one.
+/// </para>
+/// <para>
+/// A string rather than bytes, for the reason <see cref="SchedulerConstants.JobInput" /> gives: it is
+/// what every path the value can take carries unchanged.
+/// </para>
+/// <para>
+/// The interface carries no trimming annotations, exactly as <see cref="IObjectSerializer" /> carries
+/// none. An annotation on an interface member has to be repeated by every implementation or the
+/// implementation reports IL2046, and an implementation written outside Quartz cannot be made to.
+/// </para>
+/// </remarks>
+/// <seealso cref="Quartz.Impl.SystemTextJsonJobInputSerializer" />
+public interface IJobInputSerializer
+{
+    /// <summary>
+    /// Serializes a job's input for storage.
+    /// </summary>
+    /// <param name="input">The input to serialize, always non-null.</param>
+    string Serialize(object input);
+
+    /// <summary>
+    /// Deserializes a job's input from what <see cref="Serialize" /> stored.
+    /// </summary>
+    /// <param name="payload">The stored payload, always non-null.</param>
+    TInput? Deserialize<TInput>(string payload);
+}

--- a/src/Quartz/IJob.cs
+++ b/src/Quartz/IJob.cs
@@ -67,3 +67,66 @@ public interface IJob
     /// </param>
     ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// A job that declares the type of the input it is scheduled with, so the payload arrives as a
+/// parameter instead of being dug out of a <see cref="JobDataMap" /> by key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The input is put on the job or, more usually, on the trigger — <c>UsingInput</c> on either builder —
+/// and the scheduler stores it as a string under <see cref="SchedulerConstants.JobInput" />. The
+/// trigger's input wins over the job's, exactly as any other job data does.
+/// </para>
+/// <code>
+/// public sealed record SendEmail(string To, string Subject);
+///
+/// public sealed class SendEmailJob : IJob&lt;SendEmail&gt;
+/// {
+///     public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
+///     {
+///         // input.To, input.Subject
+///         return default;
+///     }
+/// }
+/// </code>
+/// <para>
+/// <typeparamref name="TInput" /> exists at compile time in exactly one place: the default
+/// implementation of <see cref="IJob.Execute" /> below. Everything that runs a job — the job factory,
+/// <c>JobRunShell</c>, the listeners — sees an <see cref="IJob" />, and dispatching to a typed job from
+/// there would mean closing a generic method over a runtime type, which no trimmed or natively compiled
+/// application can do. Being a default interface method rather than a base class also leaves a job free
+/// to derive from whatever it likes.
+/// </para>
+/// <para>
+/// A job whose input is missing fails the firing with a <see cref="SchedulerException" /> naming the
+/// key, rather than running with a default payload.
+/// </para>
+/// </remarks>
+/// <typeparam name="TInput">The type of the payload this job is scheduled with.</typeparam>
+/// <seealso cref="JobInputBuilderExtensions" />
+/// <seealso cref="JobExecutionContextInputExtensions.GetInput{TInput}" />
+/// <seealso cref="Quartz.Extensibility.IJobInputSerializer" />
+public interface IJob<TInput> : IJob
+{
+    /// <summary>
+    /// Called by the <see cref="IScheduler" /> when a <see cref="ITrigger" /> fires that is associated
+    /// with this job, with the input the job was scheduled with.
+    /// </summary>
+    /// <param name="context">The execution context.</param>
+    /// <param name="input">The payload this firing was scheduled with.</param>
+    /// <param name="cancellationToken">
+    /// Signalled when this execution is interrupted. The same token as
+    /// <see cref="IJobExecutionContext.CancellationToken" />, for the reason
+    /// <see cref="IJob.Execute" /> gives.
+    /// </param>
+    ValueTask Execute(IJobExecutionContext context, TInput input, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reads the stored input and hands it to <see cref="Execute(IJobExecutionContext, TInput, CancellationToken)" />.
+    /// </summary>
+    ValueTask IJob.Execute(IJobExecutionContext context, CancellationToken cancellationToken)
+    {
+        return Execute(context, JobInput.Read<TInput>(context), cancellationToken);
+    }
+}

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -63,9 +63,11 @@ namespace Quartz.Impl;
 /// <author>James House</author>
 /// <author>Marko Lahma (.NET)</author>
 #pragma warning disable CA1708
-public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext, IDisposable
+public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext, IJobInputSource, IDisposable
 #pragma warning restore CA1708
 {
+    private readonly IJobInputSerializer? inputSerializer;
+
     private readonly ITrigger trigger;
     private readonly IJobDetail jobDetail;
 
@@ -92,9 +94,23 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
     /// <summary>
     /// Create a JobExecutionContext with the given context data.
     /// </summary>
-    public JobExecutionContextImpl(IScheduler scheduler, TriggerFiredBundle firedBundle, IJob job)
+    /// <param name="scheduler">The scheduler this firing belongs to.</param>
+    /// <param name="firedBundle">What the job store handed back when the trigger fired.</param>
+    /// <param name="job">The job instance the factory built for this firing.</param>
+    /// <param name="inputSerializer">
+    /// What <see cref="JobExecutionContextInputExtensions.GetInput{TInput}" /> and an
+    /// <see cref="IJob{TInput}" /> read a stored input with. Quartz hands the scheduler's own; a context
+    /// built by hand without one reports a <see cref="SchedulerException" /> if a job asks it for a
+    /// stored input, rather than reflecting its way to an answer.
+    /// </param>
+    public JobExecutionContextImpl(
+        IScheduler scheduler,
+        TriggerFiredBundle firedBundle,
+        IJob job,
+        IJobInputSerializer? inputSerializer = null)
     {
         this.scheduler = scheduler;
+        this.inputSerializer = inputSerializer;
         trigger = firedBundle.Trigger;
         Calendar = firedBundle.Calendar;
         jobDetail = firedBundle.JobDetail;
@@ -111,6 +127,9 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
     /// <see cref="IJob" />.
     /// </summary>
     public IScheduler Scheduler => scheduler;
+
+    /// <inheritdoc />
+    IJobInputSerializer? IJobInputSource.JobInputSerializer => inputSerializer;
 
     /// <summary>
     /// Get a handle to the <see cref="ITrigger" /> instance that fired the

--- a/src/Quartz/Impl/SystemTextJsonJobInputSerializer.cs
+++ b/src/Quartz/Impl/SystemTextJsonJobInputSerializer.cs
@@ -1,0 +1,133 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+using Quartz.Extensibility;
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Impl;
+
+/// <summary>
+/// The default <see cref="IJobInputSerializer" />: a job's input as JSON, written by
+/// <see cref="JsonSerializer" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Built exactly as <see cref="SystemTextJsonObjectSerializer" /> is, so the two agree about what a
+/// scheduler's JSON means, and reading and writing go through the <c>GetTypeInfo</c> overloads that
+/// carry neither <c>RequiresUnreferencedCode</c> nor <c>RequiresDynamicCode</c> — which is what keeps
+/// typed input out of <c>TrimAnalysisBaseline.cs</c> and working in a trimmed or natively compiled
+/// application.
+/// </para>
+/// <para>
+/// An application published with reflection-based serialization switched off declares its own payload
+/// types through <see cref="SystemTextJsonSerializerRegistry.AddTypeInfoResolver" />, exactly as it
+/// declares a job data value type; there is no second registration to learn.
+/// </para>
+/// </remarks>
+public sealed class SystemTextJsonJobInputSerializer : IJobInputSerializer
+{
+    private readonly SystemTextJsonSerializerRegistry registry;
+    private readonly Lock optionsLock = new();
+    private volatile JsonSerializerOptions? options;
+
+    /// <summary>
+    /// Creates a serializer that knows the built-in types only.
+    /// </summary>
+    public SystemTextJsonJobInputSerializer()
+        : this(new SystemTextJsonSerializerRegistry())
+    {
+    }
+
+    /// <summary>
+    /// Creates a serializer that resolves payload metadata through the given registry, so a scheduler's
+    /// own declared types are known to its own serializer and to no other.
+    /// </summary>
+    public SystemTextJsonJobInputSerializer(SystemTextJsonSerializerRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        this.registry = registry;
+    }
+
+    /// <summary>
+    /// The options this serializer reads and writes with, built on first use.
+    /// </summary>
+    private JsonSerializerOptions Options
+    {
+        get
+        {
+            JsonSerializerOptions? current = options;
+            if (current is not null)
+            {
+                return current;
+            }
+
+            lock (optionsLock)
+            {
+                return options ??= CreateSerializerOptions();
+            }
+        }
+    }
+
+    private JsonSerializerOptions CreateSerializerOptions()
+    {
+        JsonSerializerOptions created = new JsonSerializerOptions().AddQuartzConverters(registry, newtonsoftCompatibilityMode: true);
+        created.UseQuartzContract(QuartzStoreJsonContext.Default, registry);
+        return created;
+    }
+
+    /// <summary>
+    /// Writes the input as JSON.
+    /// </summary>
+    /// <remarks>
+    /// Written as <see cref="object" />, so the payload describes the runtime type rather than whatever
+    /// static type the caller happened to hold — the same choice
+    /// <see cref="SystemTextJsonObjectSerializer.Serialize{T}" /> makes, for the same reason.
+    /// </remarks>
+    public string Serialize(object input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        JsonTypeInfo typeInfo = Options.GetTypeInfo(typeof(object));
+        return JsonSerializer.Serialize(input, typeInfo);
+    }
+
+    /// <summary>
+    /// Reads back what <see cref="Serialize" /> wrote.
+    /// </summary>
+    public TInput? Deserialize<TInput>(string payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        try
+        {
+            JsonTypeInfo<TInput> typeInfo = (JsonTypeInfo<TInput>) Options.GetTypeInfo(typeof(TInput));
+            return JsonSerializer.Deserialize(payload, typeInfo);
+        }
+        catch (Exception e) when (e is Quartz.JsonSerializationException or System.Text.Json.JsonException)
+        {
+            throw new Quartz.JsonSerializationException(
+                $"Could not read a job input of type {typeof(TInput)} from JSON: {payload}", e);
+        }
+    }
+}

--- a/src/Quartz/JobInput.cs
+++ b/src/Quartz/JobInput.cs
@@ -1,0 +1,181 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+
+namespace Quartz;
+
+/// <summary>
+/// Reads the input a job was scheduled with.
+/// </summary>
+/// <remarks>
+/// An extension rather than a member of <see cref="IJobExecutionContext" />, so that every hand-written
+/// context — a test double, an adapter — keeps compiling. An <see cref="IJob{TInput}" /> does not need
+/// this: its input arrives as a parameter.
+/// </remarks>
+public static class JobExecutionContextInputExtensions
+{
+    /// <summary>
+    /// The input this firing carries, or <see langword="default" /> when it carries none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The trigger's input wins over the job's, which is what <see cref="IJobExecutionContext.MergedJobDataMap" />
+    /// means everywhere else.
+    /// </para>
+    /// <para>
+    /// <typeparamref name="TInput" /> is the type the payload is read back as, so a job reading its own
+    /// input names the same type the scheduling side passed. An input stored as JSON by a different type
+    /// comes back as whatever this type can make of that JSON.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TInput">The type the input was scheduled as.</typeparam>
+    /// <param name="context">The firing to read the input of.</param>
+    /// <exception cref="SchedulerException">
+    /// The input is stored but cannot be read: the context was built without an
+    /// <see cref="IJobInputSerializer" />, or the stored value is neither a payload nor a
+    /// <typeparamref name="TInput" />.
+    /// </exception>
+    public static TInput? GetInput<TInput>(this IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return JobInput.TryRead(context, out TInput? input) ? input : default;
+    }
+}
+
+/// <summary>
+/// The two halves of a typed job's input round trip: normalizing it to a string on the way into a
+/// store, and reading it back on the way out.
+/// </summary>
+/// <remarks>
+/// They are apart in the code because they are apart in time and in what they know. The scheduler knows
+/// the value's <em>runtime</em> type, which is what has to be written; the job knows its
+/// <em>static</em> type, which is what has to be read. Neither knows the other's.
+/// </remarks>
+internal static class JobInput
+{
+    /// <summary>
+    /// Replaces a job input that is not already a string with its serialized form, so that whatever the
+    /// map goes on to travel through carries it unchanged.
+    /// </summary>
+    /// <remarks>
+    /// A value that is already a string is left exactly as it is. That is what makes a
+    /// <see cref="string" /> payload work, and it is what makes normalizing a map twice — a job data map
+    /// handed to a second <c>ScheduleJob</c>, for instance — do nothing the second time.
+    /// </remarks>
+    public static void Normalize(JobDataMap? map, IJobInputSerializer serializer)
+    {
+        if (map is null || !map.TryGetValue(SchedulerConstants.JobInput, out object? value) || value is null or string)
+        {
+            return;
+        }
+
+        map[SchedulerConstants.JobInput] = serializer.Serialize(value);
+    }
+
+    /// <summary>
+    /// Reads the input an <see cref="IJob{TInput}" /> declared, which it is an error not to have.
+    /// </summary>
+    public static TInput Read<TInput>(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!TryRead(context, out TInput? input))
+        {
+            Throw.SchedulerException(
+                $"Job '{context.JobDetail.Key}' takes an input of type {typeof(TInput)}, but neither its job data map nor "
+                + $"trigger '{context.Trigger.Key}' carries one under '{SchedulerConstants.JobInput}'. "
+                + "Set it with UsingInput() on the job or trigger builder.");
+        }
+
+        return input!;
+    }
+
+    /// <summary>
+    /// Reads the input this firing carries, reporting whether it carried one at all.
+    /// </summary>
+    public static bool TryRead<TInput>(IJobExecutionContext context, out TInput? input)
+    {
+        if (!context.MergedJobDataMap.TryGetValue(SchedulerConstants.JobInput, out object? stored) || stored is null)
+        {
+            input = default;
+            return false;
+        }
+
+        // A value of the asked-for type is handed straight back. That is the case for a string payload,
+        // which is stored verbatim, and for a map that never went through a store at all.
+        if (stored is TInput typed)
+        {
+            input = typed;
+            return true;
+        }
+
+        if (stored is string payload)
+        {
+            input = Serializer(context).Deserialize<TInput>(payload);
+            return true;
+        }
+
+        Throw.SchedulerException(
+            $"Job '{context.JobDetail.Key}' takes an input of type {typeof(TInput)}, but '{SchedulerConstants.JobInput}' "
+            + $"holds a {stored.GetType()}. An input is stored either as itself or as the string an IJobInputSerializer wrote.");
+        input = default;
+        return false;
+    }
+
+    /// <summary>
+    /// The serializer the context was built with.
+    /// </summary>
+    /// <remarks>
+    /// A context Quartz built has one. A context built by hand — a test double, an adapter — may not,
+    /// and is told so by name rather than left to reflect its way to an answer.
+    /// </remarks>
+    private static IJobInputSerializer Serializer(IJobExecutionContext context)
+    {
+        if (context is IJobInputSource { JobInputSerializer: { } serializer })
+        {
+            return serializer;
+        }
+
+        Throw.SchedulerException(
+            $"The execution context for job '{context.JobDetail.Key}' was built without an {nameof(IJobInputSerializer)}, "
+            + "so a stored job input cannot be read back. A context Quartz creates carries the scheduler's serializer; "
+            + $"one built by hand has to be given it through the {nameof(Impl.JobExecutionContextImpl)} constructor.");
+        return null!;
+    }
+}
+
+/// <summary>
+/// An execution context that knows how to read a stored job input.
+/// </summary>
+/// <remarks>
+/// Internal, and deliberately not a member of <see cref="IJobExecutionContext" />: the serializer is a
+/// scheduler's own part, not something a context's implementer should have to supply.
+/// </remarks>
+internal interface IJobInputSource
+{
+    /// <summary>
+    /// The serializer this firing's inputs are read with, or <see langword="null" /> when the context was
+    /// built without one.
+    /// </summary>
+    IJobInputSerializer? JobInputSerializer { get; }
+}

--- a/src/Quartz/JobInputBuilderExtensions.cs
+++ b/src/Quartz/JobInputBuilderExtensions.cs
@@ -1,0 +1,108 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Quartz;
+
+/// <summary>
+/// Puts an <see cref="IJob{TInput}" />'s input on the job or the trigger being built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extensions rather than members, because a method cannot constrain its own type's type parameter:
+/// <c>JobBuilder&lt;TJob&gt;</c> is declared for any <c>TJob : IJob</c>, and a member saying
+/// <c>where TJob : IJob&lt;TInput&gt;</c> is CS0699. Written here, the constraint is the method's own
+/// and the compiler can check it — so <c>UsingInput</c> is offered on a builder for a typed job and
+/// refused on a builder for a job that takes no input.
+/// </para>
+/// <para>
+/// The input type is inferred from the argument's <em>static</em> type. A payload held as a base type —
+/// or as <see cref="object" /> — is stored and read back as that type unless the type argument is given
+/// explicitly: <c>builder.UsingInput&lt;SendEmailJob, SendEmail&gt;(payload)</c>.
+/// </para>
+/// <para>
+/// The value goes into the map as it is; the scheduler serializes it as the job or trigger is stored,
+/// which is the only point at which a serializer exists. So a builder needs none, and a job data map
+/// built here can still be inspected before it is scheduled.
+/// </para>
+/// </remarks>
+/// <seealso cref="IJob{TInput}" />
+/// <seealso cref="SchedulerConstants.JobInput" />
+public static class JobInputBuilderExtensions
+{
+    /// <summary>
+    /// Sets the input the job carries.
+    /// </summary>
+    /// <remarks>
+    /// An input on the job is the default for every one of its triggers, and any trigger can override
+    /// it. Note that a <see cref="PersistJobDataAfterExecutionAttribute" /> job re-stores its own map
+    /// after every firing, so an input meant to differ per firing belongs on the trigger.
+    /// </remarks>
+    /// <param name="builder">The job being built.</param>
+    /// <param name="input">The payload the job runs with.</param>
+    public static JobBuilder<TJob> UsingInput<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this JobBuilder<TJob> builder,
+        TInput input) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.UsingJobData(SchedulerConstants.JobInput, input);
+    }
+
+    /// <summary>
+    /// Sets the input this trigger's firings carry, overriding any input on the job.
+    /// </summary>
+    /// <param name="builder">The trigger being built.</param>
+    /// <param name="input">The payload the job runs with when this trigger fires it.</param>
+    public static TriggerBuilder<TJob> UsingInput<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this TriggerBuilder<TJob> builder,
+        TInput input) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        return builder.UsingJobData(SchedulerConstants.JobInput, input);
+    }
+
+    /// <inheritdoc cref="UsingInput{TJob, TInput}(JobBuilder{TJob}, TInput)" />
+    /// <param name="configurator">The job being configured.</param>
+    /// <param name="input">The payload the job runs with.</param>
+    public static IJobConfigurator<TJob> UsingInput<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this IJobConfigurator<TJob> configurator,
+        TInput input) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        return configurator.UsingJobData(SchedulerConstants.JobInput, input);
+    }
+
+    /// <inheritdoc cref="UsingInput{TJob, TInput}(TriggerBuilder{TJob}, TInput)" />
+    /// <param name="configurator">The trigger being configured.</param>
+    /// <param name="input">The payload the job runs with when this trigger fires it.</param>
+    public static ITriggerConfigurator<TJob> UsingInput<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this ITriggerConfigurator<TJob> configurator,
+        TInput input) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(configurator);
+
+        return configurator.UsingJobData(SchedulerConstants.JobInput, input);
+    }
+}

--- a/src/Quartz/SchedulerConstants.cs
+++ b/src/Quartz/SchedulerConstants.cs
@@ -99,4 +99,25 @@ public static class SchedulerConstants
     /// Signals Quartz not to consider job data map as clean when deserialized - used in scenarios where data format needs to be converted.
     /// </summary>
     public const string ForceJobDataMapDirty = "QRTZ_FORCE_JOB_DATAMAP_DIRTY";
+
+    /// <summary>
+    /// The <see cref="JobDataMap" /> key an <see cref="IJob{TInput}" />'s input is carried under, on the
+    /// job's own map or — overriding it — on the trigger's.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The stored value is always a <see cref="string" />: the scheduler serializes anything else with
+    /// the scheduler's <see cref="Quartz.Extensibility.IJobInputSerializer" /> as the job or trigger is
+    /// stored. A string is what survives every path the value can take afterwards — AdoJobStore's
+    /// <c>StoreJobDataAsStrings</c> mode, the JSON write gate that refuses a job data value no reader
+    /// can produce, the Newtonsoft serializer, the binary blob column and the HTTP wire — so the round
+    /// trip does not depend on which of them the value went through.
+    /// </para>
+    /// <para>
+    /// Set it with <c>UsingInput</c> on a job or trigger builder rather than by spelling this key.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="IJob{TInput}" />
+    /// <seealso cref="JobInputBuilderExtensions" />
+    public const string JobInput = "QRTZ_JOB_INPUT";
 }


### PR DESCRIPTION
Closes #3521.

Every framework that embeds Quartz writes the same pair of classes: an adapter job that reads a payload out of a stringly `JobDataMap`, and a context type that puts it there. `IJob<TInput>` removes the pair.

```csharp
public sealed record SendEmail(string To, string Subject);

public sealed class SendEmailJob : IJob<SendEmail>
{
    public ValueTask Execute(IJobExecutionContext context, SendEmail input, CancellationToken cancellationToken = default)
    {
        // input.To, input.Subject
        return default;
    }
}

await scheduler.ScheduleJob(
    JobBuilder.Create<SendEmailJob>().WithIdentity("welcome", "email").Build(),
    TriggerBuilder.Create<SendEmailJob>()
        .WithIdentity("welcome-3401", "email")
        .StartNow()
        .UsingInput(new SendEmail("someone@example.org", "Welcome"))
        .Build());
```

## How it works

**The default interface method is the whole mechanism.** `IJob<TInput>` implements `IJob.Execute` by reading the stored input and handing it to the typed overload. `TInput` therefore exists at compile time in exactly one place; the job factory, `JobRunShell` and the listeners still see an `IJob`, and nothing closes a generic method over a runtime type. No entry was added to `src/Quartz/TrimAnalysisBaseline.cs` or `ILLink.Suppressions.xml`.

**The payload is a string in the ordinary map.** `UsingInput` puts the value into the `JobDataMap` under `SchedulerConstants.JobInput` (`"QRTZ_JOB_INPUT"`), and `QuartzScheduler` serializes anything that is not already a string as the job or trigger is stored — at `ScheduleJob(IJobDetail, ITrigger)`, `ScheduleJob(ITrigger)`, `AddJob`, `ScheduleJobs` and both `TriggerJob` overloads. That is why nothing downstream needs to know about the feature: it survives `StoreJobDataAsStrings`, the `JobDataValues` write gate (#3495), Newtonsoft, the blob column and the HTTP wire unchanged. Precedence is `MergedJobDataMap`'s: the trigger's input overrides the job's.

**The two halves of the round trip stay apart on purpose.** The scheduler knows the value's *runtime* type, which is what has to be written; the default interface method knows its *static* type, which is what has to be read. Neither can do the other's job.

**`UsingInput` is an extension, and so is `GetInput`.** `JobBuilder<TJob>` is declared for any `TJob : IJob`, so a member saying `where TJob : IJob<TInput>` is CS0699. `GetInput<TInput>()` is an extension on `IJobExecutionContext` because a new interface member would break every hand-written context fake in the wild.

**Serialization is per scheduler.** `IJobInputSerializer` is registered keyed beside `IObjectSerializer`, constructed through `ActivatorUtilities` so the scheduler's `SystemTextJsonSerializerRegistry` is injected, and carried on `QuartzSchedulerResources`. An application published trimmed or natively declares its payload types with `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — the same registration a job data value type needs, not a second one. Reading and writing go through the `GetTypeInfo` overloads that carry neither `RequiresUnreferencedCode` nor `RequiresDynamicCode`, exactly as `SystemTextJsonObjectSerializer` does.

## Public API baseline — every line that moved

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through the Verify flow (received → verified, never hand-edited). 33 lines added, 1 replaced:

**Added, namespace `Quartz`:**

```csharp
public interface IJob<TInput> : Quartz.IJob
{
    System.Threading.Tasks.ValueTask Execute(Quartz.IJobExecutionContext context, TInput input, System.Threading.CancellationToken cancellationToken = default);
}

public static class JobExecutionContextInputExtensions
{
    public static TInput? GetInput<TInput>(this Quartz.IJobExecutionContext context) { }
}

public static class JobInputBuilderExtensions
{
    public static Quartz.IJobConfigurator<TJob> UsingInput<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.IJobConfigurator<TJob> configurator, TInput input)
        where TJob : Quartz.IJob<TInput> { }
    public static Quartz.ITriggerConfigurator<TJob> UsingInput<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.ITriggerConfigurator<TJob> configurator, TInput input)
        where TJob : Quartz.IJob<TInput> { }
    public static Quartz.JobBuilder<TJob> UsingInput<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.JobBuilder<TJob> builder, TInput input)
        where TJob : Quartz.IJob<TInput> { }
    public static Quartz.TriggerBuilder<TJob> UsingInput<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.TriggerBuilder<TJob> builder, TInput input)
        where TJob : Quartz.IJob<TInput> { }
}

public static class SchedulerConstants
{
    public const string JobInput = "QRTZ_JOB_INPUT";
}
```

(The `DynamicallyAccessedMembers` argument is the full `JobTypeMembers.Required` set the builders already declare — `PublicParameterlessConstructor | PublicConstructors | PublicProperties | Interfaces`; elided above only for width.)

**Added, namespace `Quartz.Extensibility`:**

```csharp
public interface IJobInputSerializer
{
    TInput? Deserialize<TInput>(string payload);
    string Serialize(object input);
}
```

**Added, namespace `Quartz.Impl`:**

```csharp
public sealed class SystemTextJsonJobInputSerializer : Quartz.Extensibility.IJobInputSerializer
{
    public SystemTextJsonJobInputSerializer() { }
    public SystemTextJsonJobInputSerializer(Quartz.Serialization.SystemTextJson.SystemTextJsonSerializerRegistry registry) { }
    public TInput? Deserialize<TInput>(string payload) { }
    public string Serialize(object input) { }
}
```

**Changed — the only existing signature that moved:**

```diff
- public JobExecutionContextImpl(Quartz.IScheduler scheduler, Quartz.Extensibility.TriggerFiredBundle firedBundle, Quartz.IJob job) { }
+ public JobExecutionContextImpl(Quartz.IScheduler scheduler, Quartz.Extensibility.TriggerFiredBundle firedBundle, Quartz.IJob job, Quartz.Extensibility.IJobInputSerializer? inputSerializer = null) { }
```

Optional, so it is source-compatible. `JobExecutionContextImpl` also implements a new *internal* `IJobInputSource`, which is why the baseline's interface list is unchanged.

The same delta is written up in `docs/documentation/quartz-4.x/migration-guide.md` under "A job can take a typed input".

## For a reviewer to decide

1. **`QuartzSchedulerResources.JobInputSerializer` is non-nullable and defaults to `new SystemTextJsonJobInputSerializer()`.** The spec described a nullable property. `NormalizeInput` runs on every schedule, and a `QuartzSchedulerResources` built by hand — every benchmark, several tests — has nothing to supply one; the `Meters = Meters.Shared` line beside it is the precedent for a working default. The container path still replaces it with the keyed instance built from that scheduler's registry. The "no serializer" failure the spec asks for is preserved where it belongs — a `JobExecutionContextImpl` built by hand gets a `SchedulerException` naming `IJobInputSerializer` rather than reflecting.

2. **A stored value that is already a `TInput` is handed back without deserializing.** Needed because normalization deliberately leaves a `string` payload verbatim (`TInput = string` is then read verbatim too), and because a map that never reached a store still holds the live object. The consequence worth knowing: `TInput = object` reads the JSON back as the `string` it is.

3. **`TInput` is inferred from the argument's static type.** A payload held as a base type is stored and read as that base type unless the type argument is given explicitly. Documented as a known limit in both the guide and the tutorial.

## Verification

```
dotnet build Quartz.slnx                                       0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit                              3772 passed, 0 failed
dotnet test src/Quartz.Tests.AspNetCore                        549 passed, 0 failed
dotnet test src/Quartz.Tests.Integration (RAM + SQLite)        246 passed, 0 failed
dotnet fallout PublishTrimmed                                  canary exit 0, "typed job input included"
native AOT publish + run of Quartz.Trimming.Canary             exit 0, IsReflectionEnabledByDefault: False
npm run docs:check-links                                       no dead links or anchors
dotnet fallout DocsSnippets                                    93 markdown files, up to date
```

`dotnet fallout PublishAot` itself fails on this machine at ILCompiler's native link step because `vswhere.exe` is not on the shell's `PATH`; re-running the identical publish with it on `PATH` succeeds and the executable exits 0. ILCompiler reported 31 trim/AOT warnings, all already in the baseline and none naming anything this PR adds.

## Tests

- `src/Quartz.Tests.Unit/TypedJobInputTest.cs` — nine cases over a real scheduler: input on the job; the trigger's input overriding it; a `record struct` payload; the stored value being a `string` with the exact JSON asserted; `GetInput<T>()` from a plain `IJob`; `GetInput<T>()` answering `default` when nothing was scheduled; a missing input failing the firing with the key named; a hand-built context without a serializer saying so; a `[PersistJobDataAfterExecution]` job writing the input back unchanged.
- `src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs` — `ATypedJobsInputSurvivesTheStoreAndTheTriggersWins`, which runs on every dialect fixture: both maps come back holding what was put in them, and a firing built from the store's own `TriggerFiredBundle` reads the trigger's payload.
- `src/Quartz.Trimming.Canary` — a `TypedCanaryJob : IJob<CanaryInput>` scheduled over the SQLite store, with `CanaryInput`'s metadata declared through `AddTypeInfoResolver`, asserted equal to what was scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53


---

#3548 ("Scheduling over an existing trigger is one atomic call") is stacked on this branch and needs `IJob<TInput>` and `UsingInput` from it; merge this one first.
