### PR TITLE
Quartz.Aspire wires a persistent store from an Aspire connection name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,12 @@ internals behind them.
   so it is core rather than `Quartz.AspNetCore`, whose `FrameworkReference` a `dotnet/runtime` image
   cannot satisfy (#3532).
 - `Quartz.AspNetCore` — the HTTP API, and `MapHealthChecks` territory such as `ResultStatusCodes`.
+- `Quartz.Aspire` — `builder.AddQuartzPersistentStore(connectionName)`, which turns an Aspire connection
+  name into a persistent store, its telemetry subscriptions and its health check. It takes **no `Aspire.*`
+  package dependency** — `IHostApplicationBuilder` is the whole contract — and contributes through
+  `ConfigureAllQuartzSchedulers`, so it is order-independent with `AddQuartz`. Its hand-written
+  `ConfigurationSchema.json` is held to `QuartzAspireSettings` by a test, because Aspire's generator for
+  that file has never shipped.
 
 The container constructs the scheduler; there is no reflective instantiation from type-name strings, and
 there is no properties-based `StdSchedulerFactory` any more. Legacy flat `quartz.*` keys are translated

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.Data.SQLite" Version="11.0.0-preview.7.26381.103" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -36,6 +36,7 @@
   <Project Path="build/_build.csproj">
     <Build Project="false" />
   </Project>
+  <Project Path="src/Quartz.Aspire/Quartz.Aspire.csproj" />
   <Project Path="src/Quartz.AspNetCore/Quartz.AspNetCore.csproj" />
   <Project Path="src/Quartz.Dashboard/Quartz.Dashboard.csproj" />
   <Project Path="src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj" />

--- a/docs/documentation/quartz-4.x/how-tos/aspire.md
+++ b/docs/documentation/quartz-4.x/how-tos/aspire.md
@@ -17,8 +17,15 @@ connections from a `DbDataSource` the container holds. What is left is naming th
 the pipeline ServiceDefaults built, and pointing the store at the database the AppHost started. This page is
 exactly that list, and it is short.
 
-There is no Quartz integration for Aspire — no `Aspire.Hosting.Quartz` package, no `AddQuartz` resource for
-the AppHost. Everything here is ordinary Quartz configuration in an application that Aspire happens to be
+[`Quartz.Aspire`](https://www.nuget.org/packages/Quartz.Aspire) does the database half of that list in one
+call: `builder.AddQuartzPersistentStore("quartz")` reads that connection name, chooses the driver delegate
+for the database behind it, takes connections from a `DbDataSource` the container holds, registers the
+health check and names both telemetry signals. It takes no `Aspire.*` package dependency. The rest of this
+page is what that call does, written out by hand — worth reading because every line of it is ordinary
+Quartz configuration, and an application that wants to say part of it itself still can.
+
+There is no *hosting* integration — no `Aspire.Hosting.Quartz` package, no `AddQuartz` resource for the
+AppHost. Everything below is ordinary Quartz configuration in an application that Aspire happens to be
 running.
 
 ## The two lines that do the integration

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -114,6 +114,27 @@ instead — see [OpenTelemetry Integration](packages/opentelemetry-integration.m
 + <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
 ```
 
+### `Quartz.Aspire` is new
+
+Nothing to migrate: it is a new package with no 3.x counterpart, listed here because this is where the
+package list lives.
+
+`Quartz.Aspire` is the client integration for [Aspire](https://aspire.dev/). It turns an Aspire connection
+name into a persistent job store: the driver delegate for the database behind that name, connections taken
+from a `DbDataSource` the container already holds, the scheduler's health check, and Quartz's two telemetry
+signals named to the OpenTelemetry pipeline your ServiceDefaults project built.
+
+```csharp
+builder.AddQuartzPersistentStore("quartz");
+builder.AddQuartz();
+```
+
+It takes **no `Aspire.*` package dependency** — `IHostApplicationBuilder` is the whole of its contract — so
+it works in any generic-host application and is not tied to Aspire's release cadence. There is no hosting
+integration: the AppHost still declares its database resources itself. See
+[Running Quartz under Aspire](how-tos/aspire.md) for what the call expands to, and
+`QuartzAspireSettings` for the settings it reads from `Aspire:Quartz`.
+
 ### The health check is in `Quartz`, not `Quartz.AspNetCore`
 
 `Quartz.AspNetCore` carries `<FrameworkReference Include="Microsoft.AspNetCore.App" />` for the HTTP API,

--- a/src/Quartz.Aspire/ConfigurationSchema.json
+++ b/src/Quartz.Aspire/ConfigurationSchema.json
@@ -1,0 +1,62 @@
+{
+  "type": "object",
+  "properties": {
+    "Aspire": {
+      "type": "object",
+      "properties": {
+        "Quartz": {
+          "type": "object",
+          "properties": {
+            "Clustered": {
+              "type": "boolean",
+              "description": "Gets or sets whether this scheduler takes part in a cluster with every other scheduler sharing the database. Turning it on turns database locking on with it. It does not give replicas distinct instance ids, which clustering also needs.",
+              "default": false
+            },
+            "ConnectionString": {
+              "type": "string",
+              "description": "Gets or sets the connection string reaching the database, when it is not the one Aspire injected. Left unset, ConnectionStrings:<connection name> supplies it."
+            },
+            "DisableHealthChecks": {
+              "type": "boolean",
+              "description": "Gets or sets whether the Quartz scheduler health check is left unregistered.",
+              "default": false
+            },
+            "DisableMetrics": {
+              "type": "boolean",
+              "description": "Gets or sets whether the Quartz meter is left unsubscribed. No exporter is added either way.",
+              "default": false
+            },
+            "DisableTracing": {
+              "type": "boolean",
+              "description": "Gets or sets whether the Quartz activity source is left unsubscribed. No exporter is added either way.",
+              "default": false
+            },
+            "Provider": {
+              "type": "string",
+              "description": "Gets or sets which ADO.NET driver reaches the database, as one of SqlServer, Npgsql, MySql, MySqlConnector, OracleODPManaged, SQLite-Microsoft, SQLite or Firebird - or a name the application registered a DbMetadataFactory for. Left unset, it is inferred from the connection string's shape, and an ambiguous or unrecognised shape is an error rather than a guess.",
+              "examples": [
+                "SqlServer",
+                "Npgsql",
+                "MySql",
+                "MySqlConnector",
+                "OracleODPManaged",
+                "SQLite-Microsoft",
+                "SQLite",
+                "Firebird"
+              ]
+            },
+            "SchedulerName": {
+              "type": "string",
+              "description": "Gets or sets which scheduler this store belongs to, for an application that registers more than one. Left unset, every scheduler in the container gets it."
+            },
+            "TablePrefix": {
+              "type": "string",
+              "description": "Gets or sets the prefix on the Quartz table names, when the schema was created with something other than QRTZ_."
+            }
+          },
+          "description": "Provides the client configuration settings for wiring a Quartz.NET persistent job store to a database an Aspire AppHost declared."
+        }
+      }
+    }
+  }
+}

--- a/src/Quartz.Aspire/ConfigurationSchema.json
+++ b/src/Quartz.Aspire/ConfigurationSchema.json
@@ -9,7 +9,7 @@
           "properties": {
             "Clustered": {
               "type": "boolean",
-              "description": "Gets or sets whether this scheduler takes part in a cluster with every other scheduler sharing the database. Turning it on turns database locking on with it. It does not give replicas distinct instance ids, which clustering also needs.",
+              "description": "Gets or sets whether this scheduler takes part in a cluster with every other scheduler sharing the database. Turning it on turns database locking on with it, and makes the scheduler derive its InstanceId - a cluster needs distinct ids and every scheduler starts life as NON_CLUSTERED. An InstanceId or a GenerateInstanceId the application set itself is left alone.",
               "default": false
             },
             "ConnectionString": {

--- a/src/Quartz.Aspire/ConnectionStringProviderInference.cs
+++ b/src/Quartz.Aspire/ConnectionStringProviderInference.cs
@@ -1,0 +1,294 @@
+using System.Data.Common;
+using System.Text.RegularExpressions;
+
+namespace Quartz;
+
+/// <summary>
+/// Works out which ADO.NET driver a connection string is for, from the shape of the string alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An Aspire connection name arrives as a string and nothing else: the AppHost injects
+/// <c>ConnectionStrings__quartz</c> and the worker reads it back, with no note of which resource wrote
+/// it. Quartz needs to know, because the driver delegate decides the SQL — so this reads the string's
+/// keywords and matches them against the shapes the databases Aspire ships a resource for produce.
+/// </para>
+/// <para>
+/// <strong>It refuses rather than guesses.</strong> Zero matches and two matches are both errors naming
+/// <see cref="QuartzAspireSettings.Provider"/>, because the failure a guess produces is a scheduler that
+/// starts, connects, and issues SQL the database cannot run — discovered at the first trigger
+/// acquisition rather than at startup, and not obviously about the connection string when it is.
+/// </para>
+/// <para>
+/// The shapes are matched on keywords, never on substrings: the string is parsed with
+/// <see cref="DbConnectionStringBuilder"/>, which is where quoting, escaping and repeated keywords are
+/// somebody else's problem, and each keyword is then compared with spaces and underscores removed so
+/// that <c>User ID</c>, <c>userid</c> and <c>User_Id</c> are one keyword.
+/// </para>
+/// </remarks>
+internal static class ConnectionStringProviderInference
+{
+    /// <summary>
+    /// How every driver but Npgsql spells "the machine holding the database".
+    /// </summary>
+    private static readonly string[] ServerKeywords = ["server", "datasource", "address", "addr", "networkaddress"];
+
+    /// <summary>
+    /// How a driver spells "the database on it".
+    /// </summary>
+    private static readonly string[] CatalogKeywords = ["initialcatalog", "database", "attachdbfilename"];
+
+    /// <summary>
+    /// The keywords that say authentication is Windows', which only SQL Server has.
+    /// </summary>
+    private static readonly string[] IntegratedSecurityKeywords = ["integratedsecurity", "trustedconnection"];
+
+    /// <summary>
+    /// How a driver spells "the login".
+    /// </summary>
+    private static readonly string[] UserKeywords = ["uid", "userid", "username", "user", "usr"];
+
+    /// <summary>
+    /// File extensions that mean a SQLite database file.
+    /// </summary>
+    private static readonly string[] SqliteExtensions = [".db", ".db3", ".sqlite", ".sqlite3"];
+
+    /// <summary>
+    /// Oracle's EZ-connect form — <c>host:port</c>, optionally with <c>/service</c>. It is what Aspire's
+    /// Oracle resource injects, and nothing else in this table produces a colon-then-digits data source.
+    /// </summary>
+    private static readonly Regex EasyConnect = new(
+        @"^[A-Za-z0-9_.\-]+:\d{1,5}(/[A-Za-z0-9_.\-]+)?$",
+        RegexOptions.ExplicitCapture,
+        TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Works out which provider <paramref name="connectionString"/> is for.
+    /// </summary>
+    /// <param name="connectionString">The connection string, as the AppHost injected it.</param>
+    /// <param name="connectionName">The Aspire connection name, for the message when this fails.</param>
+    /// <returns>One of the names on <see cref="DataSourceOptions.Providers"/>.</returns>
+    /// <exception cref="SchedulerConfigException">
+    /// The string matched no shape, or more than one.
+    /// </exception>
+    public static string Infer(string connectionString, string connectionName)
+    {
+        Keywords keywords = Keywords.Parse(connectionString);
+
+        List<string> matches = [];
+
+        if (IsNpgsql(keywords))
+        {
+            matches.Add(DataSourceOptions.Providers.Npgsql);
+        }
+
+        if (IsSqlServer(keywords))
+        {
+            matches.Add(DataSourceOptions.Providers.SqlServer);
+        }
+
+        if (IsMySqlConnector(keywords))
+        {
+            matches.Add(DataSourceOptions.Providers.MySqlConnector);
+        }
+
+        if (IsSqlite(keywords))
+        {
+            matches.Add(DataSourceOptions.Providers.Sqlite);
+        }
+
+        if (IsOracle(keywords))
+        {
+            matches.Add(DataSourceOptions.Providers.Oracle);
+        }
+
+        if (matches.Count == 1)
+        {
+            return matches[0];
+        }
+
+        throw new SchedulerConfigException(Explain(connectionName, matches));
+    }
+
+    /// <summary>
+    /// PostgreSQL, through Npgsql: <c>Host</c> is the keyword Npgsql leads with and no other driver in
+    /// this table uses, and <c>Database</c> is its catalog.
+    /// </summary>
+    /// <remarks>
+    /// <c>Uid</c> disqualifies it. That is the MySQL and SQL Server spelling of the login; Npgsql's own
+    /// is <c>Username</c>, and every tool that writes an Npgsql string writes that one. A string saying
+    /// <c>Host</c> and <c>Uid</c> together is a MySQL string written the long way round, and refusing it
+    /// is better than reading it as PostgreSQL.
+    /// </remarks>
+    private static bool IsNpgsql(Keywords keywords)
+    {
+        return keywords.Has("host") && keywords.Has("database") && !keywords.Has("uid");
+    }
+
+    /// <summary>
+    /// Microsoft SQL Server: a server keyword together with a catalog or an integrated-security keyword.
+    /// </summary>
+    /// <remarks>
+    /// <c>Port</c> and <c>Host</c> disqualify it, and that is the rule that keeps a MySQL string out.
+    /// <c>Microsoft.Data.SqlClient</c> accepts neither keyword — passing one to
+    /// <c>SqlConnectionStringBuilder</c> throws — because SQL Server writes the port into the server
+    /// itself, as <c>Server=host,1433</c>. Aspire's SQL Server and MySQL resources otherwise inject
+    /// almost the same string, so without this they would be ambiguous with each other.
+    /// </remarks>
+    private static bool IsSqlServer(Keywords keywords)
+    {
+        return keywords.HasAny(ServerKeywords)
+               && (keywords.HasAny(CatalogKeywords) || keywords.HasAny(IntegratedSecurityKeywords))
+               && !keywords.Has("port")
+               && !keywords.Has("host");
+    }
+
+    /// <summary>
+    /// MySQL, through MySqlConnector: a server keyword, an explicit port and a login.
+    /// </summary>
+    /// <remarks>
+    /// <c>Host</c> disqualifies it, so that PostgreSQL's shape cannot also read as MySQL's. MySqlConnector
+    /// does accept <c>Host</c> as a synonym for <c>Server</c>, so a MySQL string written that way is
+    /// refused rather than misread — which is the trade this whole table makes.
+    /// </remarks>
+    private static bool IsMySqlConnector(Keywords keywords)
+    {
+        return keywords.HasAny(ServerKeywords)
+               && !keywords.Has("host")
+               && keywords.Has("port")
+               && keywords.HasAny(UserKeywords);
+    }
+
+    /// <summary>
+    /// SQLite: a data source naming a database file, or an in-memory database.
+    /// </summary>
+    private static bool IsSqlite(Keywords keywords)
+    {
+        return keywords.Value("datasource") is { } dataSource && IsSqliteTarget(dataSource, keywords);
+    }
+
+    /// <summary>
+    /// Oracle: a data source holding a TNS descriptor or an EZ-connect string.
+    /// </summary>
+    /// <remarks>
+    /// Both put the host and the port inside the data source, so a <c>Host</c> or <c>Port</c> keyword
+    /// beside one says the string is not Oracle's. A bare TNS alias — <c>Data Source=orcl</c> — is
+    /// deliberately not recognised: it is indistinguishable from a SQL Server instance name, and
+    /// guessing between the two is exactly what this refuses to do.
+    /// </remarks>
+    private static bool IsOracle(Keywords keywords)
+    {
+        if (keywords.Value("datasource") is not { } dataSource)
+        {
+            return false;
+        }
+
+        if (keywords.Has("host") || keywords.Has("port"))
+        {
+            return false;
+        }
+
+        string trimmed = dataSource.Trim();
+
+        bool tnsDescriptor = trimmed.StartsWith('(')
+                             && trimmed.Contains("description", StringComparison.OrdinalIgnoreCase);
+
+        return tnsDescriptor || EasyConnect.IsMatch(trimmed);
+    }
+
+    private static bool IsSqliteTarget(string dataSource, Keywords keywords)
+    {
+        if (string.Equals(keywords.Value("mode"), "memory", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        string trimmed = dataSource.Trim();
+
+        return string.Equals(trimmed, ":memory:", StringComparison.OrdinalIgnoreCase)
+               || SqliteExtensions.Any(extension => trimmed.EndsWith(extension, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// What to say when the string matched nothing, or matched twice.
+    /// </summary>
+    /// <remarks>
+    /// Both messages name the property that ends the argument and the class holding the values it takes,
+    /// because the reader of this message is looking at a stack trace rather than at this file.
+    /// </remarks>
+    private static string Explain(string connectionName, List<string> matches)
+    {
+        string problem = matches.Count == 0
+            ? "matches none of the connection-string shapes Quartz recognises"
+            : $"matches {string.Join(" and ", matches)}, and Quartz will not choose between them";
+
+        return $"The connection string named '{connectionName}' {problem}, so Quartz cannot tell which "
+               + "database it is for. Say so: set QuartzAspireSettings.Provider to one of the names on "
+               + "DataSourceOptions.Providers - for instance "
+               + $"builder.AddQuartzPersistentStore(\"{connectionName}\", settings => settings.Provider = "
+               + "DataSourceOptions.Providers.Npgsql), or the configuration key "
+               + $"Aspire:Quartz:{connectionName}:Provider. Inferring it would pick the driver delegate "
+               + "that writes the SQL, and the wrong one fails at the first trigger acquisition rather "
+               + "than here.";
+    }
+
+    /// <summary>
+    /// A connection string's keywords, normalized so that spelling variations are one keyword.
+    /// </summary>
+    private sealed class Keywords
+    {
+        private readonly Dictionary<string, string> values;
+
+        private Keywords(Dictionary<string, string> values) => this.values = values;
+
+        /// <summary>
+        /// Parses a connection string, treating one it cannot parse as having no keywords at all.
+        /// </summary>
+        /// <remarks>
+        /// A malformed string is a real possibility — it arrives from an environment variable — and the
+        /// message this produces then is the one that helps, naming the connection and the property that
+        /// settles it, rather than <see cref="DbConnectionStringBuilder"/>'s complaint about a character.
+        /// The driver reports the syntax error itself on the first connection, in its own words.
+        /// </remarks>
+        public static Keywords Parse(string connectionString)
+        {
+            Dictionary<string, string> values = new(StringComparer.Ordinal);
+
+            DbConnectionStringBuilder parsed = new();
+
+            try
+            {
+                parsed.ConnectionString = connectionString;
+            }
+            catch (ArgumentException)
+            {
+                return new Keywords(values);
+            }
+
+            foreach (string key in parsed.Keys.Cast<string>())
+            {
+                values[Normalize(key)] = parsed[key]?.ToString() ?? "";
+            }
+
+            return new Keywords(values);
+        }
+
+        public bool Has(string keyword) => values.ContainsKey(keyword);
+
+        public bool HasAny(string[] keywords) => keywords.Any(values.ContainsKey);
+
+        public string? Value(string keyword) => values.GetValueOrDefault(keyword);
+
+        /// <summary>
+        /// Lower-cased with spaces and underscores removed, which is how the drivers themselves treat a
+        /// keyword: <c>User ID</c>, <c>userid</c> and <c>User_Id</c> all name one thing.
+        /// </summary>
+        private static string Normalize(string keyword)
+        {
+            return keyword
+                .Replace(" ", "", StringComparison.Ordinal)
+                .Replace("_", "", StringComparison.Ordinal)
+                .ToLowerInvariant();
+        }
+    }
+}

--- a/src/Quartz.Aspire/Quartz.Aspire.csproj
+++ b/src/Quartz.Aspire/Quartz.Aspire.csproj
@@ -1,0 +1,73 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Quartz</RootNamespace>
+    <Title>Quartz.NET Aspire Integration</Title>
+    <Description>Quartz.NET Aspire client integration - wires a persistent job store, its telemetry and its health check from an Aspire connection name; $(Description)</Description>
+    <PackageTags>$(PackageTags);aspire;aspire-integration</PackageTags>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!--
+      Binding is the compiler's job here, not the reflection binder's, for the same reason it is in
+      Quartz.csproj: ConfigurationBinder.Bind says both RequiresUnreferencedCode and RequiresDynamicCode,
+      and the generator intercepts the call sites in the project they are written in. The two Bind calls
+      that read QuartzAspireSettings are this package's, so this is where the property has to be set —
+      an application turning it on does nothing for them.
+
+      Turning it off is not a quiet change: the IL2026 and IL3050 those two calls raise come straight
+      back as errors, since nothing here suppresses them.
+    -->
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!--
+      Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431),
+      exactly as Quartz.AspNetCore and Quartz.Extensions.Redis have them.
+
+      There is one warning to report and it is deliberate: AddQuartzPersistentStore chooses the dialect
+      from a provider name, so it calls UsePostgres, UseSqlServer and their siblings — the overloads
+      that resolve the driver's connection, command and parameter types from strings and say
+      [RequiresUnreferencedCode] about it. The method repeats that annotation rather than swallowing it,
+      so the warning arrives at the application's own call site where the decision belongs. That is the
+      whole of it: there is no TrimAnalysisBaseline.cs beside this file, and any other warning appearing
+      here is a new one to fix rather than to baseline.
+    -->
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <!--
+      The JSON schema an IDE reads to complete and validate an "Aspire" section in appsettings.json.
+      Aspire's own components generate this file from XML documentation with a source generator that has
+      never shipped (microsoft/aspire#3309), so it is written by hand and held to the settings type by
+      ConfigurationSchemaTest. It goes to the package root, which is where the targets below point.
+    -->
+    <None Include="ConfigurationSchema.json" Pack="true" PackagePath="\" />
+    <!--
+      What tells the SDK that the file above is a schema segment for appsettings.json. The item name and
+      the relative path are Aspire's convention, copied from src/Components/Common/Package.targets in
+      microsoft/aspire; buildTransitive means a project referencing this package transitively gets it too.
+    -->
+    <None Include="buildTransitive\net10.0\Quartz.Aspire.targets" Pack="true" PackagePath="buildTransitive\net10.0\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      No Aspire.* package reference, deliberately: a first-party client integration has none either, and
+      taking one would tie this package's supported versions to Aspire's monthly release cadence for no
+      type it actually needs. IHostApplicationBuilder is the whole of the contract, and it belongs to
+      Microsoft.Extensions.Hosting.Abstractions.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
+++ b/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
@@ -1,0 +1,371 @@
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+using Quartz.Diagnostics;
+
+namespace Quartz;
+
+/// <summary>
+/// Registers a Quartz persistent job store from an Aspire connection name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the page <c>how-tos/aspire.md</c> already documented, turned into one call. An Aspire AppHost
+/// declares a database and hands the worker its connection string as <c>ConnectionStrings:&lt;name&gt;</c>;
+/// everything after that — which driver delegate speaks that database's SQL, whether connections come
+/// from a <c>DbDataSource</c> the container holds or from the string itself, and naming Quartz's two
+/// telemetry signals to the pipeline ServiceDefaults built — follows from the name, and is what this
+/// does.
+/// </para>
+/// <para>
+/// It is <em>additive</em> and order-independent. The store is contributed through
+/// <c>ConfigureAllQuartzSchedulers</c>, so this may be called before or after <c>AddQuartz</c> and the
+/// container comes out the same; the scheduler is still configured by <c>AddQuartz</c> and the
+/// <c>Quartz</c> configuration section, and nothing here replaces either. What this call decides is only
+/// what an Aspire connection is evidence of.
+/// </para>
+/// <para>
+/// There is no <c>AddKeyedQuartzPersistentStore</c>, which every other Aspire client integration has.
+/// The keyed form exists so that an application can hold two of a thing, and Quartz already has an axis
+/// for that which is not the container's: a second scheduler, registered by name with
+/// <c>AddQuartz(name, …)</c>. <see cref="QuartzAspireSettings.SchedulerName"/> is how a second call to
+/// this method says which of them it means, so the two databases end up on two schedulers rather than on
+/// two keyed copies of one.
+/// </para>
+/// </remarks>
+public static class QuartzAspireHostApplicationBuilderExtensions
+{
+    /// <summary>
+    /// The configuration section these settings are bound from, before the per-connection section
+    /// beneath it. The name is Aspire's convention — <c>Aspire:&lt;integration&gt;</c> — and the second
+    /// segment is the package's own noun rather than a driver's, because this integration is about
+    /// Quartz and not about any one database.
+    /// </summary>
+    internal const string ConfigurationSectionName = "Aspire:Quartz";
+
+    /// <summary>
+    /// What choosing the dialect from a provider name costs a trimmed application, repeated from the
+    /// overloads it calls so that the warning arrives where the decision is made.
+    /// </summary>
+    private const string NamesTheDriversTypes =
+        "The database is chosen from the connection string or from QuartzAspireSettings.Provider, and on the "
+        + "connection-string path Quartz names the driver's connection, command and parameter types as "
+        + "strings, so a trimmed application has no guarantee they survived. Registering a DbDataSource in "
+        + "the container removes that: connections come from it, and only the half of the driver description "
+        + "that names no type is read. Otherwise configure the store directly, with the overload that takes "
+        + "the driver's DbProviderFactory.";
+
+    /// <summary>
+    /// Gives every Quartz scheduler in the application a persistent job store on the database Aspire
+    /// injected under <paramref name="connectionName"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The settings are read from <c>Aspire:Quartz</c>, then from <c>Aspire:Quartz:&lt;connectionName&gt;</c>
+    /// over it, then <c>ConnectionStrings:&lt;connectionName&gt;</c> supplies the connection string when
+    /// there is one, and <paramref name="configureSettings"/> has the last word.
+    /// </para>
+    /// <para>
+    /// Where connections come from is decided here, against the services registered so far, so the
+    /// answer does not depend on when the per-scheduler configuration happens to run. That makes the
+    /// order of <em>this</em> call and the client integration registering the data source significant,
+    /// and only that one: register the data source first, as Aspire's own samples do.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The host application builder.</param>
+    /// <param name="connectionName">
+    /// The name the AppHost gave the database resource, which is the name its connection string arrives
+    /// under and the service key a keyed <c>DbDataSource</c> would be registered with.
+    /// </param>
+    /// <param name="configureSettings">Applied last, over everything configuration said.</param>
+    /// <exception cref="SchedulerConfigException">
+    /// No provider was named and the connection string's shape matches no database, or more than one.
+    /// </exception>
+    [RequiresUnreferencedCode(NamesTheDriversTypes)]
+    public static IHostApplicationBuilder AddQuartzPersistentStore(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<QuartzAspireSettings>? configureSettings = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionName);
+
+        QuartzAspireSettings settings = ReadSettings(builder.Configuration, connectionName, configureSettings);
+        string provider = ResolveProvider(settings, connectionName);
+        Action<DataSourceOptions> connection = SelectConnection(builder.Services, provider, connectionName, settings);
+
+        string? schedulerName = string.IsNullOrWhiteSpace(settings.SchedulerName) ? null : settings.SchedulerName;
+        string? tablePrefix = string.IsNullOrWhiteSpace(settings.TablePrefix) ? null : settings.TablePrefix;
+        bool clustered = settings.Clustered;
+        bool healthChecks = !settings.DisableHealthChecks;
+
+        builder.Services.ConfigureAllQuartzSchedulers(quartz =>
+        {
+            // A settings object naming a scheduler is talking about that one. Naming none is the single
+            // scheduler an application normally has, said without having to know its name.
+            if (schedulerName is not null && !string.Equals(quartz.SchedulerName, schedulerName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            quartz.UsePersistentStore(store =>
+            {
+                UseDialect(store, provider, connection);
+
+                if (tablePrefix is not null)
+                {
+                    store.ConfigureStore(options => options.TablePrefix = tablePrefix);
+                }
+
+                if (clustered)
+                {
+                    store.UseClustering();
+                }
+            });
+
+            if (healthChecks)
+            {
+                quartz.AddQuartzHealthChecks();
+            }
+        });
+
+        AddTelemetry(builder.Services, settings);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Reads the settings: the shared section, the connection's own section over it, the injected
+    /// connection string, and then the caller.
+    /// </summary>
+    /// <remarks>
+    /// The order is the one every first-party Aspire client integration uses, and each step is more
+    /// specific than the one before it. The connection string comes after both sections because
+    /// <c>ConnectionStrings:&lt;name&gt;</c> is what the AppHost actually injected, and a stale
+    /// <c>ConnectionString</c> left in an appsettings file should not beat it.
+    /// </remarks>
+    private static QuartzAspireSettings ReadSettings(
+        IConfiguration configuration,
+        string connectionName,
+        Action<QuartzAspireSettings>? configureSettings)
+    {
+        QuartzAspireSettings settings = new();
+
+        IConfigurationSection section = configuration.GetSection(ConfigurationSectionName);
+        section.Bind(settings);
+        section.GetSection(connectionName).Bind(settings);
+
+        if (configuration.GetConnectionString(connectionName) is { Length: > 0 } connectionString)
+        {
+            settings.ConnectionString = connectionString;
+        }
+
+        configureSettings?.Invoke(settings);
+
+        return settings;
+    }
+
+    /// <summary>
+    /// Which driver reaches the database: what the settings said, or what the connection string's shape
+    /// says.
+    /// </summary>
+    /// <remarks>
+    /// A named provider is canonicalized so that <c>npgsql</c> and <c>Npgsql</c> mean the same thing —
+    /// the driver descriptions are looked up by an ordinal comparison, and a case that does not match is
+    /// otherwise a failure at the first connection. A name Quartz ships no description for passes
+    /// through as written, because that is a description the application registered.
+    /// </remarks>
+    private static string ResolveProvider(QuartzAspireSettings settings, string connectionName)
+    {
+        if (!string.IsNullOrWhiteSpace(settings.Provider))
+        {
+            return Canonical(settings.Provider);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ConnectionString))
+        {
+            throw new SchedulerConfigException(
+                $"No connection string named '{connectionName}' was found, and no provider was named, so "
+                + "Quartz has nothing to work out which database it is for from. Under Aspire the string "
+                + $"arrives from the AppHost's WithReference, as ConnectionStrings:{connectionName}; "
+                + "without one, set QuartzAspireSettings.Provider to a name on DataSourceOptions.Providers "
+                + "and configure the connection yourself.");
+        }
+
+        return ConnectionStringProviderInference.Infer(settings.ConnectionString, connectionName);
+    }
+
+    /// <summary>
+    /// The names Quartz ships a driver description for, indexed case-insensitively.
+    /// </summary>
+    private static readonly Dictionary<string, string> KnownProviders = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [DataSourceOptions.Providers.SqlServer] = DataSourceOptions.Providers.SqlServer,
+        [DataSourceOptions.Providers.Npgsql] = DataSourceOptions.Providers.Npgsql,
+        [DataSourceOptions.Providers.MySql] = DataSourceOptions.Providers.MySql,
+        [DataSourceOptions.Providers.MySqlConnector] = DataSourceOptions.Providers.MySqlConnector,
+        [DataSourceOptions.Providers.Oracle] = DataSourceOptions.Providers.Oracle,
+        [DataSourceOptions.Providers.Sqlite] = DataSourceOptions.Providers.Sqlite,
+        [DataSourceOptions.Providers.SystemDataSqlite] = DataSourceOptions.Providers.SystemDataSqlite,
+        [DataSourceOptions.Providers.Firebird] = DataSourceOptions.Providers.Firebird,
+    };
+
+    private static string Canonical(string provider) => KnownProviders.GetValueOrDefault(provider, provider);
+
+    /// <summary>
+    /// Chooses the driver delegate that speaks this database's SQL.
+    /// </summary>
+    /// <remarks>
+    /// A provider name Quartz ships no description for reaches <c>UseGenericDatabase</c>, which selects
+    /// the generic dialect and leaves the description to whatever <c>DbMetadataFactory</c> the
+    /// application registered — so naming an unknown provider is a configuration this supports rather
+    /// than an error it reports.
+    /// </remarks>
+    [RequiresUnreferencedCode(NamesTheDriversTypes)]
+    private static void UseDialect(IPersistentStoreBuilder store, string provider, Action<DataSourceOptions> connection)
+    {
+        switch (provider)
+        {
+            case DataSourceOptions.Providers.SqlServer:
+                store.UseSqlServer(connection);
+                break;
+            case DataSourceOptions.Providers.Npgsql:
+                store.UsePostgres(connection);
+                break;
+            case DataSourceOptions.Providers.MySql:
+                store.UseMySql(connection);
+                break;
+            case DataSourceOptions.Providers.MySqlConnector:
+                store.UseMySqlConnector(connection);
+                break;
+            case DataSourceOptions.Providers.Oracle:
+                store.UseOracle(connection);
+                break;
+            case DataSourceOptions.Providers.Sqlite:
+                store.UseSqlite(connection);
+                break;
+            case DataSourceOptions.Providers.SystemDataSqlite:
+                store.UseSystemDataSqlite(connection);
+                break;
+            case DataSourceOptions.Providers.Firebird:
+                store.UseFirebird(connection);
+                break;
+            default:
+                store.UseGenericDatabase(provider, connection);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Where the store's connections come from: a keyed <see cref="DbDataSource"/>, the container's one
+    /// unkeyed data source, or the connection string.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the how-to page's ladder as code. A data source is preferred because whatever it was built
+    /// with is then in play for Quartz's own statements — its type mappers, its logging, its connection
+    /// multiplexing — since commands are made by the connection rather than from a driver description.
+    /// </para>
+    /// <para>
+    /// SQL Server never takes it. <c>Microsoft.Data.SqlClient</c> ships no <see cref="DbDataSource"/>
+    /// implementation and Aspire's SQL Server client integration registers a scoped <c>SqlConnection</c>
+    /// instead, so <c>UseRegisteredDataSource</c> would resolve some other database's data source or
+    /// nothing at all — and would fail at first use rather than at startup.
+    /// </para>
+    /// <para>
+    /// The probe is against the service collection as it stands at the call site, which is what makes
+    /// this deterministic: the alternative — probing inside the per-scheduler callback — would answer
+    /// differently depending on whether <c>AddQuartz</c> had already been called, since that is what
+    /// decides when the callback runs.
+    /// </para>
+    /// </remarks>
+    private static Action<DataSourceOptions> SelectConnection(
+        IServiceCollection services,
+        string provider,
+        string connectionName,
+        QuartzAspireSettings settings)
+    {
+        string? connectionString = string.IsNullOrWhiteSpace(settings.ConnectionString)
+            ? null
+            : settings.ConnectionString;
+
+        if (!string.Equals(provider, DataSourceOptions.Providers.SqlServer, StringComparison.Ordinal))
+        {
+            if (HasDataSource(services, connectionName))
+            {
+                return options => options.DataSourceServiceKey = connectionName;
+            }
+
+            if (HasDataSource(services, serviceKey: null))
+            {
+                return options => options.UseRegisteredDataSource = true;
+            }
+        }
+
+        // Both, and in that order: ConnectionString wins over ConnectionStringName when it is set, so
+        // naming the connection as well costs nothing and covers the case where the string was not in
+        // configuration at the moment this ran.
+        return options =>
+        {
+            options.ConnectionString = connectionString;
+            options.ConnectionStringName = connectionName;
+        };
+    }
+
+    private static bool HasDataSource(IServiceCollection services, object? serviceKey)
+    {
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (descriptor.ServiceType != typeof(DbDataSource))
+            {
+                continue;
+            }
+
+            if (serviceKey is null ? !descriptor.IsKeyedService : descriptor.IsKeyedService && Equals(descriptor.ServiceKey, serviceKey))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Names Quartz's two signals to the application's OpenTelemetry pipeline.
+    /// </summary>
+    /// <remarks>
+    /// No exporter. A ServiceDefaults project calls <c>UseOtlpExporter()</c> whenever
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set, and the AppHost sets it; that method may be called only
+    /// once and cannot be combined with a signal-specific <c>AddOtlpExporter()</c>, so adding one here
+    /// would turn a working application into a <see cref="NotSupportedException"/> at startup.
+    /// <c>AddOpenTelemetry()</c> itself composes — there is one tracer provider and one meter provider
+    /// per container — so this runs before or after <c>AddServiceDefaults()</c> equally well.
+    /// </remarks>
+    private static void AddTelemetry(IServiceCollection services, QuartzAspireSettings settings)
+    {
+        if (settings.DisableTracing && settings.DisableMetrics)
+        {
+            return;
+        }
+
+        IOpenTelemetryBuilder telemetry = services.AddOpenTelemetry();
+
+        if (!settings.DisableTracing)
+        {
+            telemetry.WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName));
+        }
+
+        if (!settings.DisableMetrics)
+        {
+            telemetry.WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
+        }
+    }
+}

--- a/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
+++ b/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
@@ -131,6 +131,11 @@ public static class QuartzAspireHostApplicationBuilderExtensions
                 }
             });
 
+            if (clustered)
+            {
+                GenerateAnInstanceIdUnlessOneWasChosen(quartz);
+            }
+
             if (healthChecks)
             {
                 quartz.AddQuartzHealthChecks();
@@ -140,6 +145,40 @@ public static class QuartzAspireHostApplicationBuilderExtensions
         AddTelemetry(builder.Services, settings);
 
         return builder;
+    }
+
+    /// <summary>
+    /// Makes a clustered scheduler derive an instance id, unless the application chose one itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A cluster is a set of nodes that recognise their own check-in row and their own fired triggers by
+    /// <c>InstanceId</c>, and every scheduler starts life with the same one —
+    /// <see cref="QuartzSchedulerOptions.DefaultInstanceId"/>, <c>NON_CLUSTERED</c>. Under Aspire that is
+    /// not a hypothetical: <c>WithReplicas(2)</c> is one call, a replica set has no identity of its own to
+    /// borrow, and a cluster whose nodes all carry one id is the worst failure this area has. So
+    /// <see cref="QuartzAspireSettings.Clustered"/> supplies the other half of what clustering needs
+    /// rather than documenting a trap beside it.
+    /// </para>
+    /// <para>
+    /// It only fills a gap. An application that set <c>GenerateInstanceId</c> itself is already doing
+    /// this, and one that set <c>InstanceId</c> has said what its nodes are called — an ordinal deployment
+    /// or a hostname it trusts — so neither is touched. Reading those values here is sound because this
+    /// runs from <c>ConfigureAllQuartzSchedulers</c>, which <c>AddQuartz</c> applies <em>after</em> the
+    /// scheduler's own callback, the property bridge and the configuration binding; options are last-wins,
+    /// so what this delegate sees is everything the application said.
+    /// </para>
+    /// </remarks>
+    private static void GenerateAnInstanceIdUnlessOneWasChosen(IQuartzBuilder quartz)
+    {
+        quartz.ConfigureScheduler(options =>
+        {
+            if (!options.GenerateInstanceId
+                && string.Equals(options.InstanceId, QuartzSchedulerOptions.DefaultInstanceId, StringComparison.Ordinal))
+            {
+                options.GenerateInstanceId = true;
+            }
+        });
     }
 
     /// <summary>

--- a/src/Quartz.Aspire/QuartzAspireSettings.cs
+++ b/src/Quartz.Aspire/QuartzAspireSettings.cs
@@ -82,14 +82,18 @@ public sealed class QuartzAspireSettings
     /// Whether this scheduler takes part in a cluster with every other scheduler sharing the database.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Aspire makes replicas cheap — <c>WithReplicas(2)</c> is one call — and two schedulers on one
     /// database that are not clustered will both fire every trigger. Turning this on turns database
     /// locking on with it, as <c>UseClustering()</c> always has.
+    /// </para>
     /// <para>
-    /// It does <em>not</em> give the replicas distinct instance ids, and clustering needs them: a node
-    /// recognises its own check-in row and its own fired triggers by that id, and every replica keeps
-    /// the default <c>NON_CLUSTERED</c> until something says otherwise. Say it once, beside the
-    /// scheduler: <c>builder.AddQuartz(q =&gt; q.ConfigureScheduler(o =&gt; o.GenerateInstanceId = true))</c>.
+    /// It also makes the scheduler derive its <c>InstanceId</c>, because a cluster needs distinct ids and
+    /// a replica set has none of its own to borrow: a node recognises its own check-in row and its own
+    /// fired triggers by that id, and every replica starts life carrying
+    /// <see cref="QuartzSchedulerOptions.DefaultInstanceId"/> — <c>NON_CLUSTERED</c>. An application that
+    /// already set <c>GenerateInstanceId</c>, or that named its nodes by setting <c>InstanceId</c>, keeps
+    /// what it said; this only fills the gap.
     /// </para>
     /// </remarks>
     public bool Clustered { get; set; }

--- a/src/Quartz.Aspire/QuartzAspireSettings.cs
+++ b/src/Quartz.Aspire/QuartzAspireSettings.cs
@@ -1,0 +1,122 @@
+namespace Quartz;
+
+/// <summary>
+/// The settings <see cref="QuartzAspireHostApplicationBuilderExtensions.AddQuartzPersistentStore"/> reads,
+/// bound from <c>Aspire:Quartz</c> and then from <c>Aspire:Quartz:&lt;connection name&gt;</c> over it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two-section shape is the one every Aspire client integration has: the outer section carries what
+/// is true of every connection in the application, and the inner one — named after the connection —
+/// overrides it for that connection alone. An application with a single database never writes the inner
+/// one.
+/// </para>
+/// <para>
+/// Everything here is deliberately small. This type is not a second spelling of Quartz's own
+/// configuration: <c>Quartz:JobStore</c>, <c>Quartz:Scheduler</c> and the rest still say what they always
+/// said, and <c>AddQuartz</c> still reads them. What these settings decide is the handful of things that
+/// follow from an Aspire <em>connection</em> — which database it is, and whether the signals that come
+/// with it are wired — because that is what a connection name is evidence of.
+/// </para>
+/// </remarks>
+public sealed class QuartzAspireSettings
+{
+    /// <summary>
+    /// The connection string reaching the database, when it is not the one Aspire injected.
+    /// </summary>
+    /// <remarks>
+    /// Left unset, <c>ConnectionStrings:&lt;connection name&gt;</c> supplies it — which is the
+    /// environment variable the AppHost's <c>WithReference</c> sets, so an application under Aspire
+    /// never writes this. It matters for the value that decides the provider: the string is read at
+    /// configuration time whether or not the store ends up using it, because its shape is what says
+    /// which database this is.
+    /// </remarks>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Which ADO.NET driver reaches the database, as one of the names on
+    /// <see cref="DataSourceOptions.Providers"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Left unset, it is inferred from the connection string's shape. The inference recognises the five
+    /// shapes Aspire's own database resources produce and throws for anything it cannot place — a
+    /// guess would choose the driver delegate that writes the SQL, and SQL the database cannot run is a
+    /// worse outcome than a startup failure that names this property.
+    /// </para>
+    /// <para>
+    /// Three of the shipped provider names are never inferred, because nothing in a connection string
+    /// distinguishes them: <c>MySql</c> from <c>MySqlConnector</c>, <c>SQLite</c> from
+    /// <c>SQLite-Microsoft</c>, and <c>Firebird</c> from a connection string that looks like several
+    /// others. Naming one here is how an application chooses.
+    /// </para>
+    /// <para>
+    /// A name Quartz ships no description for is still usable: it selects the generic SQL dialect, and
+    /// whatever <c>DbMetadataFactory</c> the application registered describes the driver.
+    /// </para>
+    /// </remarks>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Which scheduler this store belongs to, for an application that registers more than one.
+    /// </summary>
+    /// <remarks>
+    /// Left unset, every scheduler in the container gets this store — which is right for the single
+    /// scheduler an application normally has, and wrong the moment two of them talk to two databases.
+    /// The name is the one passed to <c>AddQuartz(name, …)</c>, because a string means a scheduler
+    /// everywhere in Quartz.
+    /// </remarks>
+    public string? SchedulerName { get; set; }
+
+    /// <summary>
+    /// The prefix on the Quartz table names, when the schema was created with something other than
+    /// <c>QRTZ_</c>.
+    /// </summary>
+    /// <remarks>
+    /// Left unset, <c>AdoJobStoreOptions.TablePrefix</c> keeps whatever it already had — its own
+    /// default, or a value <c>Quartz:JobStore:TablePrefix</c> set.
+    /// </remarks>
+    public string? TablePrefix { get; set; }
+
+    /// <summary>
+    /// Whether this scheduler takes part in a cluster with every other scheduler sharing the database.
+    /// </summary>
+    /// <remarks>
+    /// Aspire makes replicas cheap — <c>WithReplicas(2)</c> is one call — and two schedulers on one
+    /// database that are not clustered will both fire every trigger. Turning this on turns database
+    /// locking on with it, as <c>UseClustering()</c> always has.
+    /// <para>
+    /// It does <em>not</em> give the replicas distinct instance ids, and clustering needs them: a node
+    /// recognises its own check-in row and its own fired triggers by that id, and every replica keeps
+    /// the default <c>NON_CLUSTERED</c> until something says otherwise. Say it once, beside the
+    /// scheduler: <c>builder.AddQuartz(q =&gt; q.ConfigureScheduler(o =&gt; o.GenerateInstanceId = true))</c>.
+    /// </para>
+    /// </remarks>
+    public bool Clustered { get; set; }
+
+    /// <summary>
+    /// Whether the scheduler's health check is left unregistered.
+    /// </summary>
+    /// <remarks>
+    /// The check is <c>AddQuartzHealthChecks()</c> from the core package, registered on the same
+    /// <c>IHealthChecksBuilder</c> an Aspire ServiceDefaults project put its own <c>self</c> check on,
+    /// so <c>MapDefaultEndpoints()</c> serves both.
+    /// </remarks>
+    public bool DisableHealthChecks { get; set; }
+
+    /// <summary>
+    /// Whether Quartz's <c>ActivitySource</c> is left unsubscribed.
+    /// </summary>
+    /// <remarks>
+    /// Subscribing is <c>AddSource(QuartzInstrumentation.ActivitySourceName)</c> on the application's
+    /// existing tracer provider. No exporter is added — a ServiceDefaults project already owns that, and
+    /// <c>UseOtlpExporter()</c> may be called only once.
+    /// </remarks>
+    public bool DisableTracing { get; set; }
+
+    /// <summary>
+    /// Whether Quartz's <c>Meter</c> is left unsubscribed.
+    /// </summary>
+    /// <inheritdoc cref="DisableTracing" path="/remarks"/>
+    public bool DisableMetrics { get; set; }
+}

--- a/src/Quartz.Aspire/README.md
+++ b/src/Quartz.Aspire/README.md
@@ -1,0 +1,110 @@
+# Quartz.Aspire
+
+[Quartz.Aspire](https://www.nuget.org/packages/Quartz.Aspire) is the Quartz.NET client integration for
+[Aspire](https://aspire.dev/). It turns an Aspire connection name into a persistent job store: the driver
+delegate that speaks that database's SQL, connections taken from the `DbDataSource` the container already
+holds, the scheduler's health check, and Quartz's two telemetry signals named to the OpenTelemetry pipeline
+your ServiceDefaults project built.
+
+It has **no `Aspire.*` package dependency**. `IHostApplicationBuilder` is the whole of the contract, so the
+package is not tied to Aspire's release cadence and works in any generic-host application.
+
+## Installation
+
+```shell
+dotnet add package Quartz.Aspire
+```
+
+## Usage
+
+The AppHost declares the database and hands it to the worker, exactly as it would for any other client
+integration:
+
+```csharp
+var postgres = builder.AddPostgres("postgres").WithDataVolume();
+var quartzDb = postgres.AddDatabase("quartz");
+
+builder.AddProject<Projects.Orders_Worker>("orders")
+    .WithReference(quartzDb)
+    .WaitFor(quartzDb);
+```
+
+The worker names it once:
+
+<!-- snippet: sample_aspire_add_persistent_store -->
+```csharp
+builder.AddQuartzPersistentStore("quartz");
+builder.AddQuartz();
+builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+```
+<!-- endSnippet -->
+
+That is the whole integration. `AddQuartzPersistentStore` may be called before or after `AddQuartz` — the
+store is contributed to every scheduler in the container through `ConfigureAllQuartzSchedulers`, so the
+order does not matter. `AddQuartz` still reads the `Quartz` configuration section and still configures the
+scheduler; nothing here replaces it.
+
+If the application registers a data source of its own — `builder.AddNpgsqlDataSource("quartz")` — register
+it **before** this call, and Quartz will take its connections from it rather than from the connection
+string.
+
+## Settings
+
+`QuartzAspireSettings` is bound from `Aspire:Quartz`, then from `Aspire:Quartz:<connection name>` over it,
+and a callback has the last word:
+
+```csharp
+builder.AddQuartzPersistentStore("quartz", settings =>
+{
+    settings.Provider = "Npgsql";
+    settings.Clustered = true;
+});
+```
+
+| Setting | Default | What it decides |
+|---|---|---|
+| `ConnectionString` | `ConnectionStrings:<name>` | The connection string, when it is not the one Aspire injected |
+| `Provider` | inferred | Which ADO.NET driver reaches the database |
+| `SchedulerName` | every scheduler | Which scheduler this store belongs to |
+| `TablePrefix` | `QRTZ_` | The prefix on the Quartz table names |
+| `Clustered` | `false` | Whether this scheduler joins a cluster on the database |
+| `DisableHealthChecks` | `false` | Leaves `AddQuartzHealthChecks()` unregistered |
+| `DisableTracing` | `false` | Leaves the `Quartz` activity source unsubscribed |
+| `DisableMetrics` | `false` | Leaves the `Quartz` meter unsubscribed |
+
+No exporter is ever added. `AddServiceDefaults()` owns that, and `UseOtlpExporter()` may be called only
+once.
+
+`Clustered` does not give replicas distinct instance ids, and clustering needs them — say that beside the
+scheduler with `q.ConfigureScheduler(o => o.GenerateInstanceId = true)`.
+
+## Which database the connection string is for
+
+Left unset, `Provider` is inferred from the connection string's keywords. **An ambiguous or unrecognised
+string throws**, naming `QuartzAspireSettings.Provider`: a wrong driver delegate writes SQL the database
+cannot run, and it fails at the first trigger acquisition rather than at startup.
+
+| Provider | Inferred when the connection string |
+|---|---|
+| `Npgsql` | has `Host` and `Database`, and no `Uid` |
+| `SqlServer` | has `Server`, `Data Source`, `Address`, `Addr` or `Network Address`, together with `Initial Catalog`, `Database`, `Integrated Security` or `Trusted_Connection` — and has no `Port` and no `Host`, neither of which `Microsoft.Data.SqlClient` accepts |
+| `MySqlConnector` | has `Server`, `Data Source`, `Address`, `Addr` or `Network Address` but not `Host`, together with `Port` and one of `Uid`, `User Id`, `Username` or `User` |
+| `SQLite-Microsoft` | has `Data Source` whose value is `:memory:` or ends in `.db`, `.db3`, `.sqlite` or `.sqlite3`, or has `Mode=Memory` |
+| `OracleODPManaged` | has `Data Source` holding a TNS descriptor or an EZ-connect `host:port/service` string, and no `Host` or `Port` |
+
+`MySql`, `SQLite` and `Firebird` are never inferred. The first two accept the same connection strings as
+the drivers above them, so which of each pair to use is the application's choice; name one in `Provider`.
+A name Quartz ships no description for works there too — it selects the generic SQL dialect and whatever
+`DbMetadataFactory` you registered.
+
+## The tables are still yours to create
+
+Quartz does not create or migrate its schema, under Aspire or anywhere else, and neither
+`WithInitFiles` nor `WithCreationScript` closes that gap — both run against the server rather than the
+database. Apply the schema the way you would apply an Entity Framework Core migration: a small project the
+worker waits for with `WaitForCompletion`. The scripts are in
+[`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables).
+
+## Documentation
+
+<https://www.quartz-scheduler.net/documentation/quartz-4.x/how-tos/aspire.html>

--- a/src/Quartz.Aspire/README.md
+++ b/src/Quartz.Aspire/README.md
@@ -67,7 +67,7 @@ builder.AddQuartzPersistentStore("quartz", settings =>
 | `Provider` | inferred | Which ADO.NET driver reaches the database |
 | `SchedulerName` | every scheduler | Which scheduler this store belongs to |
 | `TablePrefix` | `QRTZ_` | The prefix on the Quartz table names |
-| `Clustered` | `false` | Whether this scheduler joins a cluster on the database |
+| `Clustered` | `false` | Whether this scheduler joins a cluster on the database, deriving an instance id to do it with |
 | `DisableHealthChecks` | `false` | Leaves `AddQuartzHealthChecks()` unregistered |
 | `DisableTracing` | `false` | Leaves the `Quartz` activity source unsubscribed |
 | `DisableMetrics` | `false` | Leaves the `Quartz` meter unsubscribed |
@@ -75,8 +75,11 @@ builder.AddQuartzPersistentStore("quartz", settings =>
 No exporter is ever added. `AddServiceDefaults()` owns that, and `UseOtlpExporter()` may be called only
 once.
 
-`Clustered` does not give replicas distinct instance ids, and clustering needs them — say that beside the
-scheduler with `q.ConfigureScheduler(o => o.GenerateInstanceId = true)`.
+`Clustered` turns on database locking and makes the scheduler derive its `InstanceId`, because a cluster
+needs distinct ids and an Aspire replica set has none of its own to borrow — every replica otherwise starts
+life as `NON_CLUSTERED`, and a cluster whose nodes share one id is the worst failure this area has. An
+application that already set `GenerateInstanceId`, or that named its nodes with `InstanceId`, keeps what it
+said.
 
 ## Which database the connection string is for
 

--- a/src/Quartz.Aspire/buildTransitive/net10.0/Quartz.Aspire.targets
+++ b/src/Quartz.Aspire/buildTransitive/net10.0/Quartz.Aspire.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <JsonSchemaSegment Include="$(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json"
+                       FilePathPattern="appsettings\..*json" />
+  </ItemGroup>
+</Project>

--- a/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
@@ -18,6 +18,17 @@ namespace Quartz.Documentation.Samples.HowTos;
 /// </remarks>
 public static class AspireSamples
 {
+    public static void PersistentStoreFromAConnectionName(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_add_persistent_store
+
+        builder.AddQuartzPersistentStore("quartz");
+        builder.AddQuartz();
+        builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
+
+        #endregion
+    }
+
     public static void SubscribeToQuartzSignals(IHostApplicationBuilder builder)
     {
         #region sample_aspire_subscribe

--- a/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
+++ b/src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    <ProjectReference Include="..\Quartz.Aspire\Quartz.Aspire.csproj" />
     <ProjectReference Include="..\Quartz.AspNetCore\Quartz.AspNetCore.csproj" />
     <ProjectReference Include="..\Quartz.Dashboard\Quartz.Dashboard.csproj" />
     <ProjectReference Include="..\Quartz.Extensions.Redis\Quartz.Extensions.Redis.csproj" />

--- a/src/Quartz.Tests.Unit/Aspire/AspireApplication.cs
+++ b/src/Quartz.Tests.Unit/Aspire/AspireApplication.cs
@@ -1,0 +1,86 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// The worker an Aspire AppHost would have started, with none of Aspire running.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Quartz.Aspire</c> takes no <c>Aspire.*</c> dependency, and its whole contract is an
+/// <see cref="IHostApplicationBuilder"/> holding configuration the AppHost injected — so a test needs no
+/// DCP, no container and no Docker to be the real thing. What arrives from
+/// <c>WithReference(quartzDb)</c> is the environment variable <c>ConnectionStrings__quartz</c>, which the
+/// default configuration builder reads back as <c>ConnectionStrings:quartz</c>; an in-memory source says
+/// the same thing.
+/// </para>
+/// <para>
+/// <see cref="Host.CreateEmptyApplicationBuilder"/> rather than <c>CreateApplicationBuilder</c>, so that
+/// the machine's own environment variables and user secrets cannot reach a test.
+/// </para>
+/// </remarks>
+internal static class AspireApplication
+{
+    /// <summary>
+    /// The connection strings the databases Aspire ships a resource for actually inject, as of Aspire 13.
+    /// They are the inputs the provider inference exists to read, so they are written once and shared.
+    /// </summary>
+    public const string Postgres = "Host=127.0.0.1;Port=51234;Username=postgres;Password=secret;Database=quartz";
+
+    public const string SqlServer = "Server=127.0.0.1,51235;User ID=sa;Password=secret;TrustServerCertificate=True;Database=quartz";
+
+    public const string MySql = "Server=127.0.0.1;Port=51236;User ID=root;Password=secret;Database=quartz";
+
+    public const string Sqlite = "Data Source=quartz.db";
+
+    public const string Oracle = "Data Source=127.0.0.1:51237/FREEPDB1;User Id=system;Password=secret";
+
+    /// <summary>
+    /// A worker with the given configuration and nothing else.
+    /// </summary>
+    public static HostApplicationBuilder Worker(params (string Key, string? Value)[] configuration)
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings());
+
+        builder.Configuration.AddInMemoryCollection(
+            configuration.Select(entry => new KeyValuePair<string, string?>(entry.Key, entry.Value)));
+
+        return builder;
+    }
+
+    /// <summary>
+    /// A worker whose AppHost injected one connection string under <paramref name="connectionName"/>.
+    /// </summary>
+    public static HostApplicationBuilder WorkerWith(string connectionString, string connectionName = "quartz")
+    {
+        return Worker(($"ConnectionStrings:{connectionName}", connectionString));
+    }
+
+    /// <summary>
+    /// The data source settings the scheduler ended up with.
+    /// </summary>
+    /// <remarks>
+    /// A store's data source is named after the scheduler that owns it, and <c>quartz</c> for the default
+    /// scheduler — <see cref="PersistentStoreBuilder.DefaultDataSourceName"/> — so that is the name these
+    /// options are registered under.
+    /// </remarks>
+    public static DataSourceOptions DataSourceOf(IServiceProvider services, string? schedulerName = null)
+    {
+        return services.GetRequiredService<IOptionsMonitor<DataSourceOptions>>().Get(schedulerName ?? "quartz");
+    }
+
+    /// <summary>
+    /// The job store settings the scheduler ended up with.
+    /// </summary>
+    public static AdoJobStoreOptions StoreOf(IServiceProvider services, string? schedulerName = null)
+    {
+        return services.GetRequiredService<IOptionsMonitor<AdoJobStoreOptions>>().Get(schedulerName ?? Options.DefaultName);
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/AspirePackagingTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/AspirePackagingTest.cs
@@ -1,0 +1,129 @@
+#nullable enable
+
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Xml.Linq;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// What ships in <c>Quartz.Aspire</c>, and what an application referencing it drags in.
+/// </summary>
+/// <remarks>
+/// The whole argument for this package taking no <c>Aspire.*</c> dependency is that a client integration
+/// needs none: <see cref="Microsoft.Extensions.Hosting.IHostApplicationBuilder"/> is the contract, and
+/// <c>Aspire.Hosting</c> alone brings roughly thirty packages — <c>Grpc.AspNetCore</c>,
+/// <c>KubernetesClient</c>, <c>YamlDotNet</c>, <c>Newtonsoft.Json</c> — under this repository's transitive
+/// pinning. It is an argument that has to be enforced, because a single <c>PackageReference</c> undoes it.
+/// </remarks>
+public class AspirePackagingTest
+{
+    private static FileInfo Project => new(Path.Combine(
+        RepositoryRoot.Find().FullName, "src", "Quartz.Aspire", "Quartz.Aspire.csproj"));
+
+    private static FileInfo Schema => new(Path.Combine(
+        RepositoryRoot.Find().FullName, "src", "Quartz.Aspire", "ConfigurationSchema.json"));
+
+    [Test]
+    public void ThePackageTakesNoAspireDependency()
+    {
+        IEnumerable<string> aspire = XDocument.Load(Project.FullName)
+            .Descendants("PackageReference")
+            .Select(element => element.Attribute("Include")?.Value ?? "")
+            .Where(name => name.StartsWith("Aspire.", StringComparison.OrdinalIgnoreCase)
+                           || string.Equals(name, "Aspire", StringComparison.OrdinalIgnoreCase));
+
+        aspire.Should().BeEmpty(
+            "a client integration needs no Aspire package, and taking one would tie this package's "
+            + "supported versions to Aspire's release cadence for no type it uses");
+    }
+
+    [Test]
+    public void ThePackageTakesNoFrameworkReference()
+    {
+        XDocument.Load(Project.FullName).Descendants("FrameworkReference").Should().BeEmpty(
+            "a framework reference reaches the nuspec, and a worker on a dotnet/runtime image is exactly "
+            + "who this package is for - which is what #3532 was about");
+    }
+
+    [Test]
+    public void TheConfigurationSchemaAndItsTargetsArePacked()
+    {
+        List<XElement> packed = XDocument.Load(Project.FullName)
+            .Descendants("None")
+            .Where(element => string.Equals((string?) element.Attribute("Pack"), "true", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        List<string?> included = packed.Select(element => (string?) element.Attribute("Include")).ToList();
+
+        included.Should().Contain("ConfigurationSchema.json",
+            "an IDE completes an Aspire section in appsettings.json from the schema in the package root");
+        included.Should().Contain(@"buildTransitive\net10.0\Quartz.Aspire.targets",
+            "the schema is inert without the JsonSchemaSegment item that points the SDK at it");
+    }
+
+    [Test]
+    public void TheTargetsFilePointsAtTheSchemaInThePackageRoot()
+    {
+        FileInfo targets = new(Path.Combine(
+            RepositoryRoot.Find().FullName, "src", "Quartz.Aspire", "buildTransitive", "net10.0", "Quartz.Aspire.targets"));
+
+        targets.Exists.Should().BeTrue();
+
+        XElement segment = XDocument.Load(targets.FullName).Descendants("JsonSchemaSegment").Single();
+
+        ((string?) segment.Attribute("Include")).Should().Be(
+            @"$(MSBuildThisFileDirectory)..\..\ConfigurationSchema.json",
+            "the targets land in buildTransitive/net10.0, so two directories up is the package root");
+        ((string?) segment.Attribute("FilePathPattern")).Should().Be(@"appsettings\..*json");
+    }
+
+    /// <summary>
+    /// The schema is hand-written, because Aspire's generator for it has never shipped
+    /// (microsoft/aspire#3309). So nothing but this holds it to the type it describes.
+    /// </summary>
+    [Test]
+    public void EverySettingAppearsInTheConfigurationSchema()
+    {
+        Schema.Exists.Should().BeTrue();
+
+        JsonNode? described = JsonNode.Parse(File.ReadAllText(Schema.FullName))
+            ?["properties"]?["Aspire"]?["properties"]?["Quartz"]?["properties"];
+
+        described.Should().NotBeNull(
+            "the schema describes Aspire:Quartz, which is the section the settings are bound from");
+
+        List<string> documented = described!.AsObject().Select(property => property.Key).Order(StringComparer.Ordinal).ToList();
+
+        List<string> settings = typeof(QuartzAspireSettings)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(property => property.Name)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        documented.Should().BeEquivalentTo(settings,
+            "the schema is what an IDE completes and validates an appsettings.json against, so a setting "
+            + "missing from it is a setting nobody discovers, and one left in it after the property is "
+            + "gone is a suggestion that does nothing");
+    }
+
+    [Test]
+    public void TheConfigurationSchemaIsValidJsonWithADescriptionOnEverySetting()
+    {
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(Schema.FullName));
+
+        JsonElement described = document.RootElement
+            .GetProperty("properties").GetProperty("Aspire")
+            .GetProperty("properties").GetProperty("Quartz")
+            .GetProperty("properties");
+
+        foreach (JsonProperty setting in described.EnumerateObject())
+        {
+            setting.Value.TryGetProperty("description", out JsonElement description).Should().BeTrue(
+                $"{setting.Name} shows its description in the IDE's completion list, and one without is a "
+                + "name the reader has to go and look up");
+            description.GetString().Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/ConnectionSelectionTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/ConnectionSelectionTest.cs
@@ -1,0 +1,118 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Npgsql;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// Where the store's connections come from, once the database is known.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ladder is the one <c>how-tos/aspire.md</c> teaches by hand: a <c>DbDataSource</c> keyed with the
+/// connection name, then the container's single unkeyed one, then the connection string. A data source is
+/// preferred because whatever it was built with is then in play for Quartz's own statements — its type
+/// mappers, its logging, its connection multiplexing — since commands are made by the connection rather
+/// than from a driver description.
+/// </para>
+/// <para>
+/// The rung SQL Server does not stand on is the one worth a test of its own.
+/// </para>
+/// </remarks>
+public class ConnectionSelectionTest
+{
+    [Test]
+    public void AKeyedDataSourceUnderTheConnectionNameIsTheMostSpecificAnswer()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres, serviceKey: "quartz");
+
+        DataSourceOptions options = Configure(builder);
+
+        options.DataSourceServiceKey.Should().Be("quartz",
+            "an application talking to two databases keys them apart, and the connection name is the key "
+            + "Aspire's own AddKeyed* registrations use");
+        options.UseRegisteredDataSource.Should().BeFalse(
+            "a service key implies it, and setting both would say the same thing twice");
+    }
+
+    [Test]
+    public void TheContainersUnkeyedDataSourceIsTakenWhenNothingIsKeyed()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres);
+
+        DataSourceOptions options = Configure(builder);
+
+        options.UseRegisteredDataSource.Should().BeTrue(
+            "AddNpgsqlDataSource(\"quartz\") registers an unkeyed DbDataSource, which is the one Quartz asks for");
+        options.DataSourceServiceKey.Should().BeNull();
+    }
+
+    [Test]
+    public void AKeyedDataSourceUnderSomebodyElsesNameIsNotThisStores()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres, serviceKey: "reporting");
+
+        DataSourceOptions options = Configure(builder);
+
+        options.DataSourceServiceKey.Should().BeNull();
+        options.UseRegisteredDataSource.Should().BeFalse();
+        options.ConnectionStringName.Should().Be("quartz",
+            "a data source keyed for another connection is another database, so this store falls back to "
+            + "the string the AppHost injected rather than reaching into it");
+    }
+
+    [Test]
+    public void TheConnectionStringIsTheAnswerWhenNoDataSourceIsRegistered()
+    {
+        DataSourceOptions options = Configure(AspireApplication.WorkerWith(AspireApplication.Postgres));
+
+        options.ConnectionString.Should().Be(AspireApplication.Postgres);
+        options.ConnectionStringName.Should().Be("quartz",
+            "both are set: the string wins where it is present, and the name still resolves the store when "
+            + "configuration supplies it later");
+        options.UseRegisteredDataSource.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// SQL Server never takes the data-source path, whatever is registered.
+    /// </summary>
+    /// <remarks>
+    /// <c>Microsoft.Data.SqlClient</c> ships no <see cref="System.Data.Common.DbDataSource"/>
+    /// implementation and Aspire's SQL Server client integration registers a scoped <c>SqlConnection</c>
+    /// instead. Resolving "the container's DbDataSource" there finds some other database's, or nothing —
+    /// and finds out at the first connection rather than at startup.
+    /// </remarks>
+    [Test]
+    public void SqlServerNeverTakesADataSource()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.SqlServer);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres);
+        builder.Services.AddNpgsqlDataSource(AspireApplication.Postgres, serviceKey: "quartz");
+
+        DataSourceOptions options = Configure(builder);
+
+        options.Provider.Should().Be(DataSourceOptions.Providers.SqlServer);
+        options.UseRegisteredDataSource.Should().BeFalse();
+        options.DataSourceServiceKey.Should().BeNull(
+            "a DbDataSource beside a SQL Server connection belongs to a different database, and taking it "
+            + "would point the scheduler at that one");
+        options.ConnectionStringName.Should().Be("quartz");
+    }
+
+    private static DataSourceOptions Configure(HostApplicationBuilder builder)
+    {
+        builder.AddQuartzPersistentStore("quartz");
+        builder.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        return AspireApplication.DataSourceOf(host.Services);
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/ProviderInferenceTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/ProviderInferenceTest.cs
@@ -1,0 +1,153 @@
+#nullable enable
+
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// Working out which database a connection string is for, and refusing to when it is not clear.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An Aspire connection name arrives as a string and nothing else — the AppHost sets
+/// <c>ConnectionStrings__quartz</c> and leaves no note of which resource wrote it — so this is the one
+/// piece of guessing the package does. The cases below are the strings Aspire's own database resources
+/// actually inject, because those are the inputs that matter.
+/// </para>
+/// <para>
+/// The refusals matter more than the matches. A wrong provider name picks the driver delegate that writes
+/// the SQL, so the scheduler starts, connects, and then fails at the first trigger acquisition with a
+/// syntax error nobody would trace back to a connection string. Both failure messages therefore name
+/// <c>QuartzAspireSettings.Provider</c> and <c>DataSourceOptions.Providers</c>.
+/// </para>
+/// </remarks>
+public class ProviderInferenceTest
+{
+    [TestCase(AspireApplication.Postgres, DataSourceOptions.Providers.Npgsql)]
+    [TestCase(AspireApplication.SqlServer, DataSourceOptions.Providers.SqlServer)]
+    [TestCase(AspireApplication.MySql, DataSourceOptions.Providers.MySqlConnector)]
+    [TestCase(AspireApplication.Sqlite, DataSourceOptions.Providers.Sqlite)]
+    [TestCase(AspireApplication.Oracle, DataSourceOptions.Providers.Oracle)]
+    [TestCase("Data Source=quartz;Mode=Memory;Cache=Shared", DataSourceOptions.Providers.Sqlite)]
+    [TestCase("Data Source=:memory:", DataSourceOptions.Providers.Sqlite)]
+    [TestCase("Data Source=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=db)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=orcl)));User Id=system;Password=secret",
+        DataSourceOptions.Providers.Oracle)]
+    [TestCase("Server=db;Initial Catalog=quartz;Integrated Security=True", DataSourceOptions.Providers.SqlServer)]
+    public void AConnectionStringSaysWhichDatabaseItIsFor(string connectionString, string expected)
+    {
+        Provider(connectionString).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The two shapes that would collide without the rules that keep them apart, written out so that a
+    /// change to either rule fails here rather than in an application.
+    /// </summary>
+    /// <remarks>
+    /// Aspire's SQL Server and MySQL resources inject nearly the same string — a server, a login, a
+    /// password and a database. <c>Port</c> is the whole of the difference: SQL Server writes the port
+    /// into the server as <c>Server=host,1433</c> and <c>Microsoft.Data.SqlClient</c> rejects a
+    /// <c>Port</c> keyword outright, so a string that has one cannot be its.
+    /// </remarks>
+    [Test]
+    public void SqlServerAndMySqlAreToldApartByThePortKeyword()
+    {
+        Provider(AspireApplication.SqlServer).Should().Be(DataSourceOptions.Providers.SqlServer,
+            "SQL Server puts the port inside Server=, so there is no Port keyword to disqualify it");
+
+        Provider(AspireApplication.MySql).Should().Be(DataSourceOptions.Providers.MySqlConnector,
+            "the Port keyword is what says this is not SQL Server, which accepts no such keyword");
+    }
+
+    [Test]
+    public void AnUnrecognisedShapeThrowsRatherThanGuessing()
+    {
+        Action act = () => Provider("Data Source=orcl;User Id=scott;Password=tiger");
+
+        act.Should().Throw<SchedulerConfigException>(
+                "a bare data source name is a TNS alias and a SQL Server instance name equally, and "
+                + "choosing between them would pick the driver delegate that writes the SQL")
+            .WithMessage("*QuartzAspireSettings.Provider*")
+            .And.Message.Should().Contain("DataSourceOptions.Providers")
+            .And.Contain("quartz", "the message has to say which connection string it is about");
+    }
+
+    [Test]
+    public void AnAmbiguousShapeThrowsRatherThanPickingOne()
+    {
+        Action act = () => Provider("Data Source=quartz.db;Initial Catalog=quartz");
+
+        act.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*QuartzAspireSettings.Provider*")
+            .And.Message.Should().Contain(DataSourceOptions.Providers.Sqlite)
+            .And.Contain(DataSourceOptions.Providers.SqlServer,
+                "a message that named neither candidate would leave the reader to guess what it saw");
+    }
+
+    [Test]
+    public void NoConnectionStringAndNoProviderThrows()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker();
+
+        Action act = () => builder.AddQuartzPersistentStore("quartz");
+
+        act.Should().Throw<SchedulerConfigException>(
+                "there is nothing to infer from, and a store pointing at no database would fail later and "
+                + "less clearly")
+            .WithMessage("*ConnectionStrings:quartz*");
+    }
+
+    [Test]
+    public void ANamedProviderIsNeverInferredOver()
+    {
+        Provider(AspireApplication.Postgres, settings => settings.Provider = DataSourceOptions.Providers.MySqlConnector)
+            .Should().Be(DataSourceOptions.Providers.MySqlConnector,
+                "the inference is a fallback for a string nobody classified, not a second opinion");
+    }
+
+    [Test]
+    public void ANamedProviderIsMatchedWithoutRegardToCase()
+    {
+        Provider(AspireApplication.Postgres, settings => settings.Provider = "npgsql")
+            .Should().Be(DataSourceOptions.Providers.Npgsql,
+                "driver descriptions are looked up by an ordinal comparison, so a name that differs only "
+                + "in case would otherwise fail at the first connection rather than here");
+    }
+
+    [Test]
+    public void AProviderQuartzShipsNoDescriptionForIsStillUsable()
+    {
+        Provider(AspireApplication.Postgres, settings => settings.Provider = "MyDatabase")
+            .Should().Be("MyDatabase",
+                "an unknown name selects the generic dialect and leaves the description to whatever "
+                + "DbMetadataFactory the application registered, which is a configuration rather than a mistake");
+    }
+
+    [Test]
+    public void TheProviderCanBeNamedInConfiguration()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", "Data Source=orcl;User Id=scott;Password=tiger"),
+            ("Aspire:Quartz:quartz:Provider", DataSourceOptions.Providers.Oracle));
+
+        builder.AddQuartzPersistentStore("quartz");
+        builder.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        AspireApplication.DataSourceOf(host.Services).Provider.Should().Be(DataSourceOptions.Providers.Oracle,
+            "an application whose connection string the inference cannot place says so in configuration, "
+            + "without having to move the whole registration into code");
+    }
+
+    private static string Provider(string connectionString, Action<QuartzAspireSettings>? configureSettings = null)
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(connectionString);
+
+        builder.AddQuartzPersistentStore("quartz", configureSettings);
+        builder.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        return AspireApplication.DataSourceOf(host.Services).Provider;
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/QuartzAspireRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/QuartzAspireRegistrationTest.cs
@@ -1,0 +1,336 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// What <c>AddQuartzPersistentStore</c> puts in the container, and what each <c>Disable*</c> takes back
+/// out again.
+/// </summary>
+public class QuartzAspireRegistrationTest
+{
+    /// <summary>
+    /// The order of <c>AddQuartzPersistentStore</c> and <c>AddQuartz</c> does not matter.
+    /// </summary>
+    /// <remarks>
+    /// A package that adds something to every scheduler cannot know whether the application registers
+    /// its schedulers before or after calling it, which is what <c>ConfigureAllQuartzSchedulers</c> is
+    /// for. Written as a comparison of two whole containers rather than of one value, because the point
+    /// is that nothing differs.
+    /// </remarks>
+    [Test]
+    public void CallingItBeforeOrAfterAddQuartzGivesTheSameContainer()
+    {
+        (DataSourceOptions DataSource, AdoJobStoreOptions Store) before = Build(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.TablePrefix = "APP_");
+            builder.AddQuartz();
+        });
+
+        (DataSourceOptions DataSource, AdoJobStoreOptions Store) after = Build(builder =>
+        {
+            builder.AddQuartz();
+            builder.AddQuartzPersistentStore("quartz", settings => settings.TablePrefix = "APP_");
+        });
+
+        after.DataSource.Should().BeEquivalentTo(before.DataSource);
+        after.Store.Should().BeEquivalentTo(before.Store);
+
+        before.DataSource.Provider.Should().Be(DataSourceOptions.Providers.Npgsql,
+            "a comparison of two empty results would pass just as well, so one of them is checked for "
+            + "having happened at all");
+    }
+
+    [Test]
+    public void TheStoreIsThePersistentOneAndKnowsItsDataSource()
+    {
+        (DataSourceOptions dataSource, AdoJobStoreOptions store) = Build(Standard);
+
+        store.DataSource.Should().Be("quartz",
+            "the store's data source is named after the scheduler that owns it, and 'quartz' is the "
+            + "default scheduler's");
+        dataSource.Provider.Should().Be(DataSourceOptions.Providers.Npgsql);
+    }
+
+    [Test]
+    public void TheTablePrefixIsLeftAloneWhenNothingSetsIt()
+    {
+        (_, AdoJobStoreOptions store) = Build(Standard);
+
+        store.TablePrefix.Should().Be("QRTZ_",
+            "an unset setting must not overwrite what Quartz:JobStore:TablePrefix or the default already "
+            + "said");
+    }
+
+    [Test]
+    public void TheTablePrefixIsAppliedWhenItIsSet()
+    {
+        (_, AdoJobStoreOptions store) = Build(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.TablePrefix = "APP_");
+            builder.AddQuartz();
+        });
+
+        store.TablePrefix.Should().Be("APP_");
+    }
+
+    [Test]
+    public void ClusteringIsOffUnlessAskedFor()
+    {
+        using IHost host = Host(Standard);
+
+        Clustering(host).Enabled.Should().BeFalse();
+        AspireApplication.StoreOf(host.Services).UseDbLocks.Should().BeFalse();
+    }
+
+    [Test]
+    public void ClusteredTurnsOnClusteringAndTheDatabaseLocksItNeeds()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.Clustered = true);
+            builder.AddQuartz();
+        });
+
+        Clustering(host).Enabled.Should().BeTrue();
+        AspireApplication.StoreOf(host.Services).UseDbLocks.Should().BeTrue(
+            "clustering has never worked without database locking, and UseClustering() enables both");
+    }
+
+    [Test]
+    public void SchedulerNameLimitsTheStoreToOneScheduler()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.SchedulerName = "orders");
+            builder.AddQuartz("orders");
+            builder.AddQuartz("reporting");
+        });
+
+        AspireApplication.DataSourceOf(host.Services, "orders").Provider.Should().Be(DataSourceOptions.Providers.Npgsql);
+        AspireApplication.StoreOf(host.Services, "orders").DataSource.Should().Be("orders");
+
+        host.Services.GetKeyedService<IDbProvider>("reporting").Should().BeNull(
+            "a settings object naming a scheduler is talking about that one, and the other scheduler keeps "
+            + "whatever store it chose for itself - which is the in-memory one, with no database to reach");
+        host.Services.GetRequiredKeyedService<IDbProvider>("orders").Should().NotBeNull();
+    }
+
+    [Test]
+    public void NamingNoSchedulerReachesEveryOneOfThem()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz");
+            builder.AddQuartz("orders");
+            builder.AddQuartz("reporting");
+        });
+
+        AspireApplication.StoreOf(host.Services, "orders").DataSource.Should().Be("orders");
+        AspireApplication.StoreOf(host.Services, "reporting").DataSource.Should().Be("reporting",
+            "one database and several schedulers is a cluster, which is a configuration rather than a "
+            + "mistake");
+    }
+
+    [Test]
+    public void TheHealthCheckIsRegisteredForTheSchedulerInQuestion()
+    {
+        using IHost host = Host(Standard);
+
+        CheckNames(host).Should().Contain("quartz-scheduler");
+    }
+
+    [Test]
+    public void DisableHealthChecksLeavesTheCheckUnregistered()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.DisableHealthChecks = true);
+            builder.AddQuartz();
+        });
+
+        CheckNames(host).Should().NotContain("quartz-scheduler",
+            "an application that reports its scheduler's health some other way should not have a second "
+            + "answer appear on /health");
+    }
+
+    [Test]
+    public void EachSchedulerGetsItsOwnCheck()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz");
+            builder.AddQuartz("orders");
+            builder.AddQuartz("reporting");
+        });
+
+        CheckNames(host).Should().Contain(["quartz-scheduler-orders", "quartz-scheduler-reporting"],
+            "a check reports one scheduler's state, so two schedulers need two of them under two names");
+    }
+
+    [Test]
+    public void BothTelemetrySignalsAreNamedToThePipeline()
+    {
+        IServiceCollection services = Services(Standard);
+
+        Providers(services, "TracerProvider").Should().Be(1);
+        Providers(services, "MeterProvider").Should().Be(1);
+
+        Deferred(services, "IConfigureTracerProviderBuilder").Should().BePositive(
+            "AddSource records its name against the collection, to be replayed when the provider is built");
+        Deferred(services, "IConfigureMeterProviderBuilder").Should().BePositive();
+    }
+
+    [Test]
+    public void DisableTracingRemovesTheTracerSubscriptionAndNothingElse()
+    {
+        IServiceCollection enabled = Services(Standard);
+        IServiceCollection disabled = Services(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.DisableTracing = true);
+            builder.AddQuartz();
+        });
+
+        Providers(disabled, "TracerProvider").Should().Be(0,
+            "the one registration this call makes for tracing is the tracer provider itself");
+        Deferred(disabled, "IConfigureTracerProviderBuilder").Should().Be(0,
+            "and with it goes the deferred AddSource it existed to carry");
+
+        Providers(disabled, "MeterProvider").Should().Be(Providers(enabled, "MeterProvider"));
+        Deferred(disabled, "IConfigureMeterProviderBuilder").Should().Be(Deferred(enabled, "IConfigureMeterProviderBuilder"),
+            "the two signals are subscribed to independently, so turning one off leaves the other exactly "
+            + "as it was");
+    }
+
+    [Test]
+    public void DisableMetricsRemovesTheMeterSubscriptionAndNothingElse()
+    {
+        IServiceCollection enabled = Services(Standard);
+        IServiceCollection disabled = Services(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.DisableMetrics = true);
+            builder.AddQuartz();
+        });
+
+        Providers(disabled, "MeterProvider").Should().Be(0);
+        Deferred(disabled, "IConfigureMeterProviderBuilder").Should().Be(0);
+
+        Providers(disabled, "TracerProvider").Should().Be(Providers(enabled, "TracerProvider"));
+        Deferred(disabled, "IConfigureTracerProviderBuilder").Should().Be(Deferred(enabled, "IConfigureTracerProviderBuilder"));
+    }
+
+    [Test]
+    public void DisablingBothSignalsLeavesNoOpenTelemetryRegistrationAtAll()
+    {
+        IServiceCollection services = Services(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings =>
+            {
+                settings.DisableTracing = true;
+                settings.DisableMetrics = true;
+            });
+            builder.AddQuartz();
+        });
+
+        services.Select(descriptor => descriptor.ServiceType.Namespace ?? "")
+            .Where(name => name.StartsWith("OpenTelemetry", StringComparison.Ordinal))
+            .Should().BeEmpty(
+                "an application that wants neither signal should not pay for the pipeline that carries them");
+    }
+
+    /// <summary>
+    /// Nothing here exports. A ServiceDefaults project calls <c>UseOtlpExporter()</c> whenever the AppHost
+    /// set <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>, that method may be called only once, and it cannot be
+    /// combined with a signal-specific <c>AddOtlpExporter()</c> — so an exporter added here would turn a
+    /// working application into a <c>NotSupportedException</c> at startup.
+    /// </summary>
+    [Test]
+    public void NoExporterIsAdded()
+    {
+        IServiceCollection services = Services(Standard);
+
+        services.Select(descriptor => descriptor.ServiceType.FullName ?? "")
+            .Where(name => name.Contains("Exporter", StringComparison.Ordinal))
+            .Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// The registration an application under Aspire writes, and the one most of these start from.
+    /// </summary>
+    private static void Standard(HostApplicationBuilder builder)
+    {
+        builder.AddQuartzPersistentStore("quartz");
+        builder.AddQuartz();
+    }
+
+    private static (DataSourceOptions DataSource, AdoJobStoreOptions Store) Build(Action<HostApplicationBuilder> configure)
+    {
+        using IHost host = Host(configure);
+
+        return (AspireApplication.DataSourceOf(host.Services), AspireApplication.StoreOf(host.Services));
+    }
+
+    private static IHost Host(Action<HostApplicationBuilder> configure)
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+        configure(builder);
+        return builder.Build();
+    }
+
+    private static IServiceCollection Services(Action<HostApplicationBuilder> configure)
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+        configure(builder);
+        return builder.Services;
+    }
+
+    private static ClusteringOptions Clustering(IHost host, string? schedulerName = null)
+    {
+        return host.Services.GetRequiredService<IOptionsMonitor<ClusteringOptions>>()
+            .Get(schedulerName ?? Options.DefaultName);
+    }
+
+    private static IEnumerable<string> CheckNames(IHost host)
+    {
+        return host.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>()
+            .Value.Registrations.Select(registration => registration.Name);
+    }
+
+    /// <summary>
+    /// How many deferred OpenTelemetry configurations of one kind the container holds.
+    /// </summary>
+    /// <remarks>
+    /// <c>AddSource</c> and <c>AddMeter</c> on the builder <c>AddOpenTelemetry()</c> hands out are
+    /// deferred: each records one <c>IConfigureTracerProviderBuilder</c> or
+    /// <c>IConfigureMeterProviderBuilder</c> against the collection, to be replayed when the provider is
+    /// built. Counting them is what makes "this call subscribes to exactly one thing, and turning it off
+    /// removes exactly that" checkable without building a provider and reading process-global
+    /// <c>ActivitySource</c> state, which fixtures running in parallel would share.
+    /// </remarks>
+    private static int Deferred(IServiceCollection services, string interfaceName) => ByName(services, interfaceName);
+
+    /// <summary>
+    /// How many of one OpenTelemetry provider the container holds. This is the "exactly one registration"
+    /// a signal costs — the provider itself, added by <c>WithTracing</c> or <c>WithMetrics</c>.
+    /// </summary>
+    private static int Providers(IServiceCollection services, string typeName) => ByName(services, typeName);
+
+    /// <summary>
+    /// Counts service registrations by their service type's name.
+    /// </summary>
+    /// <remarks>
+    /// By name because <c>IConfigureTracerProviderBuilder</c> and its meter twin are internal to the
+    /// OpenTelemetry SDK. A rename does not pass silently: the positive tests assert a count above zero,
+    /// so a name that stops matching fails them rather than turning every count into zero unnoticed.
+    /// </remarks>
+    private static int ByName(IServiceCollection services, string typeName)
+    {
+        return services.Count(descriptor => string.Equals(descriptor.ServiceType.Name, typeName, StringComparison.Ordinal));
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/QuartzAspireRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/QuartzAspireRegistrationTest.cs
@@ -103,6 +103,75 @@ public class QuartzAspireRegistrationTest
             "clustering has never worked without database locking, and UseClustering() enables both");
     }
 
