### PR TITLE
Five common builder calls have a short spelling again

### DIFF
--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -175,8 +175,27 @@ without naming `CronScheduleBuilder`; call `Build()` yourself when you want the 
 value.
 
 Each field offers a single value, list, range and increment form (e.g. `WithHour`,
-`WithHours`, `WithHourRange`, `WithHourIncrements`), and the special characters are
-available through dedicated methods:
+`WithHours`, `WithHourRange`, `WithHourIncrements`). A schedule that fires once a day sets three of
+those fields to say one thing, so `AtTime` sets them together from a `TimeOnly` — add the days it
+applies to beside it:
+
+<!-- snippet: sample_cron_expressions_at_time -->
+```csharp
+CronExpressionBuilder.Create().AtTime(new TimeOnly(9, 30));            // "0 30 9 ? * *"
+
+CronExpressionBuilder.Create()
+    .AtTime(new TimeOnly(9, 30))
+    .WithDaysOfWeek(DayOfWeek.Monday, DayOfWeek.Thursday);            // "0 30 9 ? * MON,THU"
+
+CronExpressionBuilder.Create()
+    .AtTime(new TimeOnly(9, 30))
+    .WithDayOfMonth(15);                                              // "0 30 9 15 * ?"
+```
+<!-- endSnippet -->
+
+Cron resolves to a whole second, so any sub-second part of the `TimeOnly` is ignored.
+
+The special characters are available through dedicated methods:
 
 <!-- snippet: sample_cron_expressions_day_rules -->
 ```csharp

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5917,6 +5917,12 @@ taking an optional record whose defaults are the conservative choice (`Replace =
 | `AddCalendar(name, cal, false, false)` | `AddCalendar(name, cal)` |
 | `AddCalendar(name, cal, true, true)` | `AddCalendar(name, cal, new AddCalendarOptions { Replace = true, UpdateTriggers = true })` |
 
+`replace: true` on its own is nearly all of what these options are ever asked for, so each record names it:
+`AddJobOptions.Replacing`, `ScheduleJobOptions.Replacing`, `AddCalendarOptions.Replacing` and
+`AddCalendarOptions.ReplacingAndUpdatingTriggers` are the initializers above under a name — see
+[Five shorthands for the common case](#five-shorthands-for-the-common-case). The initializer stays the way to
+say anything else.
+
 `AddJobOptions` and `AddCalendarOptions` are both in the `Quartz` namespace. `IJobStore.AddCalendar` takes
 `AddCalendarOptions` too; `IJobStore.AddJob` keeps its single `bool replace`, because durability is a
 scheduler-level rule the store never sees.
@@ -7431,6 +7437,14 @@ Inside a `WithSimpleSchedule` delegate you never needed the factories at all:
 + .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(5)).RepeatForever())
 ```
 
+And an interval overload shortens even that, which is as close as 4.x comes to bringing the factories back —
+see [Five shorthands for the common case](#five-shorthands-for-the-common-case):
+
+```csharp
+.WithSimpleSchedule(TimeSpan.FromMinutes(5))                   // the same schedule
+.WithSimpleSchedule(TimeSpan.FromMinutes(5), repeatCount: 2)   // three firings rather than forever
+```
+
 ## `CronScheduleBuilder`'s convenience factories are gone
 
 `CronSchedule(string)` and `CronSchedule(CronExpression)` stay, spelled `Create(...)` now (see
@@ -7445,19 +7459,81 @@ positional and special forms (`OnWeekdays`, `OnLastDayOfMonth`, `OnLastDayOfWeek
 `CronExpression` — directly through `WithCronSchedule`, so the chain closes without naming
 `CronScheduleBuilder`.
 
+The four that took a time of day take it as one `TimeOnly` now, through `AtTime` — which sets the second,
+minute and hour fields together, so the "at 09:30" half of each old factory is one call and the "on these
+days" half is `WithDaysOfWeek` or `WithDayOfMonth` beside it. Cron resolves to a whole second, so any
+sub-second part of the `TimeOnly` is ignored.
+
 | 3.x | 4.x |
 |---|---|
-| `CronScheduleBuilder.DailyAtHourAndMinute(h, m)` | `CronScheduleBuilder.Create($"0 {m} {h} ? * *")` |
-| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDaysOfWeek(days).Build())` |
-| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDaysOfWeek(day).Build())` |
-| `CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(dom, h, m)` | `CronScheduleBuilder.Create(CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h).WithDayOfMonth(dom).Build())` |
+| `CronScheduleBuilder.DailyAtHourAndMinute(h, m)` | `CronExpressionBuilder.Create().AtTime(new TimeOnly(h, m))` |
+| `CronScheduleBuilder.AtHourAndMinuteOnGivenDaysOfWeek(h, m, days)` | `CronExpressionBuilder.Create().AtTime(new TimeOnly(h, m)).WithDaysOfWeek(days)` |
+| `CronScheduleBuilder.WeeklyOnDayAndHourAndMinute(day, h, m)` | `CronExpressionBuilder.Create().AtTime(new TimeOnly(h, m)).WithDaysOfWeek(day)` |
+| `CronScheduleBuilder.MonthlyOnDayAndHourAndMinute(dom, h, m)` | `CronExpressionBuilder.Create().AtTime(new TimeOnly(h, m)).WithDayOfMonth(dom)` |
 | `CronScheduleBuilder.CronScheduleWithHash(expr, hashKey)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashKey))` |
 | `CronScheduleBuilder.CronScheduleWithHash(expr, hashSeed)` | `CronScheduleBuilder.Create(new CronExpression(expr, hashSeed))` |
+
+`WithCronSchedule` takes the builder, so nothing in the first four rows names `CronScheduleBuilder` at all:
+
+```diff
+- .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(9, 30))
++ .WithCronSchedule(CronExpressionBuilder.Create().AtTime(new TimeOnly(9, 30)))
+```
+
+A literal expression is still the shortest thing to write when you have one:
 
 ```diff
 - .WithSchedule(CronScheduleBuilder.DailyAtHourAndMinute(9, 30))
 + .WithCronSchedule("0 30 9 ? * *")
 ```
