### PR TITLE
A host can create a scheduler without starting it

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2137,6 +2137,30 @@ options object. Subclasses registered with `AddQuartzHostedService<T>()` need th
 updated; the `Starting`/`Started`/`Stopping`/`Stopped` overrides are unchanged. The internal
 `NamedSchedulerHostedService` is gone, its work having moved into the one service.
 
+### A hosted scheduler can be started by the application
+
+New in 4.x, with nothing to migrate. `QuartzHostedServiceOptions.AutoStart` defaults to `true`, which is
+what the hosted service has always done; setting it to `false` has the scheduler resolved, initialized
+and bound with the host but left in `SchedulerStatus.Created` for the application to start:
+
+```csharp
+services.AddQuartzHostedService("Reporting", options => options.AutoStart = false);
+```
+
+On 3.x the only way not to start a scheduler was not to register the hosted service, which lost the
+shutdown handling with it. The scheduler is bound, so `ISchedulerRegistry`, the dashboard and
+`GET /schedulers` all report it, and it is still shut down when the host stops — opting out of the start
+is not opting out of the stop. `AutoStart` wins over `AwaitApplicationStarted` and `StartDelay`, both of
+which say *when* the hosted service starts a scheduler that it does not start at all.
+
+The health check follows: a scheduler in `Created` whose `AutoStart` is `false` is reported **degraded**
+rather than **unhealthy**, on the same argument as standby — it is doing what it was told, and failing
+the probe would take a correctly configured node out of rotation. A `Created` scheduler that nothing
+opted out of is unhealthy as before.
+
+A library embedding Quartz in someone else's application is what this is for, and the how-to page on
+embedding Quartz in a library covers the whole pattern.
+
 ## The ASP.NET Core methods say Quartz once
 
 | Before | After |