+    /// <summary>
+    /// The other half of what a cluster needs, which an Aspire replica set cannot supply for itself.
+    /// </summary>
+    /// <remarks>
+    /// A node recognises its own check-in row and its own fired triggers by <c>InstanceId</c>, and every
+    /// scheduler starts life carrying <c>NON_CLUSTERED</c>. <c>WithReplicas(2)</c> is one call in an
+    /// AppHost and gives the copies no identity of their own, so a cluster whose nodes all answer to one
+    /// id is not a hypothetical — it is what asking for clustering and nothing else would have produced.
+    /// </remarks>
+    [Test]
+    public void ClusteredGeneratesTheInstanceId()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.Clustered = true);
+            builder.AddQuartz();
+        });
+
+        Scheduler(host).GenerateInstanceId.Should().BeTrue(
+            "an Aspire replica has no identity of its own to borrow, and every node keeping "
+            + "NON_CLUSTERED is the worst failure clustering has");
+    }
+
+    [Test]
+    public void AnUnclusteredSchedulerIsLeftAsItWas()
+    {
+        using IHost host = Host(Standard);
+
+        Scheduler(host).GenerateInstanceId.Should().BeFalse(
+            "a single-node scheduler needs no derived id, and deriving one would change what SCHED_NAME's "
+            + "companion column says for no reason");
+    }
+
+    [Test]
+    public void ClusteredKeepsAnExplicitInstanceId()
+    {
+        using IHost host = Host(builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.Clustered = true);
+            builder.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceId = "orders-0"));
+        });
+
+        QuartzSchedulerOptions scheduler = Scheduler(host);
+
+        scheduler.InstanceId.Should().Be("orders-0");
+        scheduler.GenerateInstanceId.Should().BeFalse(
+            "an application that named its nodes has said what they are called - an ordinal deployment, or "
+            + "a hostname it trusts - and deriving one instead would ignore it");
+    }
+
+    [Test]
+    public void ClusteredKeepsAnInstanceIdThatCameFromConfiguration()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", AspireApplication.Postgres),
+            ("Quartz:Scheduler:InstanceId", "orders-1"));
+
+        builder.AddQuartzPersistentStore("quartz", settings => settings.Clustered = true);
+        builder.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        Scheduler(host).InstanceId.Should().Be("orders-1",
+            "this runs from ConfigureAllQuartzSchedulers, which AddQuartz applies after the configuration "
+            + "binding as well as after the scheduler's own callback, so what it reads is everything the "
+            + "application said");
+        Scheduler(host).GenerateInstanceId.Should().BeFalse();
+    }
+
     [Test]
     public void SchedulerNameLimitsTheStoreToOneScheduler()
     {
@@ -288,6 +357,12 @@ public class QuartzAspireRegistrationTest
         HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
         configure(builder);
         return builder.Services;
+    }
+
+    private static QuartzSchedulerOptions Scheduler(IHost host, string? schedulerName = null)
+    {
+        return host.Services.GetRequiredService<IOptionsMonitor<QuartzSchedulerOptions>>()
+            .Get(schedulerName ?? Options.DefaultName);
     }
 
     private static ClusteringOptions Clustering(IHost host, string? schedulerName = null)