+
+## Five shorthands for the common case
+
+Replacing a family of static factories with a builder makes the unusual call sayable and the usual one
+longer. Five additions give the usual one its short spelling back: an interval overload of
+`WithSimpleSchedule`, `CronExpressionBuilder.AtTime`, `IScheduler.ScheduleJob<TJob>`, a named static on each
+of the three option records, and `TriggerBuilder<TJob>.Key`. All are additive — nothing they shorten stopped
+working, and the longer form is still what to reach for the moment the call needs more than the shorthand
+says.
+
+| Instead of | Write |
+|---|---|
+| `WithSimpleSchedule(x => x.WithInterval(i).RepeatForever())` | `WithSimpleSchedule(i)` |
+| `WithSimpleSchedule(x => x.WithInterval(i).WithRepeatCount(n))` | `WithSimpleSchedule(i, n)` |
+| `CronExpressionBuilder.Create().WithSecond(0).WithMinute(m).WithHour(h)` | `CronExpressionBuilder.Create().AtTime(new TimeOnly(h, m))` |
+| `scheduler.ScheduleJob(JobBuilder.Create<TJob>().WithIdentity(trigger.Key.Name, trigger.Key.Group).Build(), trigger)` | `scheduler.ScheduleJob<TJob>(trigger)` |
+| `new AddJobOptions { Replace = true }` | `AddJobOptions.Replacing` |
+| `new ScheduleJobOptions { Replace = true }` | `ScheduleJobOptions.Replacing` |
+| `new AddCalendarOptions { Replace = true }` | `AddCalendarOptions.Replacing` |
+| `new AddCalendarOptions { Replace = true, UpdateTriggers = true }` | `AddCalendarOptions.ReplacingAndUpdatingTriggers` |
+
+The repeat count in `WithSimpleSchedule(i, n)` is the trigger's own `RepeatCount`, so it fires `n + 1` times —
+the same number `WithRepeatCount` takes, with none of the `- 1` arithmetic the 3.x `ForTotalCount` factories
+did. Omitting it repeats forever.
+
+`IScheduler.ScheduleJob<TJob>(trigger, configure)` is the imperative twin of the container's
+`q.ScheduleJob<TJob>(...)`, and names the job the same way: whatever `configure` gave it, else the job the
+trigger already points at through `ForJob`, else the trigger's own key. So neither of these names a
+`JobBuilder`, and the two read alike:
+
+```csharp
+// at start-up, in AddQuartz
+q.ScheduleJob<ReportJob>(trigger => trigger.WithIdentity("nightly").WithCronSchedule("0 30 9 ? * *"));
+
+// at run time, against a scheduler
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("nightly")
+    .WithCronSchedule("0 30 9 ? * *")
+    .Build();
+
+await scheduler.ScheduleJob<ReportJob>(trigger);
+```
+
+`TriggerBuilder<TJob>.Key` rounds out the same pass: it reports the identity the trigger was given, the way
+`JobBuilder<TJob>.Key` already did, so code that has to agree with a trigger can read its key rather than
+build the trigger to find it out. It differs in one way — a trigger builder keeps the key `Build()` generated
+when none was named, so building twice produces the same trigger, and reading `Key` after `Build()` reports
+that generated key rather than `null`.
 
 ## Day selection on `DailyTimeIntervalScheduleBuilder`
 

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -253,7 +253,7 @@ builder.Services.AddQuartz(q =>
         .WithIdentity("Simple Trigger")
         .ForJob(jobKey)
         .StartNow()
-        .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever()));
+        .WithSimpleSchedule(TimeSpan.FromSeconds(10)));
 
     q.AddTrigger<ExampleJob>(t => t
         .WithIdentity("Cron Trigger")
@@ -312,7 +312,7 @@ q.ScheduleJob<SlowJob>(
     trigger => trigger
         .WithIdentity("slowJobTrigger")
         .StartNow()
-        .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever()),
+        .WithSimpleSchedule(TimeSpan.FromSeconds(5)),
     job => job
         .WithIdentity("slowJob")
         .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -33,7 +33,7 @@ builder.Services.AddQuartz("FastScheduler", q =>
 
     q.ScheduleJob<NotificationJob>(trigger => trigger
         .WithIdentity("notify-trigger")
-        .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).RepeatForever()));
+        .WithSimpleSchedule(TimeSpan.FromSeconds(30)));
 });
 
 // Second scheduler: persistent database jobs
@@ -194,7 +194,7 @@ builder.Services.AddQuartz(q =>
 {
     q.ScheduleJob<MainJob>(trigger => trigger
         .WithIdentity("main-trigger")
-        .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever()));
+        .WithSimpleSchedule(TimeSpan.FromMinutes(1)));
 });
 
 // Additional named scheduler

--- a/docs/documentation/quartz-4.x/quick-start.md
+++ b/docs/documentation/quartz-4.x/quick-start.md
@@ -225,20 +225,19 @@ IJobDetail job = JobBuilder.Create<HelloJob>()
     .WithIdentity("job1", "group1")
     .Build();
 
-// Trigger the job to run now, and then repeat every 10 seconds
+// Trigger the job to run now, and then repeat every 10 seconds forever
+// (pass a repeat count as the second argument to stop after a while)
 ITrigger trigger = TriggerBuilder.Create()
     .WithIdentity("trigger1", "group1")
     .StartNow()
-    .WithSimpleSchedule(x => x
-        .WithInterval(TimeSpan.FromSeconds(10))
-        .RepeatForever())
+    .WithSimpleSchedule(TimeSpan.FromSeconds(10))
     .Build();
 
 // Tell Quartz to schedule the job using our trigger
 await scheduler.ScheduleJob(job, trigger);
 
 // several triggers for one job go together, in one call
