### PR TITLE
Scheduling over an existing trigger is one atomic call

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/one-off-job.md
+++ b/docs/documentation/quartz-4.x/how-tos/one-off-job.md
@@ -119,3 +119,84 @@ scheduler was down happens as soon as it is back rather than being dropped. The 
 they are worth naming, are in
 [SimpleTriggers](../tutorial/simpletriggers.md#simpletrigger-misfire-instructions).
 :::
+
+## A payload and a time, in one call
+
+When the job takes [a typed input](../tutorial/job-data-map.md#a-typed-input-the-third-read-side), there is
+nothing left to build — say what to run, what to run it with, and when:
+
+<!-- snippet: sample_one_off_job_typed_one_liner -->
+```csharp
+public sealed record SendInvoice(string CustomerId, decimal Amount);
+
+public sealed class SendInvoiceJob : IJob<SendInvoice>
+{
+    public ValueTask Execute(IJobExecutionContext context, SendInvoice input, CancellationToken cancellationToken = default)
+    {
+        // input.CustomerId, input.Amount
+        return default;
+    }
+}
+
+public sealed class Invoicing
+{
+    public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+    {
+        TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+            invoice,
+            TimeSpan.FromDays(7),
+            new OneOffJobOptions
+            {
+                // Named, so it can be replaced or cancelled; grouped by the thing it is about, so the
+                // whole conversation can be cancelled at once.
+                Name = $"invoice-{invoice.CustomerId}",
+                Group = invoice.CustomerId,
+                Replace = true
+            },
+            cancellationToken);
+
+        // ... and to call it off:
+        await scheduler.UnscheduleJob(firing, cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+There are two overloads, one taking a `DateTimeOffset` and one a `TimeSpan` from now, and both return the
+`TriggerKey` of the firing they stored — the handle to cancel it with, or to replace it by scheduling the same
+name again.
+
+What is stored is **one durable job per job type**, under
+`(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`, plus one trigger per call. That is the shape a
+message bus's Quartz integration converges on: a scheduled message is a trigger, so there is no job churn to
+pay for however many firings are in flight. The job is stored idempotently the first time a call is made on a
+scheduler and remembered afterwards, so it is safe for several nodes to do at once and costs one round trip
+rather than two from the second call on. It is left behind when the last firing is cancelled — one row per job
+type, whatever the traffic.
+
+`OneOffJobOptions` carries what would otherwise be `TriggerBuilder` calls: `Name` and `Group` (defaulting
+to a generated identifier in a group named after the job type), `Description`, `Priority`, `ExecutionGroup`,
+`MisfireInstruction`, and `Replace`. **The group is the correlation axis** — everything scheduled for one saga,
+one tenant or one conversation shares a group and can be listed, paused or unscheduled together.
+
+## Scheduling over a firing that is already there
+
+Replacing what is already scheduled is one call rather than three. The two `ScheduleJob` overloads that take a
+`ScheduleJobOptions` do the whole thing inside the store's own lock:
+
+```csharp
+// Trigger only - the job it names is already stored.
+await scheduler.ScheduleJob(trigger, new ScheduleJobOptions { Replace = true }, cancellationToken);
+
+// Job and trigger together, in one store operation.
+await scheduler.ScheduleJob(job, trigger, new ScheduleJobOptions { Replace = true }, cancellationToken);
+```
+
+Without them the only way to reschedule under a key you may or may not already hold was
+`CheckExists` → `UnscheduleJob` → `ScheduleJob`, which is three round trips and a window in which another node
+can do the same thing. `options` has no default on these two overloads, deliberately: giving it one would make
+`scheduler.ScheduleJob(trigger)` ambiguous.
+
+A replaced trigger **keeps the previous fire time it had**, so a job reading
+`context.PreviousFireTimeUtc` is not told the schedule has never fired merely because its trigger was
+rewritten. Supply a `PreviousFireTimeUtc` on the incoming trigger to say otherwise.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1633,6 +1633,123 @@ or natively declares its payload types with `SystemTextJsonSerializerRegistry.Ad
 exactly as it declares a job data value type — there is no second registration to learn. See
 [Job Data](tutorial/job-data-map.md#a-typed-input-the-third-read-side).
 
+## Scheduling a trigger can replace one atomically
+
+New in 4.0, and purely additive: `IScheduler.ScheduleJob` has two more overloads, which take a
+`ScheduleJobOptions` and can therefore replace what is already stored.
+
+```csharp
+ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default);
+ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default);
+```
+
+On 3.x — and on the two existing overloads, which are unchanged — rescheduling under a key you may or may
+not already hold meant three round trips and a window:
+
+```diff
+- if (await scheduler.CheckExists(trigger.Key, cancellationToken))
+- {
+-     await scheduler.UnscheduleJob(trigger.Key, cancellationToken);
+- }
+- await scheduler.ScheduleJob(trigger, cancellationToken);
++ await scheduler.ScheduleJob(trigger, new ScheduleJobOptions { Replace = true }, cancellationToken);
+```
+
+The new form is one store operation under the store's own lock — `SchedulerLock.TriggerAccess` on an
+ADO store, the single lock on the in-memory one — so two nodes doing it at once cannot interleave into a
+schedule with the trigger deleted and not replaced. The job-and-trigger overload goes through the store's
+`ScheduleJobs`, so the job and its trigger are written together rather than under two locks.
+
+`options` deliberately has **no default** on either overload. Giving it one would make
+`scheduler.ScheduleJob(trigger)` and `scheduler.ScheduleJob(job, trigger)` ambiguous between the pair.
+
+**A replaced trigger keeps its previous fire time.** The ADO store has done this since #1834; the in-memory
+store cloned the incoming trigger and lost it, so the same code reported "never fired" on one store and a
+real time on the other. The in-memory store now carries the value over, and `JobStoreContractTest` pins it
+on every store — along with the rule that a trigger replaced into a paused group is still born paused, so
+an upsert is not a way to escape a pause. A caller who *means* to reset the history sets
+`PreviousFireTimeUtc` on the incoming trigger, which is honoured.
+
+**Over HTTP**, `POST /triggers/schedule` takes a `replace` flag, `HttpScheduler` implements both new
+overloads, and the flag reaches the scheduler unchanged. A request that omits it behaves exactly as before.
+
+## A scheduler says which clock it keeps
+
+New in 4.0: `IScheduler.TimeProvider`, a **default interface member** answering `TimeProvider.System`.
+Nothing has to implement it — a scheduler written outside this repository keeps compiling and reports
+what its triggers would have used anyway — and the schedulers Quartz ships answer better:
+
+| Scheduler | Answers |
+|---|---|
+| the local scheduler | the `TimeProvider` it was configured with |
+| `DelegatingScheduler` | whatever it decorates |
+| the deferred scheduler `AddQuartz` registers | the built scheduler's, or the system clock while there is no scheduler yet |
+| `HttpScheduler` | the system clock — the clock that decides when a trigger fires is the remote scheduler's, and a `TimeProvider` cannot be fetched over a wire |
+
+3.x had no way to ask. Code that builds a trigger *for* a scheduler had to reach for
+`DateTimeOffset.UtcNow`, so an application or a test running the scheduler on a clock of its own
+computed "in ten minutes" against a different clock from the one the scheduling loop compares the
+answer to:
+
+```diff
+- ITrigger trigger = TriggerBuilder.Create()
+-     .StartAt(DateTimeOffset.UtcNow.AddMinutes(10))
+-     .Build();
++ ITrigger trigger = TriggerBuilder.Create(scheduler.TimeProvider)
++     .StartAt(scheduler.TimeProvider.GetUtcNow().AddMinutes(10))
++     .Build();
+```
+
+It is also what a job rescheduling itself from inside `Execute` reads, as
+`context.Scheduler.TimeProvider`, and it is what the one-call `ScheduleJob<TJob, TInput>` overloads
+below use for their `TimeSpan` form and for the trigger they build.
+
+## A typed job can be scheduled in one call
+
+Also new, on top of [typed inputs](#a-job-can-take-a-typed-input): two extension methods on `IScheduler`
+that schedule one firing of a job with a payload and a time, and nothing else to build.
+
+```csharp
+ValueTask<TriggerKey> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, DateTimeOffset at,
+    OneOffJobOptions options = default, CancellationToken cancellationToken = default) where TJob : IJob<TInput>;
+
+ValueTask<TriggerKey> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, TimeSpan delay,
+    OneOffJobOptions options = default, CancellationToken cancellationToken = default) where TJob : IJob<TInput>;
+```
+
+They are the imperative twin of `IQuartzBuilder.ScheduleJob<TJob>`, which only ever existed for the firings
+an application declares at start-up. 3.x had nothing of the kind.
+
+```csharp
+TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+    invoice, TimeSpan.FromDays(7), new OneOffJobOptions { Name = $"invoice-{invoice.CustomerId}", Group = invoice.CustomerId, Replace = true });
+
+await scheduler.UnscheduleJob(firing);
+```
+
+**One durable job per job type, many triggers.** The job is stored once under
+`(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)` — a new reserved constant spelled
+`"QRTZ_SCHEDULED"` — and every call adds a trigger to it. That is the shape a message bus's Quartz
+integration converges on: a scheduled message is a trigger, so there is no job churn to pay for. The job is
+ensured with `AddJob` and `Replace`, which is idempotent and cluster-safe, and remembered per scheduler
+instance; a store that reports the job missing gets it put back and the firing retried once, so a cluster
+restore or an operator's delete does not turn into a permanent failure.
+
+**`OneOffJobOptions` is named for what the call creates**, not for the call: one off, one firing, one
+trigger. It carries what would otherwise be `TriggerBuilder` calls — `Name`, `Group`, `Description`,
+`Priority`, `ExecutionGroup`, `MisfireInstruction` — plus `Replace`, which it passes on to the store.
+Every member is optional, and `default` is "a one-shot trigger with a generated name, in this job type's
+own group". An overload that schedules a *recurring* job would have something else to say — a schedule,
+an end time, a calendar — and will get an options type of its own rather than nullable members here that
+mean nothing to a single firing. It is a different thing from `ScheduleJobOptions`, which describes a
+*store* operation and says only whether it may over-write.
+
+The trigger group is the correlation axis: everything scheduled for one saga, one tenant or one
+conversation can share a group and be listed, paused or unscheduled together. Cancelling is
+`UnscheduleJob(key)`; the durable job stays behind, one row per job type whatever the traffic.
+
+See [One-Off Job](how-tos/one-off-job.md#a-payload-and-a-time-in-one-call).
+
 ## A component of your own is chosen the same way a shipped one is
 
 Three seams that had no code-first spelling at all, and one that only worked through a type-name string:

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -397,14 +397,16 @@ internal static class TriggerEndpoints
         EndpointHelper.AssertIsValid(request);
         return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
         {
+            ScheduleJobOptions options = new() { Replace = request.Replace };
+
             if (request.Job is null)
             {
-                var firstFireTime = await scheduler.ScheduleJob(request.Trigger, cancellationToken).ConfigureAwait(false);
+                var firstFireTime = await scheduler.ScheduleJob(request.Trigger, options, cancellationToken).ConfigureAwait(false);
                 return new ScheduleJobResponse(firstFireTime);
             }
 
             IJobDetail jobDetail = RequestedJobDetail.From(request.Job);
-            var firstFireTimeWithJob = await scheduler.ScheduleJob(jobDetail, request.Trigger, cancellationToken).ConfigureAwait(false);
+            var firstFireTimeWithJob = await scheduler.ScheduleJob(jobDetail, request.Trigger, options, cancellationToken).ConfigureAwait(false);
             return new ScheduleJobResponse(firstFireTimeWithJob);
         });
     }

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/OpenApi/Types.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/OpenApi/Types.cs
@@ -194,6 +194,7 @@ internal interface ScheduleJobRequest
 {
     Trigger Trigger { get; }
     HttpApiContract.JobDetailDto? Job { get; }
+    bool Replace { get; }
 }
 
 internal interface ScheduleJobsRequest

--- a/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
@@ -93,3 +93,40 @@ public sealed class OneOffJobScheduledOnce
 
     #endregion
 }
+
+#region sample_one_off_job_typed_one_liner
+
+public sealed record SendInvoice(string CustomerId, decimal Amount);
+
+public sealed class SendInvoiceJob : IJob<SendInvoice>
+{
+    public ValueTask Execute(IJobExecutionContext context, SendInvoice input, CancellationToken cancellationToken = default)
+    {
+        // input.CustomerId, input.Amount
+        return default;
+    }
+}
+
+public sealed class Invoicing
+{
+    public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+    {
+        TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+            invoice,
+            TimeSpan.FromDays(7),
+            new OneOffJobOptions
+            {
+                // Named, so it can be replaced or cancelled; grouped by the thing it is about, so the
+                // whole conversation can be cancelled at once.
+                Name = $"invoice-{invoice.CustomerId}",
+                Group = invoice.CustomerId,
+                Replace = true
+            },
+            cancellationToken);
+
+        // ... and to call it off:
+        await scheduler.UnscheduleJob(firing, cancellationToken);
+    }
+}
+
+#endregion

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -78,6 +78,19 @@ public sealed class HttpScheduler : IScheduler
     public string SchedulerInstanceId => GetSchedulerDetailsSync().SchedulerInstanceId;
 
     /// <summary>
+    /// The system clock, which is the only honest answer a proxy can give.
+    /// </summary>
+    /// <remarks>
+    /// The clock that decides when a trigger fires is the remote scheduler's, and this process cannot
+    /// read it: the HTTP API reports times, not a <see cref="System.TimeProvider" />, and a
+    /// <see cref="System.TimeProvider" /> is not something that can be fetched over a wire. So a client
+    /// building a trigger for a remote scheduler measures "now" against its own clock, exactly as it
+    /// would have done writing <c>DateTimeOffset.UtcNow</c> by hand — the two machines agreeing about
+    /// the time is the assumption the whole wire format already makes.
+    /// </remarks>
+    public TimeProvider TimeProvider => TimeProvider.System;
+
+    /// <summary>
     /// The remote scheduler's lifecycle state, read over the network.
     /// </summary>
     /// <remarks>
@@ -233,22 +246,34 @@ public sealed class HttpScheduler : IScheduler
     {
         ArgumentNullException.ThrowIfNull(jobDetail);
 
-        return DoScheduleJob(jobDetail, trigger, cancellationToken);
+        return DoScheduleJob(jobDetail, trigger, replace: false, cancellationToken);
+    }
+
+    public ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(jobDetail);
+
+        return DoScheduleJob(jobDetail, trigger, options.Replace, cancellationToken);
     }
 
     public ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, CancellationToken cancellationToken = default)
     {
-        return DoScheduleJob(null, trigger, cancellationToken);
+        return DoScheduleJob(null, trigger, replace: false, cancellationToken);
     }
 