@@ -8530,6 +8554,7 @@ Parameters and behavior are unchanged:
 | `AddQuartzSchedulers(IConfiguration, …)` added | `AddQuartz(configuration)` no longer fans out over a `Schedulers` section; it throws and points here |
 | `QuartzHostedService` takes an `IServiceProvider` and an `IOptionsMonitor` | It resolves every scheduler in the container when the host starts — see [The hosted service starts every scheduler](#the-hosted-service-starts-every-scheduler) |
 | `AddQuartzHostedService(string schedulerName, …)` added | `QuartzHostedServiceOptions` are named options; the unnamed call still configures every scheduler |
+| `QuartzHostedServiceOptions.AutoStart` added | Defaults to `true`, so nothing changes for an existing application. `false` has the scheduler resolved, initialized and bound but left in `Created` for the application to start, and the health check reports it degraded rather than unhealthy — see [A hosted scheduler can be started by the application](#a-hosted-scheduler-can-be-started-by-the-application) |
 | `IQuartzBuilder.AddHttpApi` / `MapQuartzApi` renamed | `services.AddQuartzHttpApi()` / `MapQuartzHttpApi`, the first of them on the service collection rather than a scheduler's builder; `AddQuartzHealthChecks` gained an `IQuartzBuilder` overload, which it keeps because a health check really is one scheduler's |
 | The health check is added on `IHealthChecksBuilder` | `AddHealthChecks().AddQuartz()` / `.AddQuartz("reporting")`, so it composes with an application's other checks. `AddQuartzHealthChecks()` is shorthand for the first — see [The ASP.NET Core methods say Quartz once](#the-asp-net-core-methods-say-quartz-once) |
 | The health check ships in `Quartz` | It was in `Quartz.AspNetCore` through `4.0.0-alpha.3`, whose `FrameworkReference` a worker on a `dotnet/runtime` image cannot satisfy. No call site changes; drop the package reference if the check was the only reason for it — see [The health check is in `Quartz`, not `Quartz.AspNetCore`](#the-health-check-is-in-quartz-not-quartz-aspnetcore) |

--- a/docs/documentation/quartz-4.x/packages/hosted-services-integration.md
+++ b/docs/documentation/quartz-4.x/packages/hosted-services-integration.md
@@ -60,6 +60,7 @@ await builder.Build().RunAsync();
 | `WaitForJobsToComplete` | `false` | Shutdown does not return until the jobs still executing have finished. Without it the host stops while they are still running. Whether they are also asked to stop is the scheduler's `ShutdownJobInterruption` setting. |
 | `AwaitApplicationStarted` | `true` | Jobs do not start until application startup has completed, so nothing fires while the rest of the application is still coming up. |
 | `StartDelay` | none | Starts the scheduler this long after it otherwise would. With `AwaitApplicationStarted`, the delay is counted from the completion of startup. |
+| `AutoStart` | `true` | Whether the hosted service starts the scheduler at all. `false` has it built, initialized and bound, but left for the application to start — see [A scheduler the application starts itself](#a-scheduler-the-application-starts-itself). |
 
 To take part in the lifecycle itself — a warm-up before the scheduler starts, a drain after it stops — derive
 from `QuartzHostedService` and register the subclass; its `StartingAsync`, `StartedAsync`, `StoppingAsync` and
@@ -87,12 +88,42 @@ registers a scheduler called `reporting`, reading its settings from `Quartz:Sche
 the section describes several. `builder.AddQuartzSchedulers()` registers one per child of that
 sub-section.
 
+## A scheduler the application starts itself
+
+A library that owns its own leader election, a message bus that has to be connected before anything may
+fire, a module that comes up after the rest of the application — each wants the container to build and
+bind its scheduler, and wants to press start itself. `AutoStart = false` says so:
+
+<!-- snippet: sample_hosted_deferred_start -->
+```csharp
+builder.AddQuartz("reporting", q => { });
+
+// Built, initialized and bound with the host, but left in Created for the application to start
+builder.AddQuartzHostedService("reporting", options => options.AutoStart = false);
+```
+<!-- endSnippet -->
+
+The scheduler is still resolved, initialized and bound when the host starts, so `ISchedulerRegistry`, the
+dashboard and `GET /schedulers` all see it; it simply sits in `Created` until something calls
+`scheduler.Start()`. Not registering the hosted service at all would have produced the same non-start
+and lost the shutdown handling with it, which is the reason this is a setting rather than an omission.
+
+`AutoStart` wins over `AwaitApplicationStarted` and `StartDelay`. Both of those say *when* the hosted
+service starts a scheduler; it does not start this one at all, so neither applies.
+
+Shutdown is unchanged. The hosted service shuts down every scheduler it created, started or not, so
+opting out of the start is not opting out of the stop.
+
+It is a per-scheduler setting like the rest, so one scheduler can be deferred while its siblings start
+with the host — the example above defers `reporting` and leaves every other scheduler in the container
+alone. A library embedding Quartz in someone else's application is the case this exists for.
+
 ## Health checks
 
 The scheduler's health check ships in the core `Quartz` package and registers on the standard
 `IHealthChecksBuilder`, so a worker with no web stack at all can carry it. It reports *healthy* while
-the scheduler is running and can reach its store, *degraded* while it is in standby, and *unhealthy*
-otherwise. Add it alongside an application's other checks:
+the scheduler is running and can reach its store, *degraded* while it is in standby or waiting for the
+application to start it, and *unhealthy* otherwise. Add it alongside an application's other checks:
 
 <!-- snippet: sample_hosted_health_check -->
 ```csharp
@@ -102,6 +133,13 @@ builder.Services.AddHealthChecks().AddQuartz();
 
 `services.AddQuartzHealthChecks()` is the same thing for an application that has no other checks to
 compose with.
+
+A scheduler whose `AutoStart` is `false` is *degraded* while it sits in `Created`, not *unhealthy*: it is
+doing what it was configured to do, and failing the probe would take a correctly configured node out of
+rotation for the whole window before the application presses start. The check reads that scheduler's own
+`QuartzHostedServiceOptions`, so a `Created` scheduler that nothing opted out of is *unhealthy* as
+before — including one in an application with no hosted service registered at all, where nothing is
+going to start it.
 
 The registration can be customized via the optional configuration callback, for example to attach tags
 so the check can be filtered into separate liveness and readiness probes:

--- a/src/Quartz.Documentation.Samples/Packages/HostedServicesSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HostedServicesSamples.cs
@@ -52,6 +52,18 @@ public static class HostedServicesSamples
         #endregion
     }
 
+    public static void DeferredStart(IHostApplicationBuilder builder)
+    {
+        #region sample_hosted_deferred_start
+
+        builder.AddQuartz("reporting", q => { });
+
+        // Built, initialized and bound with the host, but left in Created for the application to start
+        builder.AddQuartzHostedService("reporting", options => options.AutoStart = false);
+
+        #endregion
+    }
+
     public static void HealthCheck(IHostApplicationBuilder builder)
     {
         #region sample_hosted_health_check

--- a/src/Quartz.Tests.Unit/HealthChecks/QuartzHealthCheckTests.cs
+++ b/src/Quartz.Tests.Unit/HealthChecks/QuartzHealthCheckTests.cs
@@ -65,6 +65,64 @@ public class QuartzHealthCheckTests
     }
 
     /// <summary>
+    /// A scheduler the application starts itself is in <see cref="SchedulerStatus.Created" /> by design,
+    /// so the probe reports what standby reports rather than taking the node out of rotation.
+    /// </summary>
+    [Test]
+    public async Task ACreatedSchedulerTheApplicationStartsIsDegradedRatherThanUnhealthy()
+    {
+        HealthReportEntry result = await Check(SchedulerStatus.Created, hostedService: options => options.AutoStart = false);
+
+        result.Status.Should().Be(
+            HealthStatus.Degraded,
+            "AutoStart = false says the application presses start, so a created scheduler is the configuration "
+            + "working rather than failing - and unhealthy would take a correctly configured node out of rotation");
+        result.Description.Should().Contain("created").And.Contain("application").And.Contain("core");
+    }
+
+    /// <summary>
+    /// The other side of the same branch: a scheduler the hosted service was going to start, and has
+    /// not, is a fault.
+    /// </summary>
+    [Test]
+    public async Task ACreatedSchedulerTheHostedServiceWasGoingToStartIsStillUnhealthy()
+    {
+        HealthReportEntry result = await Check(SchedulerStatus.Created, hostedService: _ => { });
+
+        result.Status.Should().Be(
+            HealthStatus.Unhealthy,
+            "nothing opted out of the automatic start, so a scheduler still sitting in Created is the failure it "
+            + "always was");
+        result.Description.Should().Contain("never started");
+    }
+
+    /// <summary>
+    /// <c>AutoStart</c> is one scheduler's setting, and the check has to read the options registered under
+    /// the name of the scheduler it reports on.
+    /// </summary>
+    [Test]
+    public async Task ACheckReadsTheAutoStartOfItsOwnSchedulerRatherThanAnothers()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddSingleton(FactoryFor("core", SchedulerStatus.Created));
+        services.AddKeyedSingleton(typeof(ISchedulerFactory), "reporting", (_, _) => FactoryFor("reporting", SchedulerStatus.Created));
+        services.AddQuartzHealthChecks();
+        services.AddHealthChecks().AddQuartz("reporting");
+        services.AddQuartzHostedService("reporting", options => options.AutoStart = false);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        (await Run(provider, "quartz-scheduler-reporting")).Status.Should().Be(
+            HealthStatus.Degraded,
+            "'reporting' is the scheduler that opted out");
+
+        (await Run(provider, "quartz-scheduler")).Status.Should().Be(
+            HealthStatus.Unhealthy,
+            "the default scheduler's options are its own, and nothing set AutoStart on them");
+    }
+
+    /// <summary>
     /// A container whose schedulers are all named has no default one, and the check for it must say so
     /// rather than throw.
     /// </summary>
@@ -93,7 +151,16 @@ public class QuartzHealthCheckTests
             "the message has to name the way out, since the check cannot know which scheduler was meant");
     }
 
