### PR TITLE
A persistent store can create its own schema

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -174,7 +174,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 | `AcceptEnlistedTransactions` | bool | `false` | Lets the job store use a connection the application enlisted with `SchedulerEnlistmentExtensions.EnlistTransaction`, so scheduling commits with the application's own work. See [Joining an existing transaction](../tutorial/job-stores.md#joining-an-existing-transaction). |
 | `DoubleCheckLockMisfireHandler` | bool | `true` | Re-checks the lock before handling misfires. |
 | `UseBackgroundThreads` | bool | `false` | Runs the misfire handler and cluster manager on background threads, which do not keep the process alive. These two are the only real threads Quartz creates. |
-| `PerformSchemaValidation` | bool | `true` | Verifies the expected tables exist at startup. |
+| `SchemaProvisioning` | `SchemaProvisioning` | `Validate` | What the store does about its schema at startup: `None` does nothing, `Validate` verifies the expected tables exist, `CreateIfMissing` creates whatever is missing and then verifies. |
 | `SelectWithLockSql` | string? | none | Overrides the row-lock statement, defaulted to SQL Server's `WITH (UPDLOCK,ROWLOCK)` form when that is the database. Read only when the store builds a database-locking handler for itself — see [Locking](#locking). |
 | `OpenConnection` | bool | `false` | Whether `ExternalTransactionJobStore` opens the connections it creates; read only by that store. |
 

--- a/docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md
+++ b/docs/documentation/quartz-4.x/how-tos/trimming-and-native-aot.md
@@ -281,7 +281,7 @@ It does three checks, in order:
   serialized, read back under the very type `StdAdoDelegate` asks for, and serialized again, with the
   two payloads compared byte for byte.
 - **The store.** It creates a SQLite file from the schema Quartz ships, registers it as
-  `UseSqlite(SqliteFactory.Instance, …)` with `PerformSchemaValidation` on, schedules a job, waits for
+  `UseSqlite(SqliteFactory.Instance, …)` with `SchemaProvisioning.Validate`, schedules a job, waits for
   the job itself to signal that it fired, and reads the job and the trigger back through `IScheduler`.
   The firing is the point: that is where the job's type comes back out of `JOB_CLASS_NAME` as a string.
 - **The binding.** It builds a whole scheduler from an in-memory `IConfiguration` and reads ten values

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -565,6 +565,45 @@ The flat key `quartz.jobStore.makeThreadsDaemons` is unchanged and still sets it
 misfire handler and the cluster manager, which are the only real threads Quartz creates — so it is now
 the whole answer to "do Quartz's threads hold my console application open".
 