-    private async ValueTask<DateTimeOffset> DoScheduleJob(IJobDetail? jobDetail, ITrigger trigger, CancellationToken cancellationToken)
+    public ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        return DoScheduleJob(null, trigger, options.Replace, cancellationToken);
+    }
+
+    private async ValueTask<DateTimeOffset> DoScheduleJob(IJobDetail? jobDetail, ITrigger trigger, bool replace, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(trigger);
 
         var jobDetailsDto = jobDetail is not null ? JobDetailDto.Create(jobDetail) : null;
         var result = await httpClient.PostWithResponse<ScheduleJobRequest, ScheduleJobResponse>(
             $"{TriggerEndpointUrl()}/schedule",
-            new ScheduleJobRequest(trigger, jobDetailsDto),
+            new ScheduleJobRequest(trigger, jobDetailsDto, replace),
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -407,30 +407,32 @@ public class TriggerEndpointsTest : WebApiTest
     public async Task ScheduleJobShouldWork()
     {
         var firstFireTime = DateTimeOffset.Now;
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<CancellationToken>._)).Returns(firstFireTime);
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._)).Returns(firstFireTime);
 
         var response = await HttpScheduler.ScheduleJob(TestData.CronTrigger);
         response.Should().Be(firstFireTime);
 
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<CancellationToken>._))
-            .WhenArgumentsMatch((ITrigger trigger, CancellationToken _) =>
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((ITrigger trigger, ScheduleJobOptions options, CancellationToken _) =>
             {
                 trigger.Should().BeEquivalentTo(TestData.CronTrigger);
+                options.Replace.Should().BeFalse("a client that did not ask to replace must not be made to");
                 return true;
             })
             .MustHaveHappened(1, Times.Exactly);
 
         firstFireTime = DateTimeOffset.Now.AddDays(1);
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._)).Returns(firstFireTime);
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._)).Returns(firstFireTime);
 
         response = await HttpScheduler.ScheduleJob(TestData.JobDetail, TestData.DailyTimeIntervalTrigger);
         response.Should().Be(firstFireTime);
 
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._))
-            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, CancellationToken _) =>
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken _) =>
             {
                 jobDetail.Should().BeEquivalentTo(TestData.JobDetail);
                 trigger.Should().BeEquivalentTo(TestData.DailyTimeIntervalTrigger);
+                options.Replace.Should().BeFalse();
                 return true;
             })
             .MustHaveHappened(1, Times.Exactly);
@@ -444,10 +446,41 @@ public class TriggerEndpointsTest : WebApiTest
 
         await HttpScheduler.ScheduleJob(jobDetailWithUnresolvableType, TestData.SimpleTrigger);
 
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._))
-            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, CancellationToken _) =>
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken _) =>
             {
                 jobDetail.JobType.FullName.Should().Be(TestData.UnresolvableJobTypeName);
+                return true;
+            })
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task ScheduleJobShouldCarryTheReplaceFlagAcrossTheWire()
+    {
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._)).Returns(DateTimeOffset.Now);
+
+        await HttpScheduler.ScheduleJob(TestData.CronTrigger, new ScheduleJobOptions { Replace = true });
+
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((ITrigger trigger, ScheduleJobOptions options, CancellationToken _) =>
+            {
+                trigger.Should().BeEquivalentTo(TestData.CronTrigger);
+                options.Replace.Should().BeTrue(
+                    "an upsert over HTTP is the same one call as an upsert in process, so the flag has to reach the scheduler");
+                return true;
+            })
+            .MustHaveHappened(1, Times.Exactly);
+
+        Fake.ClearRecordedCalls(FakeScheduler);
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._)).Returns(DateTimeOffset.Now);
+
+        await HttpScheduler.ScheduleJob(TestData.JobDetail, TestData.SimpleTrigger, new ScheduleJobOptions { Replace = true });
+
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken _) =>
+            {
+                options.Replace.Should().BeTrue();
                 return true;
             })
             .MustHaveHappened(1, Times.Exactly);