-    private static async Task<HealthReportEntry> Check(SchedulerStatus status, SchedulerException? storeFailure = null)
+    /// <param name="status">The state the scheduler reports.</param>
+    /// <param name="storeFailure">What the store probe throws, when the test is about that.</param>
+    /// <param name="hostedService">
+    /// Registers the hosted service and configures it. Left <see langword="null" /> there is none in the
+    /// container at all, which is the case that leaves <c>AutoStart</c> at its default.
+    /// </param>
+    private static async Task<HealthReportEntry> Check(
+        SchedulerStatus status,
+        SchedulerException? storeFailure = null,
+        Action<QuartzHostedServiceOptions>? hostedService = null)
     {
         IScheduler scheduler = A.Fake<IScheduler>();
         A.CallTo(() => scheduler.SchedulerName).Returns("core");
@@ -112,9 +179,25 @@ public class QuartzHealthCheckTests
         services.AddSingleton(factory);
         services.AddQuartzHealthChecks();
 
+        if (hostedService is not null)
+        {
+            services.AddQuartzHostedService(hostedService);
+        }
+
         await using ServiceProvider provider = services.BuildServiceProvider();
 
         return await Run(provider, "quartz-scheduler");
+    }
+
+    private static ISchedulerFactory FactoryFor(string name, SchedulerStatus status)
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.SchedulerName).Returns(name);
+        A.CallTo(() => scheduler.Status).Returns(status);
+
+        ISchedulerFactory factory = A.Fake<ISchedulerFactory>();
+        A.CallTo(() => factory.GetScheduler(A<CancellationToken>._)).Returns(new ValueTask<IScheduler>(scheduler));
+        return factory;
     }
 
     private static async Task<HealthReportEntry> Run(ServiceProvider provider, string checkName)

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -1,6 +1,8 @@
 using FakeItEasy;
 
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using Quartz.Configuration;
@@ -318,14 +320,27 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// How many times the hosted service asked for this scheduler to start, immediately or delayed.
+        /// </summary>
+        /// <remarks>
+        /// Counted rather than inferred from <see cref="Status" />, because a start that was asked for
+        /// with a long <c>StartDelay</c> leaves the scheduler in <see cref="SchedulerStatus.Created" />
+        /// too — and "asked to start in a minute" and "not asked at all" are exactly what
+        /// <c>AutoStart</c> has to tell apart.
+        /// </remarks>
+        public int StartAttempts { get; private set; }
+
         public ValueTask Start(CancellationToken cancellationToken = default)
         {
+            this.StartAttempts++;
             this.Status = SchedulerStatus.Running;
             return default;
         }
 
         public ValueTask StartDelayed(TimeSpan delay, CancellationToken cancellationToken = default)
         {
+            this.StartAttempts++;
             _ = Task.Run(async () =>
             {
                 await Task.Delay(delay, cancellationToken)
@@ -491,6 +506,151 @@ public class QuartzHostedServiceTests
     }
 
     [Test]
+    [TestCase(false, false)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(true, true)]
+    [Parallelizable(ParallelScope.All)]
+    public async Task StartAsync_WithoutAutoStart_ShouldCreateTheSchedulerAndLeaveTheStartToTheApplication(
+        bool awaitApplicationStarted,
+        bool withStartDelay)
+    {
+        MockApplicationLifetime applicationLifetime = new();
+        MockSchedulerFactory schedulerFactory = new();
+        QuartzHostedService quartzHostedService = CreateHostedService(
+            applicationLifetime,
+            schedulerFactory,
+            awaitApplicationStarted,
+            withStartDelay,
+            autoStart: false);
+
+        using var startupCts = new CancellationTokenSource();
+
+        await quartzHostedService.StartAsync(startupCts.Token);
+
+        schedulerFactory.LastCreatedScheduler.Should().NotBeNull(
+            "the scheduler is still resolved, initialized and bound - only pressing start is the application's job");
+        schedulerFactory.LastCreatedScheduler.StartAttempts.Should().Be(
+            0,
+            "AutoStart wins over both AwaitApplicationStarted and StartDelay: neither says when to start a "
+            + "scheduler that this service does not start at all");
+        schedulerFactory.LastCreatedScheduler.Status.Should().Be(SchedulerStatus.Created);
+
+        quartzHostedService.startupTask?.IsCompleted.Should().BeTrue(
+            "nothing is left spinning on the application-started signal for a scheduler the application starts itself");
+
+        applicationLifetime.SetStarted();
+
+        if (quartzHostedService.startupTask is not null)
+        {
+            await quartzHostedService.startupTask
+                .ContinueWith(_ => { }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+        }
+
+        schedulerFactory.LastCreatedScheduler.StartAttempts.Should().Be(
+            0,
+            "application startup completing is not what starts this scheduler either");
+
+        // What the application does when its own leader election, warm-up or module load says so.
+        await schedulerFactory.LastCreatedScheduler.Start();
+        schedulerFactory.LastCreatedScheduler.Status.Should().Be(SchedulerStatus.Running);
+
+        await startupCts.CancelAsync().ConfigureAwait(false);
+
+        await quartzHostedService.StopAsync(CancellationToken.None);
+
+        schedulerFactory.LastCreatedScheduler.Status.Should().Be(
+            SchedulerStatus.Shutdown,
+            "shutdown ownership is unchanged: the hosted service shuts down every scheduler it created, started or not");
+    }
+
+    [Test]
+    public async Task StartAsync_WithoutAutoStart_ShouldBindTheSchedulerAndStartItsSiblingsAnyway()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddSingleton<Lifetime>(new MockApplicationLifetime());
+
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceName = "Hosted"));
+        services.AddQuartz("Deferred", q => { });
+        services.AddQuartzHostedService(options => options.AwaitApplicationStarted = false);
+        services.AddQuartzHostedService("Deferred", options => options.AutoStart = false);
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        QuartzHostedService hostedService = provider.GetServices<IHostedService>().OfType<QuartzHostedService>().Single();
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        IScheduler deferred = await provider.GetRequiredKeyedService<ISchedulerFactory>("Deferred").GetScheduler();
+
+        try
+        {
+            deferred.Status.Should().Be(
+                SchedulerStatus.Created,
+                "a scheduler whose AutoStart is false is built by the container and left for the application to start");
+
+            (await provider.GetRequiredService<ISchedulerFactory>().GetScheduler()).Status.Should().Be(
+                SchedulerStatus.Running,
+                "AutoStart is one scheduler's setting, read from its own named options, so a sibling that did not "
+                + "opt out is unaffected");
+
+            List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+            registrations.Should().ContainSingle(registration => registration.Name == "Deferred")
+                .Which.Status.Should().Be(
+                    SchedulerStatus.Created,
+                    "the scheduler is bound to the repository, so the registry, the dashboard and GET /schedulers all "
+                    + "see it - that is the whole point of creating it without starting it");
+
+            await deferred.Start();
+
+            deferred.Status.Should().Be(SchedulerStatus.Running, "the application presses start when it is ready");
+        }
+        finally
+        {
+            await hostedService.StopAsync(CancellationToken.None);
+        }
+
+        deferred.Status.Should().Be(SchedulerStatus.Shutdown);
+    }
+
+    [Test]
+    public async Task StopAsync_WithASchedulerThatWasNeverStarted_ShouldShutItDownAnyway()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddSingleton<Lifetime>(new MockApplicationLifetime());
+
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceName = "NeverStarted"));
+        services.AddQuartzHostedService(options =>
+        {
+            options.AutoStart = false;
+            options.AwaitApplicationStarted = false;
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        QuartzHostedService hostedService = provider.GetServices<IHostedService>().OfType<QuartzHostedService>().Single();
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        scheduler.Status.Should().Be(SchedulerStatus.Created);
+
+        Func<Task> act = async () => await hostedService.StopAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync(
+            "a scheduler that never ran still owns a job store, a thread pool and a scheduler thread, and the host "
+            + "is the only thing that will tear them down");
+
+        scheduler.Status.Should().Be(SchedulerStatus.Shutdown);
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty(
+            "the shutdown unbinds it, exactly as it would a scheduler that had been running");
+    }
+
+    [Test]
     public async Task StopAsync_ShutsEverySchedulerDownAtOnceRatherThanInTurn()
     {
         var firstEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -597,12 +757,14 @@ public class QuartzHostedServiceTests
         Lifetime applicationLifetime,
         ISchedulerFactory schedulerFactory,
         bool awaitApplicationStarted,
-        bool withStartDelay)
+        bool withStartDelay,
+        bool autoStart = true)
     {
         var options = new QuartzHostedServiceOptions
         {
             AwaitApplicationStarted = awaitApplicationStarted,
             StartDelay = withStartDelay ? TimeSpan.FromMinutes(1) : null,
+            AutoStart = autoStart,
         };
 
         return new QuartzHostedService(

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1294,6 +1294,7 @@ namespace Quartz
     public sealed class QuartzHostedServiceOptions
     {
         public QuartzHostedServiceOptions() { }
+        public bool AutoStart { get; set; }
         public bool AwaitApplicationStarted { get; set; }
         public System.TimeSpan? StartDelay { get; set; }
         public bool WaitForJobsToComplete { get; set; }

--- a/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheck.cs
+++ b/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheck.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 
 namespace Quartz;
 
@@ -16,14 +17,20 @@ internal sealed class QuartzHealthCheck : IHealthCheck
 {
     private readonly IServiceProvider serviceProvider;
     private readonly SchedulerHealthCheckTarget target;
+    private readonly IOptionsMonitor<QuartzHostedServiceOptions> hostedServiceOptions;
 
-    public QuartzHealthCheck(IServiceProvider serviceProvider, SchedulerHealthCheckTarget target)
+    public QuartzHealthCheck(
+        IServiceProvider serviceProvider,
+        SchedulerHealthCheckTarget target,
+        IOptionsMonitor<QuartzHostedServiceOptions> hostedServiceOptions)
     {
         ArgumentNullException.ThrowIfNull(serviceProvider);
         ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(hostedServiceOptions);
 
         this.serviceProvider = serviceProvider;
         this.target = target;
+        this.hostedServiceOptions = hostedServiceOptions;
     }
 
     async Task<HealthCheckResult> IHealthCheck.CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken)
@@ -60,6 +67,13 @@ internal sealed class QuartzHealthCheck : IHealthCheck
             case SchedulerStatus.Standby:
                 return HealthCheckResult.Degraded($"Quartz scheduler '{name}' is in standby");
 
+            // The same argument as standby, one step earlier: a scheduler whose AutoStart is false was
+            // never meant to be started by the host, so its being Created is the configuration working
+            // rather than failing. Unhealthy here would take a correctly configured node out of
+            // rotation for the window between the host starting and the application pressing start.
+            case SchedulerStatus.Created when StartedByTheApplication():
+                return HealthCheckResult.Degraded($"Quartz scheduler '{name}' has been created and is started by the application");
+
             case SchedulerStatus.Created:
                 return HealthCheckResult.Unhealthy($"Quartz scheduler '{name}' has been created but never started");
 
@@ -84,5 +98,20 @@ internal sealed class QuartzHealthCheck : IHealthCheck
         }
 
         return HealthCheckResult.Healthy($"Quartz scheduler '{name}' is ready");
+    }
+
+    /// <summary>
+    /// Whether this check's scheduler is one the application starts itself rather than one the hosted
+    /// service starts.
+    /// </summary>
+    /// <remarks>
+    /// The scheduler's own options, read under its own name, the way every other per-scheduler setting
+    /// is. A container with no hosted service in it has nothing configuring these options at all, so
+    /// <see cref="QuartzHostedServiceOptions.AutoStart" /> is its default and a created scheduler stays
+    /// unhealthy — which is what it should be, since nothing is going to start it.
+    /// </remarks>
+    private bool StartedByTheApplication()
+    {
+        return !hostedServiceOptions.Get(target.SchedulerName ?? Options.DefaultName).AutoStart;
     }
 }