-// await scheduler.ScheduleJob(job, [trigger1, trigger2], new ScheduleJobOptions { Replace = true });
+// await scheduler.ScheduleJob(job, [trigger1, trigger2], ScheduleJobOptions.Replacing);
 ```
 <!-- endSnippet -->
 

--- a/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
+++ b/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
@@ -53,6 +53,23 @@ public static class CronExpressionsSamples
         #endregion
     }
 
+    public static void ATimeOfDay()
+    {
+        #region sample_cron_expressions_at_time
+
+        CronExpressionBuilder.Create().AtTime(new TimeOnly(9, 30));            // "0 30 9 ? * *"
+
+        CronExpressionBuilder.Create()
+            .AtTime(new TimeOnly(9, 30))
+            .WithDaysOfWeek(DayOfWeek.Monday, DayOfWeek.Thursday);            // "0 30 9 ? * MON,THU"
+
+        CronExpressionBuilder.Create()
+            .AtTime(new TimeOnly(9, 30))
+            .WithDayOfMonth(15);                                              // "0 30 9 15 * ?"
+
+        #endregion
+    }
+
     public static void TheAwkwardDayRules()
     {
         #region sample_cron_expressions_day_rules

--- a/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
+++ b/src/Quartz.Documentation.Samples/PackageReadmeSamples.cs
@@ -40,7 +40,7 @@ public static class PackageReadmeSamples
 
             builder.AddQuartz(q => q.ScheduleJob<HelloJob>(trigger => trigger
                 .WithIdentity("hello")
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever())));
+                .WithSimpleSchedule(TimeSpan.FromSeconds(10))));
 
             builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -157,7 +157,7 @@ public static class MicrosoftDiIntegrationSamples
                 .WithIdentity("Simple Trigger")
                 .ForJob(jobKey)
                 .StartNow()
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever()));
+                .WithSimpleSchedule(TimeSpan.FromSeconds(10)));
 
             q.AddTrigger<ExampleJob>(t => t
                 .WithIdentity("Cron Trigger")
@@ -219,7 +219,7 @@ public static class MicrosoftDiIntegrationSamples
                 trigger => trigger
                     .WithIdentity("slowJobTrigger")
                     .StartNow()
-                    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever()),
+                    .WithSimpleSchedule(TimeSpan.FromSeconds(5)),
                 job => job
                     .WithIdentity("slowJob")
                     .UsingJobData(JobInterruptMonitorPlugin.JobDataMapKeyAutoInterruptable, true)

--- a/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
@@ -26,7 +26,7 @@ public static class MultipleSchedulersSamples
 
             q.ScheduleJob<NotificationJob>(trigger => trigger
                 .WithIdentity("notify-trigger")
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).RepeatForever()));
+                .WithSimpleSchedule(TimeSpan.FromSeconds(30)));
         });
 
         // Second scheduler: persistent database jobs
@@ -154,7 +154,7 @@ public static class MultipleSchedulersSamples
         {
             q.ScheduleJob<MainJob>(trigger => trigger
                 .WithIdentity("main-trigger")
-                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromMinutes(1)).RepeatForever()));
+                .WithSimpleSchedule(TimeSpan.FromMinutes(1)));
         });
 
         // Additional named scheduler

--- a/src/Quartz.Documentation.Samples/QuickStartSamples.cs
+++ b/src/Quartz.Documentation.Samples/QuickStartSamples.cs
@@ -88,20 +88,19 @@ public static class QuickStartSamples
             .WithIdentity("job1", "group1")
             .Build();
 
-        // Trigger the job to run now, and then repeat every 10 seconds
+        // Trigger the job to run now, and then repeat every 10 seconds forever
+        // (pass a repeat count as the second argument to stop after a while)
         ITrigger trigger = TriggerBuilder.Create()
             .WithIdentity("trigger1", "group1")
             .StartNow()
-            .WithSimpleSchedule(x => x
-                .WithInterval(TimeSpan.FromSeconds(10))
-                .RepeatForever())
+            .WithSimpleSchedule(TimeSpan.FromSeconds(10))
             .Build();
 
         // Tell Quartz to schedule the job using our trigger
         await scheduler.ScheduleJob(job, trigger);
 
         // several triggers for one job go together, in one call
-        // await scheduler.ScheduleJob(job, [trigger1, trigger2], new ScheduleJobOptions { Replace = true });
+        // await scheduler.ScheduleJob(job, [trigger1, trigger2], ScheduleJobOptions.Replacing);
 
         #endregion
     }

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -203,6 +203,65 @@ public class CronExpressionBuilderTest
         Invoking(x => x.WithYear(2030).WithYearRange(2031, 2032)).Should().Throw<InvalidOperationException>().WithMessage("Year has already been configured.");
     }
 
+    /// <summary>
+    /// <c>AtTime</c> is the whole of a "daily at 09:30" schedule, and is what replaces the 3.x
+    /// <c>DailyAtHourAndMinute</c> — one argument that says which number is which, rather than three
+    /// that only their order distinguishes.
+    /// </summary>
+    [Test]
+    public void TestAtTimeSetsSecondMinuteAndHour()
+    {
+        CronExpressionBuilder.Create().AtTime(new TimeOnly(9, 30)).ToString().Should().Be("0 30 9 ? * *");
+        CronExpressionBuilder.Create().AtTime(new TimeOnly(23, 59, 59)).ToString().Should().Be("59 59 23 ? * *");
+        CronExpressionBuilder.Create().AtTime(TimeOnly.MinValue).ToString().Should().Be("0 0 0 ? * *");
+    }
+
+    /// <summary>
+    /// The two 3.x factories that took a time and a day are the two calls composed.
+    /// </summary>
+    [Test]
+    public void TestAtTimeComposesWithDaySelection()
+    {
+        CronExpressionBuilder.Create()
+            .AtTime(new TimeOnly(9, 30))
+            .WithDaysOfWeek(DayOfWeek.Monday)
+            .ToString().Should().Be("0 30 9 ? * MON");
+
+        CronExpressionBuilder.Create()
+            .AtTime(new TimeOnly(9, 30))
+            .WithDayOfMonth(15)
+            .ToString().Should().Be("0 30 9 15 * ?");
+    }
+
+    /// <summary>
+    /// Cron resolves to a whole second, so a time carrying more than that keeps only the second.
+    /// </summary>
+    [Test]
+    public void TestAtTimeIgnoresSubSecondPrecision()
+    {
+        CronExpressionBuilder.Create().AtTime(new TimeOnly(9, 30, 15, 500)).ToString().Should().Be("15 30 9 ? * *");
+    }
+
+    /// <summary>
+    /// The three fields are checked together, so a builder that already carries one of them is left as
+    /// it was rather than half-updated by the throw.
+    /// </summary>
+    [Test]
+    public void TestAtTimeCannotOverwriteAFieldThatIsAlreadyConfigured()
+    {
+        Invoking(x => x.WithSecond(0).AtTime(new TimeOnly(9, 30))).Should().Throw<InvalidOperationException>().WithMessage("Second has already been configured.");
+        Invoking(x => x.WithMinute(0).AtTime(new TimeOnly(9, 30))).Should().Throw<InvalidOperationException>().WithMessage("Minute has already been configured.");
+        Invoking(x => x.WithHour(0).AtTime(new TimeOnly(9, 30))).Should().Throw<InvalidOperationException>().WithMessage("Hour has already been configured.");
+        Invoking(x => x.AtTime(new TimeOnly(9, 30)).AtTime(new TimeOnly(10, 0))).Should().Throw<InvalidOperationException>().WithMessage("Second has already been configured.");
+
+        CronExpressionBuilder builder = CronExpressionBuilder.Create().WithHour(0);
+        Action act = () => builder.AtTime(new TimeOnly(9, 30));
+
+        act.Should().Throw<InvalidOperationException>();
+        builder.ToString().Should().Be("* * 0 ? * *",
+            "the hour was rejected before the second and minute were written, so nothing was left half-applied");
+    }
+
     [Test]
     public void TestDayOfMonthAndDayOfWeekAreMutuallyExclusive()
     {

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -229,6 +229,11 @@ public class CronExpressionBuilderTest
 
         CronExpressionBuilder.Create()
             .AtTime(new TimeOnly(9, 30))
+            .WithDaysOfWeek(DayOfWeek.Monday, DayOfWeek.Thursday)
+            .ToString().Should().Be("0 30 9 ? * MON,THU");
+
+        CronExpressionBuilder.Create()
+            .AtTime(new TimeOnly(9, 30))
             .WithDayOfMonth(15)
             .ToString().Should().Be("0 30 9 15 * ?");
     }

--- a/src/Quartz.Tests.Unit/OptionsShorthandTest.cs
+++ b/src/Quartz.Tests.Unit/OptionsShorthandTest.cs
@@ -1,0 +1,132 @@
+using Quartz.Impl.Calendar;
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The named statics on the option records. Each one abbreviates the object initializer nearly every
+/// call that passes options at all was writing, and each has to keep meaning exactly that.
+/// </summary>
+public sealed class OptionsShorthandTest
+{
+    [Test]
+    public void Replacing_IsTheInitializerItAbbreviates()
+    {
+        AddJobOptions.Replacing.Should().Be(new AddJobOptions { Replace = true },
+            "the shorthand is the initializer, so it must not quietly set the other flag as well");
+        ScheduleJobOptions.Replacing.Should().Be(new ScheduleJobOptions { Replace = true });
+        AddCalendarOptions.Replacing.Should().Be(new AddCalendarOptions { Replace = true });
+        AddCalendarOptions.ReplacingAndUpdatingTriggers.Should().Be(new AddCalendarOptions { Replace = true, UpdateTriggers = true });
+    }
+
+    /// <summary>
+    /// <see cref="AddCalendarOptions" /> carries two flags, so the two shorthands have to stay
+    /// distinguishable: replacing a calendar and re-pointing the triggers at it are separate decisions.
+    /// </summary>
+    [Test]
+    public void ReplacingACalendarDoesNotTouchItsTriggersUnlessAsked()
+    {
+        AddCalendarOptions.Replacing.UpdateTriggers.Should().BeFalse(
+            "leaving stored next-fire-times alone is the conservative default the record documents");
+        AddCalendarOptions.ReplacingAndUpdatingTriggers.UpdateTriggers.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Shape is not behaviour: the shorthand has to reach the store as the flag, which the negative
+    /// half of this test is what proves — <see langword="default" /> still refuses to overwrite.
+    /// </summary>
+    [Test]
+    public async Task AddJobReplacing_OverwritesTheStoredJob()
+    {
+        IScheduler scheduler = await NewScheduler("add-job-replacing");
+
+        try
+        {
+            await scheduler.AddJob(Job("first"), AddJobOptions.Replacing);
+            await scheduler.AddJob(Job("second"), AddJobOptions.Replacing);
+
+            IJobDetail stored = await scheduler.GetJobDetail(new JobKey("compaction"));
+            stored.Description.Should().Be("second", "AddJobOptions.Replacing carries Replace = true to the store");
+
+            Func<Task> withoutTheOption = async () => await scheduler.AddJob(Job("third"));
+            await withoutTheOption.Should().ThrowAsync<ObjectAlreadyExistsException>(
+                "the default options replace nothing, so the shorthand is what made the two calls above work");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task AddCalendarReplacing_OverwritesTheStoredCalendar()
+    {
+        IScheduler scheduler = await NewScheduler("add-calendar-replacing");
+
+        try
+        {
+            await scheduler.AddCalendar("holidays", new AnnualCalendar { Description = "first" }, AddCalendarOptions.Replacing);
+            await scheduler.AddCalendar("holidays", new AnnualCalendar { Description = "second" }, AddCalendarOptions.Replacing);
+
+            ICalendar stored = await scheduler.GetCalendar("holidays");
+            stored.Description.Should().Be("second", "AddCalendarOptions.Replacing carries Replace = true to the store");
+
+            Func<Task> withoutTheOption = async () => await scheduler.AddCalendar("holidays", new AnnualCalendar { Description = "third" });
+            await withoutTheOption.Should().ThrowAsync<ObjectAlreadyExistsException>(
+                "the default options replace nothing");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ScheduleJobReplacing_OverwritesTheStoredPair()
+    {
+        IScheduler scheduler = await NewScheduler("schedule-job-replacing");
+
+        try
+        {
+            await scheduler.ScheduleJob(Job("first"), [Trigger()], ScheduleJobOptions.Replacing);
+            await scheduler.ScheduleJob(Job("second"), [Trigger()], ScheduleJobOptions.Replacing);
+
+            IJobDetail stored = await scheduler.GetJobDetail(new JobKey("compaction"));
+            stored.Description.Should().Be("second", "ScheduleJobOptions.Replacing carries Replace = true to the store");
+
+            Func<Task> withoutTheOption = async () => await scheduler.ScheduleJob(Job("third"), [Trigger()]);
+            await withoutTheOption.Should().ThrowAsync<ObjectAlreadyExistsException>(
+                "the default options replace nothing");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private static IJobDetail Job(string description)
+    {
+        return JobBuilder.Create<NoOpJob>()
+            .WithIdentity("compaction")
+            .WithDescription(description)
+            .StoreDurably()
+            .Build();
+    }
+
+    private static ITrigger Trigger()
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .ForJob("compaction")
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
+    }
+
+    private static ValueTask<IScheduler> NewScheduler(string name)
+    {
+        return QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = name)
+            .UseInMemoryStore()
+            .BuildScheduler();
+    }
+}

--- a/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerBuilderTest.cs
@@ -324,6 +324,188 @@ public class TriggerBuilderTest
     }
 
     /// <summary>
+    /// The shorthand builds the same schedule the delegate form spells out, so the 124 call sites
+    /// that say <c>x =&gt; x.WithInterval(i).RepeatForever()</c> can say <c>i</c>.
+    /// </summary>
+    [Test]
+    public void WithSimpleSchedule_TakingAnInterval_RepeatsForever()
+    {
+        ISimpleTrigger shorthand = (ISimpleTrigger) TriggerBuilder.Create()
+            .WithSimpleSchedule(TimeSpan.FromHours(1))
+            .Build();
+
+        ISimpleTrigger spelledOut = (ISimpleTrigger) TriggerBuilder.Create()
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        shorthand.RepeatInterval.Should().Be(spelledOut.RepeatInterval);
+        shorthand.RepeatCount.Should().Be(SimpleTriggerImpl.RepeatIndefinitely,
+            "omitting the repeat count is how a caller asks for the forever schedule the delegate form spells out")
+            .And.Be(spelledOut.RepeatCount);
+    }
+
+    /// <summary>
+    /// The count is the trigger's own <see cref="ISimpleTrigger.RepeatCount" />, not a total number of
+    /// firings — the "- 1" the 3.x <c>ForTotalCount</c> factories did is deliberately not repeated here.
+    /// </summary>
+    [Test]
+    public void WithSimpleSchedule_TakingARepeatCount_PassesItThroughUnchanged()
+    {
+        ISimpleTrigger trigger = (ISimpleTrigger) TriggerBuilder.Create()
+            .WithSimpleSchedule(TimeSpan.FromMinutes(5), repeatCount: 2)
+            .Build();
+
+        trigger.RepeatInterval.Should().Be(TimeSpan.FromMinutes(5));
+        trigger.RepeatCount.Should().Be(2,
+            "the argument is the repeat count the trigger carries, so this fires three times in all - "
+            + "the shorthand does no arithmetic the trigger would then have to be read back through");
+    }
+
+    /// <summary>
+    /// Zero is a repeat count, not "unset": it is how a caller says "fire once and stop", and it has to
+    /// survive the <see langword="null" /> that means forever.
+    /// </summary>
+    [Test]
+    public void WithSimpleSchedule_TakingARepeatCountOfZero_FiresOnce()
+    {
+        ISimpleTrigger trigger = (ISimpleTrigger) TriggerBuilder.Create()
+            .WithSimpleSchedule(TimeSpan.FromMinutes(5), repeatCount: 0)
+            .Build();
+
+        trigger.RepeatCount.Should().Be(0, "zero repeats is one firing, and is not the forever schedule");
+    }
+
+    [Test]
+    public void Key_IsNullUntilAnIdentityIsNamed()
+    {
+        TriggerBuilder<IJob> builder = TriggerBuilder.Create();
+
+        builder.Key.Should().BeNull("nothing has named the trigger yet, so there is no identity to report");
+    }
+
+    [Test]
+    public void Key_IsTheIdentityTheCallerNamed()
+    {
+        TriggerBuilder<IJob> builder = TriggerBuilder.Create().WithIdentity("nightly", "reports");
+
+        builder.Key.Should().Be(new TriggerKey("nightly", "reports"),
+            "code that has to agree with this trigger - a job, a registration - reads the key rather than "
+            + "building the trigger to find out");
+    }
+
+    /// <summary>
+    /// Unlike <see cref="JobBuilder{TJob}.Key" />, this one reports a generated key too: the trigger
+    /// builder keeps what <c>Build</c> generated, so building twice produces the same trigger.
+    /// </summary>
+    [Test]
+    public void Key_AfterBuild_IsTheGeneratedIdentityTheTriggerCarries()
+    {
+        TriggerBuilder<IJob> builder = TriggerBuilder.Create();
+
+        ITrigger trigger = builder.Build();
+
+        builder.Key.Should().Be(trigger.Key,
+            "Build keeps the identity it generated, so a caller can read back what it scheduled");
+        builder.Build().Key.Should().Be(trigger.Key,
+            "and a second Build is the same trigger rather than a second one");
+    }
+
+    /// <summary>
+    /// The imperative twin of the container's <c>q.ScheduleJob&lt;TJob&gt;</c>: the job detail is built
+    /// on the way through, and with nothing naming the job it takes the trigger's identity.
+    /// </summary>
+    [Test]
+    public async Task ScheduleJob_WithNoConfigurator_GivesTheJobTheTriggersIdentity()
+    {
+        IScheduler scheduler = await NewScheduler("schedule-job-borrows-identity");
+
+        try
+        {
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("nightly", "reports")
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build();
+
+            DateTimeOffset firstFire = await scheduler.ScheduleJob<TestJob>(trigger);
+
+            firstFire.Should().Be(trigger.StartTimeUtc, "the trigger has not fired yet, so its start time is next");
+
+            IJobDetail job = await scheduler.GetJobDetail(new JobKey("nightly", "reports"));
+            job.Should().NotBeNull("the job was named after the trigger, exactly as the DI ScheduleJob<T> names it")
+                .And.Match<IJobDetail>(x => x.JobType.Type == typeof(TestJob));
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ScheduleJob_WithAConfigurator_TakesTheIdentityItNames()
+    {
+        IScheduler scheduler = await NewScheduler("schedule-job-named-identity");
+
+        try
+        {
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("nightly", "reports")
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build();
+
+            await scheduler.ScheduleJob<TestJob>(trigger, job => job.WithIdentity("compaction").WithDescription("nightly compaction"));
+
+            IJobDetail job = await scheduler.GetJobDetail(new JobKey("compaction"));
+            job.Should().NotBeNull("an identity the caller named beats the one borrowed from the trigger")
+                .And.Match<IJobDetail>(x => x.Description == "nightly compaction");
+
+            ITrigger stored = await scheduler.GetTrigger(new TriggerKey("nightly", "reports"));
+            stored.JobKey.Should().Be(new JobKey("compaction"), "the trigger named no job, so it took this one");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// A trigger built with <c>ForJob</c> already says which job it is for, and that beats the trigger's
+    /// own key — otherwise the pair could not agree and the scheduler would reject them.
+    /// </summary>
+    [Test]
+    public async Task ScheduleJob_WithATriggerThatNamesItsJob_TakesThatJobsIdentity()
+    {
+        IScheduler scheduler = await NewScheduler("schedule-job-trigger-names-job");
+
+        try
+        {
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity("nightly", "reports")
+                .ForJob("compaction", "maintenance")
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build();
+
+            await scheduler.ScheduleJob<TestJob>(trigger);
+
+            IJobDetail job = await scheduler.GetJobDetail(new JobKey("compaction", "maintenance"));
+            job.Should().NotBeNull(
+                "the trigger already named the job it fires, so borrowing the trigger's own key instead "
+                + "would have scheduled a pair the scheduler rejects as not referring to each other");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private static ValueTask<IScheduler> NewScheduler(string name)
+    {
+        return QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = name)
+            .UseInMemoryStore()
+            .BuildScheduler();
+    }
+
+    /// <summary>
     /// The five shipped schedules, each of which builds a different trigger implementation.
     /// </summary>
     private static IEnumerable<TestCaseData> EveryShippedSchedule()

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -5,11 +5,14 @@ namespace Quartz
     {
         public bool Replace { get; init; }
         public bool UpdateTriggers { get; init; }
+        public static Quartz.AddCalendarOptions Replacing { get; }
+        public static Quartz.AddCalendarOptions ReplacingAndUpdatingTriggers { get; }
     }
     public readonly struct AddJobOptions : System.IEquatable<Quartz.AddJobOptions>
     {
         public bool Replace { get; init; }
         public bool StoreNonDurableWhileAwaitingScheduling { get; init; }
+        public static Quartz.AddJobOptions Replacing { get; }
     }
     public sealed class AdoJobStoreOptions
     {
@@ -135,6 +138,7 @@ namespace Quartz
     }
     public sealed class CronExpressionBuilder
     {
+        public Quartz.CronExpressionBuilder AtTime(System.TimeOnly time) { }
         public Quartz.CronExpression Build() { }
         public Quartz.CronExpressionBuilder OnLastDayOfMonth() { }
         public Quartz.CronExpressionBuilder OnLastDayOfWeek() { }
@@ -1421,6 +1425,7 @@ namespace Quartz
     public readonly struct ScheduleJobOptions : System.IEquatable<Quartz.ScheduleJobOptions>
     {
         public bool Replace { get; init; }
+        public static Quartz.ScheduleJobOptions Replacing { get; }
     }
     public sealed class SchedulerConfigException : Quartz.SchedulerException
     {
@@ -1485,6 +1490,11 @@ namespace Quartz
         SetAllJobTriggersComplete = 4,
         SetAllJobTriggersError = 5,
         SetTriggerError = 6,
+    }
+    public static class SchedulerJobExtensions
+    {
+        public static System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Action<Quartz.IJobConfigurator<TJob>>? configure = null, System.Threading.CancellationToken cancellationToken = default)
+            where TJob : Quartz.IJob { }
     }
     public sealed class SchedulerMetadata : System.IEquatable<Quartz.SchedulerMetadata>
     {
@@ -1662,6 +1672,7 @@ namespace Quartz
     public sealed class TriggerBuilder<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob> : Quartz.ITriggerConfigurator, Quartz.ITriggerConfigurator<TJob>
         where TJob : Quartz.IJob
     {
+        public Quartz.TriggerKey? Key { get; }
         public Quartz.ITrigger Build() { }
         public Quartz.TriggerBuilder<TJob> EndAt(System.DateTimeOffset? endTimeUtc) { }
         public Quartz.TriggerBuilder<TJob> ForJob(Quartz.IJobDetail jobDetail) { }
@@ -1708,6 +1719,8 @@ namespace Quartz
         public static TConfigurator WithSimpleSchedule<TConfigurator>(this TConfigurator configurator, Quartz.SimpleScheduleBuilder schedule)
             where TConfigurator : Quartz.ITriggerConfigurator { }
         public static TConfigurator WithSimpleSchedule<TConfigurator>(this TConfigurator configurator, System.Action<Quartz.SimpleScheduleBuilder>? configure = null)
+            where TConfigurator : Quartz.ITriggerConfigurator { }
+        public static TConfigurator WithSimpleSchedule<TConfigurator>(this TConfigurator configurator, System.TimeSpan interval, int? repeatCount = default)
             where TConfigurator : Quartz.ITriggerConfigurator { }
     }
     public static class TriggerConstants

--- a/src/Quartz/AddCalendarOptions.cs
+++ b/src/Quartz/AddCalendarOptions.cs
@@ -32,6 +32,20 @@ namespace Quartz;
 public readonly record struct AddCalendarOptions
 {
     /// <summary>
+    /// Over-write an already registered calendar with the same name, leaving the triggers that
+    /// reference it alone. The name for <c>new AddCalendarOptions { Replace = true }</c>.
+    /// </summary>
+    public static AddCalendarOptions Replacing => new() { Replace = true };
+
+    /// <summary>
+    /// Over-write an already registered calendar with the same name and re-compute the next fire
+    /// time of every trigger that references it. The name for
+    /// <c>new AddCalendarOptions { Replace = true, UpdateTriggers = true }</c>, which is what
+    /// replacing a calendar whose exclusions have actually moved calls for.
+    /// </summary>
+    public static AddCalendarOptions ReplacingAndUpdatingTriggers => new() { Replace = true, UpdateTriggers = true };
+
+    /// <summary>
     /// Whether an already registered calendar with the same name is over-written. When false,
     /// adding a calendar whose name already exists throws <see cref="ObjectAlreadyExistsException" />.
     /// </summary>

--- a/src/Quartz/AddJobOptions.cs
+++ b/src/Quartz/AddJobOptions.cs
@@ -34,6 +34,13 @@ namespace Quartz;
 public readonly record struct AddJobOptions
 {
     /// <summary>
+    /// Over-write an already stored job with the same key. The name for
+    /// <c>new AddJobOptions { Replace = true }</c>, which is what nearly every call that passes these
+    /// options at all is saying.
+    /// </summary>
+    public static AddJobOptions Replacing => new() { Replace = true };
+
+    /// <summary>
     /// Whether an already stored job with the same key is over-written. When false, storing a job
     /// whose key already exists throws <see cref="ObjectAlreadyExistsException" />.
     /// </summary>

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -251,6 +251,34 @@ public sealed class CronExpressionBuilder
     }
 
     /// <summary>
+    /// Set the second, minute and hour fields to one time of day, so the expression fires once a day
+    /// — or once on each day the day-of-week or day-of-month field selects.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the whole of a "daily at 09:30" schedule: <c>AtTime(new TimeOnly(9, 30))</c> is
+    /// "0 30 9 ? * *". Add <see cref="WithDaysOfWeek(ReadOnlySpan{DayOfWeek})" />,
+    /// <see cref="OnWeekdays" /> or a day-of-month method for the days it applies to.
+    /// </para>
+    /// <para>
+    /// Cron resolves to a whole second, so any sub-second part of
+    /// <paramref name="time" /> is ignored.
+    /// </para>
+    /// </remarks>
+    /// <param name="time">the time of day to fire at.</param>
+    /// <returns>the updated CronExpressionBuilder</returns>
+    public CronExpressionBuilder AtTime(TimeOnly time)
+    {
+        // Checked before anything is written, so a builder that already carries one of the three
+        // fields is left as it was rather than half-updated by the throw.
+        ThrowIfConfigured(second, "Second");
+        ThrowIfConfigured(minute, "Minute");
+        ThrowIfConfigured(hour, "Hour");
+
+        return WithSecond(time.Second).WithMinute(time.Minute).WithHour(time.Hour);
+    }
+
+    /// <summary>
     /// Set the day-of-month field to a single value. Cannot be combined with
     /// configuring the day-of-week field.
     /// </summary>
@@ -624,13 +652,17 @@ public sealed class CronExpressionBuilder
 
     private CronExpressionBuilder SetField(ref string? field, string fieldName, string value)
     {
+        ThrowIfConfigured(field, fieldName);
+        field = value;
+        return this;
+    }
+
+    private static void ThrowIfConfigured(string? field, string fieldName)
+    {
         if (field is not null)
         {
             throw new InvalidOperationException($"{fieldName} has already been configured.");
         }
-
-        field = value;
-        return this;
     }
 
     private static string GetDayName(DayOfWeek dayOfWeek, string paramName)

--- a/src/Quartz/README.md
+++ b/src/Quartz/README.md
@@ -37,7 +37,7 @@ HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 builder.AddQuartz(q => q.ScheduleJob<HelloJob>(trigger => trigger
     .WithIdentity("hello")
-    .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever())));
+    .WithSimpleSchedule(TimeSpan.FromSeconds(10))));
 
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```