@@ -464,7 +497,7 @@ public class TriggerEndpointsTest : WebApiTest
         Assert.ThrowsAsync<HttpClientException>(() => HttpScheduler.ScheduleJob(jobDetailWithEmptyType, TestData.SimpleTrigger).AsTask())!
             .Message.Should().ContainEquivalentOf("malformed job type");
 
-        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => FakeScheduler.ScheduleJob(A<IJobDetail>._, A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1952,6 +1952,82 @@ public abstract class JobStoreContractTest
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Replacing a trigger
+    //
+    // Replacing is what makes scheduling over an existing trigger one call instead of an unschedule
+    // followed by a schedule, so what survives the replacement is part of the contract rather than an
+    // implementation detail of whichever store the author had in front of them. The previous fire time
+    // is the one that used to differ: the ADO store carried it over (#1834) and the in-memory store
+    // cloned the incoming trigger and lost it, so the same code reported "never fired" on one store and
+    // a real time on the other.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task ReplacingATriggerKeepsThePreviousFireTimeItHad()
+    {
+        IJobDetail job = CreateJob("replaced", JobGroupA);
+        IOperableTrigger trigger = CreateTrigger("replaced", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        await Store.ScheduleJob(job, trigger);
+
+        (IOperableTrigger firing, IJobDetail fired) = await FireOnce(trigger);
+        await Store.TriggeredJobComplete(firing, fired, SchedulerInstruction.NoInstruction);
+
+        DateTimeOffset? previous = (await Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc;
+        previous.Should().NotBeNull("a trigger that has fired knows when it last fired");
+
+        // What a caller rewriting a schedule hands the store: a freshly built trigger, which has never
+        // fired and says so.
+        IOperableTrigger replacement = CreateTrigger("replaced", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddHours(1));
+        replacement.PreviousFireTimeUtc.Should().BeNull("the replacement is a new object with no history of its own");
+
+        await Store.AddTrigger(replacement, replace: true);
+
+        (await Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc.Should().Be(previous,
+            "a job reading context.PreviousFireTimeUtc must not be told the schedule has never fired merely "
+            + "because its trigger was rewritten");
+    }
+
+    [Test]
+    public async Task ReplacingATriggerHonoursAPreviousFireTimeTheCallerSupplied()
+    {
+        IJobDetail job = CreateJob("replaced", JobGroupA);
+        IOperableTrigger trigger = CreateTrigger("replaced", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddSeconds(5));
+        await Store.ScheduleJob(job, trigger);
+
+        (IOperableTrigger firing, IJobDetail fired) = await FireOnce(trigger);
+        await Store.TriggeredJobComplete(firing, fired, SchedulerInstruction.NoInstruction);
+
+        DateTimeOffset chosen = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        IOperableTrigger replacement = CreateTrigger("replaced", TriggerGroupA, job.Key,
+            startAt: DateTimeOffset.UtcNow.AddHours(1));
+        replacement.PreviousFireTimeUtc = chosen;
+
+        await Store.AddTrigger(replacement, replace: true);
+
+        (await Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc.Should().Be(chosen,
+            "carrying the old value over is a default for a caller who said nothing, not an override of one who did");
+    }
+
+    [Test]
+    public async Task ATriggerReplacedIntoAPausedGroupIsBornPaused()
+    {
+        IOperableTrigger trigger = await ScheduleJobWithTrigger("replaced", JobGroupA, TriggerGroupA);
+
+        await Store.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(TriggerGroupA));
+
+        IOperableTrigger replacement = CreateTrigger("replaced", TriggerGroupA, trigger.JobKey,
+            startAt: DateTimeOffset.UtcNow.AddHours(1));
+        await Store.AddTrigger(replacement, replace: true);
+
+        (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused,
+            "a paused group imposes the pause on what is written into it, whether that is an insert or a replace — "
+            + "otherwise an upsert is a way to escape a pause");
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // A typed job's input
     //
     // The input is a string under a reserved key, chosen precisely so that no store has to know

--- a/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
@@ -88,6 +88,28 @@ public class OptionsConventionTest
     };
 
     /// <summary>
+    /// Members whose options argument is mandatory, each with the reason it cannot carry a default.
+    /// A new entry needs a reason of the same kind: giving the parameter a default would not compile,
+    /// or would make a call that already exists ambiguous.
+    /// </summary>
+    /// <remarks>
+    /// The rule already tolerates a mandatory argument when a later parameter is required, and that case
+    /// is decided in the check itself. This list is for the other one: an overload pair where the
+    /// options argument is what tells the two members apart, so a default on it would leave the shorter
+    /// call with no single best candidate.
+    /// </remarks>
+    private static readonly Dictionary<string, string> mandatoryOptionsExceptions = new(StringComparer.Ordinal)
+    {
+        // #3522: the upsert twins of ScheduleJob(ITrigger, …) and ScheduleJob(IJobDetail, ITrigger, …).
+        // Both shorter overloads already exist and are what a caller who does not care about replacing
+        // writes, so the options argument is the only thing distinguishing the pair.
+        ["IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, CancellationToken)"] = "a default would make ScheduleJob(trigger) ambiguous",
+        ["IScheduler.ScheduleJob(IJobDetail, ITrigger, ScheduleJobOptions, CancellationToken)"] = "a default would make ScheduleJob(jobDetail, trigger) ambiguous",
+        ["DelegatingScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, CancellationToken)"] = "implements IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, CancellationToken)",
+        ["DelegatingScheduler.ScheduleJob(IJobDetail, ITrigger, ScheduleJobOptions, CancellationToken)"] = "implements IScheduler.ScheduleJob(IJobDetail, ITrigger, ScheduleJobOptions, CancellationToken)",
+    };
+
+    /// <summary>
     /// Types a scalar member may be: assigned wholesale, carrying no state Quartz binds into.
     /// </summary>
     private static readonly HashSet<Type> scalarTypes =
@@ -373,9 +395,9 @@ public class OptionsConventionTest
                     }
 
                     // A parameter cannot be optional while something after it is required, which is the
-                    // one reason the rule tolerates a mandatory options argument.
+                    // one reason the rule tolerates a mandatory options argument without being told.
                     bool couldBeOptional = parameters.Skip(i + 1).All(later => later.IsOptional);
-                    if (couldBeOptional && !parameter.IsOptional)
+                    if (couldBeOptional && !parameter.IsOptional && !mandatoryOptionsExceptions.ContainsKey(Signature(type, member)))
                     {
                         violations.Add($"{type.Name}.{member.Name} takes a mandatory {parameterType.Name}");
                     }
@@ -482,6 +504,15 @@ public class OptionsConventionTest
     /// generated equality members take it as a parameter, which would classify every record as a
     /// call-site argument if they were counted.
     /// </summary>
+    /// <summary>
+    /// A member spelled the way <see cref="mandatoryOptionsExceptions" /> keys it, so an exemption names
+    /// one overload rather than every member sharing its name.
+    /// </summary>
+    private static string Signature(Type type, MethodBase member)
+    {
+        return $"{type.Name}.{member.Name}({string.Join(", ", member.GetParameters().Select(parameter => parameter.ParameterType.Name))})";
+    }
+
     private static IEnumerable<Type> ConsumingTypes() => quartzAssembly.GetExportedTypes().Where(type => !IsOptionsType(type));
 
     private static IEnumerable<MethodBase> PublicMembers(Type type) => type

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -292,7 +292,17 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        public ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -474,4 +474,210 @@ public class SchedulerTest
 
         await scheduler.Shutdown(false);
     }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Scheduling over what is already there, in one call
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task SchedulingATriggerOverAnExistingOneIsOneCall()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(SchedulingATriggerOverAnExistingOneIsOneCall));
+
+        JobKey jobKey = new("upsert", "upsert");
+        TriggerKey triggerKey = new("upsert", "upsert");
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<TestJob>().WithIdentity(jobKey).StoreDurably().Build(),
+            TriggerBuilder.Create().WithIdentity(triggerKey).ForJob(jobKey).StartAt(FarFuture).Build());
+
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .StartAt(FarFuture.AddDays(1))
+            .Build();
+
+        Func<Task> withoutReplace = async () => await scheduler.ScheduleJob(replacement, new ScheduleJobOptions());
+        await withoutReplace.Should().ThrowAsync<ObjectAlreadyExistsException>(
+            "the default is still the conservative one, so a caller who did not ask to replace is told");
+
+        await scheduler.ScheduleJob(replacement, new ScheduleJobOptions { Replace = true });
+
+        ITrigger stored = await scheduler.GetTrigger(triggerKey);
+        stored.StartTimeUtc.Should().Be(FarFuture.AddDays(1),
+            "replacing is the store's own operation, so an upsert needs no unschedule-then-schedule of the caller's");
+    }
+
+    [Test]
+    public async Task SchedulingAJobAndTriggerOverExistingOnesIsOneCall()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(SchedulingAJobAndTriggerOverExistingOnesIsOneCall));
+
+        JobKey jobKey = new("upsert", "upsert");
+        TriggerKey triggerKey = new("upsert", "upsert");
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<TestJob>().WithIdentity(jobKey).UsingJobData("version", 1).Build(),
+            TriggerBuilder.Create().WithIdentity(triggerKey).ForJob(jobKey).StartAt(FarFuture).Build());
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<TestJob>().WithIdentity(jobKey).UsingJobData("version", 2).Build(),
+            TriggerBuilder.Create().WithIdentity(triggerKey).ForJob(jobKey).StartAt(FarFuture.AddDays(1)).Build(),
+            new ScheduleJobOptions { Replace = true });
+
+        IJobDetail storedJob = await scheduler.GetJobDetail(jobKey);
+        storedJob.JobDataMap.GetInt("version").Should().Be(2, "the job and its trigger are replaced together");
+
+        ITrigger storedTrigger = await scheduler.GetTrigger(triggerKey);
+        storedTrigger.StartTimeUtc.Should().Be(FarFuture.AddDays(1));
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Scheduling one firing of a typed job in one call
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task TheOneLinerStoresOneDurableJobAndOneTriggerPerCall()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerStoresOneDurableJobAndOneTriggerPerCall));
+
+        TriggerKey first = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+        TriggerKey second = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
+
+        second.Should().NotBe(first, "a call with no name of its own gets a generated one, so two calls never collide");
+
+        first.Group.Should().Be(nameof(ReminderJob),
+            "the trigger group defaults to the job type, and is the axis a caller correlates firings on");
+
+        IJobDetail job = await scheduler.GetJobDetail(new JobKey(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup));
+        job.Should().NotBeNull("one durable job per job type is what every trigger hangs off");
+        job.Durable.Should().BeTrue("it has to outlive the firings that point at it");
+
+        List<ITrigger> triggers = await scheduler.GetTriggersOfJob(job.Key);
+        triggers.Should().HaveCount(2, "each call adds a trigger; there is no job churn to pay for");
+
+        ITrigger stored = await scheduler.GetTrigger(second);
+        stored.StartTimeUtc.Should().Be(FarFuture);
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().Be("""{"Note":"second"}""",
+            "the payload rides on the trigger, so one job serves every firing");
+    }
+
+    [Test]
+    public async Task TheOneLinerReplacesAFiringOfTheSameName()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerReplacesAFiringOfTheSameName));
+
+        OneOffJobOptions options = new() { Name = "order-42", Group = "orders", Replace = true };
+
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture, options);
+        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture.AddDays(1), options);
+
+        key.Should().Be(new TriggerKey("order-42", "orders"));
+
+        IJobDetail job = await scheduler.GetJobDetail(new JobKey(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup));
+        (await scheduler.GetTriggersOfJob(job.Key)).Should().ContainSingle(
+            "naming the firing and asking to replace is how a caller upserts it, in one call rather than three");
+
+        ITrigger stored = await scheduler.GetTrigger(key);
+        stored.StartTimeUtc.Should().Be(FarFuture.AddDays(1));
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().Be("""{"Note":"second"}""");
+    }
+
+    [Test]
+    public async Task TheOneLinerRefusesToReplaceUnlessAsked()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerRefusesToReplaceUnlessAsked));
+
+        OneOffJobOptions options = new() { Name = "order-42", Group = "orders" };
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture, options);
+
+        Func<Task> again = async () => await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture, options);
+        await again.Should().ThrowAsync<ObjectAlreadyExistsException>(
+            "Replace is opt-in here too, so a name reused by accident is reported rather than silently overwritten");
+    }
+
+    [Test]
+    public async Task TheOneLinerCanBeToldADelayInsteadOfATime()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerCanBeToldADelayInsteadOfATime));
+
+        DateTimeOffset before = DateTimeOffset.UtcNow;
+        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("later"), TimeSpan.FromHours(2));
+        DateTimeOffset after = DateTimeOffset.UtcNow;
+
+        ITrigger stored = await scheduler.GetTrigger(key);
+        stored.StartTimeUtc.Should().BeOnOrAfter(before.AddHours(2)).And.BeOnOrBefore(after.AddHours(2),
+            "a delay is measured from the moment the call was made");
+    }
+
+    [Test]
+    public async Task TheOneLinerPutsTheDurableJobBackIfItWentMissing()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerPutsTheDurableJobBackIfItWentMissing));
+
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+
+        // What a cluster restore, an operator or another node's Clear() does: the job the memo says is
+        // there is gone.
+        JobKey jobKey = new(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup);
+        (await scheduler.DeleteJob(jobKey)).Should().BeTrue();
+
+        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
+
+        (await scheduler.GetJobDetail(jobKey)).Should().NotBeNull(
+            "the memo is only an optimization: a store that says the job is missing gets it back and the firing is stored");
+        (await scheduler.GetTrigger(key)).Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task TheOneLinerRunsTheJobWithItsPayload()
+    {
+        ReminderJob.Reset();
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerRunsTheJobWithItsPayload));
+        await scheduler.Start();
+
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("run me"), TimeSpan.Zero);
+
+        ReminderJob.Fired.Wait(TimeSpan.FromSeconds(30)).Should().BeTrue("the scheduled firing has to actually run");
+        ReminderJob.Received.Should().Be(new Reminder("run me"));
+    }
+
+    /// <summary>
+    /// Far enough out that nothing fires while a storage test runs, and rounded to whole seconds so a
+    /// store that keeps milliseconds and one that does not agree.
+    /// </summary>
+    private static readonly DateTimeOffset FarFuture = new(2126, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static async Task<IScheduler> NewScheduler(string name)
+    {
+        NameValueCollection properties = new()
+        {
+            ["quartz.scheduler.instanceName"] = "SchedulerTest_" + name,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType
+        };
+
+        return await QuartzSchedulerBuilder.Create().UseProperties(properties).BuildScheduler();
+    }
+
+    public sealed record Reminder(string Note);
+
+    public sealed class ReminderJob : IJob<Reminder>
+    {
+        public static readonly ManualResetEventSlim Fired = new();
+
+        public static Reminder Received { get; private set; }
+
+        public static void Reset()
+        {
+            Fired.Reset();
+            Received = null;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, Reminder input, CancellationToken cancellationToken = default)
+        {
+            Received = input;
+            Fired.Set();
+            return default;
+        }
+    }
 }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -22,6 +22,7 @@ namespace Quartz
         public string SchedulerInstanceId { get; }
         public string SchedulerName { get; }
         public Quartz.SchedulerStatus Status { get; }