--- a/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheckExtensions.cs
+++ b/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheckExtensions.cs
@@ -17,7 +17,8 @@ public static class QuartzHealthCheckExtensions
 {
     /// <summary>
     /// Registers a health check for the default Quartz scheduler: healthy while it is running and can
-    /// reach its store, degraded while it is in standby, and unhealthy otherwise.
+    /// reach its store, degraded while it is in standby or waiting for the application to start it
+    /// (<see cref="QuartzHostedServiceOptions.AutoStart" />), and unhealthy otherwise.
     /// </summary>
     /// <remarks>
     /// Shorthand for <c>services.AddHealthChecks().AddQuartz(configure)</c>, for an application that has

--- a/src/Quartz/Hosting/QuartzHostedService.cs
+++ b/src/Quartz/Hosting/QuartzHostedService.cs
@@ -16,7 +16,9 @@ namespace Quartz;
 /// <para>
 /// Every scheduler in the container is started, the default one and each named one, and each is
 /// configured by <see cref="QuartzHostedServiceOptions"/> under its own name — so one scheduler can
-/// wait for application startup while another starts immediately.
+/// wait for application startup while another starts immediately, and one whose
+/// <see cref="QuartzHostedServiceOptions.AutoStart"/> is <see langword="false"/> is created and bound
+/// but left for the application to start.
 /// </para>
 /// <para>
 /// The schedulers are resolved when the host starts rather than when the service is registered, so
@@ -78,7 +80,9 @@ public class QuartzHostedService : IHostedLifecycleService
 
             // Sensible mode: proceed with startup, and have jobs start after application startup.
             // Follow the pattern from BackgroundService.StartAsync: https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
-            if (schedulers.Exists(static scheduler => scheduler.Options.AwaitApplicationStarted))
+            // A scheduler the application starts itself is not waited for: it is nothing this service
+            // will start once startup completes, so it must not be what keeps a startup task alive.
+            if (schedulers.Exists(static scheduler => scheduler.Options is { AutoStart: true, AwaitApplicationStarted: true }))
             {
                 startupTask = AwaitStartupCompletionAndStartSchedulers(cancellationToken);
 
@@ -178,6 +182,14 @@ public class QuartzHostedService : IHostedLifecycleService
 
         foreach (var hosted in schedulers)
         {
+            // Tested before the two settings that say *when* to start, because AutoStart says whether
+            // to at all: the scheduler was created and bound by CreateSchedulers, and that is all this
+            // service does for it. The application presses start.
+            if (!hosted.Options.AutoStart)
+            {
+                continue;
+            }
+
             if (hosted.Options.AwaitApplicationStarted != waitForApplicationStarted)
             {
                 continue;

--- a/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
+++ b/src/Quartz/Hosting/QuartzHostedServiceOptions.cs
@@ -44,4 +44,29 @@ public sealed class QuartzHostedServiceOptions
     /// This avoids the running of jobs <em>during</em> application startup.
     /// </summary>
     public bool AwaitApplicationStarted { get; set; } = true;
+
+    /// <summary>
+    /// If <see langword="true" /> (the default) the hosted service starts the scheduler. Set it to
+    /// <see langword="false" /> to have the scheduler built, initialized and bound but left in
+    /// <see cref="SchedulerStatus.Created" />, for the application to start when it is ready.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A library that owns its own leader election, or a module that has work to do before anything
+    /// may fire, wants the container to produce a scheduler without the host pressing start. The
+    /// scheduler is still created and bound, so <see cref="ISchedulerRegistry" />, the dashboard and
+    /// the HTTP API all see it; it simply is not running until something calls
+    /// <see cref="IScheduler.Start" />.
+    /// </para>
+    /// <para>
+    /// This wins over <see cref="AwaitApplicationStarted" /> and <see cref="StartDelay" />: both
+    /// describe <em>when</em> the hosted service starts a scheduler, and it does not start this one at
+    /// all.
+    /// </para>
+    /// <para>
+    /// Shutdown is unaffected. The hosted service shuts down every scheduler it created, started or
+    /// not, so opting out of the start is not opting out of the stop.
+    /// </para>
+    /// </remarks>
+    public bool AutoStart { get; set; } = true;
 }


### PR DESCRIPTION
A library that owns its own leader election — a message bus, a workflow engine, a module that starts
after the application is ready — wants the container to build and bind its scheduler and then wants to
press start itself. `AddQuartzHostedService` started every scheduler it created, and the only
alternative was not to register the hosted service at all, which lost the shutdown handling too.

## What changed

`QuartzHostedServiceOptions.AutoStart` — one new public member, defaulting to `true`, which is what the
hosted service has always done:

```csharp
services.AddQuartzHostedService("reporting", options => options.AutoStart = false);
```

- **`CreateSchedulers` is untouched.** The scheduler is still resolved, initialized and *bound*, so
  `ISchedulerRegistry`, the dashboard and `GET /schedulers` all see it. It simply sits in
  `SchedulerStatus.Created` until something calls `Start()`.
- **`StartSchedulers` skips it**, and tests `AutoStart` *before* `AwaitApplicationStarted` and
  `StartDelay` — both of those say *when* the hosted service starts a scheduler, and it does not start
  this one at all. `AutoStart` wins over both, and that is documented.
- **The `AwaitApplicationStarted` spin excludes it**: the predicate in `StartAsync` is now
  `{ AutoStart: true, AwaitApplicationStarted: true }`, so a deferred scheduler is not what keeps a
  startup task alive waiting for a signal that will start nothing.
- **Shutdown ownership is unchanged.** The hosted service shuts down every scheduler it created, started
  or not. Opting out of the start is not opting out of the stop — there is a test that shuts down a real
  `QuartzScheduler` that was never started, and that it unbinds from the repository afterwards.

## The health check

`QuartzHealthCheck` reported `Created` as **Unhealthy**, which would take a correctly configured node out
of rotation for the whole window between the host starting and the application pressing start. It now
takes an `IOptionsMonitor<QuartzHostedServiceOptions>` and, for `Created`, reports **Degraded** when that
scheduler's `AutoStart` is `false` — the same argument the `Standby` branch already makes: alive,
reachable, and deliberately firing nothing is not a failure.

The options are read under the name of the scheduler being checked, like every other per-scheduler
setting, so one scheduler opting out does not change its siblings' probes. A `Created` scheduler that
nothing opted out of is **Unhealthy** as before — including in an application with no hosted service
registered at all, where nothing configures these options and `AutoStart` is therefore its default. That
is the right answer there: nothing is going to start it.

`Quartz.Aspire` needs no change; it registers this same check through `AddQuartzHealthChecks()`.

## Tests

`src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs`

- A four-case `[TestCase]` matrix over `AwaitApplicationStarted` × `StartDelay` with `AutoStart = false`:
  the scheduler is resolved, `StartAttempts` is zero (counted on the mock, because a start asked for with
  a long `StartDelay` also leaves the scheduler in `Created` — "asked to start in a minute" and "not
  asked at all" are exactly what has to be told apart), `Status == Created`, no startup task is left
  spinning, an explicit `Start()` works afterwards, and `StopAsync` still shuts it down.
- A real-container test: a deferred scheduler is bound and listed by `ISchedulerRegistry` with
  `Status == Created` while its auto-starting sibling runs.
- A real-container test that `StopAsync` shuts down and unbinds a scheduler that was never started.

`src/Quartz.Tests.Unit/HealthChecks/QuartzHealthCheckTests.cs`

- The Degraded branch, the unchanged Unhealthy branch with the hosted service registered, and a
  two-scheduler container proving the check reads its *own* scheduler's options.

All eight new cases fail against the unmodified production code; verified by reverting the two edits and
re-running.

## Verification

```
dotnet build Quartz.slnx                                       0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj     Passed: 3949, Failed: 0
dotnet test src/Quartz.Tests.AspNetCore/...csproj              Passed:  536, Failed: 0
dotnet fallout VerifyDocsSnippets                              up to date (95 markdown files)
npm run docs:check-links                                       no dead links or anchors
```

Integration suites were not run: nothing here touches a job store.

## Baseline and docs

One line in `src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through Verify:

```diff
 public sealed class QuartzHostedServiceOptions
 {
     public QuartzHostedServiceOptions() { }
+    public bool AutoStart { get; set; }
     public bool AwaitApplicationStarted { get; set; }
```

The same delta is carried into `docs/documentation/quartz-4.x/migration-guide.md` as a new
"A hosted scheduler can be started by the application" subsection plus an appendix row.
`packages/hosted-services-integration.md` gains the option in its table, a section with a generated
snippet, and a paragraph in the health-checks section.

## For the reviewer

- **The wording of the degraded description** is `"Quartz scheduler 'x' has been created and is started by
  the application"`. It is what an operator reads off a failed-ish probe, so it is worth a second opinion.
- **The "no hosted service registered" case falls out of the default rather than being detected.** With
  nothing configuring `QuartzHostedServiceOptions`, `AutoStart` is `true` and `Created` stays Unhealthy —
  which is the behaviour asked for, reached without a registration marker. The one input it cannot tell
  apart is an application that calls `services.Configure<QuartzHostedServiceOptions>(o => o.AutoStart =
  false)` and then never registers the hosted service; that reports Degraded. That reading seems right —
  the application said it starts the scheduler itself — but it is a judgement, not a fact.
- The migration guide mentions a how-to page on embedding Quartz in a library **without linking it**,
  because `how-tos/embedding-quartz-in-a-library.md` does not exist yet; a later docs item adds it and can
  turn the sentence into a link.

Closes #3525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
