### PR TITLE
A retry policy is a value, and an unbuildable one cannot be built

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3956,6 +3956,33 @@ How far your own detail travels depends on what holds it:
   Whatever your type carries beyond the interface's members is gone by then, so anything that has to
   survive a persistent store belongs in the `JobDataMap`.
 
+## A trigger can carry a retry policy
+
+3.x had no retry policy. A job that failed either asked for `RefireImmediately` — an in-process loop
+with no delay and no ceiling — or scheduled a fresh trigger for itself from inside `Execute`. 4.x adds
+`Quartz.RetryPolicy`, a value describing how many times and how far apart a failed job's trigger is
+re-fired.
+
+| Member | What it is |
+|---|---|
+| `RetryPolicy.Fixed(maxAttempts, delay)` | The same wait before every retry |
+| `RetryPolicy.Exponential(maxAttempts, initialDelay, factor = 2, maxDelay = null)` | A wait multiplied by `factor` each time, optionally clamped |
+| `RetryPolicy.Explicit(params delays)` | A table of waits; `MaxAttempts` is its length and the last entry repeats |
+| `RetryPolicy.DelayFor(attempt)` | The wait before the given retry, counting from one |
+| `RetryPolicy.ToStoredString()` / `Parse` / `TryParse` | The form the `RETRY_POLICY` column, the JSON payload and a serialized trigger all carry |
+
+There is no public constructor, so a policy that could not be honoured — no attempts, a negative wait,
+a backoff that shrinks — cannot be built. A policy carries which of the three factories made it, so
+`Exponential(3, delay, factor: 1)` waits exactly as `Fixed(3, delay)` does but is a different value and
+stores as `exp;3;…;1`: the shape says what the trigger's author chose, and turning the rate up is a
+change to make on one and not on the other. Equality is written out by hand rather than left to a
+record, because the delay table is a collection and reference equality on it would make two policies
+built from the same numbers different values; the backoff factor is compared bit for bit, which is what
+round-tripping it through the `"R"` format guarantees.
+
+`MaxAttempts` counts retries *after* the first failure, not fires: `Fixed(2, …)` runs a persistently
+failing job three times in total.
+
 ## Trimming annotations
 
 `ScheduleJob<T>`, `AddTrigger<TJob>` and `TriggerBuilder.Create<TJob>()` gained

--- a/src/Quartz.Tests.Unit/RetryPolicyStoredFormContractTest.cs
+++ b/src/Quartz.Tests.Unit/RetryPolicyStoredFormContractTest.cs
@@ -1,0 +1,180 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Pins the stored form of <see cref="RetryPolicy" /> — the string the <c>RETRY_POLICY</c> column
+/// of <c>QRTZ_TRIGGERS</c>, a trigger's JSON and a 3.x-shaped blob all carry.
+/// </summary>
+/// <remarks>
+/// The exact strings are the contract, not an implementation detail: a database written by one
+/// version is read by the next, and by another node in a mixed cluster at the same moment. Changing
+/// any string below changes what a stored policy means, so a failure here is a decision to make and
+/// not a baseline to update.
+/// </remarks>
+[TestFixture]
+public class RetryPolicyStoredFormContractTest
+{
+    /// <summary>
+    /// Every shape, spelled out. The marker comes first so a reader — and a query — can tell the
+    /// shapes apart without parsing the rest.
+    /// </summary>
+    public static IEnumerable<TestCaseData> StoredForms()
+    {
+        yield return new TestCaseData(RetryPolicy.Fixed(3, TimeSpan.FromSeconds(30)), "fixed;3;00:00:30").SetName("fixed, seconds");
+        yield return new TestCaseData(RetryPolicy.Fixed(1, TimeSpan.Zero), "fixed;1;00:00:00").SetName("fixed, no wait at all");
+        yield return new TestCaseData(RetryPolicy.Fixed(2, TimeSpan.FromDays(1)), "fixed;2;1.00:00:00").SetName("fixed, over a day");
+        yield return new TestCaseData(RetryPolicy.Fixed(2, TimeSpan.FromMilliseconds(1500)), "fixed;2;00:00:01.5000000").SetName("fixed, sub-second");
+        yield return new TestCaseData(RetryPolicy.Exponential(5, TimeSpan.FromSeconds(10)), "exp;5;00:00:10;2").SetName("exponential, default factor");
+        yield return new TestCaseData(RetryPolicy.Exponential(5, TimeSpan.FromSeconds(10), 1.5), "exp;5;00:00:10;1.5").SetName("exponential, fractional factor");
+        yield return new TestCaseData(RetryPolicy.Exponential(5, TimeSpan.FromSeconds(10), 2, TimeSpan.FromMinutes(10)), "exp;5;00:00:10;2;00:10:00").SetName("exponential, with a ceiling");
+        yield return new TestCaseData(RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30)), "list;00:00:01;00:00:05;00:00:30").SetName("explicit table");
+        yield return new TestCaseData(RetryPolicy.Explicit(TimeSpan.FromMinutes(2)), "list;00:02:00").SetName("explicit table of one");
+    }
+
+    [TestCaseSource(nameof(StoredForms))]
+    public void TheStoredFormIsExactlyThis(RetryPolicy policy, string expected)
+    {
+        policy.ToStoredString().Should().Be(expected, "the stored form is a persistence contract, not a display string");
+        policy.ToString().Should().Be(expected, "a policy has one representation, and it is the one the database holds");
+    }
+
+    [TestCaseSource(nameof(StoredForms))]
+    public void TheStoredFormParsesBackToAnEqualPolicy(RetryPolicy policy, string expected)
+    {
+        RetryPolicy parsed = RetryPolicy.Parse(expected);
+
+        parsed.Should().Be(policy);
+        parsed.ToStoredString().Should().Be(expected, "parsing and storing are each other's inverse");
+    }
+
+    [Test]
+    public void TheMarkerIsTheFactoryThatWasCalledAndNotAGuessAtTheNumbers()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), factor: 1);
+
+        policy.ToStoredString().Should().Be("exp;3;00:00:01;1",
+            "the shape is recorded, not worked back out of the numbers - deciding it would mean asking whether a double is exactly one");
+        RetryPolicy.Parse(policy.ToStoredString()).Should().Be(policy,
+            "a shape that survives the round trip is what lets the column say which policy a trigger was given");
+        RetryPolicy.Parse(policy.ToStoredString()).Should().NotBe(RetryPolicy.Fixed(3, TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public void TheCeilingIsStoredWithTheBackoffItBelongsTo()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), factor: 1, maxDelay: TimeSpan.FromSeconds(1));
+
+        policy.ToStoredString().Should().Be("exp;3;00:00:01;1;00:00:01");
+        RetryPolicy.Parse(policy.ToStoredString()).Should().Be(policy);
+    }
+
+    [Test]
+    public void TheFactorRoundTripsToTheBit()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), Math.PI);
+
+        RetryPolicy.Parse(policy.ToStoredString()).BackoffFactor.Should().Be(Math.PI,
+            "the factor is written with the round-trip format, so no precision is lost in the column");
+    }
+
+    [Test]
+    public void TheStoredFormIgnoresTheAmbientCulture()
+    {
+        CultureInfo original = CultureInfo.CurrentCulture;
+        try
+        {
+            // fi-FI writes a decimal comma and would otherwise turn 1.5 into "1,5" - which the
+            // separator would then split on the next machine to read the row.
+            CultureInfo.CurrentCulture = new CultureInfo("fi-FI");
+
+            RetryPolicy policy = RetryPolicy.Exponential(5, TimeSpan.FromSeconds(10), 1.5, TimeSpan.FromMinutes(10));
+
+            policy.ToStoredString().Should().Be("exp;5;00:00:10;1.5;00:10:00");
+            RetryPolicy.Parse("exp;5;00:00:10;1.5;00:10:00").Should().Be(policy);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Test]
+    public void TheStoredFormFitsTheColumn()
+    {
+        foreach (TestCaseData testCase in StoredForms())
+        {
+            ((string) testCase.Arguments[1]).Length.Should().BeLessThanOrEqualTo(250,
+                "RETRY_POLICY is a 250-character column in every dialect");
+        }
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("nope;3;00:00:30")]
+    [TestCase("fixed")]
+    [TestCase("fixed;3")]
+    [TestCase("fixed;3;00:00:30;extra")]
+    [TestCase("fixed;three;00:00:30")]
+    [TestCase("fixed;3;half a minute")]
+    [TestCase("fixed;0;00:00:30")]
+    [TestCase("fixed;3;-00:00:30")]
+    [TestCase("exp;3;00:00:10")]
+    [TestCase("exp;3;00:00:10;0.5")]
+    [TestCase("exp;3;00:00:10;2;00:00:01")]
+    [TestCase("exp;3;00:00:10;2;00:10:00;more")]
+    [TestCase("list")]
+    [TestCase("list;")]
+    [TestCase("list;00:00:01;nonsense")]
+    [TestCase("FIXED;3;00:00:30")]
+    public void WhatIsNotAStoredPolicyIsRefused(string value)
+    {
+        RetryPolicy.TryParse(value, out RetryPolicy policy).Should().BeFalse();
+        policy.Should().BeNull();
+
+        Action act = () => RetryPolicy.Parse(value);
+        act.Should().Throw<FormatException>().WithMessage($"*{value}*",
+            "the message names the value that could not be read, because the value came out of somebody's database");
+    }
+
+    [Test]
+    public void ANullStoredFormIsNotAPolicy()
+    {
+        RetryPolicy.TryParse(null, out RetryPolicy policy).Should().BeFalse(
+            "a trigger row with no retry policy reads as null, and that is not a parse failure to report");
+        policy.Should().BeNull();
+
+        Action act = () => RetryPolicy.Parse(null);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("value");
+    }
+
+    [Test]
+    public void ADelayTableThatOverflowsTheColumnCannotBeParsedEither()
+    {
+        string tooMany = "list" + string.Concat(Enumerable.Repeat(";00:01:00", 30));
+
+        tooMany.Length.Should().BeGreaterThan(250);
+        RetryPolicy.TryParse(tooMany, out RetryPolicy policy).Should().BeFalse(
+            "parsing goes through the same factory that refuses to build a policy the column cannot hold");
+        policy.Should().BeNull();
+    }
+}