--- a/src/Quartz/ScheduleJobOptions.cs
+++ b/src/Quartz/ScheduleJobOptions.cs
@@ -38,6 +38,13 @@ namespace Quartz;
 public readonly record struct ScheduleJobOptions
 {
     /// <summary>
+    /// Over-write already stored jobs and triggers with the same keys. The name for
+    /// <c>new ScheduleJobOptions { Replace = true }</c>, which is what nearly every call that passes
+    /// these options at all is saying.
+    /// </summary>
+    public static ScheduleJobOptions Replacing => new() { Replace = true };
+
+    /// <summary>
     /// Whether already stored jobs and triggers with the same keys are over-written. When false,
     /// scheduling a job or trigger whose key already exists throws
     /// <see cref="ObjectAlreadyExistsException" />.

--- a/src/Quartz/SchedulerJobExtensions.cs
+++ b/src/Quartz/SchedulerJobExtensions.cs
@@ -1,0 +1,82 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Quartz;
+
+/// <summary>
+/// Scheduling a job by its type, the way the container-configured builder does.
+/// </summary>
+/// <remarks>
+/// An extension rather than an <see cref="IScheduler" /> member: it composes
+/// <see cref="JobBuilder" /> and <see cref="IScheduler.ScheduleJob(IJobDetail, ITrigger, CancellationToken)" />
+/// and needs nothing an implementation could do better, so every scheduler — including one written
+/// outside this repository — gets it without having to write it.
+/// </remarks>
+public static class SchedulerJobExtensions
+{
+    /// <summary>
+    /// Schedule a job of the given type with the given trigger, building the
+    /// <see cref="IJobDetail" /> along the way.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The imperative twin of <c>q.ScheduleJob&lt;TJob&gt;(...)</c> on <see cref="IQuartzBuilder" />,
+    /// so that scheduling a job at run time reads like declaring one at start-up and neither has to
+    /// name a <see cref="JobBuilder" />.
+    /// </para>
+    /// <para>
+    /// The job's identity is the first of these that exists: the one
+    /// <paramref name="configure" /> gave it, the one <paramref name="trigger" /> already points at
+    /// through <see cref="ITrigger.JobKey" />, or the trigger's own key. Naming neither is therefore
+    /// enough to schedule the pair, and a trigger built with <c>ForJob</c> still gets the job it
+    /// asked for.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TJob">the type of the job to schedule.</typeparam>
+    /// <param name="scheduler">the scheduler to schedule the job with.</param>
+    /// <param name="trigger">the trigger that fires the job.</param>
+    /// <param name="configure">configures the job; omit to take everything from the type and the trigger.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>the first time at which the trigger will fire.</returns>
+    public static ValueTask<DateTimeOffset> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
+        this IScheduler scheduler,
+        ITrigger trigger,
+        Action<IJobConfigurator<TJob>>? configure = null,
+        CancellationToken cancellationToken = default) where TJob : IJob
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(trigger);
+
+        JobBuilder<TJob> jobBuilder = JobBuilder.Create<TJob>();
+        configure?.Invoke(jobBuilder);
+
+        if (jobBuilder.Key is null)
+        {
+            // The job was given no identity of its own, so it takes one that makes the pair agree
+            // rather than the Guid JobBuilder would otherwise generate — which would leave the
+            // trigger pointing at a job nobody can name again.
+            JobKey borrowed = trigger.JobKey ?? new JobKey(trigger.Key.Name, trigger.Key.Group);
+            jobBuilder.WithIdentity(borrowed);
+        }
+
+        return scheduler.ScheduleJob(jobBuilder.Build(), trigger, cancellationToken);
+    }
+}

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -130,6 +130,18 @@ public sealed class TriggerBuilder<[DynamicallyAccessedMembers(JobTypeMembers.Re
     }
 
     /// <summary>
+    /// The key that identifies the trigger uniquely, or <see langword="null" /> when none was set.
+    /// </summary>
+    /// <remarks>
+    /// Readable so that code building a trigger and something that has to agree with it — a job, a
+    /// registration — can tell an identity the caller chose from the one <see cref="Build" /> would
+    /// generate. Unlike <see cref="JobBuilder{TJob}.Key" />, reading it after <c>Build</c> reports a
+    /// generated key too: <c>Build</c> keeps the key it generated, so building the same builder twice
+    /// produces the same trigger rather than two.
+    /// </remarks>
+    public TriggerKey? Key => key;
+
+    /// <summary>
     /// Produce the <see cref="ITrigger" />.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/TriggerConfiguratorExtensions.cs
+++ b/src/Quartz/TriggerConfiguratorExtensions.cs
@@ -65,6 +65,43 @@ public static class TriggerConfiguratorExtensions
     }
 
     /// <summary>