+### `PerformSchemaValidation` became `SchemaProvisioning`, which has a third position
+
+A persistent store can now create its own schema ([#3531](https://github.com/quartznet/quartznet/issues/3531)),
+which the old flag had nowhere to say. The check and the creation are one decision — a store that may
+create its schema obviously validates it too — so they are one setting with three positions rather than
+two flags that can contradict each other.
+
+| Before | After |
+|---|---|
+| `AdoJobStoreOptions.PerformSchemaValidation = true` | `AdoJobStoreOptions.SchemaProvisioning = SchemaProvisioning.Validate` (the default) |
+| `AdoJobStoreOptions.PerformSchemaValidation = false` | `AdoJobStoreOptions.SchemaProvisioning = SchemaProvisioning.None` |
+| — | `AdoJobStoreOptions.SchemaProvisioning = SchemaProvisioning.CreateIfMissing`, or `store.ProvisionSchema()` |
+
+The flat key `quartz.jobStore.performSchemaValidation` still works and still means what it meant:
+`true` bridges to `Validate` and `false` to `None`. `quartz.jobStore.schemaProvisioning` is the new key
+and takes a member name — `None`, `Validate` or `CreateIfMissing`, case-insensitively. A file carrying
+both is decided by the new key, since it is the only one of the two that can express the third position.
+
+`CreateIfMissing` only ever creates: no object is altered and none is dropped, so it is safe to leave on
+against a schema that already exists and cannot turn a mis-typed `TablePrefix` into data loss — though it
+will happily create a second, empty schema under the mis-typed one. It is equally **not** an upgrade: a
+schema that has every table but is missing a column a later release added is left exactly as it is.
+`database/migrations/` is still what moves a schema forward, and the 3.x → 4.0 upgrade is still mandatory.
+
+It is not the default, because creating tables needs DDL permission that a production database is usually
+right not to grant. When the account has none, the failure names the fresh-install script for your
+database and says to run it and drop back to `Validate`.
+
+`IDriverDelegate` gained the member behind it:
+
+```csharp
+ValueTask CreateSchema(ConnectionAndTransactionHolder conn, CancellationToken cancellationToken = default);
+```
+
+A delegate deriving from `StdAdoDelegate` inherits an implementation that runs an embedded script, and
+names the script by overriding `protected virtual string? SchemaResourceName`. The six shipped delegates
+each name their own; one that names none throws when asked to provision, saying so, rather than reporting
+success and creating nothing.
+
 ### Code-first configuration is typed
 
 Settings that used to be write-only properties on the configurator are now options:
@@ -2068,8 +2107,9 @@ lands, its manager interface extends this one rather than replacing it.
 
 Two schedulers sharing a database are told apart by `SCHED_NAME` and share one table prefix. Pointing one
 of them at a different prefix by accident used to be silent in the worst possible way: the scheduler
-connects, `PerformSchemaValidation` passes against the tables it *was* pointed at, it starts, it reports
-healthy, and it never sees its tenant's data.
+connects, schema validation passes against the tables it *was* pointed at, it starts, it reports healthy,
+and it never sees its tenant's data. `SchemaProvisioning.CreateIfMissing` makes that easier to reach
+rather than harder, since it will create the mis-typed table set rather than needing one to be there.
 
 Creating a scheduler now records its database and table prefix, and a scheduler that shares a database
 with one already created but disagrees about the prefix is reported at `Warning`, naming both schedulers
@@ -5304,7 +5344,7 @@ diverged from the options everything else reads — and reading store configurat
 longer public: the mirrors a derived store legitimately reads while doing its work are `protected`
 (`AcquireTriggersWithinLock`, `CanUseProperties`, `ClusterCheckinMisfireThreshold`,
 `DataSource`, `DoubleCheckLockMisfireHandler`, `LockOnInsert`, `MaxMisfiresToHandleAtATime`,
-`MaxTransientRetries`, `ObjectSerializer`, `PerformSchemaValidation`, `SelectWithLockSql`, `TablePrefix`,
+`MaxTransientRetries`, `ObjectSerializer`, `SchemaProvisioning`, `SelectWithLockSql`, `TablePrefix`,
 `TransientRetryInterval`, `TransactionIsolationLevel`, `UseDbLocks`), and the ones only the store's
 own cluster and misfire machinery reads are internal (`AcceptEnlistedTransactions`,
 `ClusterCheckinInterval`, `DbRetryInterval`, `InstanceId`, `InstanceName`, `UseBackgroundThreads`,
@@ -5622,6 +5662,9 @@ had asked for. It is an interface member now, and every delegate participates:
 ```csharp
 ValueTask<int> ValidateSchema(ConnectionAndTransactionHolder conn, CancellationToken cancellationToken = default);
 ```
+
+`CreateSchema` sits beside it, for the `SchemaProvisioning.CreateIfMissing` the flag it replaced could not
+express — see [`PerformSchemaValidation` became `SchemaProvisioning`](#performschemavalidation-became-schemaprovisioning-which-has-a-third-position).
 
 A delegate of your own that derives from `StdAdoDelegate` inherits the implementation and can extend it to
 cover tables of its own. One written against the interface directly has to implement it; returning `0`

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -598,7 +598,7 @@ Four rules:
 - **The prefix has to match the DDL.** Nothing derives one from the other; you run the DDL with the
   prefix substituted.
 - **A prefix pointing at tables that do not exist is caught at startup.**
-  `PerformSchemaValidation` is on by default, and a missing or mis-prefixed table is reported once, by
+  `SchemaProvisioning.Validate` is the default, and a missing or mis-prefixed table is reported once, by
   name, with a message telling you to run the schema scripts — rather than surfacing as the first failing
   operation an hour later.
 - **A prefix pointing at the *wrong* tables is reported too, as a warning.** Schema validation cannot

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -39,8 +39,8 @@ A node that meets a schema it cannot use refuses to start rather than misbehavin
 want: the store issues a `SELECT 1` against every table it needs and fails with
 `SchedulerException: Database schema validation failed` if one is missing. Know its limit, though — it
 checks *tables*, not columns, so a database that is missing only a column gets past startup and fails on
-the first statement that names it. `JobStore:PerformSchemaValidation` turns the check off; there is no
-good reason to.
+the first statement that names it. `JobStore:SchemaProvisioning` set to `None` turns the check off; there
+is no good reason to.
 
 ::: warning
 The fresh-install scripts in [`database/tables/`](https://github.com/quartznet/quartznet/tree/main/database/tables)

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -195,7 +195,7 @@ builder.Services.AddQuartz(q =>
         {
             options.TablePrefix = "QRTZ_";        // the default
             options.StoreJobDataAsStrings = true; // preferred, but not the default
-            options.PerformSchemaValidation = true;
+            options.SchemaProvisioning = SchemaProvisioning.Validate; // the default
         });
 
         store.UseClustering(cluster =>

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -430,7 +430,7 @@ rather than an isolation one.
 | Groups and group matchers | Yes, `GroupMatcher<T>` | Yes, plus the paged query API |
 | `SCHED_NAME` row separation | Yes | Yes |
 | Per-scheduler table prefix | Yes | Yes |
-| Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `PerformSchemaValidation` on by default |
+| Startup schema validation | Yes, `PerformSchemaValidation` on by default | Yes, `SchemaProvisioning.Validate` by default |
 | Shared database, mismatched table prefix | No — silent; each scheduler sees an empty table set | Yes, warns naming both schedulers and both prefixes |
 | Listing tenants without starting them | No — the repository lists live schedulers only | Yes, `ISchedulerRegistry.QuerySchedulers()` |
 | Execution groups and per-node limits | Yes | Yes |
@@ -569,8 +569,9 @@ at twenty, a serious operational burden at a thousand. Groups scale where schedu
 
 **A shared database with a mismatched table prefix.** Nothing derives the prefix from the DDL or the
 DDL from the prefix; you run the scripts with the prefix substituted. A prefix pointing at tables
-that do not exist is caught at startup — `PerformSchemaValidation` is on by default on both versions,
-and it names the missing table rather than letting the first failing operation surface an hour later.
+that do not exist is caught at startup — 3.x has `PerformSchemaValidation` on by default and 4.x
+`SchemaProvisioning.Validate` — and it names the missing table rather than letting the first failing
+operation surface an hour later.
 What validation cannot catch is a prefix pointing at tables that *do* exist and belong to another
 tenant: that configuration is indistinguishable from a correct one, and it will run happily on the
 wrong data. Derive the prefix from the tenant id in code rather than pasting it into per-environment

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -104,7 +104,7 @@ public static class MicrosoftDiIntegrationSamples
                 {
                     options.TablePrefix = "QRTZ_";        // the default
                     options.StoreJobDataAsStrings = true; // preferred, but not the default
-                    options.PerformSchemaValidation = true;
+                    options.SchemaProvisioning = SchemaProvisioning.Validate; // the default
                 });
 
                 store.UseClustering(cluster =>

--- a/src/Quartz.Examples.AspNetCore/Startup.cs
+++ b/src/Quartz.Examples.AspNetCore/Startup.cs
@@ -263,7 +263,7 @@ public class Startup
                 });
                 s.ConfigureStore(options =>
                 {
-                    options.PerformSchemaValidation = true; // default
+                    options.SchemaProvisioning = SchemaProvisioning.Validate; // default
                     options.UseProperties = true; // preferred, but not default
                     options.DbRetryInterval = TimeSpan.FromSeconds(15);
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
@@ -167,7 +167,7 @@ public class AdoJobStorePagingTest
             store.ConfigureStore(o =>
             {
                 o.StoreJobDataAsStrings = false;
-                o.PerformSchemaValidation = true;
+                o.SchemaProvisioning = SchemaProvisioning.Validate;
             });
 
             store.UseGenericDatabase(dbProvider, connectionString);

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreSmokeTest.cs
@@ -280,7 +280,7 @@ public class AdoJobStoreSmokeTest
             store.ConfigureStore(o =>
             {
                 o.StoreJobDataAsStrings = false;
-                o.PerformSchemaValidation = true;
+                o.SchemaProvisioning = SchemaProvisioning.Validate;
                 o.MisfireThreshold = TimeSpan.FromSeconds(60);
             });
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigratedSchemaWorkload.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigratedSchemaWorkload.cs
@@ -283,7 +283,7 @@ internal static class MigratedSchemaWorkload
 
                 // The migrated tables have to pass the same startup check a fresh install does, and a
                 // mis-prefixed or missing one is reported by name rather than as a later failure.
-                o.PerformSchemaValidation = true;
+                o.SchemaProvisioning = SchemaProvisioning.Validate;
             });
 
             UseDialect(store, dialect, connectionString);

--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -122,7 +122,12 @@ public class LegacyPropertyKeyExhaustivenessTest
         "quartz.executionLimit.batch-jobs",
 
         // migration-guide.md
-        "quartz.timeProvider.type"
+        "quartz.timeProvider.type",
+
+        // migration-guide.md, the SchemaProvisioning row: the key that replaced
+        // performSchemaValidation, and the one it replaced, which still bridges
+        "quartz.jobStore.schemaProvisioning",
+        "quartz.jobStore.performSchemaValidation"
     ];
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
@@ -131,6 +131,59 @@ public sealed class PersistentStoreBuilderTest
         act.Should().Throw<ArgumentNullException>();
     }
 
+    [Test]
+    public void ProvisionSchema_TurnsCreateIfMissingOn()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ConnectionString);
+            store.ProvisionSchema();
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetSchedulerOptions<AdoJobStoreOptions>(null).SchemaProvisioning
+            .Should().Be(SchemaProvisioning.CreateIfMissing,
+                "the shorthand exists to spell the decision, so it has to reach the same setting "
+                + "ConfigureStore does");
+    }
+
+    [Test]
+    public void ProvisionSchema_IsNotWhatAStoreDoesUnasked()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetSchedulerOptions<AdoJobStoreOptions>(null).SchemaProvisioning
+            .Should().Be(SchemaProvisioning.Validate,
+                "creating tables needs DDL permission a production database is usually right not to "
+                + "grant, so provisioning is asked for rather than assumed");
+    }
+
+    [Test]
+    public void ProvisionSchema_AppliesToTheSchedulerThatAskedForIt()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ReportingConnectionString);
+            store.ProvisionSchema();
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetSchedulerOptions<AdoJobStoreOptions>("reporting").SchemaProvisioning
+            .Should().Be(SchemaProvisioning.CreateIfMissing);
+        provider.GetSchedulerOptions<AdoJobStoreOptions>(null).SchemaProvisioning
+            .Should().Be(SchemaProvisioning.Validate,
+                "a named scheduler's options are keyed by its name, so one scheduler granted DDL does "
+                + "not hand it to every other scheduler in the container");
+    }
+
     private sealed class CountingDriverDelegate : StdAdoDelegate
     {
         public IDbProvider? Provider { get; init; }

--- a/src/Quartz.Tests.Unit/Configuration/QuartzPropertyBridgeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzPropertyBridgeTest.cs
@@ -234,6 +234,72 @@ public class QuartzPropertyBridgeTest
             + "translating it to an explicit ReadCommitted would stop SQLite getting serializable");
     }
 