--- a/src/Quartz.Tests.Unit/Aspire/QuartzAspireSettingsBindingTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/QuartzAspireSettingsBindingTest.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// Where <see cref="QuartzAspireSettings"/> comes from, and in what order.
+/// </summary>
+/// <remarks>
+/// Four sources, each more specific than the one before it: the <c>Aspire:Quartz</c> section shared by
+/// every connection, the <c>Aspire:Quartz:&lt;connection name&gt;</c> section for one of them, the
+/// connection string the AppHost injected, and the caller's own callback. That ladder is the shape every
+/// first-party Aspire client integration has, and an application moving between them should not have to
+/// learn a second one.
+/// </remarks>
+public class QuartzAspireSettingsBindingTest
+{
+    [Test]
+    public void TheSharedSectionConfiguresEveryConnection()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", AspireApplication.Postgres),
+            ("Aspire:Quartz:TablePrefix", "SHARED_"),
+            ("Aspire:Quartz:Clustered", "true"));
+
+        QuartzAspireSettings settings = Capture(builder, "quartz");
+
+        settings.TablePrefix.Should().Be("SHARED_");
+        settings.Clustered.Should().BeTrue(
+            "Aspire:Quartz is what an application says once about all of its Quartz connections");
+    }
+
+    [Test]
+    public void TheConnectionsOwnSectionOverridesTheSharedOne()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", AspireApplication.Postgres),
+            ("Aspire:Quartz:TablePrefix", "SHARED_"),
+            ("Aspire:Quartz:Clustered", "true"),
+            ("Aspire:Quartz:quartz:TablePrefix", "OWN_"));
+
+        QuartzAspireSettings settings = Capture(builder, "quartz");
+
+        settings.TablePrefix.Should().Be("OWN_",
+            "the connection's own section is bound over the shared one, so it wins where the two disagree");
+        settings.Clustered.Should().BeTrue(
+            "it is bound over the shared section rather than instead of it, so a setting it says nothing "
+            + "about keeps the shared value");
+    }
+
+    [Test]
+    public void TheOverrideSectionIsThisConnectionsAlone()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", AspireApplication.Postgres),
+            ("Aspire:Quartz:reporting:TablePrefix", "REPORTING_"));
+
+        QuartzAspireSettings settings = Capture(builder, "quartz");
+
+        settings.TablePrefix.Should().BeNull(
+            "a section named after another connection has nothing to do with this one");
+    }
+
+    [Test]
+    public void TheConnectionStringComesFromTheConnectionStringsSection()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerWith(AspireApplication.Postgres);
+
+        QuartzAspireSettings settings = Capture(builder, "quartz");
+
+        settings.ConnectionString.Should().Be(AspireApplication.Postgres,
+            "ConnectionStrings:quartz is what the AppHost's WithReference injected, and reading it is the "
+            + "whole reason this method takes a connection name");
+    }
+
+    [Test]
+    public void TheInjectedConnectionStringWinsOverOneLeftInConfiguration()
+    {
+        const string Stale = "Host=stale;Username=u;Password=p;Database=stale";
+
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("Aspire:Quartz:ConnectionString", Stale),
+            ("ConnectionStrings:quartz", AspireApplication.Postgres));
+
+        QuartzAspireSettings settings = Capture(builder, "quartz");
+
+        settings.ConnectionString.Should().Be(AspireApplication.Postgres,
+            "the AppHost decides where the database is, so a string left in an appsettings file must not "
+            + "quietly send the scheduler somewhere else");
+    }
+
+    [Test]
+    public void TheCallbackHasTheLastWord()
+    {
+        HostApplicationBuilder builder = AspireApplication.Worker(
+            ("ConnectionStrings:quartz", AspireApplication.Postgres),
+            ("Aspire:Quartz:TablePrefix", "SHARED_"),
+            ("Aspire:Quartz:quartz:TablePrefix", "OWN_"));
+
+        QuartzAspireSettings settings = Capture(builder, "quartz", x => x.TablePrefix = "CODE_");
+
+        settings.TablePrefix.Should().Be("CODE_",
+            "code is the most specific of the four sources, so nothing configuration says can beat it");
+    }
+
+    /// <summary>
+    /// The settings as the call was about to act on them: the callback runs after every configuration
+    /// source has had its say, so what it is handed is the answer.
+    /// </summary>
+    private static QuartzAspireSettings Capture(
+        HostApplicationBuilder builder,
+        string connectionName,
+        Action<QuartzAspireSettings>? then = null)
+    {
+        QuartzAspireSettings? captured = null;
+
+        builder.AddQuartzPersistentStore(connectionName, settings =>
+        {
+            captured = settings;
+            then?.Invoke(settings);
+        });
+
+        captured.Should().NotBeNull("the callback is what this test observes the settings through");
+        return captured!;
+    }
+}

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -38,6 +38,7 @@ public class LogCallSiteTest
     private static readonly string[] Converted =
     [
         "src/Quartz",
+        "src/Quartz.Aspire",
         "src/Quartz.AspNetCore",
         "src/Quartz.Dashboard",
         "src/Quartz.Extensions.Redis",

--- a/src/Quartz.Tests.Unit/PublicApiTest.cs
+++ b/src/Quartz.Tests.Unit/PublicApiTest.cs
@@ -23,6 +23,7 @@ public class PublicApiTest
     private static readonly Assembly[] shippedAssemblies =
     [
         typeof(global::Quartz.IScheduler).Assembly,
+        typeof(global::Quartz.QuartzAspireSettings).Assembly,
         typeof(global::Quartz.Jobs.DirectoryScanJob).Assembly,
         typeof(global::Quartz.Plugins.History.LoggingJobHistoryPlugin).Assembly,
         typeof(global::Quartz.Plugins.TimeZoneConverter.TimeZoneConverterPlugin).Assembly,

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -58,6 +58,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Quartz\Quartz.csproj" />
+    <ProjectReference Include="..\Quartz.Aspire\Quartz.Aspire.csproj" />
     <!--
       The documentation samples. DocumentedConfigurationTest runs the ones the Microsoft DI page shows,
       so the page's registration is checked for what it does and not only for whether it compiles.

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Aspire.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Aspire.verified.txt
@@ -1,0 +1,21 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+namespace Quartz
+{
+    public static class QuartzAspireHostApplicationBuilderExtensions
+    {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(@"The database is chosen from the connection string or from QuartzAspireSettings.Provider, and on the connection-string path Quartz names the driver's connection, command and parameter types as strings, so a trimmed application has no guarantee they survived. Registering a DbDataSource in the container removes that: connections come from it, and only the half of the driver description that names no type is read. Otherwise configure the store directly, with the overload that takes the driver's DbProviderFactory.")]
+        public static Microsoft.Extensions.Hosting.IHostApplicationBuilder AddQuartzPersistentStore(this Microsoft.Extensions.Hosting.IHostApplicationBuilder builder, string connectionName, System.Action<Quartz.QuartzAspireSettings>? configureSettings = null) { }
+    }
+    public sealed class QuartzAspireSettings
+    {
+        public QuartzAspireSettings() { }
+        public bool Clustered { get; set; }
+        public string? ConnectionString { get; set; }
+        public bool DisableHealthChecks { get; set; }
+        public bool DisableMetrics { get; set; }
+        public bool DisableTracing { get; set; }
+        public string? Provider { get; set; }
+        public string? SchedulerName { get; set; }
+        public string? TablePrefix { get; set; }
+    }
+}


### PR DESCRIPTION
`Quartz.Aspire` is a new package: the Quartz.NET client integration for [Aspire](https://aspire.dev/).

```csharp
builder.AddQuartzPersistentStore("quartz");
builder.AddQuartz();
```

That reads the connection string the AppHost injected under `quartz`, chooses the driver delegate for the database behind it, takes connections from a `DbDataSource` the container already holds, registers the scheduler's health check, and names Quartz's activity source and meter to the OpenTelemetry pipeline ServiceDefaults built. It is `docs/documentation/quartz-4.x/how-tos/aspire.md`'s hand-written recipe turned into code; that page keeps the by-hand version and now opens by saying the package exists.

Closes #3533.

## Shape

```csharp
namespace Quartz;

public static class QuartzAspireHostApplicationBuilderExtensions
{
    [RequiresUnreferencedCode(/* the connection-string path names the driver's types */)]
    public static IHostApplicationBuilder AddQuartzPersistentStore(
        this IHostApplicationBuilder builder,
        string connectionName,
        Action<QuartzAspireSettings>? configureSettings = null);
}

public sealed class QuartzAspireSettings
{
    public string? ConnectionString { get; set; }
    public string? Provider { get; set; }
    public string? SchedulerName { get; set; }
    public string? TablePrefix { get; set; }
    public bool Clustered { get; set; }
    public bool DisableHealthChecks { get; set; }
    public bool DisableTracing { get; set; }
    public bool DisableMetrics { get; set; }
}
```

`namespace Quartz`, beside `builder.AddQuartz`, rather than Aspire's `Microsoft.Extensions.Hosting` convention. No `AddKeyed…` variant: the axis Quartz already has for a second database is a second scheduler, and `SchedulerName` is how a second call says which one it means.

**Zero `Aspire.*` package dependencies.** `IHostApplicationBuilder` is the whole contract, first-party client integrations take none either, and `Aspire.Hosting` alone would drag roughly thirty packages under this repository's transitive pinning. Package references are `Microsoft.Extensions.Configuration.Binder` (new central `PackageVersion`, 10.0.11), `Microsoft.Extensions.Hosting.Abstractions` and `OpenTelemetry.Extensions.Hosting`; project reference `Quartz` only.

## Order independence, and the one ordering that does matter

The store is contributed through `ConfigureAllQuartzSchedulers`, so `AddQuartzPersistentStore` before or after `AddQuartz` gives the same container — there is a test that builds both and compares the resolved `DataSourceOptions` and `AdoJobStoreOptions`.

Where connections come from is decided **at the call site**, against the service collection as it stands, rather than inside the per-scheduler callback: when that callback runs depends on whether `AddQuartz` has already been called, which is exactly the ordering the rest of this is indifferent to. The consequence is that a client integration registering the data source has to be called first, as Aspire's own samples do it. That is stated in the XML docs and the readme.

The ladder is the how-to's: SQL Server always takes `ConnectionStringName` (SqlClient ships no `DbDataSource`, and Aspire's SQL Server integration registers a scoped `SqlConnection`); otherwise a keyed `DbDataSource` under the connection name → `DataSourceServiceKey`, else an unkeyed one → `UseRegisteredDataSource`, else the connection string.

## Provider inference

Left unset, `Provider` is inferred from the connection string's **keywords** — parsed with `DbConnectionStringBuilder`, never substring-matched — and **an ambiguous or unrecognised string throws**, naming `QuartzAspireSettings.Provider` and `DataSourceOptions.Providers`. A wrong driver delegate writes SQL the database cannot run and fails at the first trigger acquisition, which is worse than a startup failure.

| Provider | Inferred when the connection string |
|---|---|
| `Npgsql` | has `Host` and `Database`, and no `Uid` |
| `SqlServer` | has `Server`, `Data Source`, `Address`, `Addr` or `Network Address`, together with `Initial Catalog`, `Database`, `Integrated Security` or `Trusted_Connection` — and has no `Port` and no `Host` |
| `MySqlConnector` | has `Server`, `Data Source`, `Address`, `Addr` or `Network Address` but not `Host`, together with `Port` and one of `Uid`, `User Id`, `Username` or `User` |
| `SQLite-Microsoft` | has `Data Source` whose value is `:memory:` or ends in `.db`, `.db3`, `.sqlite` or `.sqlite3`, or has `Mode=Memory` |
| `OracleODPManaged` | has `Data Source` holding a TNS descriptor or an EZ-connect `host:port/service` string, and no `Host` or `Port` |

`MySql`, `SQLite` and `Firebird` are never inferred — the first two accept the same strings as the drivers above them. A provider name Quartz ships no description for still works: it reaches `UseGenericDatabase`, which selects the generic dialect and leaves the description to whatever `DbMetadataFactory` the application registered.

**Two rules deviate from the spec, and are the reason the table works on Aspire's own resources.**

* **SQL Server is disqualified by a `Port` keyword** (and by `Host`). `Microsoft.Data.SqlClient` accepts neither — the port goes in `Server=host,1433`. Without this, Aspire's MySQL string (`Server=…;Port=…;User ID=root;Password=…;Database=quartz`) matches SQL Server's shape as written in the issue and would have been read as SQL Server, or at best reported ambiguous. `Port` is the whole of the difference between the two, and there is a test named after it.
* **MySQL is matched on any `Port` keyword, not on `Port=3306`.** A container-mapped port is never 3306, so the literal rule would never fire under Aspire.

Also deviating slightly: `Npgsql` is additionally disqualified by `Uid`, the MySQL/SQL Server spelling of a login that no Npgsql string uses — it keeps a MySQL string written with `Host=` from being read as PostgreSQL. The residual blind spots (a MySQL string spelled with `Host=` and `Username=`; a bare TNS alias, which is indistinguishable from a SQL Server instance name) are refusals or documented, never silent wrong answers.

## Clustering

`Clustered = true` calls `UseClustering()` — which turns database locking on with it — **and makes the scheduler derive its `InstanceId`**. A cluster's nodes recognise their own check-in row and their own fired triggers by that id, every scheduler starts life carrying `NON_CLUSTERED`, and an Aspire replica set has no identity of its own to borrow; `WithReplicas(2)` is one call. Asking for a cluster and getting one whose nodes all answer to the same id is the worst failure this area has, so the setting supplies both halves rather than documenting the trap beside one of them.

It fills a gap, never overrides: an application that already set `GenerateInstanceId`, or that named its nodes with `InstanceId`, keeps what it said. That is readable here because `AddQuartz` applies the container-wide delegates at `QuartzServiceCollectionExtensions.cs:457`, **after** the property bridge, the configuration binding and the scheduler's own callback at `:452` — and `ConfigureAllQuartzSchedulers` applies to an already-registered scheduler at the same point in its order. Options are last-wins, so this delegate is registered last and sees everything the application said, from code or from `Quartz:Scheduler:InstanceId`. Four tests: `ClusteredGeneratesTheInstanceId`, `AnUnclusteredSchedulerIsLeftAsItWas` (the control, so the first is not vacuous), `ClusteredKeepsAnExplicitInstanceId` and `ClusteredKeepsAnInstanceIdThatCameFromConfiguration`.

## Telemetry and health

`AddOpenTelemetry().WithTracing(AddSource("Quartz")).WithMetrics(AddMeter("Quartz"))`, and **no exporter** — ServiceDefaults calls `UseOtlpExporter()` whenever the AppHost set `OTEL_EXPORTER_OTLP_ENDPOINT`, that may be called only once, and it cannot be combined with a signal-specific `AddOtlpExporter()`. A test asserts no `OpenTelemetry` service type mentioning `Exporter` is registered. Health is `AddQuartzHealthChecks()` from the core package (A1), registered per scheduler, so two schedulers get two checks under two names. No `ResultStatusCodes` mapping — that is an ASP.NET Core type and stays documented.

## Packaging

`ConfigurationSchema.json` at the project root, packed to the package root, hand-written because Aspire's generator for it has never shipped (microsoft/aspire#3309); `buildTransitive/net10.0/Quartz.Aspire.targets` carries the `JsonSchemaSegment` item as `src/Components/Common/Package.targets` in microsoft/aspire does. `AspirePackagingTest` asserts no `Aspire.*` reference, no `FrameworkReference`, that both files are packed, that the targets point two directories up at the schema, and that every public `QuartzAspireSettings` property appears in the JSON with a description.

The nupkg contains exactly: `README.md`, `ConfigurationSchema.json`, `buildTransitive/net10.0/Quartz.Aspire.targets`, `lib/net10.0/Quartz.Aspire.{dll,xml}`, the icon and the nuspec. The nuspec's dependency group is `Quartz`, `Microsoft.Extensions.Configuration.Binder`, `Microsoft.Extensions.Hosting.Abstractions`, `OpenTelemetry.Extensions.Hosting` plus the `Microsoft.Extensions.*` transitives central pinning surfaces — **no `Aspire.*`, and no framework reference**.

`EnableConfigurationBindingGenerator` is on, as in `Quartz.csproj`: `ConfigurationBinder.Bind` says both `RequiresUnreferencedCode` and `RequiresDynamicCode`, and the generator intercepts the two `Bind` call sites here. With the trim, AOT and single-file analyzers on and warnings as errors, the package builds clean — the single declared `[RequiresUnreferencedCode]` is the dialect selection, and it is repeated from the overloads it calls so the warning arrives at the application's own call site.

## What a reviewer has to decide

1. **Trusted publishing.** A new package id needs the nuget.org trusted-publishing policy extended before the first tag. `build/Build.Publish.cs` globs `*.nupkg` and pushes with the exchanged key, so nothing in the build needs changing — but the policy `lahma` created has to cover `Quartz.Aspire`, and the id has to exist or be reserved on nuget.org, or the first tagged release will fail on this package alone.
2. **The provider-inference table**, especially the three rules above that are not literally what #3533 specified. They are the reason Aspire's MySQL resource is not read as SQL Server.
3. ~~**`Clustered` does not set `GenerateInstanceId`.**~~ **Settled — it does now.** The first push documented the trap beside the setting instead; that was ruled insufficient, and the second commit implements it. See [Clustering](#clustering) above.

## Not here

`Quartz.Aspire.Hosting`, `AddQuartzSchema`, `WithQuartzDashboard()`, `ResultStatusCodes` and `QuartzAspireSettings.ProvisionSchema` — all out of scope per the issue; `ProvisionSchema` is additive after S2. The documentation pages are A3; this carries the package readme, the migration guide's new-package section, one line in `AGENTS.md`, and the opening paragraph of `how-tos/aspire.md` so the page stops saying no integration exists.

## Verification

```
dotnet build Quartz.slnx                     Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit            Passed! Failed: 0, Passed: 3863, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore      Passed! Failed: 0, Passed: 536, Skipped: 0
dotnet pack src/Quartz.Aspire -c Release     Quartz.Aspire.4.0.0.nupkg, contents as above
dotnet fallout PublishTrimmed                Succeeded (canary: store round-trips, schedules, binds)
dotnet fallout VerifyDocsSnippets            Documentation snippets are up to date (95 files)
node docs/.vuepress/check-links.mjs          214 pages, 912 links, 556 fragments, no dead links
```

Integration tests were not run: they need a Docker daemon, and nothing here touches the database or the store's runtime behaviour. `Quartz.Tests.AOT` does not exist in this repository — the equivalent coverage is `PublishTrimmed`, which publishes and runs `Quartz.Trimming.Canary` and is unchanged by this.

54 new tests in `src/Quartz.Tests.Unit/Aspire/`: both binding sections and their precedence, connection-string pickup, provider inference per database and both refusals, SQL Server never taking the data-source path, keyed vs unkeyed vs connection string, each `Disable*`, clustering and the instance id it derives, before/after `AddQuartz`, and the schema-to-settings check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