+    /// Set the trigger to fire on a fixed interval, repeating forever unless a repeat count is given.
+    /// </summary>
+    /// <remarks>
+    /// The shorthand for the schedule almost every fixed-interval trigger wants, so that
+    /// <c>WithSimpleSchedule(x =&gt; x.WithInterval(interval).RepeatForever())</c> can be written
+    /// <c>WithSimpleSchedule(interval)</c>. Reach for the delegate overload when the schedule needs
+    /// more than an interval and a count — a misfire instruction, say.
+    /// </remarks>
+    /// <param name="configurator">the trigger being configured.</param>
+    /// <param name="interval">the interval at which the trigger repeats.</param>
+    /// <param name="repeatCount">
+    /// How many times the trigger repeats <em>after</em> its first firing, so the total number of
+    /// firings is one more than this — the same number
+    /// <see cref="SimpleScheduleBuilder.WithRepeatCount" /> and
+    /// <see cref="ISimpleTrigger.RepeatCount" /> carry, with no arithmetic of its own.
+    /// <see langword="null" />, the default, repeats forever.
+    /// </param>
+    public static TConfigurator WithSimpleSchedule<TConfigurator>(
+        this TConfigurator configurator,
+        TimeSpan interval,
+        int? repeatCount = null) where TConfigurator : ITriggerConfigurator
+    {
+        SimpleScheduleBuilder builder = SimpleScheduleBuilder.Create().WithInterval(interval);
+        if (repeatCount is null)
+        {
+            builder.RepeatForever();
+        }
+        else
+        {
+            builder.WithRepeatCount(repeatCount.Value);
+        }
+
+        configurator.WithSchedule(builder);
+        return configurator;
+    }
+
+    /// <summary>
     /// Set the trigger to fire on a cron schedule.
     /// </summary>
     /// <param name="configurator">the trigger being configured.</param>