+    [TestCase("true", SchemaProvisioning.Validate)]
+    [TestCase("false", SchemaProvisioning.None)]
+    public void ThePerformSchemaValidationFlagBecomesAProvisioningPosition(string configured, SchemaProvisioning expected)
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+            ["quartz.jobStore.performSchemaValidation"] = configured,
+        });
+
+        Options<AdoJobStoreOptions>(provider).SchemaProvisioning.Should().Be(expected,
+            "the 3.x key said only whether the store checked, which is two of the three positions the "
+            + "setting that replaced it has");
+    }
+
+    [TestCase("None", SchemaProvisioning.None)]
+    [TestCase("Validate", SchemaProvisioning.Validate)]
+    [TestCase("CreateIfMissing", SchemaProvisioning.CreateIfMissing)]
+    [TestCase("createifmissing", SchemaProvisioning.CreateIfMissing)]
+    public void TheSchemaProvisioningKeyNamesThePositionDirectly(string configured, SchemaProvisioning expected)
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+            ["quartz.jobStore.schemaProvisioning"] = configured,
+        });
+
+        Options<AdoJobStoreOptions>(provider).SchemaProvisioning.Should().Be(expected,
+            "a value in a configuration file is written by hand, so its case is not the reader's to insist on");
+    }
+
+    [Test]
+    public void TheSchemaProvisioningKeyWinsOverThePerformSchemaValidationFlag()
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+            ["quartz.jobStore.performSchemaValidation"] = "true",
+            ["quartz.jobStore.schemaProvisioning"] = "CreateIfMissing",
+        });
+
+        Options<AdoJobStoreOptions>(provider).SchemaProvisioning.Should().Be(SchemaProvisioning.CreateIfMissing,
+            "a file carrying both is a file mid-migration, and only one of the two keys can express the "
+            + "third position — so the one that can decides");
+    }
+
+    [Test]
+    public void AMisspelledSchemaProvisioningValueIsRejectedWithTheOnesThatWouldWork()
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+            ["quartz.jobStore.schemaProvisioning"] = "CreateIfMissng",
+        });
+
+        // The keys are translated when the options are built rather than when the bridge is applied,
+        // so reading them is what runs the parser.
+        var act = () => Options<AdoJobStoreOptions>(provider);
+
+        act.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*CreateIfMissng*")
+            .WithMessage("*None, Validate, CreateIfMissing*",
+                "'not found' sends a reader back to the documentation; the names that would have worked "
+                + "are already here");
+    }
+
     [Test]
     public void InMemoryJobStoreKeepsItsOwnMisfireThreshold()
     {

--- a/src/Quartz.Tests.Unit/Configuration/QuartzTypedOptionsTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzTypedOptionsTest.cs
@@ -118,7 +118,7 @@ public class QuartzTypedOptionsTest
         options.TablePrefix.Should().Be("MY_");
         options.StoreJobDataAsStrings.Should().BeTrue();
         options.UseDbLocks.Should().BeTrue();
-        options.PerformSchemaValidation.Should().BeTrue("unset booleans keep their default");
+        options.SchemaProvisioning.Should().Be(SchemaProvisioning.Validate, "unset settings keep their default");
 
         var clustering = provider.GetRequiredService<IOptions<ClusteringOptions>>().Value;
 

--- a/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedDatabaseValidatorTest.cs
@@ -199,7 +199,7 @@ public sealed class SharedDatabaseValidatorTest
             {
                 options.DataSource = "tenants";
                 options.TablePrefix = tablePrefix;
-                options.PerformSchemaValidation = false;
+                options.SchemaProvisioning = SchemaProvisioning.None;
             });
 
             store.Services.AddKeyedSingleton<IDbProvider>(builder.SchedulerName, new StubDbProvider(ConnectionString));

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningSqliteTest.cs
@@ -1,0 +1,241 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// A store creating its own schema, against a real database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQLite is a file, so a whole empty database costs a temporary path and the scheduler that
+/// provisions it runs in this process. That makes it the one dialect whose provisioning can be
+/// exercised end to end without a container, which is why the case lives here rather than only in
+/// <c>SchemaProvisioningTest</c>, where the other five dialects are.
+/// </para>
+/// <para>
+/// What is under test is the store's decision and the round trip, not the DDL: the SQL that runs is
+/// the same generated script <c>SchemaScriptTest</c> compares with the fresh-install one, and the
+/// integration legs are where the resulting catalog is compared against a real one per dialect.
+/// </para>
+/// </remarks>
+public sealed class SchemaProvisioningSqliteTest
+{
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        // Not created here: an empty path is a valid SQLite database the moment something opens it,
+        // which is exactly the "nothing is there yet" case provisioning is for.
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-provisioning-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task AStoreThatProvisionsStartsAgainstAnEmptyDatabase()
+    {
+        await ScheduleFireAndReadBack(nameof(AStoreThatProvisionsStartsAgainstAnEmptyDatabase));
+    }
+
+    [Test]
+    public async Task AStoreThatDoesNotProvisionRefusesToStartAgainstAnEmptyDatabase()
+    {
+        Func<Task> act = () => ScheduleFireAndReadBack(
+            nameof(AStoreThatDoesNotProvisionRefusesToStartAgainstAnEmptyDatabase), provision: false);
+
+        await act.Should().ThrowAsync<SchedulerException>().WithMessage("*schema validation failed*",
+            "Validate is still the default, so an empty database is a startup failure naming the schema "
+            + "rather than a scheduler that starts and never fires");
+    }
+
+    [Test]
+    public async Task ProvisioningASchemaThatIsAlreadyThereChangesNothing()
+    {
+        await ScheduleFireAndReadBack("first");
+
+        // Everything the first scheduler wrote is still in the file, so a create that was not guarded
+        // would fail, and one that recreated a table would take the rows with it.
+        await ScheduleFireAndReadBack("second");
+
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        (await Scalar(connection, "SELECT COUNT(*) FROM QRTZ_JOB_DETAILS")).Should().Be(2,
+            "provisioning creates what is missing and touches nothing else, so the first scheduler's job "
+            + "is still there beside the second's");
+    }
+
+    [Test]
+    public async Task ProvisioningCreatesEveryObjectUnderTheConfiguredPrefix()
+    {
+        await ScheduleFireAndReadBack(nameof(ProvisioningCreatesEveryObjectUnderTheConfiguredPrefix), tablePrefix: "QRTZP_");
+
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        (await Scalar(connection, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'QRTZP!_%' ESCAPE '!'"))
+            .Should().Be(12, "every table Quartz reads or writes is created, under the prefix that was asked for");
+
+        (await Scalar(connection, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'QRTZP!_DELETE!_%' ESCAPE '!'"))
+            .Should().Be(4,
+                "SQLite enforces no foreign keys unless the connection asks it to, so the four delete "
+                + "triggers are what keeps the type tables from leaking rows — and they carry the prefix, "
+                + "which is what lets a second schema live in the same file");
+
+        (await Scalar(connection, "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'QRTZ!_%' ESCAPE '!'"))
+            .Should().Be(0,
+                "nothing may be created under the default prefix when another one was configured — a "
+                + "literal QRTZ_ left in the script is exactly the object two schedulers would fight over");
+    }
+
+    [Test]
+    public async Task ADelegateWithNoSchemaScriptSaysWhatToRunInstead()
+    {
+        Func<Task> act = () => ScheduleFireAndReadBack(
+            nameof(ADelegateWithNoSchemaScriptSaysWhatToRunInstead),
+            configure: store => store.UseDriverDelegate<ScriptlessDelegate>());
+
+        SchedulerException failure = (await act.Should().ThrowAsync<SchedulerException>())
+            .WithMessage("*database/tables/*")
+            .WithMessage("*SchemaProvisioning.Validate*",
+                "a reader who cannot be granted DDL needs the file to run and the setting to go back to, "
+                + "not only the news that something failed")
+            .Which;
+
+        failure.InnerException.Should().BeOfType<JobPersistenceException>()
+            .Which.Message.Should().Contain(nameof(ScriptlessDelegate),
+                "the delegate that has no script is the thing to change, so it is named");
+    }
+
+    private async Task ScheduleFireAndReadBack(
+        string schedulerName,
+        bool provision = true,
+        string? tablePrefix = null,
+        Action<IPersistentStoreBuilder>? configure = null)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = schedulerName;
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                // Before the database is chosen: choosing one registers a driver delegate, and the
+                // registrations are TryAdd, so the first one to name a delegate is the one that runs.
+                configure?.Invoke(store);
+
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+
+                if (tablePrefix is not null)
+                {
+                    store.ConfigureStore(options => options.TablePrefix = tablePrefix);
+                }
+
+                if (provision)
+                {
+                    store.ProvisionSchema();
+                }
+            });
+        });
+
+        await using ServiceProvider container = services.BuildServiceProvider();
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        TaskCompletionSource fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        scheduler.Context[SignallingJob.SignalKey] = fired;
+
+        JobKey jobKey = new("job", schedulerName);
+        TriggerKey triggerKey = new("trigger", schedulerName);
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<SignallingJob>().WithIdentity(jobKey).Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .StartNow()
+                // Repeating, so reading it back afterwards reads a trigger rather than finding the row a
+                // completed one-shot trigger took with it.
+                .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build());
+
+        await scheduler.Start();
+        await fired.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        (await scheduler.GetTrigger(triggerKey)).Should().NotBeNull(
+            "a schema the store created has to be one the store can read back through");
+
+        await scheduler.Shutdown(waitForJobsToComplete: true);
+    }
+
+    private static async Task<long> Scalar(SqliteConnection connection, string sql)
+    {
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        return Convert.ToInt64(await command.ExecuteScalarAsync());
+    }
+
+    /// <summary>
+    /// A driver delegate of the kind somebody writes for a database Quartz ships no script for.
+    /// </summary>
+    private sealed class ScriptlessDelegate : SQLiteDelegate
+    {
+        protected override string? SchemaResourceName => null;
+    }
+
+    /// <summary>
+    /// Public with a public constructor, because the store hands the job factory nothing but the type
+    /// name it read back out of <c>JOB_CLASS_NAME</c>.
+    /// </summary>
+    public sealed class SignallingJob : IJob
+    {
+        internal const string SignalKey = "fired";
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((TaskCompletionSource) context.Scheduler.Context[SignalKey]!).TrySetResult();
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectWithLockSqlWarningTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectWithLockSqlWarningTest.cs
@@ -99,7 +99,7 @@ public sealed class SelectWithLockSqlWarningTest
             : base(TestJobStores.Dependencies(
                 storeOptions: TestJobStores.StoreOptions(configure: options =>
                 {
-                    options.PerformSchemaValidation = false;
+                    options.SchemaProvisioning = SchemaProvisioning.None;
                     options.SelectWithLockSql = selectWithLockSql;
                 }))
                 // Through `with`, because the fixture's null means "none configured" — the case where

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -164,6 +164,12 @@
     "RetryExecuteInLocalTransactionLock: RuntimeException {ExceptionMessage}"
 3038  Warning  AdoJobStoreLog.TransientFailureInLocalTransactionLock
     "Transient exception on attempt {Attempt} of {TotalAttempts} in ExecuteInLocalTransactionLock, will retry after {RetryInterval}"
+3039  Information  AdoJobStoreLog.SchemaCreated
+    "Created the schema objects missing under table prefix '{TablePrefix}'"
+3040  Debug  AdoJobStoreLog.SchemaCreatedByAnotherNode
+    "Schema creation under table prefix '{TablePrefix}' failed, but the schema validates, so another node created it first"
+3041  Debug  AdoJobStoreLog.SchemaCreationRetrying
+    "Schema creation under table prefix '{TablePrefix}' failed on attempt {Attempt} of {Attempts} and the schema does not validate yet, retrying"
 3100  Debug  AdoJobStoreLog.SqlPrepared
     "Prepared SQL: {Sql}"
 3110  Error  AdoJobStoreLog.ConnectionCloseFailed

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -29,8 +29,8 @@ namespace Quartz
         public System.TimeSpan? MisfireHandlerFrequency { get; set; }
         public System.TimeSpan MisfireThreshold { get; set; }
         public bool OpenConnection { get; set; }
-        public bool PerformSchemaValidation { get; set; }
         public int RetryableActionErrorLogThreshold { get; set; }
+        public Quartz.SchemaProvisioning SchemaProvisioning { get; set; }
         public string? SelectWithLockSql { get; set; }
         public bool StoreJobDataAsStrings { get; set; }
         public string TablePrefix { get; set; }
@@ -580,6 +580,7 @@ namespace Quartz
         string SchedulerName { get; }
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
         Quartz.IPersistentStoreBuilder ConfigureStore(System.Action<Quartz.AdoJobStoreOptions> configure);
+        Quartz.IPersistentStoreBuilder ProvisionSchema();
         Quartz.IPersistentStoreBuilder UseClustering(System.Action<Quartz.ClusteringOptions>? configure = null);
         Quartz.IPersistentStoreBuilder UseConnectionProvider(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.Common.IDbProvider> factory);
         Quartz.IPersistentStoreBuilder UseConnectionProvider<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
@@ -1654,6 +1655,12 @@ namespace Quartz
         public bool OverwriteExistingData { get; set; }
         public bool ScheduleTriggerRelativeToReplacedTrigger { get; set; }
     }
+    public enum SchemaProvisioning
+    {
+        None = 0,
+        Validate = 1,
+        CreateIfMissing = 2,
+    }
     public enum ShutdownJobInterruption
     {
         Never = 0,
@@ -2272,7 +2279,7 @@ namespace Quartz.Impl.AdoJobStore
         public System.TimeSpan MisfireThreshold { get; }
         protected System.DateTimeOffset MisfireTime { get; }
         protected Quartz.Extensibility.IObjectSerializer? ObjectSerializer { get; }
-        protected bool PerformSchemaValidation { get; }
+        protected Quartz.SchemaProvisioning SchemaProvisioning { get; }
         protected string? SelectWithLockSql { get; }
         protected System.TimeSpan StaleAcquiredTriggerThreshold { get; }
         public bool SupportsPersistence { get; }
@@ -2515,6 +2522,7 @@ namespace Quartz.Impl.AdoJobStore
     public class FirebirdDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public FirebirdDelegate() { }
+        protected override string? SchemaResourceName { get; }
         protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public sealed class FiredTriggerQuery : System.IEquatable<Quartz.Impl.AdoJobStore.FiredTriggerQuery>
@@ -2559,6 +2567,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask ClearMisfireOriginalFireTime(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask CreateSchema(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> DeleteFiredTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string entryId, System.Threading.CancellationToken cancellationToken = default);
@@ -2707,6 +2716,7 @@ namespace Quartz.Impl.AdoJobStore
     public class MySQLDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public MySQLDelegate() { }
+        protected override string? SchemaResourceName { get; }
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override string GetCountMisfiredTriggersInStateSql() { }
@@ -2722,6 +2732,7 @@ namespace Quartz.Impl.AdoJobStore
     public class OracleDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public OracleDelegate() { }
+        protected override string? SchemaResourceName { get; }
         public override bool GetBooleanFromDbValue(object columnValue) { }
         public override object GetDbBooleanValue(bool booleanValue) { }
         protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
@@ -2729,6 +2740,7 @@ namespace Quartz.Impl.AdoJobStore
     public class PostgreSQLDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public PostgreSQLDelegate() { }
+        protected override string? SchemaResourceName { get; }
         protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
     public class PostgreSqlSelectForUpdateLockHandler : Quartz.Impl.AdoJobStore.SelectForUpdateLockHandler
@@ -2761,6 +2773,7 @@ namespace Quartz.Impl.AdoJobStore
     public class SQLiteDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public SQLiteDelegate() { }
+        protected override string? SchemaResourceName { get; }
         protected override void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
         protected override string ApplyPaging(string sql, bool takeLimited) { }
         protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
@@ -2862,6 +2875,7 @@ namespace Quartz.Impl.AdoJobStore
     public class SqlServerDelegate : Quartz.Impl.AdoJobStore.StdAdoDelegate
     {
         public SqlServerDelegate() { }
+        protected override string? SchemaResourceName { get; }
         public override void AddCommandParameter(System.Data.Common.DbCommand cmd, string paramName, object? paramValue, System.Enum? dataType = null, int? size = default) { }
         protected override Quartz.Impl.AdoJobStore.SqlRowLimit GetRowLimit(int count) { }
     }
@@ -2889,6 +2903,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual bool CanUseProperties { get; }
         protected Quartz.Impl.AdoJobStore.Common.IDbProvider DbProvider { get; }
         public virtual bool FiltersAcquisitionJobTypeExclusions { get; }
+        protected virtual string? SchemaResourceName { get; }
         public virtual void AddCommandParameter(System.Data.Common.DbCommand cmd, string paramName, object? paramValue, System.Enum? dataType = null, int? size = default) { }
         protected virtual void AddDefaultTriggerPersistenceDelegates() { }
         protected virtual void AddPagingParameters(System.Data.Common.DbCommand cmd, int skip, int take, bool takeLimited) { }
@@ -2904,6 +2919,7 @@ namespace Quartz.Impl.AdoJobStore
         protected virtual System.Collections.Specialized.NameValueCollection ConvertToProperty(System.Collections.Generic.IDictionary<string, object?> data) { }
         public virtual System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> CountTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask CreateSchema(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteBlobTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> DeleteFiredTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string entryId, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Trimming.Canary/StoreCheck.cs
+++ b/src/Quartz.Trimming.Canary/StoreCheck.cs
@@ -97,7 +97,7 @@ internal static class StoreCheck
                     // The registration this whole check exists for: the driver's own factory, so nothing
                     // is resolved from a type name and nothing is constructed by reflection.
                     store.UseSqlite(SqliteFactory.Instance, connectionString);
-                    store.ConfigureStore(options => options.PerformSchemaValidation = true);
+                    store.ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.Validate);
                 });
             });
 