--- a/src/Quartz.Tests.Unit/RetryPolicyTest.cs
+++ b/src/Quartz.Tests.Unit/RetryPolicyTest.cs
@@ -1,0 +1,249 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Collections.Immutable;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What the three factories accept, what they refuse, and what waits they hand out.
+/// </summary>
+[TestFixture]
+public class RetryPolicyTest
+{
+    [Test]
+    public void FixedRepeatsTheOneDelay()
+    {
+        RetryPolicy policy = RetryPolicy.Fixed(3, TimeSpan.FromSeconds(30));
+
+        policy.MaxAttempts.Should().Be(3);
+        policy.InitialDelay.Should().Be(TimeSpan.FromSeconds(30));
+        policy.BackoffFactor.Should().Be(1, "a fixed policy does not back off");
+        policy.MaxDelay.Should().BeNull();
+        policy.Delays.Should().BeEmpty("a computed policy carries no delay table");
+
+        policy.DelayFor(1).Should().Be(TimeSpan.FromSeconds(30));
+        policy.DelayFor(2).Should().Be(TimeSpan.FromSeconds(30));
+        policy.DelayFor(3).Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
+    public void ExponentialMultipliesEachDelayByTheFactor()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(4, TimeSpan.FromSeconds(10));
+
+        policy.BackoffFactor.Should().Be(2, "two is the default factor");
+        policy.DelayFor(1).Should().Be(TimeSpan.FromSeconds(10));
+        policy.DelayFor(2).Should().Be(TimeSpan.FromSeconds(20));
+        policy.DelayFor(3).Should().Be(TimeSpan.FromSeconds(40));
+        policy.DelayFor(4).Should().Be(TimeSpan.FromSeconds(80));
+    }
+
+    [Test]
+    public void ExponentialClampsToTheMaximumDelay()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(5, TimeSpan.FromSeconds(10), factor: 3, maxDelay: TimeSpan.FromMinutes(1));
+
+        policy.DelayFor(1).Should().Be(TimeSpan.FromSeconds(10));
+        policy.DelayFor(2).Should().Be(TimeSpan.FromSeconds(30));
+        policy.DelayFor(3).Should().Be(TimeSpan.FromMinutes(1), "90 seconds is past the ceiling");
+        policy.DelayFor(4).Should().Be(TimeSpan.FromMinutes(1));
+    }
+
+    [Test]
+    public void ExponentialSaturatesInsteadOfOverflowingTheTimeSpan()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(2000, TimeSpan.FromDays(1), factor: 10);
+
+        policy.DelayFor(1000).Should().Be(TimeSpan.MaxValue,
+            "a wait that outgrows a TimeSpan saturates; overflowing to a negative delay would schedule the retry into the past");
+    }
+
+    [Test]
+    public void ExplicitWalksTheTableAndThenRepeatsItsLastEntry()
+    {
+        RetryPolicy policy = RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30));
+
+        policy.MaxAttempts.Should().Be(3, "the table's length is the attempt count");
+        policy.InitialDelay.Should().Be(TimeSpan.FromSeconds(1));
+        policy.Delays.Should().Equal(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(30));
+
+        policy.DelayFor(1).Should().Be(TimeSpan.FromSeconds(1));
+        policy.DelayFor(2).Should().Be(TimeSpan.FromSeconds(5));
+        policy.DelayFor(3).Should().Be(TimeSpan.FromSeconds(30));
+        policy.DelayFor(4).Should().Be(TimeSpan.FromSeconds(30),
+            "the last entry repeats, so arithmetic past the last attempt still answers rather than throwing");
+    }
+
+    [Test]
+    public void ExplicitAcceptsACollectionAsWellAsAnArgumentList()
+    {
+        List<TimeSpan> delays = [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)];
+
+        RetryPolicy.Explicit(delays).Should().Be(RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)),
+            "params takes an existing list, and the policy is the same value either way");
+    }
+
+    [Test]
+    public void DelaysIsNeverTheDefaultImmutableArray()
+    {
+        RetryPolicy.Fixed(1, TimeSpan.Zero).Delays.IsDefault.Should().BeFalse(
+            "an uninitialized ImmutableArray throws on every member, so a computed policy carries the empty one");
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void APolicyThatNeverRetriesIsRefused(int maxAttempts)
+    {
+        Action fixedPolicy = () => RetryPolicy.Fixed(maxAttempts, TimeSpan.FromSeconds(1));
+        fixedPolicy.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("maxAttempts");
+
+        Action exponential = () => RetryPolicy.Exponential(maxAttempts, TimeSpan.FromSeconds(1));
+        exponential.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("maxAttempts");
+    }
+
+    [Test]
+    public void ANegativeDelayIsRefused()
+    {
+        Action fixedPolicy = () => RetryPolicy.Fixed(1, TimeSpan.FromSeconds(-1));
+        fixedPolicy.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("delay");
+
+        Action exponential = () => RetryPolicy.Exponential(1, TimeSpan.FromSeconds(-1));
+        exponential.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("initialDelay");
+
+        Action explicitPolicy = () => RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(-1));
+        explicitPolicy.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("delays");
+    }
+
+    [TestCase(0.5)]
+    [TestCase(0)]
+    [TestCase(-2)]
+    [TestCase(double.NaN)]
+    [TestCase(double.PositiveInfinity)]
+    public void ABackoffThatIsNotABackoffIsRefused(double factor)
+    {
+        Action act = () => RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), factor);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("factor");
+    }
+
+    [Test]
+    public void AFactorOfExactlyOneIsAllowedAndWaitsTheSameEveryTime()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(7), factor: 1);
+
+        policy.DelayFor(1).Should().Be(TimeSpan.FromSeconds(7));
+        policy.DelayFor(3).Should().Be(TimeSpan.FromSeconds(7), "a backoff of one never grows");
+    }
+
+    [Test]
+    public void TheShapeIsPartOfTheValueEvenWhenTheWaitsMatch()
+    {
+        RetryPolicy backoff = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(7), factor: 1);
+        RetryPolicy flat = RetryPolicy.Fixed(3, TimeSpan.FromSeconds(7));
+
+        backoff.Should().NotBe(flat,
+            "the two hand out the same waits, but one says 'back off, at this rate' and the other says 'wait this long' - "
+            + "and turning the rate up is a change to make on the first and not on the second");
+    }
+
+    [Test]
+    public void ACeilingBelowTheFirstWaitIsRefused()
+    {
+        Action act = () => RetryPolicy.Exponential(3, TimeSpan.FromMinutes(5), maxDelay: TimeSpan.FromMinutes(1));
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("maxDelay",
+            "a ceiling under the initial delay would silently replace every wait with the ceiling");
+    }
+
+    [Test]
+    public void AnEmptyDelayTableIsRefused()
+    {
+        Action act = () => RetryPolicy.Explicit();
+
+        act.Should().Throw<ArgumentException>().WithParameterName("delays");
+    }
+
+    [Test]
+    public void ANullDelayTableIsRefused()
+    {
+        Action act = () => RetryPolicy.Explicit(null);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("delays");
+    }
+
+    [Test]
+    public void ADelayTableTooLongForTheColumnIsRefused()
+    {
+        ImmutableArray<TimeSpan> delays = [.. Enumerable.Repeat(TimeSpan.FromMinutes(1), 30)];
+
+        Action act = () => RetryPolicy.Explicit(delays);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("delays").WithMessage("*250*",
+            "RETRY_POLICY is 250 characters wide in every dialect, so an oversized policy has to fail where it is built rather than where it is inserted");
+    }
+
+    [Test]
+    public void AnAttemptBelowOneIsRefused()
+    {
+        RetryPolicy policy = RetryPolicy.Fixed(3, TimeSpan.FromSeconds(1));
+
+        Action act = () => policy.DelayFor(0);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("attempt",
+            "attempts count from one: DelayFor(1) is the wait after the first failure");
+    }
+
+    [Test]
+    public void EqualityComparesTheWaitsAndNotTheReference()
+    {
+        RetryPolicy left = RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+        RetryPolicy right = RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
+
+        left.Should().Be(right, "a policy is a value; the delay table is compared entry by entry");
+        left.GetHashCode().Should().Be(right.GetHashCode());
+        (left == right).Should().BeTrue();
+        (left != right).Should().BeFalse();
+
+        left.Should().NotBe(RetryPolicy.Explicit(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3)));
+        left.Should().NotBe(RetryPolicy.Fixed(2, TimeSpan.FromSeconds(1)),
+            "a table that happens to start with the fixed delay is still a different policy");
+    }
+
+    [Test]
+    public void EqualityHandlesNull()
+    {
+        RetryPolicy policy = RetryPolicy.Fixed(1, TimeSpan.FromSeconds(1));
+
+        policy.Equals(null).Should().BeFalse();
+        (policy == null).Should().BeFalse();
+        (null == policy).Should().BeFalse();
+        ((RetryPolicy) null == null).Should().BeTrue();
+        policy.Equals((object) "not a policy").Should().BeFalse();
+    }
+
+    [Test]
+    public void TheCeilingIsPartOfTheValue()
+    {
+        RetryPolicy bounded = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), 2, TimeSpan.FromSeconds(3));
+        RetryPolicy unbounded = RetryPolicy.Exponential(3, TimeSpan.FromSeconds(1), 2);
+
+        bounded.Should().NotBe(unbounded, "the two hand out different waits from the third attempt onwards");
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1436,6 +1436,27 @@ namespace Quartz
         FireAndProceed = 1,
         DoNothing = 2,
     }