### PR DESCRIPTION
Closes #3528.

The 3.x → 4.0 delta replaced several families of static factories with builders, which made the
unusual call sayable and the usual one longer. This adds the five members the issue's ledger asks
for — L1, L4, L5, L6 and L12. Every one is additive; nothing is removed or deprecated.

| Item | Signature |
|---|---|
| L1 | `TConfigurator WithSimpleSchedule<TConfigurator>(this TConfigurator configurator, TimeSpan interval, int? repeatCount = null) where TConfigurator : ITriggerConfigurator` |
| L4 | `TriggerKey? Key { get; }` on `TriggerBuilder<TJob>` |
| L5 | `CronExpressionBuilder AtTime(TimeOnly time)` |
| L6 | `ValueTask<DateTimeOffset> ScheduleJob<TJob>(this IScheduler scheduler, ITrigger trigger, Action<IJobConfigurator<TJob>>? configure = null, CancellationToken cancellationToken = default) where TJob : IJob` |
| L12 | `AddJobOptions.Replacing`, `ScheduleJobOptions.Replacing`, `AddCalendarOptions.Replacing`, `AddCalendarOptions.ReplacingAndUpdatingTriggers` |

**L16 is not in here.** It is a question on the issue, not work: whether a trigger given no identity
should default to the job type name rather than a `Guid`. That changes what an existing configuration
produces, so it needs its own decision and its own issue. #3528 stays open on that point after this
merges; the "Closes" above is for the five shipped items, and the issue's own "Done means" list says
L16 is answered in the thread, not here.