--- a/src/Quartz/Configuration/AdoJobStoreOptions.cs
+++ b/src/Quartz/Configuration/AdoJobStoreOptions.cs
@@ -181,9 +181,15 @@ public sealed class AdoJobStoreOptions
     public bool UseBackgroundThreads { get; set; }
 
     /// <summary>
-    /// Whether the expected schema objects are verified to exist at startup.
+    /// What the store does about its schema at startup: nothing, verify it, or create what is
+    /// missing and then verify it.
     /// </summary>
-    public bool PerformSchemaValidation { get; set; } = true;
+    /// <remarks>
+    /// Defaults to <see cref="Quartz.SchemaProvisioning.Validate"/>, which is what
+    /// <c>PerformSchemaValidation = true</c> meant. <see cref="Quartz.SchemaProvisioning.None"/> is
+    /// the old <see langword="false"/>.
+    /// </remarks>
+    public SchemaProvisioning SchemaProvisioning { get; set; } = SchemaProvisioning.Validate;
 
     /// <summary>
     /// Overrides the SQL statement used to acquire the row lock. Defaulted for SQL Server to its

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -152,6 +152,31 @@ public interface IPersistentStoreBuilder
     IPersistentStoreBuilder UseClustering(Action<ClusteringOptions>? configure = null);
 
     /// <summary>
