### PR TITLE
Cross-cutting concerns run as job execution middleware

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -110,6 +110,7 @@ export const sidebarEn: SidebarConfig = [
               "/documentation/quartz-4.x/tutorial/time-and-timeprovider",
               "/documentation/quartz-4.x/tutorial/trigger-and-job-listeners",
               "/documentation/quartz-4.x/tutorial/scheduler-listeners",
+              "/documentation/quartz-4.x/tutorial/job-execution-middleware",
               "/documentation/quartz-4.x/tutorial/job-stores",
               "/documentation/quartz-4.x/tutorial/configuration-resource-usage-and-scheduler-factory",
               "/documentation/quartz-4.x/tutorial/standalone-scheduler",

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1833,6 +1833,49 @@ The entry was Quartz's plumbing in a map that belongs to the application, and th
 ([#3408](https://github.com/quartznet/quartznet/issues/3408)). That endpoint renders every value as
 text now, so a context entry of any type reads back.
 
+## Cross-cutting concerns run as middleware
+
+A log scope, a tenant context, a metric or a translation of what a library throws has to *surround* the
+call to the job, and on 3.x nothing could. `IJobListener` is notification-only — it is told a job is
+about to run and told what it did, with the execution happening between the two notifications rather
+than inside them — so the only place left was a job that wrapped another job. That adapter is what ABP,
+Elsa and Brighter each ship, and asking for the seam has been open since 2021
+([#988](https://github.com/quartznet/quartznet/discussions/988)).
+
+4.0 adds it:
+
+```csharp
+public delegate ValueTask JobExecutionDelegate(IJobExecutionContext context, CancellationToken cancellationToken);
+
+public interface IJobExecutionMiddleware
+{
+    ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default);
+}
+```
+
+registered on the scheduler's builder in the three shapes listeners already have:
+
+```csharp
+q.AddJobMiddleware<LogScopeMiddleware>();
+q.AddJobMiddleware(provider => new MeteredMiddleware(provider.GetRequiredService<IMeterFactory>()));
+q.AddJobMiddleware(new TenantScopeMiddleware());
+```
+
+Middleware is keyed per scheduler, so a named scheduler's is its own; it runs in registration order,
+outermost first; and the chain is composed once when the scheduler is built, so one instance serves
+every firing and per-firing state belongs in an `AsyncLocal<T>` or in the job's scope rather than in a
+field. A scheduler with no middleware has no pipeline at all, so nothing changes for an application
+that adds none.
+
+It runs inside the execution span and the duration measurement — what a middleware costs is part of
+what the firing cost — and outside the run shell's exception handling, so a `JobExecutionException` a
+middleware throws is honoured exactly like one the job raised, `RefireImmediately` and all.
+
+**Nothing about listeners changed.** They stay notification-only, `VetoJobExecution` stays the way to
+refuse a fire, and matchers stay a listener's way of choosing which jobs it hears about. The tutorial's
+[Job Execution Middleware](tutorial/job-execution-middleware.md) lesson has the whole of it, including
+which of the two a given concern belongs in.
+
 ## Registered schedulers can be listed without being started
 
 `ISchedulerFactory.GetAllSchedulers()` — `GetAllSchedulers()` on 3.x too — lists the schedulers
@@ -3895,6 +3938,7 @@ already have them.
 * **`ISchedulerListener.TriggerInError` / `TriggersInError`** — observe a trigger being moved to `TriggerState.Error`, including two ADO store transitions that reached nothing at all before (see [Triggers entering the error state are reported](#triggers-entering-the-error-state-are-reported))
 * **Every listener callback names its scheduler** — one listener can serve several schedulers in one host and still say which of them paused a trigger or failed, and `SchedulerError` carries the trigger, job and firing it was raised for. A listener still carrying a signature from 3.x or from alpha.1 is refused when it is registered, with a message naming the member, rather than being attached and never called (see [Listeners are told which scheduler is calling](#listeners-are-told-which-scheduler-is-calling))
 * **Joining a transaction the application owns** — the ADO job store can take part in a transaction you started, so saving your own data and scheduling the job that acts on it commit together or not at all. Turn it on with `store.ConfigureStore(o => o.AcceptEnlistedTransactions = true)`, `JobStore:AcceptEnlistedTransactions`, or `quartz.jobStore.acceptEnlistedTransactions`, then hand the store a connection for the duration of a scope with `IScheduler.EnlistTransaction` / `EnlistConnection`. Handing over a connection is the only way to take part: a connection the job store opens for itself is deliberately kept out of any ambient `TransactionScope`, since a second connection in that transaction would require promoting it to a distributed one. See [Joining an existing transaction](tutorial/job-stores.md#joining-an-existing-transaction)
+* **Job execution middleware** — `IJobExecutionMiddleware` wraps every firing a scheduler performs, which is where a log scope, a tenant context, a metric or a translation of a library's exceptions belongs. A listener could never do it: it is notified before and after the execution rather than around it. Registered with `AddJobMiddleware<T>()` and its factory and instance overloads (see [Cross-cutting concerns run as middleware](#cross-cutting-concerns-run-as-middleware))
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
 * **Pause, resume and reset a set of keys in one call** — `PauseTriggers`, `ResumeTriggers`, `PauseJobs`, `ResumeJobs` and `ResetTriggersFromErrorState` take a key collection, do the whole set in one lock and one transaction, and answer with the keys they applied to (see [A set of keys pauses, resumes or resets in one call](#a-set-of-keys-pauses-resumes-or-resets-in-one-call))

--- a/docs/documentation/quartz-4.x/tutorial/README.md
+++ b/docs/documentation/quartz-4.x/tutorial/README.md
@@ -19,13 +19,14 @@ next: false
 * [Lesson 10: Time and TimeProvider](time-and-timeprovider.md)
 * [Lesson 11: TriggerListeners & JobListeners](trigger-and-job-listeners.md)
 * [Lesson 12: SchedulerListeners](scheduler-listeners.md)
-* [Lesson 13: JobStores](job-stores.md)
-* [Lesson 14: Configuration, Resource Usage and Building a Scheduler](configuration-resource-usage-and-scheduler-factory.md)
-* [Lesson 15: Building a Scheduler Without a Host](standalone-scheduler.md)
-* [Lesson 16: Clustering](advanced-enterprise-features.md)
-* [Lesson 17: Execution Groups](execution-groups.md)
-* [Lesson 18: Node Affinity (Preferred Node)](node-affinity.md)
-* [Lesson 19: Testing](testing.md)
+* [Lesson 13: Job Execution Middleware](job-execution-middleware.md)
+* [Lesson 14: JobStores](job-stores.md)
+* [Lesson 15: Configuration, Resource Usage and Building a Scheduler](configuration-resource-usage-and-scheduler-factory.md)
+* [Lesson 16: Building a Scheduler Without a Host](standalone-scheduler.md)
+* [Lesson 17: Clustering](advanced-enterprise-features.md)
+* [Lesson 18: Execution Groups](execution-groups.md)
+* [Lesson 19: Node Affinity (Preferred Node)](node-affinity.md)
+* [Lesson 20: Testing](testing.md)
 
 The cron expression syntax the CronTriggers lesson builds on has its own page:
 [Cron Expression Reference](../cron-expressions.md).

--- a/docs/documentation/quartz-4.x/tutorial/job-execution-middleware.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-execution-middleware.md
@@ -1,0 +1,251 @@
+---
+
+title: 'Job Execution Middleware'
+---
+
+# Job Execution Middleware
+
+Middleware wraps every job a scheduler executes. It is where a cross-cutting concern lives — a log
+scope, a tenant context, a metric, a translation of what a third-party library throws — when that
+concern has to *surround* the call to the job rather than merely hear about it.
+
+Listeners cannot do this. An `IJobListener` is notified before the job runs and again after it has
+run, but the execution happens *between* the two notifications rather than *inside* them, so a
+listener cannot open an `await using` around it, cannot decline to run it, and cannot catch what it
+threw. Before 4.0 the only place left for such code was a job that wrapped another job, which is why
+several frameworks built on Quartz ship exactly that adapter.
+
+## The interface
+
+<!-- Quartz's own declaration, so it is written out here rather than compiled from the samples
+     project: a second `Quartz.IJobExecutionMiddleware` in that project would shadow the real one. -->
+
+```csharp
+public delegate ValueTask JobExecutionDelegate(IJobExecutionContext context, CancellationToken cancellationToken);
+
+public interface IJobExecutionMiddleware
+{
+    ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default);
+}
+```
+
+`next` is the rest of the chain, ending in the job. Await it to run the job; do not, and the job does
+not run.
+
+## Writing one
+
+<!-- snippet: sample_job_middleware_log_scope -->
+```csharp
+public sealed class LogScopeMiddleware(ILogger<LogScopeMiddleware> logger) : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        using IDisposable? scope = logger.BeginScope(new Dictionary<string, object>
+        {
+            ["JobKey"] = context.JobDetail.Key,
+            ["FireInstanceId"] = context.FireInstanceId,
+        });
+
+        await next(context, cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+## Registering
+
+Middleware belongs to a scheduler, so it is registered where the scheduler is configured. The same
+three shapes listeners have: the container builds it, you build it from the container, or you hand
+over one you already have.
+
+<!-- snippet: sample_job_middleware_register -->
+```csharp
+builder.AddQuartz(q =>
+{
+    // built by the container, so it can take dependencies of its own
+    q.AddJobMiddleware<LogScopeMiddleware>();
+
+    // built by you, from this scheduler's services
+    q.AddJobMiddleware(provider => new MeteredMiddleware(provider.GetRequiredService<IMeterFactory>()));
+
+    // one you already have
+    q.AddJobMiddleware(new TenantScopeMiddleware());
+});
+```
+<!-- endSnippet -->
+
+The standalone builder takes the same calls, because it *is* an `IQuartzBuilder`:
+
+<!-- snippet: sample_job_middleware_standalone -->
+```csharp
+IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+    .UseInMemoryStore()
+    .AddJobMiddleware<LogScopeMiddleware>()
+    .BuildScheduler();
+```
+<!-- endSnippet -->
+
+::: tip
+Registering a middleware for `AddQuartz("reporting", …)` puts it in that scheduler's pipeline alone.
+A named scheduler's middleware is its own, the way its listeners and its job store are.
+:::
+
+## Order
+
+Middleware runs in registration order, **outermost first**. The first registered sees the firing
+before the second does and sees its result after it, which is the ordering a log scope or a
+transaction has to be planned around:
+
+```text
+q.AddJobMiddleware<A>();     A ─┐
+q.AddJobMiddleware<B>();        B ─┐
+                                   job
+                                B ─┘
+                             A ─┘
+```
+
+Each call adds a stage, so registering the same type twice puts it in the chain twice.
+
+The chain is composed **once**, when the scheduler is built, and one instance of each middleware
+serves every firing that scheduler performs. A middleware must therefore keep no per-firing state in
+a field — see [Per-firing state](#per-firing-state) below.
+
+## Where it runs
+
+| | |
+| -- | -- |
+| after the trigger and job listeners have been notified | a fire a listener vetoed never reaches the pipeline |
+| inside the execution span and the duration measurement | what a middleware costs is part of what the firing cost, and anything it traces is a child of `Quartz.Job.Execute` |
+| outside the run shell's exception handling | what a middleware throws is classified exactly as though the job had thrown it |
+| inside the store's concurrency handling | `[DisallowConcurrentExecution]` is enforced above the pipeline, so a middleware never sees two firings of one job overlapping |
+
+## Short-circuiting
+
+A middleware that does not call `next` keeps the call to itself. The job does not run; everything
+else about the firing is unchanged — the listeners are notified as usual, and the trigger is left
+where a successful execution leaves it.
+
+<!-- snippet: sample_job_middleware_short_circuit -->
+```csharp
+public sealed class FeatureFlagMiddleware(FeatureFlags flags) : IJobExecutionMiddleware
+{
+    public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        // Not calling next means the job does not run. The firing still completes, the listeners are
+        // still notified, and the trigger is left where a successful execution leaves it.
+        return flags.IsEnabled(context.JobDetail.Key) ? next(context, cancellationToken) : default;
+    }
+}
+```
+<!-- endSnippet -->
+
+This is not a veto. A trigger listener's `VetoJobExecution` is the *scheduler's* refusal: it raises
+`JobExecutionVetoed`, and the firing ends there. A middleware that declines is invisible from
+outside.
+
+## Translating exceptions
+
+A middleware runs outside the run shell's exception classification, so a `JobExecutionException` it
+throws is honoured exactly like one the job raised — including `RefireImmediately` and the unschedule
+flags — and a plain exception is wrapped the same way. That makes middleware the place to teach
+Quartz what a library's own failures mean:
+
+<!-- snippet: sample_job_middleware_translate -->
+```csharp
+public sealed class TransientFailureMiddleware : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await next(context, cancellationToken);
+        }
+        catch (HttpRequestException e) when (e.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+        {
+            // Quartz understands this; it does not understand HttpRequestException.
+            throw new JobExecutionException(e) { RefireImmediately = true };
+        }
+    }
+}
+```
+<!-- endSnippet -->
+
+::: warning
+Catching a failure and awaiting a delay before calling `next` again is not a retry. It holds a
+thread-pool slot for the whole wait, and the attempt is lost if the process stops. A trigger's retry
+policy is the tool for that.
+:::
+
+## Per-firing state
+
+One middleware instance serves every firing, so a field is the wrong place to keep anything about the
+firing in hand. Two things that are the right place:
+
+**An `AsyncLocal<T>`.** The value travels with the execution context, so the job and everything it
+calls read the one their own firing set:
+
+<!-- snippet: sample_job_middleware_ambient -->
+```csharp
+public sealed class TenantScopeMiddleware : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        // An AsyncLocal, not a field: one instance of this middleware serves every firing the scheduler
+        // performs, and several of them can be in flight at once.
+        TenantScope.Current.Value = context.Trigger.Key.Group;
+        try
+        {
+            await next(context, cancellationToken);
+        }
+        finally
+        {
+            TenantScope.Current.Value = null;
+        }
+    }
+}
+```
+<!-- endSnippet -->
+
+**The job's dependency-injection scope.** `ConfigureJobScope` runs once per firing, before anything
+in the scope is resolved, and is handed the `TriggerFiredBundle`:
+
+<!-- snippet: sample_job_middleware_job_scope -->
+```csharp
+builder.AddQuartz(q =>
+{
+    // Populated once per firing, before anything in the job's scope is resolved.
+    q.ConfigureJobScope((scope, bundle, scheduler) =>
+        scope.ServiceProvider.GetRequiredService<TenantHolder>().Tenant = bundle.Trigger.Key.Group);
+});
+```
+<!-- endSnippet -->
+
+No `IServiceScope` is threaded through `Invoke`, deliberately: the scope belongs to the firing rather
+than to any one middleware, and code that needs the firing itself can read it from
+`IJobExecutionContextAccessor.Current`, which is set for the whole execution — including inside the
+pipeline, on the way in and on the way out.
+
+## The cancellation token
+
+Forward the token you were given. Passing a different one to `next` changes what the job's `Execute`
+parameter is without changing `IJobExecutionContext.CancellationToken`, so the two stop being the
+same token and a job that reads the context sees the wrong one. That is the trap in writing a timeout
+as a middleware.
+
+## Middleware or a listener?
+
+| Use middleware when you need to | Use a listener when you need to |
+| -- | -- |
+| wrap the execution — a scope, a stopwatch, a transaction | be told that something happened |
+| decide whether the job runs at all | veto a fire (`ITriggerListener.VetoJobExecution`) |
+| catch or translate what the job threw | react to the failure the run shell reports |
+| set ambient state the job will read | react to scheduling events that are not executions at all — a trigger paused, the scheduler shutting down |
+| act only on this scheduler's job executions | select which jobs or triggers you hear about, with a matcher |
+
+Listeners stay notification-only, and none of this changes them. The two compose: a middleware can do
+its work and a listener can still record what happened.
+
+## See also
+
+* [Trigger and Job Listeners](trigger-and-job-listeners.md)
+* [More About Jobs](more-about-jobs.md) — job scopes and `ConfigureJobScope`

--- a/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
+++ b/docs/documentation/quartz-4.x/tutorial/trigger-and-job-listeners.md
@@ -177,5 +177,21 @@ A listener is handed the context and can keep it for the duration of the executi
 be matched up. The migration guide has the whole thing in about thirty lines, under
 [what is running is a listing](/documentation/quartz-4.x/migration-guide.html#what-is-running-is-a-listing-not-a-list-of-contexts).
 
+## A listener or a middleware?
+
+Listeners are notification-only, and that is the whole distinction. A listener is *told* that a job is
+about to run and *told* what it did; the execution happens between the two notifications rather than
+inside them. So a listener cannot wrap the call in a scope or a stopwatch, cannot decline to make it,
+and cannot catch or translate what it threw — the exception it is handed has already been classified,
+and the trigger's fate has already been decided.
+
+Code that needs to *surround* the execution is a
+[job execution middleware](job-execution-middleware.md): a log scope, a tenant context, a timing, a
+translation of what a third-party library throws. Code that needs to *observe* one — audit a
+completion, chain the next job, count failures — is a listener, and gets matchers to choose which jobs
+and triggers it hears about, which middleware has no equivalent of. Vetoing stays a listener's job:
+`ITriggerListener.VetoJobExecution` is the scheduler's own refusal, and it raises `JobExecutionVetoed`,
+whereas a middleware that declines to run the job is invisible from outside the pipeline.
+
 Listeners are not used by most users of Quartz.NET, but are handy when application requirements create the need
 for the notification of events, without the Job itself explicitly notifying the application.

--- a/src/Quartz.Documentation.Samples/Tutorial/JobExecutionMiddlewareSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobExecutionMiddlewareSamples.cs
@@ -1,0 +1,158 @@
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Documentation.Samples.Tutorial;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/tutorial/job-execution-middleware.md.
+/// </summary>
+public static class JobExecutionMiddlewareSamples
+{
+    public static void Registering(IHostApplicationBuilder builder)
+    {
+        #region sample_job_middleware_register
+
+        builder.AddQuartz(q =>
+        {
+            // built by the container, so it can take dependencies of its own
+            q.AddJobMiddleware<LogScopeMiddleware>();
+
+            // built by you, from this scheduler's services
+            q.AddJobMiddleware(provider => new MeteredMiddleware(provider.GetRequiredService<IMeterFactory>()));
+
+            // one you already have
+            q.AddJobMiddleware(new TenantScopeMiddleware());
+        });
+
+        #endregion
+    }
+
+    public static async Task Standalone()
+    {
+        #region sample_job_middleware_standalone
+
+        IScheduler scheduler = await QuartzSchedulerBuilder.Create()
+            .UseInMemoryStore()
+            .AddJobMiddleware<LogScopeMiddleware>()
+            .BuildScheduler();
+
+        #endregion
+    }
+
+    public static void PerFiringState(IHostApplicationBuilder builder)
+    {
+        #region sample_job_middleware_job_scope
+
+        builder.AddQuartz(q =>
+        {
+            // Populated once per firing, before anything in the job's scope is resolved.
+            q.ConfigureJobScope((scope, bundle, scheduler) =>
+                scope.ServiceProvider.GetRequiredService<TenantHolder>().Tenant = bundle.Trigger.Key.Group);
+        });
+
+        #endregion
+    }
+}
+
+#region sample_job_middleware_log_scope
+
+public sealed class LogScopeMiddleware(ILogger<LogScopeMiddleware> logger) : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        using IDisposable? scope = logger.BeginScope(new Dictionary<string, object>
+        {
+            ["JobKey"] = context.JobDetail.Key,
+            ["FireInstanceId"] = context.FireInstanceId,
+        });
+
+        await next(context, cancellationToken);
+    }
+}
+
+#endregion
+
+#region sample_job_middleware_translate
+
+public sealed class TransientFailureMiddleware : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await next(context, cancellationToken);
+        }
+        catch (HttpRequestException e) when (e.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+        {
+            // Quartz understands this; it does not understand HttpRequestException.
+            throw new JobExecutionException(e) { RefireImmediately = true };
+        }
+    }
+}
+
+#endregion
+
+#region sample_job_middleware_short_circuit
+
+public sealed class FeatureFlagMiddleware(FeatureFlags flags) : IJobExecutionMiddleware
+{
+    public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        // Not calling next means the job does not run. The firing still completes, the listeners are
+        // still notified, and the trigger is left where a successful execution leaves it.
+        return flags.IsEnabled(context.JobDetail.Key) ? next(context, cancellationToken) : default;
+    }
+}
+
+#endregion
+
+#region sample_job_middleware_ambient
+
+public sealed class TenantScopeMiddleware : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        // An AsyncLocal, not a field: one instance of this middleware serves every firing the scheduler
+        // performs, and several of them can be in flight at once.
+        TenantScope.Current.Value = context.Trigger.Key.Group;
+        try
+        {
+            await next(context, cancellationToken);
+        }
+        finally
+        {
+            TenantScope.Current.Value = null;
+        }
+    }
+}
+
+#endregion
+
+/// <summary>
+/// The supporting types the samples above name, which the page describes rather than shows.
+/// </summary>
+public static class TenantScope
+{
+    public static readonly AsyncLocal<string?> Current = new();
+}
+
+public sealed class TenantHolder
+{
+    public string? Tenant { get; set; }
+}
+
+public sealed class FeatureFlags
+{
+    public bool IsEnabled(JobKey jobKey) => true;
+}
+
+public sealed class MeteredMiddleware(IMeterFactory meterFactory) : IJobExecutionMiddleware
+{
+    public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+    {
+        return next(context, cancellationToken);
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/JobExecutionMiddlewareTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobExecutionMiddlewareTest.cs
@@ -1,0 +1,733 @@
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Core;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// The execution seam: what a middleware wraps, what it may decide, and what it deliberately cannot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every scheduler here is built the way an application builds one, because the registration is half of
+/// the feature — a middleware that runs but is wired to the wrong scheduler, or in the wrong order, is
+/// not something anybody can reason about.
+/// </para>
+/// <para>
+/// The pipeline is composed once when the scheduler is built, so these tests keep what happened in a
+/// recorder resolved from the container rather than in fields on the middleware. That is the same
+/// constraint an application is under, and writing the tests inside it keeps them honest about it.
+/// </para>
+/// </remarks>
+public sealed class JobExecutionMiddlewareTest
+{
+    [Test]
+    public async Task MiddlewareRunsInRegistrationOrder_FirstRegisteredOutermost()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+
+        await RunScheduler(recorder, quartz =>
+        {
+            quartz.AddJobMiddleware<OuterMiddleware>();
+            quartz.AddJobMiddleware<InnerMiddleware>();
+        });
+
+        recorder.Steps.Should().Equal(["outer:before", "inner:before", "job", "inner:after", "outer:after"],
+            "middleware runs in registration order, outermost first — the first registered sees the "
+            + "firing before the second and its result after it, which is the only ordering a log scope "
+            + "or a transaction can be planned around");
+    }
+
+    [Test]
+    public async Task AllThreeRegistrationOverloadsPutTheMiddlewareInThePipeline()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+
+        await RunScheduler(recorder, quartz =>
+        {
+            quartz.AddJobMiddleware<OuterMiddleware>();
+            quartz.AddJobMiddleware(provider => new NamedMiddleware("factory", provider.GetRequiredService<Recorder>()));
+            quartz.AddJobMiddleware(new NamedMiddleware("instance", recorder));
+        });
+
+        recorder.Steps.Should().Equal(
+            ["outer:before", "factory:before", "instance:before", "job", "instance:after", "factory:after", "outer:after"],
+            "the type, the factory and the instance overloads are three ways to say the same thing, and "
+            + "each takes its place in the chain by when it was registered rather than by which overload "
+            + "was used");
+    }
+
+    [Test]
+    public async Task TheStandaloneBuilderRegistersMiddlewareToo()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create();
+        builder.Services.AddSingleton(recorder);
+
+        IScheduler scheduler = await builder
+            .ConfigureScheduler(options => options.InstanceName = $"standalone-{Guid.NewGuid():N}")
+            .AddJobMiddleware<OuterMiddleware>()
+            .AddJobListener(new CompletionListener(recorder))
+            .ScheduleJob<RecordingJob>(
+                trigger => trigger.WithIdentity("standalone").StartNow(),
+                job => job.WithIdentity("standalone"))
+            .BuildScheduler();
+
+        try
+        {
+            await scheduler.Start();
+            await recorder.WaitForCompletion();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        recorder.Steps.Should().Equal(["outer:before", "job", "outer:after"],
+            "QuartzSchedulerBuilder is an IQuartzBuilder over a container it creates itself, so a chain "
+            + "that registers middleware has to reach the registration AddQuartz reaches");
+    }
+
+    /// <summary>
+    /// A middleware that declines to call the rest of the chain.
+    /// </summary>
+    /// <remarks>
+    /// This is the thing a listener cannot do. A trigger listener's veto is the scheduler's own refusal —
+    /// it raises <c>JobExecutionVetoed</c> and the firing ends there — whereas a middleware that keeps
+    /// the call to itself is invisible from outside: the listeners were notified as usual, and the
+    /// trigger is left exactly as a successful execution leaves it.
+    /// </remarks>
+    [Test]
+    public async Task MiddlewareThatDoesNotCallNext_SkipsTheJobWhileTheFiringStillCompletes()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+
+        await RunScheduler(
+            recorder,
+            quartz => quartz.AddJobMiddleware<ShortCircuitingMiddleware>(),
+            // A trigger that may fire again, so the instruction reports what this firing decided rather
+            // than that the trigger has run out of fire times.
+            trigger => trigger.WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
+
+        recorder.Steps.Should().Equal(["short-circuit"], "the job was never called");
+        recorder.JobExecutions.Should().Be(0, "the middleware kept the call to itself");
+
+        recorder.ToBeExecutedCount.Should().Be(1,
+            "the listeners are notified by the run shell around the whole pipeline, so a job listener "
+            + "still hears that the firing happened — a middleware is not a veto");
+        recorder.WasExecutedCount.Should().Be(1);
+        recorder.JobException.Should().BeNull("declining to run the job is not a failure");
+
+        recorder.Instruction.Should().Be(SchedulerInstruction.NoInstruction,
+            "a firing whose middleware short-circuited leaves the trigger where a successful one does");
+    }
+
+    /// <summary>
+    /// A middleware translating what a job threw into Quartz's own vocabulary, which is the shape an
+    /// adapter around a third-party library takes.
+    /// </summary>
+    [Test]
+    public async Task MiddlewareTranslatingAnException_IsHonouredExactlyAsOneTheJobThrew()
+    {
+        Recorder recorder = new(expectedFirings: 1) { FailFirstExecution = true };
+
+        await RunScheduler(recorder, quartz => quartz.AddJobMiddleware<TranslatingMiddleware>());
+
+        recorder.JobExecutions.Should().Be(2,
+            "the middleware turned the job's InvalidOperationException into a JobExecutionException "
+            + "asking for an immediate refire, and the run shell honoured it the way it honours one the "
+            + "job raised itself — which is the whole point of running outside the classification");
+
+        recorder.RefireCounts.Should().Equal([0, 1], "the second attempt is the refire of the first");
+
+        recorder.WasExecutedCount.Should().Be(1,
+            "a refire is not a completion — job listeners hear about the firing once, when it is over");
+        recorder.JobException.Should().BeNull("the second attempt succeeded, so the firing completed cleanly");
+    }
+
+    /// <summary>
+    /// The pipeline runs inside the run shell's concurrency handling rather than around it.
+    /// </summary>
+    [Test]
+    public async Task DisallowConcurrentExecution_IsUnaffectedByMiddleware()
+    {
+        Recorder recorder = new(expectedFirings: 2);
+
+        await RunScheduler(
+            recorder,
+            quartz =>
+            {
+                // Both triggers are ready at once and the pool has room for both, so nothing but the
+                // attribute keeps them apart.
+                quartz.ConfigureScheduler(options => options.IdleWaitTime = TimeSpan.FromSeconds(1));
+                quartz.UseDefaultThreadPool(maxConcurrency: 5);
+                quartz.AddJobMiddleware<ConcurrencyWatchingMiddleware>();
+            },
+            secondTrigger: true,
+            jobType: typeof(ExclusiveRecordingJob));
+
+        recorder.JobExecutions.Should().Be(2, "both triggers fired");
+        recorder.MaxConcurrentJobs.Should().Be(1,
+            "[DisallowConcurrentExecution] is enforced by the store handing out one firing of the job at "
+            + "a time, which is above the pipeline — a middleware cannot widen it");
+        recorder.MaxConcurrentMiddleware.Should().Be(1,
+            "and the middleware sits inside that same window, so it never sees two firings of one job "
+            + "overlapping either");
+    }
+
+    [Test]
+    public async Task TheFiringIsAmbientInsideMiddleware()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+
+        await RunScheduler(recorder, quartz => quartz.AddJobMiddleware<AmbientReadingMiddleware>());
+
+        recorder.AmbientBefore.Should().NotBeNull().And.BeSameAs(recorder.JobContext,
+            "the firing is ambient before the pipeline is entered, so a middleware reads it through "
+            + "IJobExecutionContextAccessor without being handed anything — which is why no IServiceScope "
+            + "is threaded through the signature");
+        recorder.AmbientAfter.Should().BeSameAs(recorder.JobContext,
+            "and it is still ambient on the way out, where a middleware's finally block runs");
+    }
+
+    /// <summary>
+    /// A named scheduler's middleware is its own, the way its listeners and its job store are.
+    /// </summary>
+    [Test]
+    public async Task ANamedSchedulerRunsOnlyItsOwnMiddleware()
+    {
+        Recorder recorder = new(expectedFirings: 1);
+        string id = Guid.NewGuid().ToString("N");
+
+        ServiceCollection services = new();
+        services.AddSingleton(recorder);
+        services.AddQuartz("reporting", quartz =>
+        {
+            quartz.AddJobMiddleware(new NamedMiddleware("reporting", recorder));
+            quartz.AddJobListener(new CompletionListener(recorder));
+            quartz.ScheduleJob<RecordingJob>(
+                trigger => trigger.WithIdentity($"trigger-{id}").StartNow(),
+                job => job.WithIdentity($"job-{id}"));
+        });
+        services.AddQuartz(quartz => quartz.AddJobMiddleware(new NamedMiddleware("default", recorder)));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler scheduler = provider.GetRequiredKeyedService<IScheduler>("reporting");
+        try
+        {
+            await scheduler.Start();
+            await recorder.WaitForCompletion();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        recorder.Steps.Should().Equal(["reporting:before", "job", "reporting:after"],
+            "middleware is registered under its scheduler's service key, so the default scheduler's "
+            + "never wraps a named scheduler's firing");
+    }
+
+    /// <summary>
+    /// The configuration nearly every application runs: no middleware, and therefore no pipeline at all.
+    /// </summary>
+    /// <remarks>
+    /// The run shell calls the job directly when this is null. A chain that was always composed — even
+    /// one stage long, wrapping only the job — would put a delegate allocation and an extra call on the
+    /// hot path of every firing in every application, to buy a feature almost none of them use.
+    /// </remarks>
+    [Test]
+    public async Task ASchedulerWithNoMiddleware_HasNoPipeline()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(quartz => quartz.ConfigureScheduler(options => options.InstanceName = $"bare-{Guid.NewGuid():N}"));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<QuartzSchedulerResources>().JobExecutionPipeline.Should().BeNull(
+            "a scheduler nobody gave middleware to executes its jobs through the call it always did");
+    }
+
+    /// <summary>
+    /// One instance per scheduler, shared by every firing — which is why a middleware must keep no
+    /// per-firing state in a field.
+    /// </summary>
+    [Test]
+    public async Task TheMiddlewareIsBuiltOncePerScheduler_AndSharedByEveryFiring()
+    {
+        Recorder recorder = new(expectedFirings: 2);
+
+        await RunScheduler(
+            recorder,
+            quartz =>
+            {
+                quartz.ConfigureScheduler(options => options.IdleWaitTime = TimeSpan.FromSeconds(1));
+                quartz.AddJobMiddleware<CountingMiddleware>();
+            },
+            secondTrigger: true);
+
+        recorder.JobExecutions.Should().Be(2, "both triggers fired");
+        recorder.MiddlewareConstructions.Should().Be(1,
+            "the chain is folded once when the scheduler is built, not per firing — so the middleware is "
+            + "constructed once and its dependencies are resolved once");
+    }
+
+    /// <summary>
+    /// Builds a scheduler with the given middleware, runs the job its trigger fires, and shuts
+    /// everything down before returning — so an assertion never races the execution it is about.
+    /// </summary>
+    private static async Task RunScheduler(
+        Recorder recorder,
+        Action<IQuartzBuilder> configure,
+        Action<ITriggerConfigurator<IJob>>? trigger = null,
+        bool secondTrigger = false,
+        Type? jobType = null)
+    {
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"job-{id}", $"group-{id}");
+
+        ServiceCollection services = new();
+        services.AddSingleton(recorder);
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"middleware-{id}");
+            quartz.AddJobListener(new CompletionListener(recorder));
+            quartz.AddTriggerListener(new InstructionListener(recorder));
+            configure(quartz);
+
+            // Durable, so the job is added once and its triggers are scheduled once. A non-durable job
+            // is scheduled and then rescheduled by the content processor, and rescheduling moves a
+            // simple trigger's start time out of the past while keeping the fire time it already had —
+            // which makes a repeating trigger fire twice in a row and has nothing to do with middleware.
+            quartz.AddJob(jobType ?? typeof(RecordingJob), job => job.WithIdentity(jobKey).StoreDurably());
+            quartz.AddTrigger(configurator =>
+            {
+                configurator.ForJob(jobKey).WithIdentity($"trigger-{id}").StartNow();
+                trigger?.Invoke(configurator);
+            });
+
+            if (secondTrigger)
+            {
+                quartz.AddTrigger(configurator => configurator.ForJob(jobKey).WithIdentity($"trigger-{id}-2").StartNow());
+            }
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler scheduler = provider.GetRequiredService<IScheduler>();
+        try
+        {
+            await scheduler.Start();
+            await recorder.WaitForCompletion();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// What the pipeline did, shared by the middleware, the job and the listeners.
+    /// </summary>
+    public sealed class Recorder
+    {
+        private readonly Lock gate = new();
+        private readonly List<string> steps = [];
+        private readonly List<int> refireCounts = [];
+        private readonly TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly int expectedFirings;
+
+        private int concurrentJobs;
+        private int concurrentMiddleware;
+
+        public Recorder(int expectedFirings)
+        {
+            this.expectedFirings = expectedFirings;
+        }
+
+        /// <summary>
+        /// Whether the job's first execution should throw, so a translating middleware has something to
+        /// translate.
+        /// </summary>
+        public bool FailFirstExecution { get; init; }
+
+        public int JobExecutions { get; private set; }
+
+        public int MiddlewareConstructions { get; private set; }
+
+        public int ToBeExecutedCount { get; private set; }
+
+        public int WasExecutedCount { get; private set; }
+
+        public int MaxConcurrentJobs { get; private set; }
+
+        public int MaxConcurrentMiddleware { get; private set; }
+
+        public SchedulerInstruction? Instruction { get; private set; }
+
+        public JobExecutionException? JobException { get; private set; }
+
+        public IJobExecutionContext? JobContext { get; set; }
+
+        public IJobExecutionContext? AmbientBefore { get; set; }
+
+        public IJobExecutionContext? AmbientAfter { get; set; }
+
+        public IReadOnlyList<string> Steps
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return [.. steps];
+                }
+            }
+        }
+
+        public IReadOnlyList<int> RefireCounts
+        {
+            get
+            {
+                lock (gate)
+                {
+                    return [.. refireCounts];
+                }
+            }
+        }
+
+        public void Step(string step)
+        {
+            lock (gate)
+            {
+                steps.Add(step);
+            }
+        }
+
+        public void MiddlewareConstructed()
+        {
+            lock (gate)
+            {
+                MiddlewareConstructions++;
+            }
+        }
+
+        /// <summary>
+        /// Records one job execution, and answers whether this one is supposed to fail.
+        /// </summary>
+        public bool EnterJob(IJobExecutionContext context)
+        {
+            lock (gate)
+            {
+                JobContext = context;
+                JobExecutions++;
+                refireCounts.Add(context.RefireCount);
+                concurrentJobs++;
+                MaxConcurrentJobs = Math.Max(MaxConcurrentJobs, concurrentJobs);
+                return FailFirstExecution && JobExecutions == 1;
+            }
+        }
+
+        public void ExitJob()
+        {
+            lock (gate)
+            {
+                concurrentJobs--;
+            }
+        }
+
+        public void EnterMiddleware()
+        {
+            lock (gate)
+            {
+                concurrentMiddleware++;
+                MaxConcurrentMiddleware = Math.Max(MaxConcurrentMiddleware, concurrentMiddleware);
+            }
+        }
+
+        public void ExitMiddleware()
+        {
+            lock (gate)
+            {
+                concurrentMiddleware--;
+            }
+        }
+
+        public void JobToBeExecuted()
+        {
+            lock (gate)
+            {
+                ToBeExecutedCount++;
+            }
+        }
+
+        public void JobWasExecuted(JobExecutionException? jobException)
+        {
+            bool done;
+            lock (gate)
+            {
+                WasExecutedCount++;
+                JobException = jobException;
+                done = WasExecutedCount >= expectedFirings;
+            }
+
+            if (done)
+            {
+                completed.TrySetResult();
+            }
+        }
+
+        public void TriggerComplete(SchedulerInstruction instruction)
+        {
+            lock (gate)
+            {
+                Instruction = instruction;
+            }
+        }
+
+        public Task WaitForCompletion() => completed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    public class RecordingJob : IJob
+    {
+        private readonly Recorder recorder;
+
+        public RecordingJob(Recorder recorder)
+        {
+            this.recorder = recorder;
+        }
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            bool fail = recorder.EnterJob(context);
+            recorder.Step("job");
+            try
+            {
+                await Work(cancellationToken).ConfigureAwait(false);
+                if (fail)
+                {
+                    throw new InvalidOperationException("this execution fails on purpose");
+                }
+            }
+            finally
+            {
+                recorder.ExitJob();
+            }
+        }
+
+        protected virtual Task Work(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The same job, held long enough that two firings would overlap if anything let them.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class ExclusiveRecordingJob : RecordingJob
+    {
+        public ExclusiveRecordingJob(Recorder recorder) : base(recorder)
+        {
+        }
+
+        protected override Task Work(CancellationToken cancellationToken) => Task.Delay(250, cancellationToken);
+    }
+
+    public sealed class OuterMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+
+        public OuterMiddleware(Recorder recorder) => this.recorder = recorder;
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.Step("outer:before");
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recorder.Step("outer:after");
+            }
+        }
+    }
+
+    public sealed class InnerMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+
+        public InnerMiddleware(Recorder recorder) => this.recorder = recorder;
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.Step("inner:before");
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recorder.Step("inner:after");
+            }
+        }
+    }
+
+    /// <summary>
+    /// A middleware that says which registration overload put it there.
+    /// </summary>
+    public sealed class NamedMiddleware : IJobExecutionMiddleware
+    {
+        private readonly string name;
+        private readonly Recorder recorder;
+
+        public NamedMiddleware(string name, Recorder recorder)
+        {
+            this.name = name;
+            this.recorder = recorder;
+        }
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.Step($"{name}:before");
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recorder.Step($"{name}:after");
+            }
+        }
+    }
+
+    public sealed class ShortCircuitingMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+
+        public ShortCircuitingMiddleware(Recorder recorder) => this.recorder = recorder;
+
+        public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.Step("short-circuit");
+            return default;
+        }
+    }
+
+    public sealed class TranslatingMiddleware : IJobExecutionMiddleware
+    {
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new JobExecutionException(e) { RefireImmediately = true };
+            }
+        }
+    }
+
+    public sealed class ConcurrencyWatchingMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+
+        public ConcurrencyWatchingMiddleware(Recorder recorder) => this.recorder = recorder;
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.EnterMiddleware();
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recorder.ExitMiddleware();
+            }
+        }
+    }
+
+    public sealed class CountingMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+
+        public CountingMiddleware(Recorder recorder)
+        {
+            this.recorder = recorder;
+            recorder.MiddlewareConstructed();
+        }
+
+        public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            return next(context, cancellationToken);
+        }
+    }
+
+    public sealed class AmbientReadingMiddleware : IJobExecutionMiddleware
+    {
+        private readonly Recorder recorder;
+        private readonly IJobExecutionContextAccessor accessor;
+
+        public AmbientReadingMiddleware(Recorder recorder, IJobExecutionContextAccessor accessor)
+        {
+            this.recorder = recorder;
+            this.accessor = accessor;
+        }
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            recorder.AmbientBefore = accessor.Current;
+            try
+            {
+                await next(context, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                recorder.AmbientAfter = accessor.Current;
+            }
+        }
+    }
+
+    private sealed class CompletionListener : IJobListener
+    {
+        private readonly Recorder recorder;
+
+        public CompletionListener(Recorder recorder) => this.recorder = recorder;
+
+        public string Name => "completion";
+
+        public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            recorder.JobToBeExecuted();
+            return default;
+        }
+
+        public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
+        {
+            recorder.JobWasExecuted(jobException);
+            return default;
+        }
+    }
+
+    private sealed class InstructionListener : ITriggerListener
+    {
+        private readonly Recorder recorder;
+
+        public InstructionListener(Recorder recorder) => this.recorder = recorder;
+
+        public string Name => "instruction";
+
+        public ValueTask TriggerComplete(
+            ITrigger trigger,
+            IJobExecutionContext context,
+            SchedulerInstruction triggerInstructionCode,
+            CancellationToken cancellationToken = default)
+        {
+            recorder.TriggerComplete(triggerInstructionCode);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -402,6 +402,54 @@ public sealed class JobExecutionObservabilityTest
     }
 
     /// <summary>
+    /// The span is opened around the whole pipeline, not around the job alone.
+    /// </summary>
+    /// <remarks>
+    /// Middleware is invoked inside the activity and the meter bracket on purpose: what a log scope, a
+    /// tenant lookup or a timeout costs is part of what the firing cost, and a trace that showed the job
+    /// but not the middleware wrapped around it would attribute that time to nothing.
+    /// </remarks>
+    [Test]
+    public async Task TheExecutionSpanWrapsTheWholeMiddlewareChain()
+    {
+        ActivityReadingMiddleware middleware = new();
+
+        Execution execution = await RunJob<SucceedingJob>(middleware: middleware);
+
+        Activity activity = ActivityFor(execution.JobKey);
+
+        middleware.OnTheWayIn.Should().BeSameAs(activity,
+            "a middleware is entered after the span has been started, so anything it traces is a child "
+            + "of the execution rather than an orphan");
+        middleware.OnTheWayOut.Should().BeSameAs(activity,
+            "and the span is still open while a middleware's finally block runs, which is where a "
+            + "timing or a cleanup middleware does its work");
+    }
+
+    /// <summary>
+    /// A middleware runs outside the run shell's exception handling, so what it throws is classified as
+    /// though the job had thrown it.
+    /// </summary>
+    [Test]
+    public async Task AMiddlewareThatThrows_FailsTheSpanTheWayAJobDoes()
+    {
+        Execution execution = await RunJob<SucceedingJob>(middleware: new ThrowingMiddleware());
+
+        Activity activity = ActivityFor(execution.JobKey);
+
+        activity.Status.Should().Be(ActivityStatusCode.Error,
+            "the job itself succeeded, but the firing did not — and the firing is what the span is about");
+        activity.GetTagItem(ErrorTypeTag).Should().Be(typeof(InvalidOperationException).FullName,
+            "an exception a middleware lets out is unwrapped and reported exactly like one the job threw");
+
+        MeasurementsFor(execution.JobKey).Single(m => m.Instrument == ExecuteDuration)
+            .Tags.Should().ContainKey(ErrorTypeTag)
+            .WhoseValue.Should().Be(typeof(InvalidOperationException).FullName,
+                "the histogram and the span agree about what failed, whether the failure came from the "
+                + "job or from something wrapped around it");
+    }
+
+    /// <summary>
     /// A vetoed fire is a span of its own, and nothing an execution histogram ever hears about.
     /// </summary>
     /// <remarks>
@@ -459,7 +507,10 @@ public sealed class JobExecutionObservabilityTest
     /// Builds a scheduler the way an application does, runs the job its trigger fires exactly once, and
     /// shuts everything down before returning — so an assertion never races the execution it is about.
     /// </summary>
-    private static async Task<Execution> RunJob<TJob>(bool veto = false, string executionGroup = null) where TJob : IJob
+    private static async Task<Execution> RunJob<TJob>(
+        bool veto = false,
+        string executionGroup = null,
+        IJobExecutionMiddleware middleware = null) where TJob : IJob
     {
         string id = Guid.NewGuid().ToString("N");
         JobKey jobKey = new($"job-{id}", $"job-group-{id}");
@@ -477,6 +528,11 @@ public sealed class JobExecutionObservabilityTest
             if (veto)
             {
                 quartz.AddTriggerListener(new VetoingTriggerListener());
+            }
+
+            if (middleware is not null)
+            {
+                quartz.AddJobMiddleware(middleware);
             }
             quartz.AddJob<TJob>(job => job.WithIdentity(jobKey));
             quartz.AddTrigger<TJob>(trigger => trigger
@@ -598,6 +654,40 @@ public sealed class JobExecutionObservabilityTest
         {
             executed.TrySetResult(context.FireInstanceId);
             return default;
+        }
+    }
+
+    /// <summary>
+    /// Reads the ambient <see cref="Activity" /> on both sides of the rest of the pipeline.
+    /// </summary>
+    public sealed class ActivityReadingMiddleware : IJobExecutionMiddleware
+    {
+        public Activity OnTheWayIn { get; private set; }
+
+        public Activity OnTheWayOut { get; private set; }
+
+        public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            OnTheWayIn = Activity.Current;
+            try
+            {
+                await next(context, cancellationToken);
+            }
+            finally
+            {
+                OnTheWayOut = Activity.Current;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Fails the firing without the job having anything to do with it.
+    /// </summary>
+    public sealed class ThrowingMiddleware : IJobExecutionMiddleware
+    {
+        public ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("this middleware fails on purpose");
         }
     }
 

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -532,6 +532,10 @@ namespace Quartz
     {
         Quartz.IJobExecutionContext? Current { get; }
     }
+    public interface IJobExecutionMiddleware
+    {
+        System.Threading.Tasks.ValueTask Invoke(Quartz.IJobExecutionContext context, Quartz.JobExecutionDelegate next, System.Threading.CancellationToken cancellationToken = default);
+    }
     public interface IJobListener
     {
         string Name { get; }
@@ -605,6 +609,12 @@ namespace Quartz
             where T :  class, Quartz.IJobListener;
         Quartz.IQuartzBuilder AddJobListener<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(T listener, [System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IReadOnlyCollection<Quartz.IMatcher<Quartz.JobKey>> matchers)
             where T :  class, Quartz.IJobListener;
+        Quartz.IQuartzBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
+            where T :  class, Quartz.IJobExecutionMiddleware;
+        Quartz.IQuartzBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(System.Func<System.IServiceProvider, T> factory)
+            where T :  class, Quartz.IJobExecutionMiddleware;
+        Quartz.IQuartzBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(T middleware)
+            where T :  class, Quartz.IJobExecutionMiddleware;
         Quartz.IQuartzBuilder AddPlugin<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(string? name = null)
             where T :  class, Quartz.Extensibility.ISchedulerPlugin;
         Quartz.IQuartzBuilder AddPlugin<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(System.Func<System.IServiceProvider, T> factory, string? name = null)
@@ -920,6 +930,7 @@ namespace Quartz
     {
         public static TInput? GetInput<TInput>(this Quartz.IJobExecutionContext context) { }
     }
+    public delegate System.Threading.Tasks.ValueTask JobExecutionDelegate(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken);
     public sealed class JobExecutionException : Quartz.SchedulerException
     {
         public JobExecutionException() { }
@@ -1326,6 +1337,12 @@ namespace Quartz
             where T :  class, Quartz.IJobListener { }
         public Quartz.QuartzSchedulerBuilder AddJobListener<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(T listener, [System.Runtime.CompilerServices.ParamCollection] System.Collections.Generic.IReadOnlyCollection<Quartz.IMatcher<Quartz.JobKey>> matchers)
             where T :  class, Quartz.IJobListener { }
+        public Quartz.QuartzSchedulerBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
+            where T :  class, Quartz.IJobExecutionMiddleware { }
+        public Quartz.QuartzSchedulerBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(System.Func<System.IServiceProvider, T> factory)
+            where T :  class, Quartz.IJobExecutionMiddleware { }
+        public Quartz.QuartzSchedulerBuilder AddJobMiddleware<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>(T middleware)
+            where T :  class, Quartz.IJobExecutionMiddleware { }
         public Quartz.QuartzSchedulerBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>()
             where TJob :  class, Quartz.IJob { }
         public Quartz.QuartzSchedulerBuilder AddJobType<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime)

--- a/src/Quartz/Configuration/IQuartzBuilder.cs
+++ b/src/Quartz/Configuration/IQuartzBuilder.cs
@@ -391,6 +391,44 @@ public interface IQuartzBuilder
         Func<IServiceProvider, T> factory, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) where T : class, ITriggerListener;
 
     /// <summary>
+    /// Adds a middleware the container builds, which wraps every job this scheduler executes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Middleware is where a cross-cutting concern lives — a log scope, a tenant context, a timeout, a
+    /// translation of what a library throws. A listener cannot do any of those: it is notified before
+    /// and after the job rather than around it, so it can neither wrap the call, decline to make it, nor
+    /// see what it threw. See <see cref="IJobExecutionMiddleware" /> for what a middleware may and may
+    /// not decide.
+    /// </para>
+    /// <para>
+    /// Middleware runs in registration order, outermost first, so the first registered is the first to
+    /// see a firing and the last to see its result. Each call adds a stage: registering the same type
+    /// twice puts it in the chain twice, the same way registering the same job twice schedules it twice.
+    /// </para>
+    /// <para>
+    /// One instance is built per scheduler and shared by every firing, so a middleware must keep no
+    /// per-firing state in a field. It is registered for this scheduler alone, like its listeners and
+    /// its job store, so a named scheduler's middleware wraps only its own executions.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="T">The middleware's type.</typeparam>
+    IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+        where T : class, IJobExecutionMiddleware;
+
+    /// <inheritdoc cref="AddJobMiddleware{T}()" path="/remarks" />
+    /// <typeparam name="T">The middleware's type.</typeparam>
+    /// <param name="factory">Builds the middleware from this scheduler's view of the container.</param>
+    IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        Func<IServiceProvider, T> factory) where T : class, IJobExecutionMiddleware;
+
+    /// <inheritdoc cref="AddJobMiddleware{T}()" path="/remarks" />
+    /// <typeparam name="T">The middleware's type.</typeparam>
+    /// <param name="middleware">The middleware, already built.</param>
+    IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        T middleware) where T : class, IJobExecutionMiddleware;
+
+    /// <summary>
     /// Configures execution group limits, so resource-hungry jobs cannot saturate every thread. Each
     /// limit is counted on this node or across the cluster, as its <see cref="ExecutionLimitScope"/> says.
     /// </summary>

--- a/src/Quartz/Configuration/JobExecutionMiddlewareRegistration.cs
+++ b/src/Quartz/Configuration/JobExecutionMiddlewareRegistration.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// One middleware a scheduler was told to wrap its job executions in, as a type, a factory or a
+/// ready-made instance.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The same shape a listener registration has, and registered the same way: held under the scheduler's
+/// service key, so a named scheduler's middleware is its own and is never even seen by another
+/// scheduler in the container. Resolution preserves registration order, which is what makes "outermost
+/// first" a thing an application can rely on.
+/// </para>
+/// <para>
+/// Unlike a listener, there is nothing to verify about the shape. Every member of the listener
+/// interfaces has a default implementation, so a method with the right name and the wrong signature
+/// compiles and silently stops implementing anything; <see cref="IJobExecutionMiddleware.Invoke" /> has
+/// no default, so the compiler is the check.
+/// </para>
+/// </remarks>
+internal sealed class JobExecutionMiddlewareRegistration
+{
+    private readonly Func<IServiceProvider, IJobExecutionMiddleware>? middlewareFactory;
+    private readonly IJobExecutionMiddleware? middlewareInstance;
+
+    /// <summary>
+    /// Backing field for <see cref="MiddlewareType" />, written out rather than left to the compiler.
+    /// </summary>
+    /// <remarks>
+    /// An auto-property's annotation does not reach its generated backing field, and ILCompiler checks
+    /// the field — see the same field on <see cref="ListenerRegistration{TListener}" />, where a native
+    /// AOT publish reported IL2078 for a requirement that is satisfied at both ends in the source.
+    /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)]
+    private readonly Type middlewareType;
+
+    public JobExecutionMiddlewareRegistration(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)]
+        Type middlewareType,
+        Func<IServiceProvider, IJobExecutionMiddleware>? middlewareFactory = null,
+        IJobExecutionMiddleware? middlewareInstance = null)
+    {
+        this.middlewareType = middlewareType;
+        this.middlewareFactory = middlewareFactory;
+        this.middlewareInstance = middlewareInstance;
+    }
+
+    /// <summary>
+    /// The type the middleware was registered as.
+    /// </summary>
+    /// <remarks>
+    /// Only used to describe the registration. A factory overload may well return a subtype, so this is
+    /// not an identity the middleware can be found by.
+    /// </remarks>
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)]
+    public Type MiddlewareType => middlewareType;
+
+    /// <summary>
+    /// Produces the middleware, once there is a scheduler to compose it into.
+    /// </summary>
+    /// <param name="serviceProvider">
+    /// The provider of the scheduler this registration belongs to, so a middleware built here is given
+    /// that scheduler's collaborators rather than the default scheduler's.
+    /// </param>
+    public IJobExecutionMiddleware CreateMiddleware(IServiceProvider serviceProvider)
+    {
+        if (middlewareInstance is not null)
+        {
+            return middlewareInstance;
+        }
+
+        if (middlewareFactory is not null)
+        {
+            return middlewareFactory(serviceProvider);
+        }
+
+        return (IJobExecutionMiddleware) ActivatorUtilities.CreateInstance(serviceProvider, MiddlewareType);
+    }
+}

--- a/src/Quartz/Configuration/QuartzBuilder.cs
+++ b/src/Quartz/Configuration/QuartzBuilder.cs
@@ -415,6 +415,34 @@ internal sealed class QuartzBuilder : IQuartzBuilder
         return this;
     }
 
+    /// <remarks>
+    /// Registered as content rather than as a service, for the reason a listener is: a middleware that
+    /// was also resolvable as <c>IJobExecutionMiddleware</c> would be a second source the pipeline would
+    /// have to deduplicate against, and there is no name to deduplicate by.
+    /// </remarks>
+    public IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+        where T : class, IJobExecutionMiddleware
+    {
+        AddContent(new JobExecutionMiddlewareRegistration(typeof(T)));
+        return this;
+    }
+
+    public IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        Func<IServiceProvider, T> factory) where T : class, IJobExecutionMiddleware
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        AddContent(new JobExecutionMiddlewareRegistration(typeof(T), middlewareFactory: provider => factory(provider)));
+        return this;
+    }
+
+    public IQuartzBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        T middleware) where T : class, IJobExecutionMiddleware
+    {
+        ArgumentNullException.ThrowIfNull(middleware);
+        AddContent(new JobExecutionMiddlewareRegistration(typeof(T), middlewareInstance: middleware));
+        return this;
+    }
+
     public IQuartzBuilder UseExecutionLimits(Action<ExecutionLimitsBuilder> configure)
     {
         ArgumentNullException.ThrowIfNull(configure);

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -221,6 +221,7 @@ internal static class QuartzServiceRegistration
                 JobStore = Instrument(provider.GetScheduler<IJobStore>(key), meters, timeProvider),
                 JobRunShellFactory = provider.GetScheduler<IJobRunShellFactory>(key),
                 SchedulerRepository = provider.GetRequiredService<ISchedulerRepository>(),
+                JobExecutionPipeline = ComposeJobExecutionPipeline(provider, key),
             };
 
             // Plugins are added by the scheduler factory rather than here, because those named by
@@ -281,6 +282,37 @@ internal static class QuartzServiceRegistration
         {
             services.TryAddKeyedSingleton(key, (provider, serviceKey) => factory(provider, serviceKey));
         }
+    }
+
+    /// <summary>
+    /// Builds this scheduler's middleware and folds it around the job, once, on the way into the
+    /// resources.
+    /// </summary>
+    /// <remarks>
+    /// Here rather than in <see cref="SchedulerContentInitializer" /> because the pipeline is part of
+    /// what the scheduler <em>is</em> rather than content applied to it once it exists: the run shell
+    /// reads it out of the resources on every firing, so it has to be there before the first one. Each
+    /// middleware is built from this scheduler's own view of the container, so a middleware that takes a
+    /// scheduler's parts is handed that scheduler's.
+    /// </remarks>
+    private static JobExecutionDelegate? ComposeJobExecutionPipeline(IServiceProvider provider, object? key)
+    {
+        List<JobExecutionMiddlewareRegistration> registrations =
+            [.. provider.GetSchedulerServices<JobExecutionMiddlewareRegistration>(key)];
+
+        if (registrations.Count == 0)
+        {
+            return null;
+        }
+
+        IServiceProvider scoped = Scoped(provider, key);
+        List<IJobExecutionMiddleware> middleware = new(registrations.Count);
+        foreach (JobExecutionMiddlewareRegistration registration in registrations)
+        {
+            middleware.Add(registration.CreateMiddleware(scoped));
+        }
+
+        return JobExecutionPipeline.Compose(middleware);
     }
 
     /// <summary>

--- a/src/Quartz/Core/JobExecutionPipeline.cs
+++ b/src/Quartz/Core/JobExecutionPipeline.cs
@@ -1,0 +1,76 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz.Core;
+
+/// <summary>
+/// Folds a scheduler's <see cref="IJobExecutionMiddleware" /> list into the single delegate the run
+/// shell calls.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Composed once, when the scheduler's resources are built, rather than per firing: every stage of the
+/// chain is a closure, and building the chain on the hot path would allocate one per middleware per
+/// fire. The terminal step reads the job off the context rather than closing over it, which is what
+/// makes the whole chain reusable — the only thing that differs between two firings is the context, and
+/// that is an argument.
+/// </para>
+/// <para>
+/// A scheduler with no middleware gets <see langword="null" /> rather than a one-element chain around
+/// the job. The run shell calls the job directly in that case, so the pipeline costs a null check and
+/// nothing else in the configuration nearly every application runs.
+/// </para>
+/// </remarks>
+internal static class JobExecutionPipeline
+{
+    /// <summary>
+    /// The end of every pipeline: the job itself.
+    /// </summary>
+    private static readonly JobExecutionDelegate executeJob =
+        static (context, cancellationToken) => context.JobInstance.Execute(context, cancellationToken);
+
+    /// <summary>
+    /// Wraps the middleware around the job, first registered outermost.
+    /// </summary>
+    /// <param name="middleware">The middleware registered for this scheduler, in registration order.</param>
+    /// <returns>
+    /// The composed pipeline, or <see langword="null" /> when there is no middleware to compose.
+    /// </returns>
+    public static JobExecutionDelegate? Compose(IReadOnlyList<IJobExecutionMiddleware> middleware)
+    {
+        if (middleware.Count == 0)
+        {
+            return null;
+        }
+
+        // Built back to front, so the first registered middleware ends up holding the rest of the chain
+        // and therefore runs first.
+        JobExecutionDelegate next = executeJob;
+        for (int i = middleware.Count - 1; i >= 0; i--)
+        {
+            IJobExecutionMiddleware stage = middleware[i];
+            JobExecutionDelegate rest = next;
+            next = (context, cancellationToken) => stage.Invoke(context, rest, cancellationToken);
+        }
+
+        return next;
+    }
+}

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -220,10 +220,18 @@ internal sealed class JobRunShell
                 Instrumentation instrumentation = qs.resources.Meters.StartJobExecute(context);
 
 
-                // Execute the job
+                // Execute the job, through this scheduler's middleware when it has any. Inside the
+                // activity and the instrumentation above, so what a middleware costs is part of what the
+                // firing cost, and outside the classification below, so an exception a middleware throws
+                // is treated exactly as one the job threw.
                 try
                 {
-                    await jobScope.Job.Execute(context, context.CancellationToken).ConfigureAwait(false);
+                    JobExecutionDelegate? pipeline = qs.resources.JobExecutionPipeline;
+                    ValueTask execution = pipeline is null
+                        ? jobScope.Job.Execute(context, context.CancellationToken)
+                        : pipeline(context, context.CancellationToken);
+
+                    await execution.ConfigureAwait(false);
                     endTimestamp = timeProvider.GetTimestamp();
                 }
                 catch (OperationCanceledException) when (context.CancellationToken.IsCancellationRequested)

--- a/src/Quartz/Core/QuartzSchedulerResources.cs
+++ b/src/Quartz/Core/QuartzSchedulerResources.cs
@@ -311,5 +311,17 @@ internal sealed class QuartzSchedulerResources
     /// </remarks>
     internal IJobInputSerializer JobInputSerializer { get; set; } = new Impl.SystemTextJsonJobInputSerializer();
 
+    /// <summary>
+    /// The <see cref="IJobExecutionMiddleware" /> chain wrapped around this scheduler's job executions,
+    /// or <see langword="null" /> when it has none.
+    /// </summary>
+    /// <remarks>
+    /// Composed once here rather than per firing, because the chain is the same for every firing a
+    /// scheduler performs — see <see cref="Core.JobExecutionPipeline.Compose" />. Null rather than a
+    /// chain that is only the job, so a scheduler with no middleware runs the job through exactly the
+    /// call it always did.
+    /// </remarks>
+    internal JobExecutionDelegate? JobExecutionPipeline { get; set; }
+
     internal ISchedulerRepository SchedulerRepository { get; set; }
 }

--- a/src/Quartz/IJobExecutionMiddleware.cs
+++ b/src/Quartz/IJobExecutionMiddleware.cs
@@ -1,0 +1,124 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// The rest of the job execution pipeline, as a middleware sees it: the middleware registered after
+/// this one, ending in the job itself.
+/// </summary>
+/// <remarks>
+/// The cancellation token has no default. A middleware is handed one and is expected to pass it on, so
+/// leaving it out would have to be written out rather than being what happens when nothing is said.
+/// </remarks>
+/// <param name="context">The firing being executed.</param>
+/// <param name="cancellationToken">
+/// Signalled when this execution is interrupted. The same token
+/// <see cref="IJobExecutionContext.CancellationToken" /> carries.
+/// </param>
+public delegate ValueTask JobExecutionDelegate(IJobExecutionContext context, CancellationToken cancellationToken);
+
+/// <summary>
+/// Wraps every job execution a scheduler performs, so a cross-cutting concern has somewhere to live
+/// that is neither the job nor a listener.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A log scope, a tenant context, a timeout, a translation of what a third-party library throws: each
+/// of these has to <em>surround</em> the call to the job, and a listener cannot. Listeners are
+/// notification-only — they are told a job is about to run and told what it did, but the job runs
+/// between the two notifications rather than inside them, so a listener cannot open an
+/// <c>await using</c> around it, cannot decline to run it, and cannot catch what it threw. Before this
+/// existed the only place to put such code was a job that wrapped another job, which is why several
+/// frameworks built on Quartz ship exactly that adapter.
+/// </para>
+/// <para>
+/// <strong>What a middleware may do.</strong> Run code before and after <c>next</c>; not
+/// call it at all, which means the job does not run; catch what it threw and rethrow something else;
+/// and set ambient state that the job and everything it calls will read. What it may <em>not</em> do is
+/// decide what the scheduler does with the trigger afterwards, except in the way a job decides it — by
+/// throwing a <see cref="JobExecutionException" />, whose <see cref="JobExecutionException.RefireImmediately" />
+/// and unschedule flags are honoured exactly as they are when the job raises one itself.
+/// </para>
+/// <para>
+/// <strong>Where it runs.</strong> Inside the execution span and the duration measurement, so what a
+/// middleware costs is part of what the firing cost, and outside the run shell's exception handling, so
+/// an exception a middleware lets out is classified as though the job had thrown it. It runs after the
+/// trigger and job listeners have been notified that the job is about to execute, which means a fire a
+/// listener vetoed never reaches the pipeline at all.
+/// </para>
+/// <para>
+/// <strong>Order.</strong> Middleware is registered on the scheduler's builder and runs in registration
+/// order, outermost first: the first registered sees the firing before the second, and sees the result
+/// after it. The chain is composed once when the scheduler is built, so a middleware instance is shared
+/// by every firing of that scheduler and must not keep per-firing state in a field. Per-firing state
+/// belongs in an <see cref="System.Threading.AsyncLocal{T}" />, or in the job's dependency-injection
+/// scope — which is prepared by <c>ConfigureJobScope</c> and read back through
+/// <see cref="IJobExecutionContextAccessor" />. No <c>IServiceScope</c> is threaded through this
+/// signature, because the scope belongs to the firing rather than to any one middleware.
+/// </para>
+/// <para>
+/// <strong>The token.</strong> Forward the one you were given. Passing a different token to
+/// <c>next</c> changes what the job's <c>Execute</c> parameter is without changing
+/// <see cref="IJobExecutionContext.CancellationToken" />, so the two stop being the same token and a
+/// job that reads the context sees the wrong one — which is the trap in writing a timeout as a
+/// middleware.
+/// </para>
+/// <para>
+/// <strong>Not a retry mechanism.</strong> Catching a failure and awaiting a delay before calling
+/// <c>next</c> again holds a thread-pool slot for the whole wait and loses the attempt if
+/// the process stops; a trigger's retry policy is the tool for that.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class TenantScopeMiddleware(TenantContext tenants) : IJobExecutionMiddleware
+/// {
+///     public async ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default)
+///     {
+///         using IDisposable scope = tenants.Enter(context.Trigger.Key.Group);
+///         await next(context, cancellationToken);
+///     }
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="IJobListener" />
+/// <seealso cref="IJobExecutionContextAccessor" />
+public interface IJobExecutionMiddleware
+{
+    /// <summary>
+    /// Executes this stage of the pipeline.
+    /// </summary>
+    /// <param name="context">The firing being executed.</param>
+    /// <param name="next">
+    /// The rest of the pipeline. Await it to run the job; do not, and the job does not run.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Signalled when this execution is interrupted. Pass it on to <paramref name="next" /> and to
+    /// anything else awaited here.
+    /// </param>
+    // CA1716: the parameter is called next because that is what this shape has been called since
+    // ASP.NET Core named it that on IMiddleware.InvokeAsync, and a name every reader of a middleware
+    // already knows is worth more here than sparing a Visual Basic implementation a pair of brackets.
+#pragma warning disable CA1716
+    ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default);
+#pragma warning restore CA1716
+}

--- a/src/Quartz/QuartzSchedulerBuilder.cs
+++ b/src/Quartz/QuartzSchedulerBuilder.cs
@@ -551,6 +551,30 @@ public sealed class QuartzSchedulerBuilder : IQuartzBuilder
         return this;
     }
 
+    /// <inheritdoc cref="IQuartzBuilder.AddJobMiddleware{T}()" />
+    public QuartzSchedulerBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()
+        where T : class, IJobExecutionMiddleware
+    {
+        inner.AddJobMiddleware<T>();
+        return this;
+    }
+
+    /// <inheritdoc cref="IQuartzBuilder.AddJobMiddleware{T}(Func{IServiceProvider, T})" />
+    public QuartzSchedulerBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        Func<IServiceProvider, T> factory) where T : class, IJobExecutionMiddleware
+    {
+        inner.AddJobMiddleware(factory);
+        return this;
+    }
+
+    /// <inheritdoc cref="IQuartzBuilder.AddJobMiddleware{T}(T)" />
+    public QuartzSchedulerBuilder AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        T middleware) where T : class, IJobExecutionMiddleware
+    {
+        inner.AddJobMiddleware(middleware);
+        return this;
+    }
+
     /// <inheritdoc cref="IQuartzBuilder.UseExecutionLimits" />
     public QuartzSchedulerBuilder UseExecutionLimits(Action<ExecutionLimitsBuilder> configure)
     {
@@ -849,6 +873,14 @@ public sealed class QuartzSchedulerBuilder : IQuartzBuilder
 
     IQuartzBuilder IQuartzBuilder.AddTriggerListener<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         Func<IServiceProvider, T> factory, params IReadOnlyCollection<IMatcher<TriggerKey>> matchers) => AddTriggerListener(factory, matchers);
+
+    IQuartzBuilder IQuartzBuilder.AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>() => AddJobMiddleware<T>();
+
+    IQuartzBuilder IQuartzBuilder.AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        Func<IServiceProvider, T> factory) => AddJobMiddleware(factory);
+
+    IQuartzBuilder IQuartzBuilder.AddJobMiddleware<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
+        T middleware) => AddJobMiddleware(middleware);
 
     IQuartzBuilder IQuartzBuilder.UseExecutionLimits(Action<ExecutionLimitsBuilder> configure) => UseExecutionLimits(configure);
 }


### PR DESCRIPTION
Closes #3526.

A log scope, a tenant context, a metric or a translation of what a library throws has to *surround*
the call to the job. A listener cannot: it is told a job is about to run and told what it did, with
the execution happening between the two notifications rather than inside them, so it can neither wrap
the call, decline to make it, nor see what it threw. The only place left was a job that wraps another
job — the adapter ABP, Elsa and Brighter each ship, and the reason #988 has been open since 2021.

## The seam

```csharp
namespace Quartz;

public delegate ValueTask JobExecutionDelegate(IJobExecutionContext context, CancellationToken cancellationToken);

public interface IJobExecutionMiddleware
{
    ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default);
}
```

Registered on the scheduler's builder in the three shapes listeners already have — a type, a factory,
an instance — keyed per scheduler, running in registration order, outermost first:

```csharp
q.AddJobMiddleware<LogScopeMiddleware>();
q.AddJobMiddleware(provider => new MeteredMiddleware(provider.GetRequiredService<IMeterFactory>()));
q.AddJobMiddleware(new TenantScopeMiddleware());
```

`QuartzSchedulerBuilder` mirrors all three, because it implements `IQuartzBuilder`.

## How it is wired

* **Composed once per scheduler.** `JobExecutionPipeline.Compose` folds the middleware list around a
  terminal delegate `(context, ct) => context.JobInstance.Execute(context, ct)`, and the result is
  stored on `QuartzSchedulerResources`. The closures are allocated when the scheduler is built, not
  per firing; the terminal step reads the job off the context rather than closing over it, which is
  what makes one chain serve every firing.
* **Zero middleware costs nothing.** `Compose` returns `null` for an empty list, and
  `JobRunShell` calls `jobScope.Job.Execute(...)` directly in that case — the call it always made.
  `ASchedulerWithNoMiddleware_HasNoPipeline` pins that, and the benchmark numbers below show the
  allocation profile is byte-identical.
* **Invocation point.** `src/Quartz/Core/JobRunShell.cs`, replacing the single `Execute` line:
  **inside** the activity and the meter bracket, so a middleware's cost is part of the firing's, and
  **outside** the exception classification, so a `JobExecutionException` a middleware throws is
  honoured exactly like one the job raised and a plain exception is wrapped the same way. The change
  is four lines in one `try` block, kept deliberately tight so the retry-engine work around
  `ExecutionComplete` rebases cleanly.
* **Listeners are untouched**, and no `IServiceScope` is threaded through `Invoke`. Per-firing state
  is an `AsyncLocal<T>` or the job's own scope (`ConfigureJobScope` + `IJobExecutionContextAccessor`),
  which the documentation says in as many words.

## Public API delta

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through Verify — eight
added lines, nothing moved or removed:

```csharp
// namespace Quartz
public delegate ValueTask JobExecutionDelegate(IJobExecutionContext context, CancellationToken cancellationToken);

public interface IJobExecutionMiddleware
{
    ValueTask Invoke(IJobExecutionContext context, JobExecutionDelegate next, CancellationToken cancellationToken = default);
}

// IQuartzBuilder (T carries the same DynamicallyAccessedMembers annotation the listener methods carry)
IQuartzBuilder AddJobMiddleware<T>() where T : class, IJobExecutionMiddleware;
IQuartzBuilder AddJobMiddleware<T>(Func<IServiceProvider, T> factory) where T : class, IJobExecutionMiddleware;
IQuartzBuilder AddJobMiddleware<T>(T middleware) where T : class, IJobExecutionMiddleware;

// QuartzSchedulerBuilder — the same three, returning QuartzSchedulerBuilder
```

The same delta is written up in `docs/documentation/quartz-4.x/migration-guide.md` under
**Cross-cutting concerns run as middleware**, with a **New Features** bullet pointing at it.

## Tests

`src/Quartz.Tests.Unit/Core/JobExecutionMiddlewareTest.cs` (10 tests): registration order; all three
overloads; the standalone builder; short-circuiting (the job does not run, the listeners are still
notified, the trigger instruction is `NoInstruction`); exception translation (plain →
`JobExecutionException { RefireImmediately = true }`, honoured once, then the firing completes with
one `JobWasExecuted`); `[DisallowConcurrentExecution]` unaffected; `IJobExecutionContextAccessor.Current`
visible on both sides of `next`; a named scheduler running only its own middleware; no pipeline at all
when nothing is registered; one middleware instance shared by every firing.

`JobExecutionObservabilityTest` gains two: the execution span wraps the whole chain
(`Activity.Current` inside the middleware is the `Quartz.Job.Execute` activity, going in and coming
out), and a middleware that throws fails the span and tags the histogram exactly as a throwing job
does.

## Documentation

* New lesson `docs/documentation/quartz-4.x/tutorial/job-execution-middleware.md`, samples compiled
  from `src/Quartz.Documentation.Samples/Tutorial/JobExecutionMiddlewareSamples.cs`, sidebar entry
  added and the tutorial index renumbered.
* `tutorial/trigger-and-job-listeners.md` gains **A listener or a middleware?** — what belongs in
  each, and why vetoing stays a listener's job.
* Migration-guide section as above.

## Benchmarks

The only change on the firing path is the call site, so the measurement isolates it: the same tree
with `JobRunShell.cs` at its base-commit contents ("before") and as it stands ("after"). `net10.0`,
Release, AMD Ryzen 9 5950X.

| Benchmark | Mean before | Mean after | Allocated before | Allocated after |
| -- | --: | --: | --: | --: |
| `JobDispatchBenchmark.Run` | 1.248 µs ± 0.088 | 1.169 µs ± 0.071 | 944 B | **944 B** |
| `JobRunShellBenchmark.Success_…_MayFireAgain` | 922.2 ns ± 17.9 | 991.7 ns ± 46.5 | 776 B | **776 B** |
| `JobRunShellBenchmark.Success_…_WithScopedLogger` | 943.6 ns ± 93.8 | 914.2 ns ± 40.0 | 776 B | **776 B** |

Allocations are identical to the byte, which is the load-bearing number: nothing new is allocated per
firing. The times move in both directions inside their own standard deviations — a repeat run of
"after" gave 907.4 ns and 866.1 ns for the two `JobRunShell` cases — so the null check does not
register.

## Verification

Rebased onto `206466fbb` (main after #3544, #3545, #3546, #3547, #3549). Two conflicts, both
additive and both resolved by keeping both sides: `QuartzSchedulerResources` now carries
`JobInputSerializer` beside `JobExecutionPipeline`, and the public-API baseline was regenerated through
Verify against the new main rather than hand-merged — the regenerated diff is still exactly the
seventeen lines listed above and nothing else. `JobRunShell` needed no resolution: the execute call is
this PR's only difference from main in that file. A typed `IJob<TInput>` reaches the pipeline
unchanged, because `IJob<TInput>.Execute` is dispatched by a default interface implementation of
`IJob.Execute`, which is what the terminal delegate calls.

Numbers below are from the post-rebase run.

| Command | Result |
| -- | -- |
| `dotnet build Quartz.slnx` | 0 warnings, 0 errors |
| `dotnet test src/Quartz.Tests.Unit` | 3952 passed, 0 failed |
| `dotnet test src/Quartz.Tests.AspNetCore` | 536 passed, 0 failed |
| `dotnet test src/Quartz.Tests.Integration --filter TestCategory=db-sqlite` | 12 passed, 0 failed (pre-rebase) |
| `dotnet test src/Quartz.Tests.Integration --filter TestCategory=db-postgres` | 157 passed, 0 failed (Docker, pre-rebase) |
| `dotnet fallout PublishTrimmed` | succeeded, trim canary passes (pre-rebase) |
| `dotnet fallout PublishAot` | succeeded, native canary passes (pre-rebase) |
| `dotnet fallout VerifyDocsSnippets` | up to date, 96 markdown files checked |
| `npm run docs:check-links` | 215 pages, 921 internal links, 559 fragments, no dead links or anchors |
| `dotnet run -c Release --project src/Quartz.Benchmark -- --smoke` | 280 benchmarks, exit 0 (pre-rebase) |

`TrimAnalysisBaseline.cs` gains no entry: the registration methods carry the same
`DynamicallyAccessedMembers` annotation the listener methods do, and `JobExecutionMiddlewareRegistration`
keeps its type in an explicitly written backing field for the reason `ListenerRegistration` does.

## For the reviewer to decide

* **`next` and CA1716.** The parameter is called `next`, which is what ASP.NET Core's
  `IMiddleware.InvokeAsync` calls it and what every middleware tutorial since has called it. CA1716
  refuses it as a Visual Basic keyword, and `TreatWarningsAsErrors` makes that fatal, so there is a
  three-line `#pragma warning disable CA1716` around the member with the reason written down. The
  alternative is a name nobody who has written middleware before would expect.
* **`JobExecutionDelegate`'s token has no default.** A middleware is handed a token and is meant to
  pass it on, so omitting it should have to be written out. `AGENTS.md`'s rule is about async members;
  this is a delegate. Say the word and it gains `= default`.
* **Registering the same type twice adds two stages.** That is the mechanism listeners already use —
  `SchedulerContentRegistration.Add` is a plain `AddSingleton`, ordered and not deduplicated — and it
  is what a pipeline should do, but it is worth a look because the spec asked for a `TryAddEnumerable`
  dedupe rule that listeners turn out not to have (see the deviations below).

## Deviations from the spec

* **The instance overload is `AddJobMiddleware<T>(T middleware)`**, per the ruling, not the issue
  body's `AddJobMiddleware(IJobExecutionMiddleware instance)`. The generic form matches the listener
  trio and is what lets the parameter carry the trimming annotation.
* **`where T : class, IJobExecutionMiddleware`**, not the issue's `where T : IJobExecutionMiddleware`
  — the class constraint is what the listener methods carry and what the registration needs to hold a
  reference.
* **No `TryAddEnumerable` dedupe.** The spec says the registration should dedupe by implementation
  type, "the same rule listeners already live by". Listeners do not live by that rule: `AddJobListener`
  and its siblings go through `SchedulerContentRegistration.Add`, which is `services.AddSingleton(content)`
  — a plain add, order-preserving, no deduplication. `ListenerRegistration`'s own remarks say so
  explicitly ("two `AddJobListener<AuditListener>` calls with different matchers"). Middleware follows
  the actual listener mechanism, so two registrations of one type are two stages, and the interface
  documentation says that in as many words rather than leaving it to be discovered.
* **`how-tos/embedding-quartz-in-a-library.md` is not cross-referenced**, because it does not exist on
  this branch. That is W3's page; the reference belongs in its PR.
* **`QuartzBuilderExtensionsMirrorTest` and `BuilderSeamsTest` needed no change.** The mirror test
  covers `QuartzBuilderExtensions` extension methods only; `AddJobMiddleware` is an interface member,
  so the mirror is enforced by the compiler. `BuilderSeamsTest` is about listener matchers and custom
  stores. Both were read.

## Found and left alone

A job registered with `AddJob` + `AddTrigger` (rather than `AddJob(…).StoreDurably()`) is
non-durable, so `XmlSchedulingDataProcessor.ScheduleJobs` schedules its trigger in the per-job loop
and then reschedules the *same* trigger object in the "triggers not associated with a new job" loop,
because that loop iterates the full trigger list rather than what the first loop consumed. The
reschedule runs `QuartzScheduler.AdjustSimpleTriggerStartTimeIfInPast`, which moves `StartTimeUtc`
forward while the already-computed `NextFireTimeUtc` is deliberately preserved — leaving
`NextFireTime < StartTime`. A repeating simple trigger then fires twice a few milliseconds apart
(`GetFireTimeAfter(next)` returns the start time), and only then settles onto its interval.

Reproduced with no middleware involved and entirely in scheduling code this PR does not touch; the
tests here use `StoreDurably()` to stay out of it. Worth its own issue.