## Things a reviewer has to decide

**1. `ScheduleJob<TJob>` prefers `trigger.JobKey` over the trigger's own key.** The spec said "identity
from the trigger when the configurator names none, exactly as the DI `q.ScheduleJob<T>` does". Taken
literally, `scheduler.ScheduleJob<MyJob>(TriggerBuilder.Create().WithIdentity("nightly").ForJob("compaction").Build())`
would name the job `nightly`, and `QuartzScheduler.ScheduleJob` would then throw
`"Trigger does not reference given job!"` — a guaranteed failure for any trigger built with `ForJob`.
The DI path cannot hit this because it builds the trigger itself and re-points it; the imperative one
is handed a built trigger it must not mutate. So the rule here is: whatever `configure` named, else
`trigger.JobKey`, else the trigger's own key. That is a superset of the DI behaviour — identical
whenever the trigger names no job — and `ScheduleJob_WithATriggerThatNamesItsJob_TakesThatJobsIdentity`
is the test that fails without it.

**2. The L12 tests are in a new `OptionsShorthandTest`, not `BuilderSeamsTest`.** The issue named
`Configuration/BuilderSeamsTest.cs`, but that fixture documents itself as "the seams that let an
application bring a component of its own: a job store, an instance id generator, and matchers for a
listener". Named statics on `IScheduler`'s option records are not a seam, so they got a fixture of
their own. Happy to move them if you would rather keep the file count down.