+    /// Creates whatever this store's schema is missing when the scheduler starts, instead of
+    /// requiring it to be there already.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Shorthand for <c>ConfigureStore(options =&gt; options.SchemaProvisioning =
+    /// SchemaProvisioning.CreateIfMissing)</c>, spelled as the decision it is.
+    /// </para>
+    /// <para>
+    /// Only ever creates. Nothing is altered and nothing is dropped, so this cannot turn a mis-typed
+    /// <see cref="AdoJobStoreOptions.TablePrefix"/> into data loss — but it will happily create a
+    /// second, empty schema under the mis-typed one, so the prefix is still worth reading twice.
+    /// Neither is it an upgrade: a schema that has every table but is missing a column a later
+    /// release added is left as it is. <c>database/migrations/</c> is what moves a schema forward.
+    /// </para>
+    /// <para>
+    /// The account the store connects with needs permission to create tables and indexes, which a
+    /// production database is usually right not to grant, and which is why this is opt-in rather than
+    /// the default. Several schedulers may call it against one database at once: whichever loses the
+    /// race finds the schema the winner created.
+    /// </para>
+    /// </remarks>
+    IPersistentStoreBuilder ProvisionSchema();
+
+    /// <summary>
     /// Uses a specific serializer for job data held in the database.
     /// </summary>
     IPersistentStoreBuilder UseSerializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -250,6 +250,11 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         return ConfigureStore(options => options.UseDbLocks = true);
     }
 
+    public IPersistentStoreBuilder ProvisionSchema()
+    {
+        return ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.CreateIfMissing);
+    }
+
     public IPersistentStoreBuilder UseSerializer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()
         where T : class, IObjectSerializer
     {

--- a/src/Quartz/Configuration/QuartzPropertyBridge.cs
+++ b/src/Quartz/Configuration/QuartzPropertyBridge.cs
@@ -669,7 +669,12 @@ internal static class QuartzPropertyBridge
             "quartz.jobStore.txIsolationLevelSerializable",
             value => options.TransactionIsolationLevel = value ? IsolationLevel.Serializable : null);
         parser.Bool("quartz.jobStore.doubleCheckLockMisfireHandler", value => options.DoubleCheckLockMisfireHandler = value);
-        parser.Bool("quartz.jobStore.performSchemaValidation", value => options.PerformSchemaValidation = value);
+        // The 3.x key said only whether the store checked, which is two of the three things it can now
+        // do. Read first, so a file carrying both keys is decided by the one that can say all three.
+        parser.Bool(
+            "quartz.jobStore.performSchemaValidation",
+            value => options.SchemaProvisioning = value ? SchemaProvisioning.Validate : SchemaProvisioning.None);
+        parser.Enum<SchemaProvisioning>("quartz.jobStore.schemaProvisioning", value => options.SchemaProvisioning = value);
         parser.String("quartz.jobStore.selectWithLockSQL", value => options.SelectWithLockSql = value);
     }
 
@@ -963,6 +968,31 @@ internal static class QuartzPropertyBridge
             {
                 apply(bool.Parse(value));
             }
+        }
+
+        /// <summary>
+        /// Reads a value naming one of an enum's members, case-insensitively.
+        /// </summary>
+        /// <remarks>
+        /// A misspelled member is reported with the names that would have worked. <see cref="Enum.Parse{T}(string, bool)"/>
+        /// would otherwise say only that the value "was not found", and it accepts a bare number, which
+        /// in a configuration file is a value nobody meant to write.
+        /// </remarks>
+        public void Enum<TEnum>(string key, Action<TEnum> apply) where TEnum : struct, Enum
+        {
+            if (String(key) is not { } value)
+            {
+                return;
+            }
+
+            if (!System.Enum.TryParse(value, ignoreCase: true, out TEnum parsed)
+                || !System.Enum.IsDefined(parsed))
+            {
+                Throw.SchedulerConfigException(
+                    $"Value '{value}' of '{key}' is not one of {string.Join(", ", System.Enum.GetNames<TEnum>())}.");
+            }
+
+            apply(parsed);
         }
 
         /// <summary>

--- a/src/Quartz/Configuration/SharedDatabaseValidator.cs
+++ b/src/Quartz/Configuration/SharedDatabaseValidator.cs
@@ -21,8 +21,14 @@ namespace Quartz.Configuration;
 /// primary key and every statement filters on it. Separate table sets in one database are legal, and
 /// occasionally deliberate for backup or permissions reasons, but a prefix that differs by *accident*
 /// produces the worst failure this area has: the misconfigured scheduler connects, passes
-/// <c>PerformSchemaValidation</c> against its own empty table set, starts, reports healthy, and fires
-/// nothing ever again.
+/// <see cref="SchemaProvisioning.Validate"/> against its own empty table set, starts, reports healthy,
+/// and fires nothing ever again.
+/// </para>
+/// <para>
+/// <see cref="SchemaProvisioning.CreateIfMissing"/> makes that failure easier to reach rather than
+/// harder: where a mis-typed prefix used to need an empty table set to already exist for the scheduler
+/// to start, a provisioning store creates one. Which is why this reports on the prefixes rather than on
+/// whether the tables are there.
 /// </para>
 /// <para>
 /// Schema validation is the natural neighbour and cannot see this — it asks whether the tables this
@@ -30,6 +36,11 @@ namespace Quartz.Configuration;
 /// knowable one level up, where the schedulers of a container are all visible. So the check lives here,
 /// and each scheduler records its arrangement as it is created; the first pair that disagrees is
 /// reported.
+/// </para>
+/// <para>
+/// Two schedulers sharing a database *and* a prefix are the supported arrangement and are never
+/// reported, whether or not either provisions — that is the one Quartz table set with two tenants in
+/// it, and both of them creating it if it is missing is exactly what a cluster does.
 /// </para>
 /// <para>
 /// It only ever warns. Deliberately separate table sets are a legitimate arrangement, and an error that

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -122,7 +122,7 @@ public abstract partial class AdoJobStoreBase : IJobStore
         AcceptEnlistedTransactions = options.AcceptEnlistedTransactions;
         DoubleCheckLockMisfireHandler = options.DoubleCheckLockMisfireHandler;
         UseBackgroundThreads = options.UseBackgroundThreads;
-        PerformSchemaValidation = options.PerformSchemaValidation;
+        SchemaProvisioning = options.SchemaProvisioning;
         SelectWithLockSql = options.SelectWithLockSql;
         CommandTimeout = options.CommandTimeout;
 
@@ -429,10 +429,10 @@ public abstract partial class AdoJobStoreBase : IJobStore
     protected internal bool DoubleCheckLockMisfireHandler { get; }
 
     /// <summary>