+    public sealed class RetryPolicy : System.IEquatable<Quartz.RetryPolicy>
+    {
+        public double BackoffFactor { get; }
+        public System.Collections.Immutable.ImmutableArray<System.TimeSpan> Delays { get; }
+        public System.TimeSpan InitialDelay { get; }
+        public int MaxAttempts { get; }
+        public System.TimeSpan? MaxDelay { get; }
+        public System.TimeSpan DelayFor(int attempt) { }
+        public bool Equals(Quartz.RetryPolicy? other) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public string ToStoredString() { }
+        public override string ToString() { }
+        public static Quartz.RetryPolicy Explicit([System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IReadOnlyList<System.TimeSpan> delays) { }
+        public static Quartz.RetryPolicy Exponential(int maxAttempts, System.TimeSpan initialDelay, double factor = 2, System.TimeSpan? maxDelay = default) { }
+        public static Quartz.RetryPolicy Fixed(int maxAttempts, System.TimeSpan delay) { }
+        public static Quartz.RetryPolicy Parse(string value) { }
+        public static bool TryParse(string? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Quartz.RetryPolicy? policy) { }
+        public static bool operator !=(Quartz.RetryPolicy? left, Quartz.RetryPolicy? right) { }
+        public static bool operator ==(Quartz.RetryPolicy? left, Quartz.RetryPolicy? right) { }
+    }
     public readonly struct ScheduleJobOptions : System.IEquatable<Quartz.ScheduleJobOptions>
     {
         public bool Replace { get; init; }

--- a/src/Quartz/RetryPolicy.cs
+++ b/src/Quartz/RetryPolicy.cs
@@ -1,0 +1,613 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+
+namespace Quartz;
+
+/// <summary>
+/// How often, and how far apart, the scheduler re-fires a trigger whose job has failed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A policy is a value: two policies of the same shape that would produce the same waits are equal.
+/// There is no public constructor — <see cref="Fixed" />, <see cref="Exponential" /> and
+/// <see cref="Explicit" /> are the only ways to make one, so a policy that could not be honoured
+/// (no attempts, a negative wait, a backoff that shrinks) cannot be built at all.
+/// </para>
+/// <para>
+/// <see cref="MaxAttempts" /> counts retries <i>after</i> the first failure, not fires: a trigger
+/// carrying <c>Fixed(2, …)</c> whose job keeps throwing runs three times in total and is then back
+/// on its ordinary schedule.
+/// </para>
+/// <para>
+/// A retry never displaces the trigger's own next occurrence. The scheduler drops a retry that
+/// would land at (or within a second of) the regular next fire time and lets the schedule win, so
+/// a policy whose waits are longer than the gap between occurrences quietly does nothing.
+/// </para>
+/// </remarks>
+public sealed class RetryPolicy : IEquatable<RetryPolicy>
+{
+    /// <summary>
+    /// Which of the three factories made a policy. Carried rather than inferred from the numbers: a
+    /// policy's shape is a decision its author made, and working it back out would mean asking
+    /// whether a <see cref="double" /> is exactly one.
+    /// </summary>
+    private enum Shape
+    {
+        Fixed,
+        Exponential,
+        Explicit,
+    }
+
+    /// <summary>
+    /// The field separator in the stored form. Neither the round-trip (<c>"R"</c>) form of a
+    /// <see cref="double" /> nor the constant (<c>"c"</c>) form of a <see cref="TimeSpan" /> can
+    /// contain it, so the stored form splits unambiguously.
+    /// </summary>
+    private const char Separator = ';';
+
+    private const string FixedMarker = "fixed";
+    private const string ExponentialMarker = "exp";
+    private const string ExplicitMarker = "list";
+
+    /// <summary>
+    /// How many characters of stored form the triggers table can hold: <c>RETRY_POLICY</c> is 250
+    /// characters wide in every dialect. Only <see cref="Explicit" /> can produce a longer one, and
+    /// it rejects the policy rather than letting the insert truncate it.
+    /// </summary>
+    internal const int MaxStoredLength = 250;
+
+    private readonly Shape shape;
+    private readonly string storedForm;
+
+    /// <summary>
+    /// Creates a policy from its parts. Callers are the three factories, which have validated the
+    /// parts already.
+    /// </summary>
+    private RetryPolicy(Shape shape, int maxAttempts, TimeSpan initialDelay, double backoffFactor, TimeSpan? maxDelay, ImmutableArray<TimeSpan> delays)
+    {
+        this.shape = shape;
+        MaxAttempts = maxAttempts;
+        InitialDelay = initialDelay;
+        BackoffFactor = backoffFactor;
+        MaxDelay = maxDelay;
+        Delays = delays;
+        storedForm = BuildStoredForm(shape, maxAttempts, initialDelay, backoffFactor, maxDelay, delays);
+    }
+
+    /// <summary>
+    /// How many times the scheduler retries after the first failure. Always at least one.
+    /// </summary>
+    /// <remarks>
+    /// This is the authoritative count: an <see cref="Explicit" /> policy's is the length of its
+    /// delay table, and once the attempts are spent the trigger returns to its ordinary schedule
+    /// rather than going into an error state.
+    /// </remarks>
+    public int MaxAttempts { get; }
+
+    /// <summary>
+    /// The wait before the first retry. For an <see cref="Explicit" /> policy this is the first
+    /// entry of <see cref="Delays" />.
+    /// </summary>
+    public TimeSpan InitialDelay { get; }
+
+    /// <summary>
+    /// What each wait is multiplied by to get the next one. <c>1</c> means a fixed wait.
+    /// </summary>
+    /// <remarks>
+    /// Persisted with the round-trip (<c>"R"</c>) format and the invariant culture, so a policy
+    /// written on one machine reads back bit for bit on another.
+    /// </remarks>
+    public double BackoffFactor { get; }
+
+    /// <summary>
+    /// The ceiling every computed wait is clamped to, or <see langword="null" /> when the backoff
+    /// grows unbounded.
+    /// </summary>
+    public TimeSpan? MaxDelay { get; }
+
+    /// <summary>
+    /// The explicit table of waits, longest-lived entry last; empty when the waits are computed
+    /// from <see cref="InitialDelay" /> and <see cref="BackoffFactor" />.
+    /// </summary>
+    /// <remarks>
+    /// A table shorter than the number of attempts cannot happen — <see cref="MaxAttempts" /> is
+    /// its length — but the last entry repeats for any attempt beyond it, so the property is safe
+    /// to index through <see cref="DelayFor" /> alone.
+    /// </remarks>
+    public ImmutableArray<TimeSpan> Delays { get; }
+
+    /// <summary>
+    /// A policy that waits the same amount of time before every retry.
+    /// </summary>
+    /// <param name="maxAttempts">How many times to retry after the first failure; at least one.</param>
+    /// <param name="delay">The wait before each retry; not negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maxAttempts" /> is less than one, or <paramref name="delay" /> is negative.
+    /// </exception>
+    public static RetryPolicy Fixed(int maxAttempts, TimeSpan delay)
+    {
+        EnsureAttempts(maxAttempts, nameof(maxAttempts));
+        EnsureNotNegative(delay, nameof(delay));
+
+        return new RetryPolicy(Shape.Fixed, maxAttempts, delay, backoffFactor: 1, maxDelay: null, delays: ImmutableArray<TimeSpan>.Empty);
+    }
+
+    /// <summary>
+    /// A policy whose wait grows by a constant factor with every retry.
+    /// </summary>
+    /// <param name="maxAttempts">How many times to retry after the first failure; at least one.</param>
+    /// <param name="initialDelay">The wait before the first retry; not negative.</param>
+    /// <param name="factor">
+    /// What each wait is multiplied by to get the next one. At least <c>1</c>, which makes the
+    /// policy wait the same amount every time; a shrinking backoff is not a backoff.
+    /// </param>
+    /// <param name="maxDelay">
+    /// A ceiling for the computed waits, or <see langword="null" /> to let them grow unbounded.
+    /// Not shorter than <paramref name="initialDelay" />, which a ceiling below the first wait
+    /// would silently undo.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maxAttempts" /> is less than one, <paramref name="initialDelay" /> is
+    /// negative, <paramref name="factor" /> is less than one or is not a number, or
+    /// <paramref name="maxDelay" /> is shorter than <paramref name="initialDelay" />.
+    /// </exception>
+    /// <remarks>
+    /// A factor of <c>1</c> is legal and produces the same waits as <see cref="Fixed" />, but it is
+    /// a different value: it says the trigger's author chose a backoff and set its rate to one,
+    /// which is a thing to change rather than a fixed wait spelled the long way.
+    /// </remarks>
+    public static RetryPolicy Exponential(int maxAttempts, TimeSpan initialDelay, double factor = 2, TimeSpan? maxDelay = null)
+    {
+        EnsureAttempts(maxAttempts, nameof(maxAttempts));
+        EnsureNotNegative(initialDelay, nameof(initialDelay));
+
+        if (double.IsNaN(factor) || double.IsInfinity(factor) || factor < 1)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(factor),
+                "A backoff factor is a finite number of at least 1, not " + factor.ToString("R", CultureInfo.InvariantCulture) + ".");
+        }
+
+        if (maxDelay is not null && maxDelay.Value < initialDelay)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(maxDelay),
+                "A maximum delay of " + FormatDelay(maxDelay.Value) + " is shorter than the initial delay of " + FormatDelay(initialDelay)
+                + ", which would make every wait the maximum.");
+        }
+
+        return new RetryPolicy(Shape.Exponential, maxAttempts, initialDelay, factor, maxDelay, ImmutableArray<TimeSpan>.Empty);
+    }
+
+    /// <summary>
+    /// A policy that waits the given amounts, in order. <see cref="MaxAttempts" /> is the number of
+    /// waits given.
+    /// </summary>
+    /// <param name="delays">
+    /// The wait before each retry, none of them negative and at least one of them present.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="delays" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="delays" /> is empty, holds a negative wait, or is long enough that the
+    /// stored form would not fit the triggers table's 250-character retry policy column.
+    /// </exception>
+    public static RetryPolicy Explicit(params IReadOnlyList<TimeSpan> delays)
+    {
+        if (delays is null)
+        {
+            Throw.ArgumentNullException(nameof(delays));
+        }
+
+        if (delays.Count == 0)
+        {
+            Throw.ArgumentException("A retry policy needs at least one delay.", nameof(delays));
+        }
+
+        ImmutableArray<TimeSpan>.Builder builder = ImmutableArray.CreateBuilder<TimeSpan>(delays.Count);
+        for (int i = 0; i < delays.Count; i++)
+        {
+            if (delays[i] < TimeSpan.Zero)
+            {
+                Throw.ArgumentOutOfRangeException(
+                    nameof(delays),
+                    string.Create(CultureInfo.InvariantCulture, $"Retry delay {i + 1} of {delays.Count} is negative ({FormatDelay(delays[i])}); a retry cannot be scheduled into the past."));
+            }
+
+            builder.Add(delays[i]);
+        }
+
+        RetryPolicy policy = new RetryPolicy(Shape.Explicit, delays.Count, delays[0], backoffFactor: 1, maxDelay: null, builder.MoveToImmutable());
+
+        if (policy.storedForm.Length > MaxStoredLength)
+        {
+            Throw.ArgumentException(
+                string.Create(CultureInfo.InvariantCulture, $"A retry policy with {delays.Count} delays does not fit the {MaxStoredLength}-character retry policy column (it would need {policy.storedForm.Length}). Use fewer delays, or an exponential policy."),
+                nameof(delays));
+        }
+
+        return policy;
+    }
+
+    /// <summary>
+    /// The wait before the given retry.
+    /// </summary>
+    /// <param name="attempt">
+    /// Which retry to compute the wait for, counting from one: <c>1</c> is the wait after the first
+    /// failure.
+    /// </param>
+    /// <returns>
+    /// The wait, clamped to <see cref="MaxDelay" /> when there is one. An attempt beyond
+    /// <see cref="MaxAttempts" /> answers as the last one does rather than throwing, because the
+    /// decision to stop retrying belongs to the scheduler and not to the arithmetic.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="attempt" /> is less than one.</exception>
+    public TimeSpan DelayFor(int attempt)
+    {
+        if (attempt < 1)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(attempt),
+                string.Create(CultureInfo.InvariantCulture, $"Retry attempts count from 1; {attempt} is not an attempt."));
+        }
+
+        switch (shape)
+        {
+            case Shape.Fixed:
+                return InitialDelay;
+
+            case Shape.Explicit:
+                return Delays[Math.Min(attempt, Delays.Length) - 1];
+
+            default:
+                // Ticks as a double: an exponential policy left running long enough overflows a
+                // TimeSpan long before it overflows a double, and saturating at TimeSpan.MaxValue is
+                // the honest answer for a wait nothing will ever come back from.
+                double ticks = InitialDelay.Ticks * Math.Pow(BackoffFactor, attempt - 1);
+                TimeSpan delay = ticks >= long.MaxValue ? TimeSpan.MaxValue : TimeSpan.FromTicks((long) ticks);
+
+                if (MaxDelay is not null && delay > MaxDelay.Value)
+                {
+                    delay = MaxDelay.Value;
+                }
+
+                return delay;
+        }
+    }
+
+    /// <summary>
+    /// The policy as the triggers table holds it: a compact, culture-invariant string that starts
+    /// with a marker naming the policy's shape.
+    /// </summary>
+    /// <returns>
+    /// The stored form. Two policies that are <see cref="Equals(RetryPolicy)">equal</see> produce
+    /// the same string, and <see cref="Parse" /> turns that string back into an equal policy.
+    /// </returns>
+    public string ToStoredString()
+    {
+        return storedForm;
+    }
+
+    /// <summary>
+    /// Rebuilds a policy from the string <see cref="ToStoredString" /> produced.
+    /// </summary>
+    /// <param name="value">The stored form.</param>
+    /// <returns>The policy.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="value" /> is <see langword="null" />.</exception>
+    /// <exception cref="FormatException"><paramref name="value" /> is not a stored retry policy.</exception>
+    public static RetryPolicy Parse(string value)
+    {
+        if (value is null)
+        {
+            Throw.ArgumentNullException(nameof(value));
+        }
+
+        if (!TryParseCore(value, out RetryPolicy? policy, out string? problem))
+        {
+            Throw.FormatException($"'{value}' is not a retry policy: {problem}");
+        }
+
+        return policy;
+    }
+
+    /// <summary>
+    /// Rebuilds a policy from the string <see cref="ToStoredString" /> produced, answering whether
+    /// the string was one.
+    /// </summary>
+    /// <param name="value">The stored form, which may be <see langword="null" /> or blank.</param>
+    /// <param name="policy">The policy, or <see langword="null" /> when there was not one.</param>
+    /// <returns><see langword="true" /> when <paramref name="value" /> was a stored retry policy.</returns>
+    /// <remarks>
+    /// A <see langword="null" /> or blank string answers <see langword="false" /> rather than
+    /// throwing: that is what a trigger row with no retry policy reads as.
+    /// </remarks>
+    public static bool TryParse(string? value, [NotNullWhen(true)] out RetryPolicy? policy)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            policy = null;
+            return false;
+        }
+
+        return TryParseCore(value, out policy, out _);
+    }
+
+    private static bool TryParseCore(string value, [NotNullWhen(true)] out RetryPolicy? policy, out string? problem)
+    {
+        string[] parts = value.Split(Separator);
+
+        try
+        {
+            switch (parts[0])
+            {
+                case FixedMarker:
+                    return TryParseFixed(parts, out policy, out problem);
+
+                case ExponentialMarker:
+                    return TryParseExponential(parts, out policy, out problem);
+
+                case ExplicitMarker:
+                    return TryParseExplicit(parts, out policy, out problem);
+
+                default:
+                    policy = null;
+                    problem = $"'{parts[0]}' is not one of the policy shapes '{FixedMarker}', '{ExponentialMarker}' and '{ExplicitMarker}'";
+                    return false;
+            }
+        }
+        catch (ArgumentException ex)
+        {
+            // The factories own every rule about what a policy may say, so parsing goes through
+            // them and reports what they refused rather than repeating their checks here.
+            policy = null;
+            problem = ex.Message;
+            return false;
+        }
+    }
+
+    private static bool TryParseFixed(string[] parts, [NotNullWhen(true)] out RetryPolicy? policy, out string? problem)
+    {
+        policy = null;
+
+        if (parts.Length != 3)
+        {
+            problem = $"a fixed policy is '{FixedMarker}{Separator}<attempts>{Separator}<delay>'";
+            return false;
+        }
+
+        if (!TryReadAttempts(parts[1], out int attempts) || !TryReadDelay(parts[2], out TimeSpan delay))
+        {
+            problem = "the attempt count or the delay is not a number";
+            return false;
+        }
+
+        policy = Fixed(attempts, delay);
+        problem = null;
+        return true;
+    }
+
+    private static bool TryParseExponential(string[] parts, [NotNullWhen(true)] out RetryPolicy? policy, out string? problem)
+    {
+        policy = null;
+
+        if (parts.Length is not (4 or 5))
+        {
+            problem = $"an exponential policy is '{ExponentialMarker}{Separator}<attempts>{Separator}<initial delay>{Separator}<factor>' with an optional '{Separator}<maximum delay>'";
+            return false;
+        }
+
+        if (!TryReadAttempts(parts[1], out int attempts)
+            || !TryReadDelay(parts[2], out TimeSpan initialDelay)
+            || !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out double factor))
+        {
+            problem = "the attempt count, the initial delay or the factor is not a number";
+            return false;
+        }
+
+        TimeSpan? maxDelay = null;
+        if (parts.Length == 5)
+        {
+            if (!TryReadDelay(parts[4], out TimeSpan parsedMaxDelay))
+            {
+                problem = "the maximum delay is not a duration";
+                return false;
+            }
+
+            maxDelay = parsedMaxDelay;
+        }
+
+        policy = Exponential(attempts, initialDelay, factor, maxDelay);
+        problem = null;
+        return true;
+    }
+
+    private static bool TryParseExplicit(string[] parts, [NotNullWhen(true)] out RetryPolicy? policy, out string? problem)
+    {
+        policy = null;
+
+        if (parts.Length < 2)
+        {
+            problem = $"an explicit policy is '{ExplicitMarker}' followed by at least one delay";
+            return false;
+        }
+
+        TimeSpan[] delays = new TimeSpan[parts.Length - 1];
+        for (int i = 1; i < parts.Length; i++)
+        {
+            if (!TryReadDelay(parts[i], out delays[i - 1]))
+            {
+                problem = string.Create(CultureInfo.InvariantCulture, $"delay {i} is not a duration");
+                return false;
+            }
+        }
+
+        policy = Explicit(delays);
+        problem = null;
+        return true;
+    }
+
+    /// <summary>
+    /// The policy as the triggers table holds it, which is the whole of its state.
+    /// </summary>
+    public override string ToString()
+    {
+        return storedForm;
+    }
+
+    /// <summary>
+    /// Whether the other policy has the same shape and would produce exactly the same waits, the
+    /// same number of times.
+    /// </summary>
+    /// <param name="other">The policy to compare with.</param>
+    /// <returns><see langword="true" /> when the two policies are the same value.</returns>
+    /// <remarks>
+    /// Written out by hand rather than left to a record: the delay table is a collection, and
+    /// reference equality on it would make two policies built from the same numbers unequal — which
+    /// the store contract tests compare through. The backoff factor is compared bit for bit, which
+    /// is what round-tripping it through the <c>"R"</c> format guarantees and what "the same policy
+    /// came back out of the column" means.
+    /// </remarks>
+    public bool Equals(RetryPolicy? other)
+    {
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (other is null)
+        {
+            return false;
+        }
+
+        return shape == other.shape
+               && MaxAttempts == other.MaxAttempts
+               && InitialDelay == other.InitialDelay
+               && BitConverter.DoubleToInt64Bits(BackoffFactor) == BitConverter.DoubleToInt64Bits(other.BackoffFactor)
+               && Nullable.Equals(MaxDelay, other.MaxDelay)
+               && Delays.AsSpan().SequenceEqual(other.Delays.AsSpan());
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return Equals(obj as RetryPolicy);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        HashCode hash = new HashCode();
+        hash.Add(shape);
+        hash.Add(MaxAttempts);
+        hash.Add(InitialDelay);
+        hash.Add(BitConverter.DoubleToInt64Bits(BackoffFactor));
+        hash.Add(MaxDelay);
+        foreach (TimeSpan delay in Delays)
+        {
+            hash.Add(delay);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    /// <summary>
+    /// Whether two policies are the same value.
+    /// </summary>
+    /// <param name="left">The first policy.</param>
+    /// <param name="right">The second policy.</param>
+    /// <returns><see langword="true" /> when both are <see langword="null" /> or both are equal.</returns>
+    public static bool operator ==(RetryPolicy? left, RetryPolicy? right) => left is null ? right is null : left.Equals(right);
+
+    /// <summary>
+    /// Whether two policies are different values.
+    /// </summary>
+    /// <param name="left">The first policy.</param>
+    /// <param name="right">The second policy.</param>
+    /// <returns><see langword="true" /> when the two are not the same value.</returns>
+    public static bool operator !=(RetryPolicy? left, RetryPolicy? right) => !(left == right);
+
+    private static string BuildStoredForm(Shape shape, int maxAttempts, TimeSpan initialDelay, double backoffFactor, TimeSpan? maxDelay, ImmutableArray<TimeSpan> delays)
+    {
+        string attempts = maxAttempts.ToString(CultureInfo.InvariantCulture);
+
+        switch (shape)
+        {
+            case Shape.Fixed:
+                return FixedMarker + Separator + attempts + Separator + FormatDelay(initialDelay);
+
+            case Shape.Explicit:
+                StringBuilder explicitForm = new StringBuilder(ExplicitMarker);
+                foreach (TimeSpan delay in delays)
+                {
+                    explicitForm.Append(Separator).Append(FormatDelay(delay));
+                }
+
+                return explicitForm.ToString();
+
+            default:
+                string form = ExponentialMarker + Separator + attempts + Separator + FormatDelay(initialDelay)
+                              + Separator + backoffFactor.ToString("R", CultureInfo.InvariantCulture);
+
+                return maxDelay is null ? form : form + Separator + FormatDelay(maxDelay.Value);
+        }
+    }
+
+    /// <summary>
+    /// A duration in the constant (<c>"c"</c>) format, which is culture-independent by definition
+    /// and keeps every tick.
+    /// </summary>
+    private static string FormatDelay(TimeSpan value)
+    {
+        return value.ToString("c", CultureInfo.InvariantCulture);
+    }
+
+    private static bool TryReadDelay(string text, out TimeSpan value)
+    {
+        return TimeSpan.TryParseExact(text, "c", CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryReadAttempts(string text, out int value)
+    {
+        return int.TryParse(text, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static void EnsureAttempts(int maxAttempts, string paramName)
+    {
+        if (maxAttempts < 1)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                string.Create(CultureInfo.InvariantCulture, $"A retry policy retries at least once; {maxAttempts} attempts is not a policy."));
+        }
+    }
+
+    private static void EnsureNotNegative(TimeSpan delay, string paramName)
+    {
+        if (delay < TimeSpan.Zero)
+        {
+            Throw.ArgumentOutOfRangeException(
+                paramName,
+                "A retry delay of " + FormatDelay(delay) + " is negative; a retry cannot be scheduled into the past.");
+        }
+    }
+}


### PR DESCRIPTION
`RetryPolicy` — the value a trigger will carry once the rest of #3520 lands. Nothing reads it yet: this is R2 of the four-part set (value type → persistence and read/write surface → engine → tests and docs), which merges only as a set that is green end to end.

## What is here

`src/Quartz/RetryPolicy.cs`, a sealed class with value semantics and no public constructor. Three factories are the only way to make one:

| Factory | Waits |
|---|---|
| `Fixed(maxAttempts, delay)` | the same wait every time |
| `Exponential(maxAttempts, initialDelay, factor = 2, maxDelay = null)` | multiplied by `factor` each time, clamped to `maxDelay` |
| `Explicit(params delays)` | the table given; `MaxAttempts` is its length and the last entry repeats |

`DelayFor(attempt)` is 1-based and saturates at `TimeSpan.MaxValue` rather than overflowing into a negative wait. `MaxAttempts` counts retries *after* the first failure, so `Fixed(2, …)` means three fires in total.

## Decisions a reviewer should look at

* **A policy carries which factory made it.** `Exponential(3, d, factor: 1)` waits exactly as `Fixed(3, d)` does, but it is a different value and stores as `exp;3;…;1`. The shape says what the trigger's author chose — turning the rate up is a change to make on one and not on the other — and deciding it from the numbers would mean asking whether a `double` is exactly one.
* **The stored form is a persistence contract, so it is pinned string by string** in `RetryPolicyStoredFormContractTest` rather than snapshotted — a failure there is a decision to make, not a baseline to update. It leads with the shape marker (`fixed`, `exp`, `list`), writes durations in the constant (`"c"`) format and the factor with `"R"`, and is culture-invariant end to end. `fi-FI` would otherwise write `1,5` for a factor and the next node to read the row would split on the comma.
* **Equality is hand-written**, as the spec requires: the delay table is a collection, and a record's reference equality on it would make two policies built from the same numbers unequal — which the store contract tests compare through. The factor is compared with `BitConverter.DoubleToInt64Bits`, which is exactly what round-tripping through `"R"` guarantees.
* **`Explicit` refuses a table whose stored form exceeds 250 characters**, the width of `RETRY_POLICY` in every dialect. A policy that cannot be persisted should fail where it is built, not where it is inserted. `Parse` goes through the same factories, so it refuses the same things and there is one place that owns what a policy may say.
* **`maxDelay` below `initialDelay` is refused.** A ceiling under the first wait would silently replace every wait with the ceiling. This is a rule the spec did not name.

## Public API delta

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through Verify — 21 added lines, one new type, nothing moved or removed:

```
public sealed class RetryPolicy : System.IEquatable<Quartz.RetryPolicy>
{
    public double BackoffFactor { get; }
    public System.Collections.Immutable.ImmutableArray<System.TimeSpan> Delays { get; }
    public System.TimeSpan InitialDelay { get; }
    public int MaxAttempts { get; }
    public System.TimeSpan? MaxDelay { get; }
    public System.TimeSpan DelayFor(int attempt) { }
    public bool Equals(Quartz.RetryPolicy? other) { }
    public override bool Equals(object? obj) { }
    public override int GetHashCode() { }
    public string ToStoredString() { }
    public override string ToString() { }
    public static Quartz.RetryPolicy Explicit([ParamCollection] System.Collections.Generic.IReadOnlyList<System.TimeSpan> delays) { }
    public static Quartz.RetryPolicy Exponential(int maxAttempts, System.TimeSpan initialDelay, double factor = 2, System.TimeSpan? maxDelay = default) { }
    public static Quartz.RetryPolicy Fixed(int maxAttempts, System.TimeSpan delay) { }
    public static Quartz.RetryPolicy Parse(string value) { }
    public static bool TryParse(string? value, [NotNullWhen(true)] out Quartz.RetryPolicy? policy) { }
    public static bool operator !=(Quartz.RetryPolicy? left, Quartz.RetryPolicy? right) { }
    public static bool operator ==(Quartz.RetryPolicy? left, Quartz.RetryPolicy? right) { }
}
```

The shape marker is a private nested enum, so it is not on the surface.

The same delta is in `docs/documentation/quartz-4.x/migration-guide.md` under **A trigger can carry a retry policy**, which R3 and R4 extend as the members and the engine arrive. The how-to page and the `RefireImmediately`-versus-retry explanation belong to R5.

## Sonar findings, all fixed rather than overridden

The gate failed `new_reliability_rating` on the first push. What changed:

| Rule | Fix |
|---|---|
| S1244 (bug ×2) | No exact floating-point comparison remains. The stored form switches on the recorded shape instead of testing `factor == 1`, and `Equals` compares the factor through `BitConverter.DoubleToInt64Bits`. |
| S3776 | `TryParseCore` is a four-branch switch over the marker delegating to `TryParseFixed` / `TryParseExponential` / `TryParseExplicit`. |
| MA0076 | Every `TimeSpan` and `double` in an exception message is formatted with `CultureInfo.InvariantCulture` (`"c"` / `"R"`); messages carrying an `int` use `string.Create(CultureInfo.InvariantCulture, …)`. |
| MA0185 | The two `string.Create` calls whose holes were all strings are plain concatenation now. |
| S8969 | The two null-forgiving `!` are gone; `TryParseCore` and the three parsers carry `[NotNullWhen(true)]` on their out parameter instead. |
| IDE0022 | Block bodies for the methods, per `csharp_style_expression_bodied_methods = false`. |

Note for whoever reads the next Sonar run: **none of these were build failures locally.** `Meziantou.Analyzer` is a `GlobalPackageReference`, but MA0076 and MA0185 ship at info severity, so `TreatWarningsAsErrors` never saw them; the `S*` rules come from SonarCloud's own analysis and have no local analyzer package at all. I verified the Meziantou and IDE ones by temporarily escalating MA0076, MA0185, MA0011, IDE0021 and IDE0022 to `error` in a throwaway `src/Quartz/.editorconfig`: `RetryPolicy.cs` reports **zero** findings, and MA0185/IDE0021/IDE0022 are clean across the whole project. That run also shows **76 pre-existing MA0076 findings** elsewhere in `src/Quartz` (`CronExpression.cs`, `RecurrenceRule.cs`, `DailyCalendar.cs`, `MonthDay.cs` and others) — untouched here, but they are why the rule is worth a decision at some point.

## Verification

```
dotnet build Quartz.slnx          ->  0 Warning(s), 0 Error(s) (20 projects)
dotnet test src/Quartz.Tests.Unit ->  Passed! Failed: 0, Passed: 3871, Skipped: 0   (run twice, both green)
dotnet fallout VerifyDocsSnippets ->  Succeeded (94 markdown files checked)
```

68 of those tests are the new ones. One earlier run of the suite reported a single failure that did not reproduce on either of the two runs above and whose name I did not capture; nothing in this change is timing-dependent, so it looks like an unrelated flake — worth a second glance if CI shows the same count.

Rebased onto `main` at 346b52060.

Part of #3520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