**3. The mirror test is untouched, deliberately.** `QuartzBuilderExtensionsMirrorTest` only inspects
`QuartzBuilderExtensions` methods whose first parameter is `IQuartzBuilder`, and exists so a
`QuartzSchedulerBuilder` chain stays buildable. `SchedulerJobExtensions.ScheduleJob` extends
`IScheduler`, is in a different class, and has no mirror to keep in step — so an `IScheduler`
extension does not belong there at all.

**4. File name, to avoid a collision.** A concurrent PR for #3522 adds `SchedulerScheduleExtensions.cs`
with `ScheduleJob<TJob, TInput>` overloads. This one is `src/Quartz/SchedulerJobExtensions.cs` so the
two do not conflict in the tree; **the two classes should be consolidated into one after both merge.**

## Behaviour worth a second look

* `AtTime` checks second, minute and hour *before* writing any of them, so a builder that already
  carries one of the three is left as it was rather than half-updated by the throw. `SetField`'s
  guard was extracted into `ThrowIfConfigured` so the message is the same one every other field
  gives.
* `AtTime` ignores any sub-second part of the `TimeOnly`, because cron has no sub-second resolution.
  Documented on the method and on both pages rather than thrown on.
* `WithSimpleSchedule(interval, repeatCount)` passes the count through untouched: it is the trigger's
  own `RepeatCount`, so `repeatCount: 2` fires three times. None of the 3.x `ForTotalCount` `- 1`
  arithmetic. `null` (the default) repeats forever, and `0` is a real count meaning "fire once".
* `TriggerBuilder<TJob>.Key` does **not** behave identically to `JobBuilder<TJob>.Key` after `Build()`.
  `JobBuilder.Build()` generates a key without keeping it; `TriggerBuilder.Build()` keeps the key it
  generated, on purpose, so building twice produces the same trigger. The property documents the
  difference rather than papering over it.

## Documentation

* New migration-guide section **Five shorthands for the common case**, plus cross-references from
  the two sections that previously showed the long spelling.
* The `CronScheduleBuilder`'s convenience factories table now maps the four time-of-day factories onto
  `AtTime` + `WithDaysOfWeek`/`WithDayOfMonth` instead of the three-call `WithSecond/WithMinute/WithHour`
  chain the guide previously prescribed. `docs/documentation/quartz-3.x/` is untouched.
* `cron-expressions.md` — the page that teaches `CronExpressionBuilder` — gains an `AtTime` sample of
  its own (second commit), since a schedule assembled from a UI is exactly that audience. Its three
  expression strings are asserted in `CronExpressionBuilderTest`.
* Six sample call sites where the schedule is incidental to what the page teaches (quick start, the
  package README, microsoft-di-integration, multiple-schedulers) now use the interval shorthand; the
  tutorial pages that *teach* `SimpleScheduleBuilder` keep the long form on purpose. Regenerated with
  `dotnet fallout DocsSnippets`.
* Baseline accepted through Verify; the diff is 13 added lines and 0 removed.

## Left alone deliberately

The remaining `new AddJobOptions { Replace = true }` / `new AddCalendarOptions { … }` call sites in
`src/Quartz.Documentation.Samples`, `src/Quartz.Examples` and the how-to pages still spell the
initializer. Converting them is a mechanical sweep that would triple this diff and touch the
version-neutral `best-practices.md`; better as its own change.

## Verification

```
dotnet build Quartz.slnx                 → Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit        → Passed! Failed: 0, Passed: 3781, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore  → Passed! Failed: 0, Passed: 549, Skipped: 0
dotnet fallout VerifyDocsSnippets        → up to date (93 markdown files checked)
node docs/.vuepress/check-links.mjs      → 214 pages, 901 internal links, 547 fragments; no dead links or anchors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