-    /// Whether to perform a schema check on scheduler startup and try to determine if correct tables are in place.
-    /// Defaults to true.
+    /// What this store does about its schema when it starts: nothing, verify it, or create what is
+    /// missing and then verify it. Defaults to <see cref="Quartz.SchemaProvisioning.Validate" />.
     /// </summary>
-    protected internal bool PerformSchemaValidation { get; } = true;
+    protected internal SchemaProvisioning SchemaProvisioning { get; } = SchemaProvisioning.Validate;
 
     public TimeSpan GetAcquireRetryDelay(int failureCount) => DbRetryInterval;
 
@@ -653,7 +653,12 @@ public abstract partial class AdoJobStoreBase : IJobStore
             LoggerFactory = LoggerFactory,
         });
 
-        if (PerformSchemaValidation)
+        if (SchemaProvisioning == SchemaProvisioning.CreateIfMissing)
+        {
+            await CreateSchema(cancellationToken).ConfigureAwait(false);
+        }
+
+        if (SchemaProvisioning != SchemaProvisioning.None)
         {
             try
             {
@@ -664,12 +669,122 @@ public abstract partial class AdoJobStoreBase : IJobStore
             {
                 const string error = "Database schema validation failed."
                                      + " Make sure you have created the database tables that Quartz requires using the database schema scripts."
-                                     + " You can disable this check by setting quartz.jobStore.performSchemaValidation to false";
+                                     + " You can disable this check by setting quartz.jobStore.schemaProvisioning to None";
 
                 throw new SchedulerException(error, ex);
             }
         }
 
+    }
+
+    /// <summary>How many times the schema is created before the failure is reported as one.</summary>
+    /// <remarks>
+    /// More than one because a create that failed is usually a race, and a retry is not passive
+    /// waiting: the script is guarded throughout, so re-running it skips whatever the other node
+    /// finished and makes whatever it has not reached yet. Two nodes converge in a round or two, and
+    /// ten of them are a few seconds of tolerance for a database that creates a table slowly.
+    /// </remarks>
+    private const int SchemaCreationAttempts = 10;
+
+    private static readonly TimeSpan SchemaCreationRetryDelay = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// Creates whatever the schema is missing, and treats a failure as a lost race until the schema
+    /// itself says otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several nodes of a cluster start at once, and only one of them can be the node that creates a
+    /// given object — the rest see whatever their database says about that, which every dialect spells
+    /// differently and some spell the same way as a permission failure. Firebird does not even spell it
+    /// consistently with itself: it serializes DDL through its own catalog and answers the loser with a
+    /// primary-key violation on <c>RDB$RELATIONS</c> or with a deadlock, depending on timing. So the
+    /// outcome is decided by asking the schema rather than by reading the exception.
+    /// </para>
+    /// <para>
+    /// And asked more than once, because "the winner has finished" and "the winner is halfway through"
+    /// look identical from here: the first thing the loser sees is a table it could not create, and the
+    /// next thing is a table the winner has not created yet. Both are transient. Each attempt runs the
+    /// whole guarded script again, so the two nodes are not waiting for each other so much as filling
+    /// in each other's gaps, and they converge in a round or two.
+    /// </para>
+    /// <para>
+    /// Under the same <c>ExecuteWithoutLock</c> as validation, which takes no lock on any dialect but
+    /// SQLite. It cannot take one: <c>QRTZ_LOCKS</c> is one of the tables this is here to create.
+    /// </para>
+    /// </remarks>
+    private async ValueTask CreateSchema(CancellationToken cancellationToken)
+    {
+        Exception? creationFailure = null;
+        Exception? validationFailure = null;
+
+        for (int attempt = 1; attempt <= SchemaCreationAttempts; attempt++)
+        {
+            try
+            {
+                await ExecuteWithoutLock<object?>(async conn =>
+                {
+                    await Delegate.CreateSchema(conn, cancellationToken).ConfigureAwait(false);
+                    return null;
+                }, cancellationToken).ConfigureAwait(false);
+
+                Logger.SchemaCreated(TablePrefix);
+                return;
+            }
+            catch (Exception failure)
+            {
+                creationFailure = failure;
+            }
+
+            try
+            {
+                await ExecuteWithoutLock<int>(conn => Delegate.ValidateSchema(conn, cancellationToken), cancellationToken).ConfigureAwait(false);
+                Logger.SchemaCreatedByAnotherNode(TablePrefix, creationFailure);
+                return;
+            }
+            catch (Exception failure)
+            {
+                validationFailure = failure;
+            }
+
+            if (attempt < SchemaCreationAttempts)
+            {
+                Logger.SchemaCreationRetrying(TablePrefix, attempt, SchemaCreationAttempts, creationFailure);
+                await Task.Delay(SchemaCreationRetryDelay, timeProvider, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        throw new SchedulerException(
+            $"Could not create the database schema in {SchemaCreationAttempts} attempts, and the schema is"
+            + " not there to be used either."
+            + " Either grant the account Quartz connects with permission to create tables and indexes,"
+            + $" or run {SchemaScriptName()} by hand and drop back to SchemaProvisioning.Validate."
+            + " Why the creation failed is this exception's inner exception; why the schema is still"
+            + $" unusable is: {validationFailure?.Message}",
+            creationFailure);
+    }
+
+    /// <summary>
+    /// The fresh-install script for the database this store is talking to, named so that a reader who
+    /// cannot grant DDL knows exactly which file to run.
+    /// </summary>
+    /// <remarks>
+    /// Off the delegate rather than the provider, because the delegate is what the dialect was chosen
+    /// as. A delegate outside this list is somebody else's, and Quartz does not know which file its
+    /// database wants.
+    /// </remarks>
+    private string SchemaScriptName()
+    {
+        return Delegate switch
+        {
+            SqlServerDelegate => "database/tables/tables_sqlServer.sql",
+            PostgreSQLDelegate => "database/tables/tables_postgres.sql",
+            MySQLDelegate => "database/tables/tables_mysql_innodb.sql",
+            OracleDelegate => "database/tables/tables_oracle.sql",
+            SQLiteDelegate => "database/tables/tables_sqlite.sql",
+            FirebirdDelegate => "database/tables/tables_firebird.sql",
+            _ => "the script for your database under database/tables/",
+        };
     }
 
     /// <seealso cref="IJobStore.SchedulerStarted(CancellationToken)" />

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreLog.cs
@@ -88,6 +88,20 @@ internal static partial class AdoJobStoreLog
     [LoggerMessage(EventId = 3014, Level = LogLevel.Information, Message = "Successfully validated presence of {SchemaObjectCount} schema objects")]
     public static partial void SchemaValidated(this ILogger logger, int schemaObjectCount);
 
+    [LoggerMessage(EventId = 3039, Level = LogLevel.Information, Message = "Created the schema objects missing under table prefix '{TablePrefix}'")]
+    public static partial void SchemaCreated(this ILogger logger, string tablePrefix);
+
+    // Debug: on a cluster starting together this is every node but one, every time, and it is not a
+    // problem -- the schema is there and the store is about to validate it.
+    [LoggerMessage(EventId = 3040, Level = LogLevel.Debug, Message = "Schema creation under table prefix '{TablePrefix}' failed, but the schema validates, so another node created it first")]
+    public static partial void SchemaCreatedByAnotherNode(this ILogger logger, string tablePrefix, Exception exception);
+
+    // Debug: on a cluster starting together this is the ordinary way round a race, and the attempt
+    // after it usually succeeds. It is here so that a few seconds spent converging is visible rather
+    // than being a stall nobody can account for.
+    [LoggerMessage(EventId = 3041, Level = LogLevel.Debug, Message = "Schema creation under table prefix '{TablePrefix}' failed on attempt {Attempt} of {Attempts} and the schema does not validate yet, retrying")]
+    public static partial void SchemaCreationRetrying(this ILogger logger, string tablePrefix, int attempt, int attempts, Exception exception);
+
     [LoggerMessage(EventId = 3015, Level = LogLevel.Error, Message = "Failure occurred during job recovery: {ExceptionMessage}")]
     public static partial void JobRecoveryFailed(this ILogger logger, string exceptionMessage, Exception exception);
 

--- a/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/FirebirdDelegate.cs
@@ -5,6 +5,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// </summary>
 public class FirebirdDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_firebird.sql";
+
     /// <summary>
     /// Firebird limits rows with a trailing <c>ROWS n</c>.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -1502,15 +1502,47 @@ public interface IDriverDelegate
     /// were checked.
     /// </summary>
     /// <remarks>
-    /// Called at startup when <c>PerformSchemaValidation</c> is on, so that a missing or mis-prefixed
-    /// table is reported once, by name, instead of as the first failing operation. A delegate that owns
-    /// tables of its own checks those too.
+    /// Called at startup for every <see cref="SchemaProvisioning"/> but
+    /// <see cref="SchemaProvisioning.None"/>, so that a missing or mis-prefixed table is reported once,
+    /// by name, instead of as the first failing operation. A delegate that owns tables of its own
+    /// checks those too.
     /// </remarks>
     /// <param name="conn">The DB connection.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>The number of schema objects validated.</returns>
     /// <exception cref="JobPersistenceException">An object could not be queried.</exception>
     ValueTask<int> ValidateSchema(
+        ConnectionAndTransactionHolder conn,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates whatever this delegate's schema is missing, and leaves everything that is already there
+    /// exactly as it is.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called at startup, before <see cref="ValidateSchema"/>, when
+    /// <see cref="SchemaProvisioning.CreateIfMissing"/> is configured. Every statement it runs is
+    /// guarded, so this is a no-op against a schema that already exists; nothing is altered and nothing
+    /// is dropped, which is what makes it safe to leave on and what keeps a mis-typed table prefix from
+    /// costing data.
+    /// </para>
+    /// <para>
+    /// It is not a migration. A schema that has every table but is missing a column a later release
+    /// added is left alone, and <see cref="ValidateSchema"/> passes over it, because that check is
+    /// table-level. Upgrading a schema is what <c>database/migrations/</c> is for.
+    /// </para>
+    /// <para>
+    /// A delegate that has no script for its database throws rather than pretending to have created
+    /// anything, naming itself and the script to run by hand.
+    /// </para>
+    /// </remarks>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <exception cref="JobPersistenceException">
+    /// A statement failed, or this delegate has no schema script.
+    /// </exception>
+    ValueTask CreateSchema(
         ConnectionAndTransactionHolder conn,
         CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -27,6 +27,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma</author>
 public class MySQLDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_mysql_innodb.sql";
+
     /// <summary>
     /// MySQL pages with LIMIT/OFFSET rather than the ANSI clause.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/OracleDelegate.cs
@@ -27,6 +27,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma</author>
 public class OracleDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_oracle.sql";
+
     /// <summary>
     /// Oracle limits rows from an enclosing select: <c>SELECT * FROM (…) WHERE rownum &lt;= n</c>.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/PostgreSQLDelegate.cs
@@ -27,6 +27,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma</author>
 public class PostgreSQLDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_postgres.sql";
+
     /// <summary>
     /// PostgreSQL limits rows with a trailing <c>LIMIT n</c>.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SQLiteDelegate.cs
@@ -25,6 +25,9 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma</author>
 public class SQLiteDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_sqlite.sql";
+
     /// <summary>
     /// SQLite pages with LIMIT/OFFSET rather than the ANSI clause. A negative LIMIT means no limit,
     /// which is how SQLite writes an offset without one.

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -29,6 +29,14 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma</author>
 public class SqlServerDelegate : StdAdoDelegate
 {
+    /// <inheritdoc />
+    /// <remarks>
+    /// The standard schema. The memory-optimized and pre-2016 variants under
+    /// <c>database/tables/</c> have no counterpart: each is a deliberate departure a person chose for
+    /// a particular deployment, not something a scheduler should decide to create.
+    /// </remarks>
+    protected override string? SchemaResourceName => "Quartz.Impl.AdoJobStore.Schema.create_sqlServer.sql";
+
     /// <summary>
     /// SQL Server names its row limit in the projection: <c>SELECT TOP n …</c>.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -705,4 +705,115 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
 
         return AdoConstants.AllTableNames.Length;
     }
+
+    /// <summary>
+    /// The embedded script that creates this dialect's schema, or <see langword="null" /> when this
+    /// delegate has none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Null on <see cref="StdAdoDelegate" /> itself, because there is no dialect-neutral DDL: the
+    /// six shipped delegates each name their own script, and a delegate written outside Quartz names
+    /// one or leaves provisioning unavailable. Overriding it is the whole of what a delegate has to
+    /// do to support <see cref="SchemaProvisioning.CreateIfMissing" />.
+    /// </para>
+    /// <para>
+    /// The name is a manifest resource name in the assembly that declares the delegate, so a delegate
+    /// of somebody else's can embed a script of its own beside itself.
+    /// </para>
+    /// </remarks>
+    protected virtual string? SchemaResourceName => null;
+
+    /// <summary>
+    /// The line the schema scripts separate their statements with.
+    /// </summary>
+    /// <remarks>
+    /// A sentinel rather than a terminator, because there is no terminator that works: a semicolon
+    /// ends a statement on one dialect and a line inside a PL/SQL block on another, and finding out
+    /// which would mean lexing SQL here. The generator writes the sentinel, so splitting on it is
+    /// exact.
+    /// </remarks>
+    private const string SchemaStatementSeparator = "--;;";
+
+    /// <inheritdoc />
+    public virtual async ValueTask CreateSchema(ConnectionAndTransactionHolder conn, CancellationToken cancellationToken = default)
+    {
+        string script = ReadSchemaScript();
+
+        foreach (string statement in SplitSchemaStatements(script))
+        {
+            try
+            {
+                DbCommand cmd = PrepareCommand(conn, statement);
+                await using (cmd.ConfigureAwait(false))
+                {
+                    await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new JobPersistenceException(
+                    $"Unable to create the schema with table prefix '{tablePrefix}': {ex.Message}"
+                    + Environment.NewLine + statement, ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads this delegate's schema script and substitutes the configured table prefix into it.
+    /// </summary>
+    private string ReadSchemaScript()
+    {
+        if (SchemaResourceName is not { } resourceName)
+        {
+            throw new JobPersistenceException(
+                $"{GetType().Name} ships no schema script, so it cannot create a schema. Create it by hand "
+                + "from the script for your database under database/tables/, and set "
+                + "SchemaProvisioning.Validate (the default). A driver delegate of your own supports "
+                + "provisioning by overriding StdAdoDelegate.SchemaResourceName with the name of an embedded "
+                + "script.");
+        }
+
+        // The resource lives beside the delegate that named it, which for a delegate written outside
+        // Quartz is not this assembly.
+        using Stream? stream = GetType().Assembly.GetManifestResourceStream(resourceName);
+        if (stream is null)
+        {
+            throw new JobPersistenceException(
+                $"{GetType().Name} names the schema script '{resourceName}', which is not embedded in "
+                + $"{GetType().Assembly.GetName().Name}.");
+        }
+
+        using StreamReader reader = new(stream, Encoding.UTF8);
+        return AdoJobStoreUtil.ReplaceTablePrefix(reader.ReadToEnd(), tablePrefix);
+    }
+
+    /// <summary>
+    /// Splits a schema script into the statements the provider is given one at a time, dropping the
+    /// chunks that are nothing but comments — the file's header, and nothing else.
+    /// </summary>
+    private static List<string> SplitSchemaStatements(string script)
+    {
+        return script
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split($"\n{SchemaStatementSeparator}\n")
+            .Where(HasSql)
+            .Select(chunk => chunk.Trim())
+            .ToList();
+    }
+
+    /// <summary>Whether a chunk holds anything but blank lines and whole-line comments.</summary>
+    private static bool HasSql(string chunk)
+    {
+        foreach (string line in chunk.Split('\n'))
+        {
+            string trimmed = line.Trim();
+            if (trimmed.Length > 0 && !trimmed.StartsWith("--", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Quartz/SchemaProvisioning.cs
+++ b/src/Quartz/SchemaProvisioning.cs
@@ -1,0 +1,86 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// What a persistent job store does about its schema when it starts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This replaces the <c>PerformSchemaValidation</c> flag, which could only say whether the store
+/// checked. The check and the creation are one decision — a store that may create its schema
+/// obviously validates it too — so they are one setting with three positions rather than two flags
+/// that can contradict each other.
+/// </para>
+/// <para>
+/// There is deliberately no "create or migrate" position. Nothing in the schema records which
+/// version it is, and SQLite's <c>ADD COLUMN</c> has no conditional form, so a store cannot tell a
+/// schema that is one release old from one that is five and cannot safely try. Upgrading a schema
+/// stays a decision someone makes with the scripts under <c>database/migrations/</c>.
+/// </para>
+/// </remarks>
+public enum SchemaProvisioning
+{
+    /// <summary>
+    /// Assume the schema is there. The store issues its first statement against whatever it finds.
+    /// </summary>
+    /// <remarks>
+    /// The failure this saves a few milliseconds at the cost of is a bad one: the first operation to
+    /// touch a missing table reports a provider error naming one table, at whatever moment the
+    /// scheduler happened to need it, rather than a startup failure naming the schema.
+    /// </remarks>
+    None = 0,
+
+    /// <summary>
+    /// Check at startup that every table the store reads and writes can be queried, and refuse to
+    /// start when one cannot. The default.
+    /// </summary>
+    /// <remarks>
+    /// The check is table-level rather than column-level, so a schema that has every table but is
+    /// missing a column added by a later release starts and then fails on the first statement naming
+    /// that column. <c>database/migrations/4.0/</c> is what closes that gap.
+    /// </remarks>
+    Validate = 1,
+
+    /// <summary>
+    /// Create whatever the schema is missing, then validate it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only ever creates: no object is altered and none is dropped, so this is safe to leave on
+    /// against a schema that already exists and cannot turn a mis-typed table prefix into data loss.
+    /// It is equally not an upgrade — a schema that has every table but is missing a column added by
+    /// a later release is left exactly as it is, and then fails validation's successor, the first
+    /// statement that names the column.
+    /// </para>
+    /// <para>
+    /// Not the default, because creating tables needs DDL permission and a production database is
+    /// usually right not to grant the scheduler any. It is what a test fixture, a container that
+    /// starts with an empty volume, or a desktop application with a SQLite file wants.
+    /// </para>
+    /// <para>
+    /// Safe on several nodes starting at once: whichever loses the race sees its create fail, finds
+    /// the schema another node created, and carries on.
+    /// </para>
+    /// </remarks>
+    CreateIfMissing = 2,
+}


### PR DESCRIPTION
> **Merge order.** This is the second of a chain of three: #3550 → **#3551** → #3552, and they have
> to land in that order. The base is `main` rather than #3550's branch so that the `pr-integration-*`
> workflows run at all — they trigger only on pull requests targeting `main` — which means the diff
> below carries #3550's commit as well until that one has merged. Rebase this branch on `main` after
> #3550 lands and the diff is only its own commit.

Automatic schema creation was asked for on #988 in 2022. Delegating it failed measurably: AppAny 0.6.0
carries four open drift issues from 2026-07 — missing `EXECUTION_GROUP`, missing `PREFERRED_NODE*`,
drifted indexes — which are exactly the columns 4.x made **mandatory**, because 4.x has no
`Supports*Column` probes to degrade behind.

## The setting

`AdoJobStoreOptions.SchemaProvisioning` **replaces** `PerformSchemaValidation`. The check and the
creation are one decision — a store that may create its schema obviously validates it too — so they
are one setting with three positions rather than two flags that can contradict each other.

| Before | After |
|---|---|
| `PerformSchemaValidation = true` | `SchemaProvisioning.Validate` — still the default |
| `PerformSchemaValidation = false` | `SchemaProvisioning.None` |
| — | `SchemaProvisioning.CreateIfMissing`, or `store.ProvisionSchema()` |

`IPersistentStoreBuilder.ProvisionSchema()` is a `ConfigureStore` shorthand that reads as the decision
it is, like `UseClustering`.

The legacy key `quartz.jobStore.performSchemaValidation` still works and still means what it meant —
`true` bridges to `Validate`, `false` to `None`. `quartz.jobStore.schemaProvisioning` is the new key
and takes a member name, case-insensitively; a misspelled one is rejected naming the three that would
have worked. A file carrying both is decided by the new key, the only one of the two that can express
the third position.

## The mechanism

`IDriverDelegate.CreateSchema` sits beside `ValidateSchema` and is implemented once in
`StdAdoDelegate`: it splits the embedded script on the `--;;` sentinel and sends each statement to the
provider with the configured table prefix substituted in. Each dialect delegate names its own script
through `protected virtual string? SchemaResourceName`; a delegate that names none throws rather than
reporting success, naming itself and the script to run instead.

Wired into `AdoJobStoreBase.Initialize` before validation, under the same `ExecuteWithoutLock` shape —
which it has to be, since `QRTZ_LOCKS` is one of the tables it is there to create.

**Never drops, never alters.** So it is safe to leave on against a schema that already exists, and it
cannot turn a mis-typed `TablePrefix` into data loss. It is equally not an upgrade: a schema missing a
column a later release added is left as it is, and `database/migrations/` is still what moves a schema
forward.

**Not the default**, because creating tables needs DDL permission a production database is usually
right not to grant.

### The clustered race, and what Firebird and Oracle had to say about it

Nodes start together and only one can create any given object. Rather than reading a duplicate-object
error that every dialect spells differently — and that some spell the same way as a permission failure
— the outcome is decided by asking the schema: attempt the create, and on **any** exception run
`ValidateSchema`. A pass means another node won.

That was the whole of it in the first push of this branch, and the Firebird and Oracle legs of #3552
showed it was half an answer. The loser's first error is a table it could not create, and the very
next thing it finds is a table the winner **has not created yet** — so validation fails and a perfectly
ordinary race was reported as a hard failure:

```
ORA-00955: name is already used by an existing object          (creating QRTZC_JOB_DETAILS)
ORA-00942: table or view does not exist                        (validating QRTZC_TRIGGERS)
```

Firebird said the same thing in its own words, sometimes as a primary-key violation on
`RDB$RELATIONS` and sometimes as a deadlock, depending on timing.

So the create-then-validate is now a bounded loop — ten attempts, half a second apart. A retry is not
passive waiting: the script is guarded throughout, so re-running it skips whatever the other node
finished and makes whatever it has not reached yet. The two nodes fill in each other's gaps rather
than waiting on each other, and converge in a round or two. Only after ten attempts is the failure
reported as one, naming the fresh-install script for that database and the setting to drop back to.

## Also here

- `SharedDatabaseValidator`'s remarks: it named `PerformSchemaValidation`, and now says why
  `CreateIfMissing` makes the failure it reports *easier* to reach rather than harder — a mis-typed
  prefix used to need an empty table set to already exist, and a provisioning store creates one. Two
  schedulers sharing a database *and* a prefix are still never reported, provisioning or not; that is
  the supported arrangement, and both creating it if it is missing is exactly what a cluster does.
- The migration-guide row for the rename, and the `CreateSchema` note beside the existing
  `ValidateSchema` section.
- Every 4.x documentation page that named the old member now names the new one. That is the rename
  only — the pages that need to *teach* provisioning (`quick-start.md`, `db/index.md`,
  `tutorial/job-stores.md`, `database/README.md`, the third-party page) are the docs PR's, which is
  why this one says "Part of" rather than "Closes". `configuration/reference.md`'s row is updated
  here because it named a member that would otherwise not exist.
- Baselines accepted through Verify: `PublicApiTest_Quartz` and `LogEventCatalogTest_Quartz`.

## Tests

`SchemaProvisioningSqliteTest` is the end-to-end case that needs no container: an empty SQLite file,
provisioned, scheduled against, fired and read back. It also covers the default refusing an empty
database, a second pass leaving the first scheduler's rows alone, every object landing under a
configured `QRTZP_` prefix with nothing under `QRTZ_`, and a delegate with no script saying what to run
instead. Plus builder, bridge and exhaustiveness cases.

## Verification

```
dotnet build Quartz.slnx                                    0 warnings, 0 errors
dotnet fallout VerifySchema VerifyMigrations VerifyDocsSnippets   all up to date
dotnet test src/Quartz.Tests.Unit                           3835 passed, 0 failed
dotnet test src/Quartz.Tests.AspNetCore                     549 passed, 0 failed
npm run docs:check-links                                    214 pages, no dead links or anchors
QUARTZ_TEST_DATABASE=sqlite   TestCategory=db-sqlite        14 passed, 0 failed
QUARTZ_TEST_DATABASE=postgres TestCategory=db-postgres      159 passed, 0 failed
```

SQLite and PostgreSQL are the two run locally — several suites share this machine's Docker daemon, so
one container dialect at a time. All eight `pr-integration-*` workflows were green on the previous
push of this branch; the four dialects not run locally are covered there and on this one.

Part of #3531