+        public System.TimeProvider TimeProvider { get; }
         public System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail jobDetail, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
@@ -67,6 +68,8 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail jobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger> triggersForJob, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SetExecutionLimits(Quartz.ExecutionLimits? limits, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -675,6 +675,7 @@ namespace Quartz
         string SchedulerInstanceId { get; }
         string SchedulerName { get; }
         Quartz.SchedulerStatus Status { get; }
+        System.TimeProvider TimeProvider { get; }
         System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail jobDetail, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
@@ -719,6 +720,8 @@ namespace Quartz
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail jobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger> triggersForJob, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SetExecutionLimits(Quartz.ExecutionLimits? limits, System.Threading.CancellationToken cancellationToken = default);
@@ -1126,6 +1129,16 @@ namespace Quartz
         public Quartz.JobKey? JobKey { get; }
         public Quartz.TriggerKey? TriggerKey { get; }
     }
+    public readonly struct OneOffJobOptions : System.IEquatable<Quartz.OneOffJobOptions>
+    {
+        public string? Description { get; init; }
+        public string? ExecutionGroup { get; init; }
+        public string? Group { get; init; }
+        public Quartz.SimpleTriggerMisfireInstruction? MisfireInstruction { get; init; }
+        public string? Name { get; init; }
+        public int? Priority { get; init; }
+        public bool Replace { get; init; }
+    }
     public sealed class OrMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
     {
@@ -1496,6 +1509,7 @@ namespace Quartz
         public const string FailedJobOriginalTriggerScheduledFireTime = "QRTZ_FAILED_JOB_ORIG_TRIGGER_SCHEDULED_FIRETIME_AS_STRING";
         public const string ForceJobDataMapDirty = "QRTZ_FORCE_JOB_DATAMAP_DIRTY";
         public const string JobInput = "QRTZ_JOB_INPUT";
+        public const string ScheduledJobGroup = "QRTZ_SCHEDULED";
     }
     public sealed class SchedulerContext : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IDictionary<string, object?>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyDictionary<string, object?>, System.Collections.IEnumerable
     {
@@ -1550,6 +1564,10 @@ namespace Quartz
     {
         public static System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Action<Quartz.IJobConfigurator<TJob>>? configure = null, System.Threading.CancellationToken cancellationToken = default)
             where TJob : Quartz.IJob { }
+        public static System.Threading.Tasks.ValueTask<Quartz.TriggerKey> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.DateTimeOffset at, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
+            where TJob : Quartz.IJob<TInput> { }
+        public static System.Threading.Tasks.ValueTask<Quartz.TriggerKey> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.TimeSpan delay, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
+            where TJob : Quartz.IJob<TInput> { }
     }
     public sealed class SchedulerMetadata : System.IEquatable<Quartz.SchedulerMetadata>
     {
@@ -3344,6 +3362,7 @@ namespace Quartz.Impl
         public virtual string SchedulerInstanceId { get; }
         public virtual string SchedulerName { get; }
         public virtual Quartz.SchedulerStatus Status { get; }
+        public virtual System.TimeProvider TimeProvider { get; }
         public virtual System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail jobDetail, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
@@ -3389,6 +3408,8 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail jobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger> triggersForJob, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.ITrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask SetExecutionLimits(Quartz.ExecutionLimits? limits, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -618,10 +618,40 @@ internal sealed class QuartzScheduler
     /// will be set to reference the Job passed with it into this method.
     /// </para>
     /// </summary>
-    public async ValueTask<DateTimeOffset> ScheduleJob(
+    public ValueTask<DateTimeOffset> ScheduleJob(
         IJobDetail jobDetail,
         ITrigger trigger,
         CancellationToken cancellationToken = default)
+    {
+        return DoScheduleJob(jobDetail, trigger, options: null, cancellationToken);
+    }
+
+    /// <inheritdoc cref="ScheduleJob(IJobDetail, ITrigger, CancellationToken)" />
+    public ValueTask<DateTimeOffset> ScheduleJob(
+        IJobDetail jobDetail,
+        ITrigger trigger,
+        ScheduleJobOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return DoScheduleJob(jobDetail, trigger, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Stores a job and its trigger, through the store operation the caller's overload asks for.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="options" /> is <see langword="null" /> when the caller used the overload that
+    /// takes none, which is stored through <see cref="IJobStore.ScheduleJob" /> exactly as it always has
+    /// been — that member keeps its caller, and the span and metric a store reports for the plain call
+    /// keep their names. An overload that was given options goes through
+    /// <see cref="IJobStore.ScheduleJobs" /> instead, because replacing a job and its trigger has to be
+    /// one store operation under one lock.
+    /// </remarks>
+    private async ValueTask<DateTimeOffset> DoScheduleJob(
+        IJobDetail jobDetail,
+        ITrigger trigger,
+        ScheduleJobOptions? options,
+        CancellationToken cancellationToken)
     {
         ValidateState();
 
@@ -680,7 +710,19 @@ internal sealed class QuartzScheduler
             Throw.SchedulerException(message);
         }
 
-        await resources.JobStore.ScheduleJob(jobDetail, trig, cancellationToken).ConfigureAwait(false);
+        if (options is { } scheduleOptions)
+        {
+            // One store operation rather than an AddJob followed by an AddTrigger: the store takes its
+            // lock once, so a caller replacing a job and its trigger together cannot be seen half
+            // applied and cannot lose a race with another node doing the same thing.
+            Dictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> one = new(1) { [jobDetail] = [trig] };
+            await resources.JobStore.ScheduleJobs(one, scheduleOptions.Replace, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await resources.JobStore.ScheduleJob(jobDetail, trig, cancellationToken).ConfigureAwait(false);
+        }
+
         await NotifySchedulerListenersJobAdded(jobDetail, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(trigger.NextFireTimeUtc);
         await NotifySchedulerListenersScheduled(trigger, cancellationToken).ConfigureAwait(false);
@@ -694,6 +736,7 @@ internal sealed class QuartzScheduler
     /// </summary>
     public async ValueTask<DateTimeOffset> ScheduleJob(
         ITrigger trigger,
+        ScheduleJobOptions options = default,
         CancellationToken cancellationToken = default)
     {
         ValidateState();
@@ -727,7 +770,9 @@ internal sealed class QuartzScheduler
             Throw.SchedulerException(message);
         }
 
-        await resources.JobStore.AddTrigger(trig, false, cancellationToken).ConfigureAwait(false);
+        // Replacing is the store's own operation, taken under the store's lock, so an upsert is one
+        // call rather than a CheckExists / UnscheduleJob / ScheduleJob a caller has to serialize itself.
+        await resources.JobStore.AddTrigger(trig, options.Replace, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(trigger.NextFireTimeUtc);
         await NotifySchedulerListenersScheduled(trigger, cancellationToken).ConfigureAwait(false);
 

--- a/src/Quartz/HttpApiContract/RequestAndResponses.cs
+++ b/src/Quartz/HttpApiContract/RequestAndResponses.cs
@@ -101,7 +101,7 @@ internal record DeleteJobsRequest(KeyDto[] Jobs) : IValidatable
 }
 
 // When updating this, make same changes also into Quartz.AspNetCore.HttpApi.OpenApi.ScheduleJobRequest
-internal record ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job) : IValidatable
+internal record ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job, bool Replace = false) : IValidatable
 {
     public IEnumerable<string> Validate()
     {

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -122,6 +122,29 @@ public interface IScheduler : IAsyncDisposable
     string SchedulerInstanceId { get; }
 
     /// <summary>
+    /// The clock this scheduler reads: what it calls "now" when it decides a trigger is due, and what a
+    /// trigger built for it should compute its fire times from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A scheduler configured with a <see cref="System.TimeProvider" /> of its own — a test driving one
+    /// forward by hand, an application on a clock it controls — answers with that one. Code that builds
+    /// a trigger for a scheduler should read the clock from the scheduler rather than reach for
+    /// <see cref="System.TimeProvider.System" />, or it computes "in ten minutes" against a different
+    /// clock from the one the scheduling loop will compare the answer to. That includes a job
+    /// rescheduling itself from inside <c>Execute</c>, which reads
+    /// <c>context.Scheduler.TimeProvider</c>.
+    /// </para>
+    /// <para>
+    /// A default implementation answers <see cref="System.TimeProvider.System" />, so a scheduler
+    /// written outside this repository needs no change and reports what its triggers would have used
+    /// anyway. A proxy for a scheduler in another process answers the same, and cannot do better: the
+    /// clock that matters is the remote scheduler's, and it is not this process's to read.
+    /// </para>
+    /// </remarks>
+    TimeProvider TimeProvider => TimeProvider.System;
+
+    /// <summary>
     /// Returns the <see cref="SchedulerContext" /> of the <see cref="IScheduler" />.
     /// </summary>
     SchedulerContext Context { get; }
@@ -321,12 +344,58 @@ public interface IScheduler : IAsyncDisposable
         ITrigger trigger,
         CancellationToken cancellationToken = default);
 
+    /// <inheritdoc cref="ScheduleJob(IJobDetail, ITrigger, CancellationToken)" />
+    /// <param name="jobDetail">The job to store.</param>
+    /// <param name="trigger">The trigger to store.</param>
+    /// <param name="options">
+    /// Whether an already stored job or trigger with the same key is over-written. The whole operation
+    /// is one store operation under one lock, so an upsert needs no read-then-write of its own and
+    /// cannot lose a race with another node doing the same thing.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="options" /> has no default, unlike everywhere else it appears. Giving it one
+    /// would make <c>ScheduleJob(job, trigger)</c> ambiguous between this overload and the one above.
+    /// </para>
+    /// </remarks>
+    ValueTask<DateTimeOffset> ScheduleJob(
+        IJobDetail jobDetail,
+        ITrigger trigger,
+        ScheduleJobOptions options,
+        CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Schedule the given <see cref="ITrigger" /> with the
     /// <see cref="IJob" /> identified by the <see cref="ITrigger" />'s settings.
     /// </summary>
     ValueTask<DateTimeOffset> ScheduleJob(
         ITrigger trigger,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="ScheduleJob(ITrigger, CancellationToken)" />
+    /// <param name="trigger">The trigger to store.</param>
+    /// <param name="options">
+    /// Whether an already stored trigger with the same key is over-written. Replacing is one store
+    /// operation under the store's own lock, so scheduling over an existing trigger needs no
+    /// <c>CheckExists</c> / <c>UnscheduleJob</c> / <c>ScheduleJob</c> dance and cannot lose a race with
+    /// another node doing the same thing.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <remarks>
+    /// <para>
+    /// A replaced trigger keeps its <see cref="ITrigger.PreviousFireTimeUtc" />, so a job that reads
+    /// <see cref="IJobExecutionContext.PreviousFireTimeUtc" /> is not told the schedule has never fired
+    /// merely because its trigger was rewritten.
+    /// </para>
+    /// <para>
+    /// <paramref name="options" /> has no default, unlike everywhere else it appears. Giving it one
+    /// would make <c>ScheduleJob(trigger)</c> ambiguous between this overload and the one above.
+    /// </para>
+    /// </remarks>
+    ValueTask<DateTimeOffset> ScheduleJob(
+        ITrigger trigger,
+        ScheduleJobOptions options,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -101,6 +101,17 @@ internal sealed class DeferredScheduler : IScheduler
 
     public string SchedulerInstanceId => Resolved.SchedulerInstanceId;
 
+    /// <summary>
+    /// The built scheduler's clock, or the system clock while there is no scheduler yet.
+    /// </summary>
+    /// <remarks>
+    /// The field rather than <see cref="Resolved" />: reading a clock is not a reason to build a
+    /// scheduler, and building one here would turn a property read into a blocking wait on
+    /// asynchronous work. Every scheduler this defers to that was given a clock of its own reports it
+    /// from the moment it exists, which is before anything can have scheduled anything on it.
+    /// </remarks>
+    public TimeProvider TimeProvider => scheduler?.TimeProvider ?? TimeProvider.System;
+
     public SchedulerContext Context => Resolved.Context;
 
     public SchedulerStatus Status => Resolved.Status;
@@ -172,10 +183,22 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.ScheduleJob(jobDetail, trigger, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.ScheduleJob(jobDetail, trigger, options, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);
         return await target.ScheduleJob(trigger, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.ScheduleJob(trigger, options, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -19,6 +19,7 @@ public class DelegatingScheduler : IScheduler
 
     public virtual string SchedulerName => scheduler.SchedulerName;
     public virtual string SchedulerInstanceId => scheduler.SchedulerInstanceId;
+    public virtual TimeProvider TimeProvider => scheduler.TimeProvider;
     public virtual SchedulerContext Context => scheduler.Context;
     public virtual SchedulerStatus Status => scheduler.Status;
 
@@ -79,9 +80,19 @@ public class DelegatingScheduler : IScheduler
         return scheduler.ScheduleJob(jobDetail, trigger, cancellationToken);
     }
 
+    public virtual ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(jobDetail, trigger, options, cancellationToken);
+    }
+
     public virtual ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, CancellationToken cancellationToken = default)
     {
         return scheduler.ScheduleJob(trigger, cancellationToken);
+    }
+
+    public virtual ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options, CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(trigger, options, cancellationToken);
     }
 
     public virtual ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -258,8 +258,24 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="cancellationToken">The cancellation instruction.</param>
     public async ValueTask ScheduleJob(IJobDetail job, IOperableTrigger trigger, CancellationToken cancellationToken = default)
     {
-        await AddJob(job, replace: false, cancellationToken).ConfigureAwait(false);
-        await AddTrigger(trigger, replace: false, cancellationToken).ConfigureAwait(false);
+        PendingSignals pending = default;
+
+        // One acquisition rather than the two that AddJob followed by AddTrigger took: storing a job
+        // with its trigger is one operation, and between the two locks another caller could see the job
+        // without the trigger that gives it a reason to exist. The ADO store has always done both
+        // inside one ExecuteInLock.
+        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            AddJobNoLock(job, replace: false);
+            AddTriggerNoLock(trigger, replace: false, ref pending);
+        }
+        finally
+        {
+            lockObject.Release();
+        }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -508,11 +524,20 @@ public sealed class RAMJobStore : IJobStore
     private void AddTriggerNoLock(IOperableTrigger trigger, bool replace, ref PendingSignals pending)
     {
         TriggerWrapper tw = new((IOperableTrigger) trigger.Clone());
-        if (triggersByKey.ContainsKey(tw.TriggerKey))
+        if (triggersByKey.TryGetValue(tw.TriggerKey, out TriggerWrapper? replaced))
         {
             if (!replace)
             {
                 Throw.ObjectAlreadyExistsException(trigger);
+            }
+
+            // Carry the previous fire time over from the trigger being replaced, so that
+            // context.PreviousFireTimeUtc does not report "never fired" merely because the schedule was
+            // rewritten (#1834). The ADO store has done this since that fix; this store cloned the
+            // incoming trigger and dropped the old wrapper, so the two disagreed.
+            if (tw.Trigger.PreviousFireTimeUtc is null && replaced.Trigger.PreviousFireTimeUtc is not null)
+            {
+                tw.Trigger.PreviousFireTimeUtc = replaced.Trigger.PreviousFireTimeUtc;
             }
 
             // don't delete orphaned job, this trigger has the job anyways

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -58,6 +58,11 @@ internal sealed class StdScheduler : IScheduler
     public string SchedulerInstanceId => scheduler.SchedulerInstanceId;
 
     /// <summary>
+    /// The clock the proxied <see cref="QuartzScheduler" /> was built with.
+    /// </summary>
+    public TimeProvider TimeProvider => scheduler.resources.TimeProvider;
+
+    /// <summary>
     /// Get a <see cref="SchedulerMetadata"/> object describing the settings
     /// and capabilities of the scheduler instance.
     /// <para>
@@ -186,10 +191,33 @@ internal sealed class StdScheduler : IScheduler
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
     /// </summary>
     public ValueTask<DateTimeOffset> ScheduleJob(
+        IJobDetail jobDetail,
+        ITrigger trigger,
+        ScheduleJobOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(jobDetail, trigger, options, cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
+    /// </summary>
+    public ValueTask<DateTimeOffset> ScheduleJob(
         ITrigger trigger,
         CancellationToken cancellationToken = default)
     {
-        return scheduler.ScheduleJob(trigger, cancellationToken);
+        return scheduler.ScheduleJob(trigger, cancellationToken: cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
+    /// </summary>
+    public ValueTask<DateTimeOffset> ScheduleJob(
+        ITrigger trigger,
+        ScheduleJobOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.ScheduleJob(trigger, options, cancellationToken);
     }
 
     /// <summary>

--- a/src/Quartz/OneOffJobOptions.cs
+++ b/src/Quartz/OneOffJobOptions.cs
@@ -1,0 +1,100 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// What the one-call <c>ScheduleJob&lt;TJob, TInput&gt;</c> overloads may be told about the single
+/// firing they arrange, past the payload and the time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every member is optional and every default is the one the equivalent builder call would have
+/// produced, so <see langword="default" /> — what omitting the argument gives — is "a one-shot trigger
+/// with a generated name, in this job type's own group".
+/// </para>
+/// <para>
+/// Named for what the call creates rather than for the call: one off, one firing, one trigger. An
+/// overload that schedules a <em>recurring</em> job would say something else — a schedule, an end time,
+/// a calendar — and gets an options type of its own rather than nullable members here that mean
+/// nothing to this one.
+/// </para>
+/// <para>
+/// It is not <see cref="ScheduleJobOptions" />, whose one member says whether a store may over-write
+/// what it already holds. That one describes a <em>store</em> operation and is what
+/// <see cref="IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, System.Threading.CancellationToken)" />
+/// takes; this one describes the <em>trigger</em> the one-liner builds, and carries <see cref="Replace" />
+/// so that it can pass it on.
+/// </para>
+/// </remarks>
+/// <seealso cref="SchedulerJobExtensions" />
+public readonly record struct OneOffJobOptions
+{
+    /// <summary>
+    /// The trigger's name. Defaults to a generated identifier, so two calls never collide by accident;
+    /// give one when the firing has an identity of its own — a message id, a saga step — and it becomes
+    /// the handle to <see cref="IScheduler.UnscheduleJob" /> or to replace with.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// The trigger's group. Defaults to the job type's name.
+    /// </summary>
+    /// <remarks>
+    /// The group is the correlation axis: everything scheduled for one saga, one tenant or one
+    /// conversation can share a group and be listed, paused or unscheduled together.
+    /// </remarks>
+    public string? Group { get; init; }
+
+    /// <summary>
+    /// The trigger's description.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// The trigger's priority, which breaks ties when more triggers are due at once than the thread
+    /// pool can run. Defaults to <see cref="TriggerConstants.DefaultPriority" />.
+    /// </summary>
+    public int? Priority { get; init; }
+
+    /// <summary>
+    /// The execution group the firing counts against, when execution limits are in use.
+    /// </summary>
+    /// <seealso cref="ITrigger.ExecutionGroup" />
+    public string? ExecutionGroup { get; init; }
+
+    /// <summary>
+    /// What to do when the scheduler was not running at the moment the firing was due. Defaults to
+    /// <see cref="SimpleTriggerMisfireInstruction.SmartPolicy" />, which for a one-shot trigger means
+    /// fire as soon as the scheduler is back.
+    /// </summary>
+    public SimpleTriggerMisfireInstruction? MisfireInstruction { get; init; }
+
+    /// <summary>
+    /// Whether a trigger already stored under the same key is over-written rather than reported as a
+    /// conflict. Scheduling over an existing trigger is then one store operation under one lock — no
+    /// <c>CheckExists</c> / <c>UnscheduleJob</c> / <c>ScheduleJob</c> for the caller to serialize.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful together with <see cref="Name" />: a generated name has nothing to replace.
+    /// </remarks>
+    public bool Replace { get; init; }
+}

--- a/src/Quartz/SchedulerConstants.cs
+++ b/src/Quartz/SchedulerConstants.cs
@@ -120,4 +120,15 @@ public static class SchedulerConstants
     /// <seealso cref="IJob{TInput}" />
     /// <seealso cref="JobInputBuilderExtensions" />
     public const string JobInput = "QRTZ_JOB_INPUT";
+
+    /// <summary>
+    /// The <see cref="IJobDetail" /> group the one-call
+    /// <see cref="SchedulerJobExtensions.ScheduleJob{TJob, TInput}(IScheduler, TInput, DateTimeOffset, OneOffJobOptions, CancellationToken)" />
+    /// overloads keep their durable jobs in — one per job type, named after the type.
+    /// </summary>
+    /// <remarks>
+    /// Clients should not use this value for a job group of their own. It is named here so that a
+    /// dashboard, a query or a clean-up can say which jobs it means without spelling the string.
+    /// </remarks>
+    public const string ScheduledJobGroup = "QRTZ_SCHEDULED";
 }

--- a/src/Quartz/SchedulerJobExtensions.cs
+++ b/src/Quartz/SchedulerJobExtensions.cs
@@ -17,7 +17,9 @@
  */
 #endregion
 
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Quartz;
 
@@ -25,10 +27,10 @@ namespace Quartz;
 /// Scheduling a job by its type, the way the container-configured builder does.
 /// </summary>
 /// <remarks>
-/// An extension rather than an <see cref="IScheduler" /> member: it composes
-/// <see cref="JobBuilder" /> and <see cref="IScheduler.ScheduleJob(IJobDetail, ITrigger, CancellationToken)" />
-/// and needs nothing an implementation could do better, so every scheduler — including one written
-/// outside this repository — gets it without having to write it.
+/// Extensions rather than <see cref="IScheduler" /> members: they compose <see cref="JobBuilder" />,
+/// <see cref="TriggerBuilder" /> and the scheduler's own operations, and need nothing an implementation
+/// could do better, so every scheduler — including one written outside this repository — gets them
+/// without having to write them.
 /// </remarks>
 public static class SchedulerJobExtensions
 {
@@ -78,5 +80,191 @@ public static class SchedulerJobExtensions
         }
 
         return scheduler.ScheduleJob(jobBuilder.Build(), trigger, cancellationToken);
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // One firing of a typed job: a payload, a time, and nothing else to build.
+    //
+    // The imperative twin of IQuartzBuilder.ScheduleJob<TJob>, for the firings an application
+    // arranges while it runs rather than at start-up - a retry, a timeout, a reminder, the next step
+    // of a saga.
+    //
+    // One durable job per job type, many triggers. The job is stored once under
+    // (typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup) and every call adds a trigger to it,
+    // which is the shape a message bus's Quartz integration converges on: a scheduled message is a
+    // trigger, and there is no job churn to pay for. The job is ensured with AddJobOptions.Replacing,
+    // so it is idempotent and safe for several nodes to do at once, and the result is remembered per
+    // scheduler instance so the second call is one round trip rather than two.
+    //
+    // Cancelling is UnscheduleJob. Give the firing a name and the returned TriggerKey is the handle
+    // to cancel or to replace with; the durable job stays behind, one row per job type whatever the
+    // traffic.
+    // -------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The job types already ensured on a scheduler, per scheduler instance.
+    /// </summary>
+    /// <remarks>
+    /// Weak on the scheduler, so remembering does not keep a shut-down scheduler alive. The memo is only
+    /// ever an optimization: forgetting one costs an extra idempotent <see cref="IScheduler.AddJob" />,
+    /// and a stale one is corrected by the retry in <see cref="Schedule{TJob, TInput}" />.
+    /// </remarks>
+    private static readonly ConditionalWeakTable<IScheduler, ConcurrentDictionary<Type, bool>> ensuredJobs = new();
+
+    /// <summary>
+    /// Schedules one firing of <typeparamref name="TJob" /> with the given payload, at the given time.
+    /// </summary>
+    /// <typeparam name="TJob">The job to fire.</typeparam>
+    /// <typeparam name="TInput">The payload's type, inferred from <paramref name="input" />.</typeparam>
+    /// <param name="scheduler">The scheduler to schedule on.</param>
+    /// <param name="input">The payload the firing carries, put on the trigger.</param>
+    /// <param name="at">When the job should run.</param>
+    /// <param name="options">The trigger's identity and the rest of what can be said about one firing.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The key of the trigger that was stored, which is the handle to cancel or replace it.</returns>
+    public static ValueTask<TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this IScheduler scheduler,
+        TInput input,
+        DateTimeOffset at,
+        OneOffJobOptions options = default,
+        CancellationToken cancellationToken = default) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return Schedule<TJob, TInput>(scheduler, input, at, options, cancellationToken);
+    }
+
+    /// <inheritdoc cref="ScheduleJob{TJob, TInput}(IScheduler, TInput, DateTimeOffset, OneOffJobOptions, CancellationToken)" />
+    /// <param name="scheduler">The scheduler to schedule on.</param>
+    /// <param name="input">The payload the firing carries, put on the trigger.</param>
+    /// <param name="delay">How long from now the job should run.</param>
+    /// <param name="options">The trigger's identity and the rest of what can be said about one firing.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <remarks>
+    /// "Now" is <see cref="IScheduler.TimeProvider" />, so a delay is measured against the same clock
+    /// the scheduling loop will compare it to.
+    /// </remarks>
+    public static ValueTask<TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        this IScheduler scheduler,
+        TInput input,
+        TimeSpan delay,
+        OneOffJobOptions options = default,
+        CancellationToken cancellationToken = default) where TJob : IJob<TInput>
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return Schedule<TJob, TInput>(scheduler, input, scheduler.TimeProvider.GetUtcNow() + delay, options, cancellationToken);
+    }
+
+    private static async ValueTask<TriggerKey> Schedule<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        IScheduler scheduler,
+        TInput input,
+        DateTimeOffset at,
+        OneOffJobOptions options,
+        CancellationToken cancellationToken) where TJob : IJob<TInput>
+    {
+        JobKey jobKey = JobKeyFor<TJob>();
+        await EnsureJob<TJob>(scheduler, cancellationToken).ConfigureAwait(false);
+
+        ITrigger trigger = BuildTrigger<TJob, TInput>(scheduler, jobKey, input, at, options);
+        ScheduleJobOptions storeOptions = new() { Replace = options.Replace };
+
+        try
+        {
+            await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
+        }
+        catch (JobPersistenceException)
+        {
+            // A store refuses a trigger whose job is missing, and the job can go missing under a memo
+            // that says it is there: another node cleared the schedule, an operator deleted it, the
+            // database was restored. Forget what was remembered, put the job back and try once. A
+            // second failure, or a failure with the job present, is the caller's to see.
+            Forget<TJob>(scheduler);
+
+            if (await scheduler.Exists(jobKey, cancellationToken).ConfigureAwait(false))
+            {
+                throw;
+            }
+
+            await EnsureJob<TJob>(scheduler, cancellationToken).ConfigureAwait(false);
+            await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        return trigger.Key;
+    }
+
+    /// <summary>
+    /// The single durable job every firing of <typeparamref name="TJob" /> hangs off.
+    /// </summary>
+    private static JobKey JobKeyFor<TJob>() where TJob : IJob
+    {
+        return new JobKey(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup);
+    }
+
+    private static ValueTask EnsureJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
+        IScheduler scheduler,
+        CancellationToken cancellationToken) where TJob : IJob
+    {
+        ConcurrentDictionary<Type, bool> ensured = ensuredJobs.GetOrCreateValue(scheduler);
+        if (ensured.ContainsKey(typeof(TJob)))
+        {
+            return default;
+        }
+
+        return Store(scheduler, ensured, cancellationToken);
+
+        static async ValueTask Store(IScheduler scheduler, ConcurrentDictionary<Type, bool> ensured, CancellationToken cancellationToken)
+        {
+            IJobDetail job = JobBuilder.Create<TJob>()
+                .WithIdentity(JobKeyFor<TJob>())
+                .WithDescription($"Scheduled firings of {typeof(TJob).FullName}.")
+                .StoreDurably()
+                .Build();
+
+            // Replacing rather than asking first: storing the same durable job over itself is what every
+            // node in a cluster does, and it neither races nor throws. Asking would be a round trip and
+            // a window.
+            await scheduler.AddJob(job, AddJobOptions.Replacing, cancellationToken).ConfigureAwait(false);
+            ensured[typeof(TJob)] = true;
+        }
+    }
+
+    private static void Forget<TJob>(IScheduler scheduler) where TJob : IJob
+    {
+        if (ensuredJobs.TryGetValue(scheduler, out ConcurrentDictionary<Type, bool>? ensured))
+        {
+            ensured.TryRemove(typeof(TJob), out _);
+        }
+    }
+
+    private static ITrigger BuildTrigger<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+        IScheduler scheduler,
+        JobKey jobKey,
+        TInput input,
+        DateTimeOffset at,
+        OneOffJobOptions options) where TJob : IJob<TInput>
+    {
+        // The scheduler's clock rather than the machine's: the trigger built here is Quartz's, not the
+        // caller's, so it has to compute its fire times from what the scheduling loop calls "now".
+        TriggerBuilder<TJob> builder = TriggerBuilder.Create<TJob>(scheduler.TimeProvider)
+            .WithIdentity(options.Name ?? Guid.NewGuid().ToString(), options.Group ?? typeof(TJob).Name)
+            .ForJob(jobKey)
+            .StartAt(at)
+            .WithDescription(options.Description)
+            .WithExecutionGroup(options.ExecutionGroup)
+            .UsingInput(input);
+
+        if (options.Priority is { } priority)
+        {
+            builder = builder.WithPriority(priority);
+        }
+
+        if (options.MisfireInstruction is { } misfireInstruction)
+        {
+            // The schedule is otherwise left at its default, which is a simple trigger that fires once.
+            builder = builder.WithSimpleSchedule(schedule => schedule.WithMisfireInstruction(misfireInstruction));
+        }
+
+        return builder.Build();
     }
 }


### PR DESCRIPTION
Closes #3522.

Rebased onto `main` at `137011184` — #3544 has merged, so this branch now carries only its own commit and targets `main` directly.

`MassTransit.QuartzIntegration` hand-rolls upsert three times over — `Exists` → `UnscheduleJob` → `ScheduleJob(trigger)` — and partitions its consumers by correlation id purely to serialize those round trips. There was no overload to reach for.

```csharp
// Was: three round trips and a window in which another node can interleave.
await scheduler.ScheduleJob(trigger, ScheduleJobOptions.Replacing, cancellationToken);

// And the whole thing, for a job that declares its input:
TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
    invoice,
    TimeSpan.FromDays(7),
    new OneOffJobOptions { Name = $"invoice-{invoice.CustomerId}", Group = invoice.CustomerId, Replace = true });

await scheduler.UnscheduleJob(firing);
```

## What changed

**Two `IScheduler` overloads that take `ScheduleJobOptions`.** The trigger-only form goes to `IJobStore.AddTrigger(trigger, options.Replace)`, which takes `SchedulerLock.TriggerAccess` on an ADO store and the single lock on the in-memory one. The job-and-trigger form goes to `IJobStore.ScheduleJobs(single-entry dictionary, options.Replace)`, so the job and its trigger are written under one lock.

**The overloads that take no options are untouched.** `QuartzScheduler.ScheduleJob(jobDetail, trigger, ct)` still calls `IJobStore.ScheduleJob(job, trigger)`, so that SPI member keeps its caller and the span and metric a store reports for the plain call keep their names. The two shapes meet in a private `DoScheduleJob(…, ScheduleJobOptions? options, …)` whose `null` means "the caller used the overload that takes none".

**`options` is mandatory on both new overloads**, which is the one place this PR deviates from the house rule that a call-site-argument options parameter carries `= default`. A default would leave `ScheduleJob(trigger)` and `ScheduleJob(job, trigger)` with no single best candidate. `OptionsConventionTest` grew a named exemption list rather than having its rule weakened — the entries name the exact overload and say why.

**RAM/ADO parity: a replaced trigger keeps its previous fire time.** ADO has carried it over since #1834; `RAMJobStore.AddTriggerNoLock` built `new TriggerWrapper((IOperableTrigger) trigger.Clone())` and dropped the old wrapper, so the same code reported "never fired" on one store and a real time on the other. Fixed, and pinned in `JobStoreContractTest` on every dialect — the new case fails on the in-memory store without the fix (verified by reverting it):

> Expected `(Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc` to represent the same point in time as `<2026-08-30 15:12:17 +0h>` … but found a `<null> DateTimeOffset`.

A caller who *means* to reset the history still can: a `PreviousFireTimeUtc` supplied on the incoming trigger wins, which is also pinned. And a trigger replaced into a paused group is still born paused on both stores, so an upsert is not a way out of a pause.

**`RAMJobStore.ScheduleJob` takes its lock once.** It called `AddJob` then `AddTrigger`, each acquiring `lockObject`, so between them a job was visible without the trigger that gives it a reason to exist. The ADO store has always done both inside one `ExecuteInLock`.

**`IScheduler.TimeProvider`, a default interface member.** A scheduler now says which clock it keeps, answering `TimeProvider.System` by default so nothing has to implement it:

| Scheduler | Answers |
|---|---|
| `StdScheduler` | the `TimeProvider` the scheduler was configured with |
| `DelegatingScheduler` | whatever it decorates |
| `DeferredScheduler` | the built scheduler's, or the system clock while there is no scheduler yet — the field, not `Resolved`, because reading a clock is not a reason to build a scheduler |
| `HttpScheduler` | the system clock, with an XML doc saying why a remote clock cannot be fetched over a wire |

Code that builds a trigger *for* a scheduler can now read the clock the scheduling loop will compare its answer to instead of reaching for `DateTimeOffset.UtcNow`. The one-liner below uses it for both its `TimeSpan` form and the trigger it builds, and the XML doc names the other case it serves: a job rescheduling itself from inside `Execute` reads `context.Scheduler.TimeProvider`.

**`OneOffJobOptions` is named for what the call creates**, not for the call: one off, one firing, one trigger. An overload that schedules a *recurring* job would have something else to say — a schedule, an end time, a calendar — and gets an options type of its own rather than nullable members here that mean nothing to a single firing. (It was `ScheduledJobOptions` in the first revision of this PR, one letter from `ScheduleJobOptions`, which is a name a reader can get wrong silently.)

**The one-liner, on `SchedulerJobExtensions`.** `ScheduleJob<TJob, TInput>(input, at | delay, OneOffJobOptions)` lives beside #3546's `ScheduleJob<TJob>(trigger, configure)` rather than in a class of its own. It stores **one durable job per job type**, under `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`, and one trigger per call. That is MassTransit's proven shape: a scheduled message is a trigger, so there is no job churn however many firings are in flight. The job is ensured with `AddJobOptions.Replacing` (idempotent, cluster-safe, no exception-driven flow) and memoized per scheduler instance in a `ConditionalWeakTable`; a store that reports the job missing has the memo dropped, the job put back and the firing retried once. The returned `TriggerKey` is the handle to cancel (`UnscheduleJob`) or to replace with, and the trigger group is the correlation axis.

**Over HTTP.** `ScheduleJobRequest` gains `bool Replace = false`, `HttpScheduler` implements both new overloads, the OpenAPI shape gains the property, and `TriggerEndpoints.ScheduleJob` passes it through. A request that omits it behaves exactly as before. No wire snapshot moved — they snapshot response bodies, and this is a request field.

## Public API baseline — every line that moved

Accepted through the Verify flow (received → verified, never hand-edited). **24 lines added, none removed or changed.**

### `src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt` — 21 added

```csharp
// Quartz.IScheduler
System.TimeProvider TimeProvider { get; }
ValueTask<DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default);
ValueTask<DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default);

// Quartz.OneOffJobOptions — new
public readonly struct OneOffJobOptions : System.IEquatable<Quartz.OneOffJobOptions>
{
    public string? Description { get; init; }
    public string? ExecutionGroup { get; init; }
    public string? Group { get; init; }
    public Quartz.SimpleTriggerMisfireInstruction? MisfireInstruction { get; init; }
    public string? Name { get; init; }
    public int? Priority { get; init; }
    public bool Replace { get; init; }
}

// Quartz.SchedulerConstants
public const string ScheduledJobGroup = "QRTZ_SCHEDULED";

// Quartz.SchedulerJobExtensions — added to the class #3546 introduced
public static ValueTask<Quartz.TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.DateTimeOffset at, Quartz.OneOffJobOptions options = default, CancellationToken cancellationToken = default)
    where TJob : Quartz.IJob<TInput> { }
public static ValueTask<Quartz.TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(...)] TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.TimeSpan delay, Quartz.OneOffJobOptions options = default, CancellationToken cancellationToken = default)
    where TJob : Quartz.IJob<TInput> { }

// Quartz.Impl.DelegatingScheduler
public virtual System.TimeProvider TimeProvider { get; }
public virtual ValueTask<DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default) { }
public virtual ValueTask<DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default) { }
```

(The `DynamicallyAccessedMembers` argument is the full `JobTypeMembers.Required` set the builders already declare; elided above only for width.)

### `src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt` — 3 added

```csharp
// Quartz.HttpClient.HttpScheduler
public System.TimeProvider TimeProvider { get; }
public ValueTask<DateTimeOffset> ScheduleJob(Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default) { }
public ValueTask<DateTimeOffset> ScheduleJob(Quartz.IJobDetail jobDetail, Quartz.ITrigger trigger, Quartz.ScheduleJobOptions options, CancellationToken cancellationToken = default) { }
```

Nothing moved in `src/Quartz.Tests.AspNetCore/Verify/`. All three sections are written up in `docs/documentation/quartz-4.x/migration-guide.md` — "Scheduling a trigger can replace one atomically", "A scheduler says which clock it keeps" and "A typed job can be scheduled in one call" — plus a "A payload and a time, in one call" section in `how-tos/one-off-job.md` with a compiled `#region sample_one_off_job_typed_one_liner`.

## Verification

```
dotnet build Quartz.slnx                                        0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit                               3893 passed, 0 failed
dotnet test src/Quartz.Tests.AspNetCore                          537 passed, 0 failed
dotnet test src/Quartz.Tests.Integration (RAM + SQLite ×2)       255 passed, 0 failed
dotnet test src/Quartz.Tests.Integration (Postgres, Docker)       85 passed, 0 failed   [before the rebase]
dotnet fallout PublishTrimmed                                   canary exit 0           [before the rebase]
native AOT publish + run of Quartz.Trimming.Canary              exit 0                  [before the rebase]
dotnet fallout DocsSnippets                                     94 markdown files, up to date
npm run docs:check-links                                        916 links, 560 fragments, no dead links or anchors
npm run docs:lint                                               only the pre-existing errors; none in the added ranges
```

The Postgres leg and the two canary legs were run against the pre-rebase tree; nothing in the rebase or in the three follow-up changes touches the ADO store or the trimming surface. The other dialect legs (SQL Server, MySQL, Oracle, Firebird) were not run locally — CI covers them, and nothing here is dialect-specific.

`dotnet fallout PublishAot` fails on this machine at ILCompiler's native link step because `vswhere.exe` is not on the shell's `PATH`; the identical publish with it on `PATH` succeeds and the executable exits 0.

## Tests

- `src/Quartz.Tests.Unit/SchedulerTest.cs` — nine new cases: the trigger-only upsert (and that it still refuses without `Replace`); the job-and-trigger upsert; the one-liner storing one durable job and one trigger per call, with the payload on the trigger; replacing a named firing; refusing to replace an unnamed one; the delay overload; the durable job being put back after it goes missing; and the firing actually running with its payload.
- `src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs` — three new cases on every dialect fixture: the previous fire time surviving a replace, a caller-supplied one winning, and a replace into a paused group being born paused.
- `src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs` — the existing schedule tests now assert `Replace` is false when nobody asked, plus a new case that a `true` reaches the scheduler through both HTTP overloads. `RequestDelegatesAreSourceGeneratedTest` still green.
- `src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs` — the mandatory-options exemption list, keyed by full signature so it names one overload rather than every member sharing a name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
