### PR TITLE
Jobs and triggers can be removed by group

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/one-off-job.md
+++ b/docs/documentation/quartz-4.x/how-tos/one-off-job.md
@@ -179,6 +179,41 @@ to a generated identifier in a group named after the job type), `Description`, `
 `MisfireInstruction`, and `Replace`. **The group is the correlation axis** — everything scheduled for one saga,
 one tenant or one conversation shares a group and can be listed, paused or unscheduled together.
 
+## Calling off a whole correlation
+
+The group that made those firings findable is what cancels them:
+
+<!-- snippet: sample_one_off_job_cancel_by_group -->
+```csharp
+public async ValueTask<int> CustomerWentAway(IScheduler scheduler, string customerId, CancellationToken cancellationToken)
+{
+    // Every firing scheduled under this customer's group goes in one call: the group the one-liner
+    // put them in is the handle for calling all of them off, and nothing has to list the keys first.
+    List<TriggerKey> calledOff = await scheduler.UnscheduleJobs(
+        GroupMatcher<TriggerKey>.GroupEquals(customerId),
+        cancellationToken);
+
+    // The answer names what went, so "there was nothing left to cancel" is a count, not a guess.
+    return calledOff.Count;
+}
+```
+<!-- endSnippet -->
+
+`UnscheduleJobs(GroupMatcher<TriggerKey>)` removes every trigger in the matching groups in one call, and
+answers with the keys it removed — so a cancellation that found nothing is an empty list rather than
+something to infer. There is no listing step to lose a race against: the store resolves the group inside
+the same lock that empties it, so a firing scheduled by another node a moment earlier goes with the rest.
+
+`DeleteJobs(GroupMatcher<JobKey>)` is the same operation one level up, for jobs and every trigger that
+references them. The one-liner's durable job is shared by every firing of its type and is *not* what you
+want to delete to cancel a correlation — unschedule the trigger group instead.
+
+::: warning A matcher is required
+Both members throw `ArgumentNullException` on a `null` matcher rather than reading it as "the default
+group", which is what the pause and resume group forms do. A pause taken by mistake can be resumed; a
+delete cannot.
+:::
+
 ## Scheduling over a firing that is already there
 
 Replacing what is already scheduled is one call rather than three. The two `ScheduleJob` overloads that take a

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6601,6 +6601,60 @@ Over HTTP, `POST …/jobs/delete` and `POST …/triggers/unschedule` answer `{"j
 [the key-set family](packages/http-api.md#a-whole-set-of-keys-in-one-call) and removes the one
 exception to the flag-naming rule.
 
+## Jobs and triggers can be removed by group
+
+Pause has always had a group form and delete has not, so calling off everything that belonged to one
+saga, one tenant or one import meant listing the keys and then deleting them — two calls, and a window
+between them in which another node can schedule one more thing into the group that the delete will
+then miss. Both members now take a `GroupMatcher` as well as a key set:
+
+| New member (on `IScheduler`) | Returns |
+|---|---|
+| `DeleteJobs(GroupMatcher<JobKey>)` | `ValueTask<List<JobKey>>` of the jobs it deleted |
+| `UnscheduleJobs(GroupMatcher<TriggerKey>)` | `ValueTask<List<TriggerKey>>` of the triggers it removed |
+
+```csharp
+// Everything scheduled for one saga, called off in one call.
+List<TriggerKey> calledOff = await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(sagaId));
+```
+
+The answer is the **keys**, not the group names that `PauseJobs(matcher)` returns. A pause has
+something to remember per group — a group stays paused, and a job added to it later is born paused —
+and a delete has nothing: the group is simply emptier than it was. What a caller can still act on is
+what went, so that is what it gets.
+
+* **`null` is an `ArgumentNullException`, not "the default group".** `PauseJobs(null)` and
+  `ResumeJobs(null)` read a missing matcher as `GroupEquals(JobKey.DefaultGroup)`. These do not, and
+  will not: a pause taken by mistake can be resumed. A `null` literal now also needs a cast to pick an
+  overload, exactly as it did when the key-set forms arrived —
+  `DeleteJobs((IReadOnlyCollection<JobKey>) null!)`.
+* **One scheduling signal per call and one listener event per key**, the same shape the key-set forms
+  have: an `ISchedulerListener.JobDeleted` or `JobUnscheduled` for each key removed, nothing for an
+  empty group, and no group-level event — `JobsPaused(null)` means *every group* and a monitoring
+  listener would read it as a total outage.
+* **A non-durable job orphaned by `UnscheduleJobs(matcher)` is deleted, and is not named.** That is
+  what the single-key `UnscheduleJob` and the key-set `DeleteTriggers` already do; the answer is about
+  triggers.
+
+`IJobStore` gains `DeleteJobs(GroupMatcher<JobKey>)` and `DeleteTriggers(GroupMatcher<TriggerKey>)` as
+**default implementations** that list the matching keys and then delete them, so a store of your own
+keeps compiling and stays correct. What the default cannot be is atomic — the listing and the deletion
+are two operations — so both shipped stores override the pair to resolve the group inside the lock that
+empties it: `RAMJobStore` under its single lock, the ADO store inside one `SchedulerLock.TriggerAccess`
+scope and one transaction, using the `SelectJobKeysInGroup` / `SelectTriggerKeysInGroup` its driver
+delegate already had. `JobStoreContractTest` fails a shipped store that has left the default in place.
+
+The ADO store's walk stays per key once the group is resolved, for the reason
+[the key-set forms give](#the-key-set-delete-and-unschedule-answer-with-the-keys-they-removed): the
+answer has to name the keys it hit, and a set-based `DELETE … WHERE … IN (…)` reports a row count.
+
+Over HTTP the group forms are new endpoints, `POST …/jobs/delete-by-group` and
+`POST …/triggers/unschedule-by-group`, taking the same four `group*` query parameters as
+`…/jobs/pause` and answering with the same `{"jobs": […]}` / `{"triggers": […]}` bodies the key-set
+forms do — [described here](packages/http-api.md#a-whole-group-in-one-call). They carry `-by-group` in
+the path because the plain `delete` and `unschedule` paths were taken by the key-set forms before
+there was a group form to give them to.
+
 ## One wire contract, and its enums have names
 
 The DTOs that define the HTTP API's JSON used to live in `Quartz.HttpClient`, and `Quartz.AspNetCore`

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -99,7 +99,7 @@ one of them.
 | `POST` | `{ApiPath}/schedulers/{name}/execution-limits` | empty — replaces the whole set |
 | `DELETE` | `{ApiPath}/schedulers/{name}/execution-limits` | empty — the same as posting an empty set |
 
-### Jobs — 20
+### Jobs — 21
 
 Every path below is prefixed `{ApiPath}/schedulers/{name}`.
 
@@ -122,11 +122,12 @@ Every path below is prefixed `{ApiPath}/schedulers/{name}`.
 | `POST` | `…/jobs/interrupt/{fireInstanceId}` | `{ applied }` — the one firing |
 | `DELETE` | `…/jobs/{jobGroup}/{jobName}` | `{ applied }` |
 | `POST` | `…/jobs/delete` | `{ jobs }` |
+| `POST` | `…/jobs/delete-by-group` | `{ jobs }` — selects by group matcher in the query string |
 | `POST` | `…/jobs` | empty — adds the job; `replace` and `storeNonDurableWhileAwaitingScheduling` are body fields |
 | `GET` | `…/jobs/groups` | paged job groups: `name`, `paused` |
 | `GET` | `…/jobs/groups/{jobGroup}/paused` | `{ paused }` |
 
-### Triggers — 20
+### Triggers — 21
 
 | Method | Path | Answers |
 |---|---|---|
@@ -149,6 +150,7 @@ Every path below is prefixed `{ApiPath}/schedulers/{name}`.
 | `POST` | `…/triggers/schedule-multiple` | empty — several jobs and their triggers in one call |
 | `POST` | `…/triggers/{triggerGroup}/{triggerName}/unschedule` | `{ applied }` |
 | `POST` | `…/triggers/unschedule` | `{ triggers }` |
+| `POST` | `…/triggers/unschedule-by-group` | `{ triggers }` — selects by group matcher in the query string |
 | `POST` | `…/triggers/{triggerGroup}/{triggerName}/reschedule` | `{ firstFireTimeUtc }`, **`null`** when the trigger did not exist |
 
 ### Calendars — 4
@@ -530,8 +532,8 @@ were.
 
 The pause, resume and reset forms live under `keys/` because the collection-level `pause` and
 `resume` already belong to the group-matcher forms, which select by query string rather than by body.
-`delete` and `unschedule` have no group-matcher form to make room for, so they keep the plain path
-they have always had.
+`delete` and `unschedule` had no group-matcher form when they were named, so the plain path is theirs
+and the group form says which one it is: `delete-by-group` and `unschedule-by-group`.
 
 The server does the whole set in one pass — one lock and one transaction for the ADO store — and
 signals the scheduling change once for the call. Listener events stay per key: one `TriggerPaused` /
@@ -539,6 +541,27 @@ signals the scheduling change once for the call. Listener events stay per key: o
 operation applied to, and nothing at all for the rest. There is no key-set listener event,
 deliberately: `TriggersPaused(null)` means *every group*, and a monitoring listener would read it as
 a total outage.
+
+### A whole group in one call
+
+Deleting by group is how a caller calls off a correlation — a saga, a tenant, a conversation, all of
+whose firings share a trigger group — without listing its keys first, which is a window in which
+another node can add one more.
+
+| Endpoint | Selects by | Answers |
+|---|---|---|
+| `POST …/jobs/delete-by-group` | `?groupEquals=`, `?groupStartsWith=`, `?groupEndsWith=`, `?groupContains=` | `{ "jobs": [ … ] }` |
+| `POST …/triggers/unschedule-by-group` | the same four | `{ "triggers": [ … ] }` |
+
+The four query parameters are the ones `…/jobs/pause` and `…/triggers/pause` take, and naming none of
+them means *every group*. The answer is the keys, not the group names the pause endpoints return: a
+deleted group has nothing left to remember about it, so what a caller can act on is what went. A job
+left with no triggers and no durability goes with its triggers and is not named — the answer to an
+unschedule is about triggers.
+
+The server resolves the group inside the same lock that empties it, and signals the scheduling change
+once. Listener events are per key here too: one `JobDeleted` or `JobUnscheduled` for each key removed,
+and nothing when the group was empty.
 
 ## Configuration options
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/JobEndpoints.cs
@@ -68,6 +68,11 @@ internal static class JobEndpoints
         yield return builder.MapPost(patternPrefix + "/delete", DeleteJobs)
             .WithQuartzDefaults(nameof(DeleteJobs), "Delete jobs");
 
+        // "delete" was taken by the key-set form before there was a group form, so the group form
+        // says so in its path rather than taking the plain one away from an endpoint that has it.
+        yield return builder.MapPost(patternPrefix + "/delete-by-group", DeleteJobsByGroup)
+            .WithQuartzDefaults(nameof(DeleteJobsByGroup), "Delete jobs by group");
+
         yield return builder.MapPost(patternPrefix, AddJob)
             .WithQuartzDefaults(nameof(AddJob), "Add job");
 
@@ -444,6 +449,33 @@ internal static class JobEndpoints
         {
             var jobKeys = request.Jobs.Select(x => x.AsJobKey()).ToArray();
             var deleted = await scheduler.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
+            return new AppliedJobKeysResponse([.. deleted.Select(KeyDto.Create)]);
+        });
+    }
+
+    /// <summary>
+    /// Deletes every job in the matching groups, answering with the keys it deleted.
+    /// </summary>
+    /// <remarks>
+    /// The group matcher is the same one the pause and resume endpoints take, and the answer is the
+    /// keys rather than the group names: a delete leaves nothing behind to remember about a group,
+    /// so what a caller can use is what went.
+    /// </remarks>
+    [ProducesResponseType(typeof(AppliedJobKeysResponse), StatusCodes.Status200OK)]
+    private static Task<IResult> DeleteJobsByGroup(
+        EndpointHelper endpointHelper,
+        ISchedulerRepository schedulerRepository,
+        string schedulerName,
+        string? groupContains = null,
+        string? groupEndsWith = null,
+        string? groupStartsWith = null,
+        string? groupEquals = null,
+        CancellationToken cancellationToken = default)
+    {
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        {
+            var matcher = EndpointHelper.GetGroupMatcher<JobKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
+            var deleted = await scheduler.DeleteJobs(matcher, cancellationToken).ConfigureAwait(false);
             return new AppliedJobKeysResponse([.. deleted.Select(KeyDto.Create)]);
         });
     }

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/TriggerEndpoints.cs
@@ -74,6 +74,11 @@ internal static class TriggerEndpoints
         yield return builder.MapPost(patternPrefix + "/unschedule", UnscheduleJobs)
             .WithQuartzDefaults(nameof(UnscheduleJobs), "Unschedule jobs");
 
+        // "unschedule" was taken by the key-set form before there was a group form, so the group
+        // form says so in its path rather than taking the plain one away from an endpoint that has it.
+        yield return builder.MapPost(patternPrefix + "/unschedule-by-group", UnscheduleJobsByGroup)
+            .WithQuartzDefaults(nameof(UnscheduleJobsByGroup), "Unschedule jobs by group");
+
         yield return builder.MapPost(patternPrefix + "/{triggerGroup}/{triggerName}/reschedule", RescheduleJob)
             .WithQuartzDefaults(nameof(RescheduleJob), "Reschedule job");
     }
@@ -472,6 +477,34 @@ internal static class TriggerEndpoints
         {
             var triggerKeys = request.Triggers.Select(x => x.AsTriggerKey()).ToArray();
             var unscheduled = await scheduler.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
+            return new AppliedTriggerKeysResponse([.. unscheduled.Select(KeyDto.Create)]);
+        });
+    }
+
+    /// <summary>
+    /// Removes every trigger in the matching groups, answering with the keys it removed.
+    /// </summary>
+    /// <remarks>
+    /// The group matcher is the same one the pause and resume endpoints take, and the answer is the
+    /// keys rather than the group names: unscheduling leaves nothing behind to remember about a
+    /// group, so what a caller can use is what went. A job left with no triggers and no durability
+    /// goes with them, and is not named — the answer is about triggers.
+    /// </remarks>
+    [ProducesResponseType(typeof(AppliedTriggerKeysResponse), StatusCodes.Status200OK)]
+    private static Task<IResult> UnscheduleJobsByGroup(
+        EndpointHelper endpointHelper,
+        ISchedulerRepository schedulerRepository,
+        string schedulerName,
+        string? groupContains = null,
+        string? groupEndsWith = null,
+        string? groupStartsWith = null,
+        string? groupEquals = null,
+        CancellationToken cancellationToken = default)
+    {
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        {
+            var matcher = EndpointHelper.GetGroupMatcher<TriggerKey>(groupContains, groupEndsWith, groupStartsWith, groupEquals);
+            var unscheduled = await scheduler.UnscheduleJobs(matcher, cancellationToken).ConfigureAwait(false);
             return new AppliedTriggerKeysResponse([.. unscheduled.Select(KeyDto.Create)]);
         });
     }

--- a/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
@@ -130,3 +130,22 @@ public sealed class Invoicing
 }
 
 #endregion
+
+public sealed class InvoicingCancellation
+{
+    #region sample_one_off_job_cancel_by_group
+
+    public async ValueTask<int> CustomerWentAway(IScheduler scheduler, string customerId, CancellationToken cancellationToken)
+    {
+        // Every firing scheduled under this customer's group goes in one call: the group the one-liner
+        // put them in is the handle for calling all of them off, and nothing has to list the keys first.
+        List<TriggerKey> calledOff = await scheduler.UnscheduleJobs(
+            GroupMatcher<TriggerKey>.GroupEquals(customerId),
+            cancellationToken);
+
+        // The answer names what went, so "there was nothing left to cancel" is a count, not a guess.
+        return calledOff.Count;
+    }
+
+    #endregion
+}

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -332,6 +332,20 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        var urlParams = matcher.ToUrlParameters();
+        var result = await httpClient.PostWithResponse<AppliedTriggerKeysResponse>(
+            $"{TriggerEndpointUrl()}/unschedule-by-group?{urlParams}",
+            jsonSerializerOptions,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        return [.. result.Triggers.Select(x => x.AsTriggerKey())];
+    }
+
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(newTrigger);
@@ -439,6 +453,20 @@ public sealed class HttpScheduler : IScheduler
         var result = await httpClient.PostWithResponse<DeleteJobsRequest, AppliedJobKeysResponse>(
             $"{JobEndpointUrl()}/delete",
             new DeleteJobsRequest(jobKeys.Select(KeyDto.Create).ToArray()),
+            jsonSerializerOptions,
+            cancellationToken
+        ).ConfigureAwait(false);
+
+        return [.. result.Jobs.Select(x => x.AsJobKey())];
+    }
+
+    public async ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        var urlParams = matcher.ToUrlParameters();
+        var result = await httpClient.PostWithResponse<AppliedJobKeysResponse>(
+            $"{JobEndpointUrl()}/delete-by-group?{urlParams}",
             jsonSerializerOptions,
             cancellationToken
         ).ConfigureAwait(false);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/JobEndpointsTest.cs
@@ -513,6 +513,44 @@ public class JobEndpointsTest : WebApiTest
     }
 
     [Test]
+    public async Task DeleteJobsByGroupShouldCarryEveryMatcherAndAnswerWithTheKeys()
+    {
+        var matchers = new[]
+        {
+            GroupMatcher<JobKey>.AnyGroup(),
+            GroupMatcher<JobKey>.GroupContains("contains"),
+            GroupMatcher<JobKey>.GroupEquals("equals"),
+            GroupMatcher<JobKey>.GroupEndsWith("ends"),
+            GroupMatcher<JobKey>.GroupStartsWith("starts")
+        };
+
+        foreach (var matcher in matchers)
+        {
+            Fake.ClearRecordedCalls(FakeScheduler);
+            A.CallTo(() => FakeScheduler.DeleteJobs(matcher, A<CancellationToken>._))
+                .Returns(new List<JobKey> { jobKeyOne, jobKeyTwo });
+
+            List<JobKey> deleted = await HttpScheduler.DeleteJobs(matcher);
+
+            deleted.Should().Equal([jobKeyOne, jobKeyTwo],
+                "the group form answers with the keys it removed, not with the group names — there is "
+                + "no deleted group left to name");
+            A.CallTo(() => FakeScheduler.DeleteJobs(matcher, A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
+        }
+    }
+
+    [Test]
+    public async Task DeleteJobsByGroupShouldAnswerWithAnEmptyListWhenNothingMatched()
+    {
+        A.CallTo(() => FakeScheduler.DeleteJobs(A<GroupMatcher<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey>());
+
+        List<JobKey> deleted = await HttpScheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("nothing"));
+
+        deleted.Should().BeEmpty("an empty group is not an error over the wire any more than it is in process");
+    }
+
+    [Test]
     public async Task AddJobShouldWork()
     {
         await HttpScheduler.AddJob(TestData.JobDetail, new AddJobOptions { Replace = true });

--- a/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
@@ -34,9 +34,9 @@ public class RequestDelegatesAreSourceGeneratedTest
     private static readonly Dictionary<string, int> mappedRoutes = new(StringComparer.Ordinal)
     {
         ["CalendarEndpoints.cs"] = 4,
-        ["JobEndpoints.cs"] = 20,
+        ["JobEndpoints.cs"] = 21,
         ["SchedulerEndpoints.cs"] = 13,
-        ["TriggerEndpoints.cs"] = 20
+        ["TriggerEndpoints.cs"] = 21
     };
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -622,6 +622,44 @@ public class TriggerEndpointsTest : WebApiTest
     }
 
     [Test]
+    public async Task UnscheduleJobsByGroupShouldCarryEveryMatcherAndAnswerWithTheKeys()
+    {
+        var matchers = new[]
+        {
+            GroupMatcher<TriggerKey>.AnyGroup(),
+            GroupMatcher<TriggerKey>.GroupContains("contains"),
+            GroupMatcher<TriggerKey>.GroupEquals("equals"),
+            GroupMatcher<TriggerKey>.GroupEndsWith("ends"),
+            GroupMatcher<TriggerKey>.GroupStartsWith("starts")
+        };
+
+        foreach (var matcher in matchers)
+        {
+            Fake.ClearRecordedCalls(FakeScheduler);
+            A.CallTo(() => FakeScheduler.UnscheduleJobs(matcher, A<CancellationToken>._))
+                .Returns(new List<TriggerKey> { triggerKeyOne, triggerKeyTwo });
+
+            List<TriggerKey> unscheduled = await HttpScheduler.UnscheduleJobs(matcher);
+
+            unscheduled.Should().Equal([triggerKeyOne, triggerKeyTwo],
+                "the group form answers with the keys it removed, not with the group names — there is "
+                + "no unscheduled group left to name");
+            A.CallTo(() => FakeScheduler.UnscheduleJobs(matcher, A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
+        }
+    }
+
+    [Test]
+    public async Task UnscheduleJobsByGroupShouldAnswerWithAnEmptyListWhenNothingMatched()
+    {
+        A.CallTo(() => FakeScheduler.UnscheduleJobs(A<GroupMatcher<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey>());
+
+        List<TriggerKey> unscheduled = await HttpScheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals("nothing"));
+
+        unscheduled.Should().BeEmpty("an empty group is not an error over the wire any more than it is in process");
+    }
+
+    [Test]
     public async Task RescheduleJobShouldWork()
     {
         var firstFireTime = DateTimeOffset.Now;

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -615,6 +615,125 @@ public abstract class JobStoreContractTest
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////
+    // Deleting a whole group
+    //
+    // The group form exists so that a caller can call off a correlation - a saga, a tenant, a
+    // conversation - without first listing its keys, because between the listing and the deletion
+    // another node can add one more. Whether the store honours that is invisible from outside; what
+    // is visible, and asserted here, is that both stores select the same groups and answer with the
+    // same keys. The in-memory store resolves the matcher against its own dictionaries and the ADO
+    // store turns it into a LIKE predicate, so "the same groups" is a real claim about two different
+    // implementations - a dialect that mangles an operator shows up here and nowhere else.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    [Test]
+    public async Task DeletingAGroupOfJobsRemovesEveryJobInItAndNamesThem()
+    {
+        await ScheduleJobWithTrigger("first", JobGroupA, TriggerGroupA);
+        await ScheduleJobWithTrigger("second", JobGroupA, TriggerGroupA);
+        await ScheduleJobWithTrigger("elsewhere", JobGroupB, TriggerGroupB);
+
+        JobKey firstJob = new JobKey("first", JobGroupA);
+        JobKey secondJob = new JobKey("second", JobGroupA);
+        JobKey survivor = new JobKey("elsewhere", JobGroupB);
+
+        List<JobKey> deleted = await Store.DeleteJobs(GroupMatcher<JobKey>.GroupEquals(JobGroupA));
+
+        deleted.Should().BeEquivalentTo([firstJob, secondJob],
+            "the answer names the jobs the call deleted — a group is not worth naming back, since a "
+            + "deleted group has nothing left to remember about it");
+
+        (await Store.Exists(firstJob)).Should().BeFalse();
+        (await Store.Exists(secondJob)).Should().BeFalse();
+        (await Store.Exists(survivor)).Should().BeTrue("a job in another group is not touched");
+
+        (await Store.QueryTriggers(new TriggerQuery { Group = GroupMatcher<TriggerKey>.GroupEquals(TriggerGroupA) }))
+            .Items.Should().BeEmpty("deleting a job takes the triggers that reference it, as the single-key form does");
+    }
+
+    [Test]
+    public async Task DeletingAGroupOfTriggersRemovesThemAndTheJobsTheyOrphan()
+    {
+        IOperableTrigger first = await ScheduleJobWithTrigger("first", JobGroupA, TriggerGroupA);
+        IOperableTrigger second = await ScheduleJobWithTrigger("second", JobGroupA, TriggerGroupA);
+        IOperableTrigger survivor = await ScheduleJobWithTrigger("elsewhere", JobGroupB, TriggerGroupB);
+
+        IJobDetail durable = JobBuilder.Create<ContractTestJob>()
+            .WithIdentity("durable", JobGroupA)
+            .StoreDurably()
+            .Build();
+        await Store.AddJob(durable, replace: false);
+        await Store.AddTrigger(CreateTrigger("durable", TriggerGroupA, durable.Key), replace: false);
+
+        List<TriggerKey> deleted = await Store.DeleteTriggers(GroupMatcher<TriggerKey>.GroupEquals(TriggerGroupA));
+
+        deleted.Should().BeEquivalentTo([first.Key, second.Key, new TriggerKey("durable", TriggerGroupA)],
+            "the answer names triggers only — a job the removal orphaned went with it, but it is not "
+            + "a trigger and this call was about triggers");
+
+        (await Store.Exists(new JobKey("first", JobGroupA))).Should().BeFalse(
+            "the last trigger of a non-durable job takes the job with it, exactly as the single-key form does");
+        (await Store.Exists(durable.Key)).Should().BeTrue("a durable job survives losing its last trigger");
+        (await Store.Exists(survivor.Key)).Should().BeTrue("a trigger in another group is not touched");
+    }
+
+    [Test]
+    public async Task DeletingByGroupHonoursEveryMatcherOperator()
+    {
+        await ScheduleJobWithTrigger("one", "prefix-alpha", TriggerGroupA);
+        await ScheduleJobWithTrigger("two", "prefix-beta", TriggerGroupA);
+        await ScheduleJobWithTrigger("three", OtherGroup, TriggerGroupB);
+
+        List<JobKey> deleted = await Store.DeleteJobs(GroupMatcher<JobKey>.GroupStartsWith("prefix-"));
+
+        deleted.Should().BeEquivalentTo([new JobKey("one", "prefix-alpha"), new JobKey("two", "prefix-beta")],
+            "a starts-with matcher selects the same groups here as it does for a listing or a pause");
+        (await Store.Exists(new JobKey("three", OtherGroup))).Should().BeTrue();
+
+        List<TriggerKey> unscheduled = await Store.DeleteTriggers(GroupMatcher<TriggerKey>.AnyGroup());
+
+        unscheduled.Should().BeEquivalentTo([new TriggerKey("three", TriggerGroupB)],
+            "every group is a matcher like any other, and only the one trigger was left");
+    }
+
+    [Test]
+    public async Task AGroupThatMatchesNothingDeletesNothing()
+    {
+        await ScheduleJobWithTrigger("untouched", JobGroupA, TriggerGroupA);
+
+        (await Store.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("no-such-group"))).Should().BeEmpty(
+            "an empty answer is the plural of the single-key false, not a failure");
+        (await Store.DeleteTriggers(GroupMatcher<TriggerKey>.GroupEquals("no-such-group"))).Should().BeEmpty();
+
+        (await Store.Exists(new JobKey("untouched", JobGroupA))).Should().BeTrue();
+    }
+
+    [Test]
+    public void TheGroupDeleteMembersAreImplementedRatherThanLeftToTheListThenDeleteDefault()
+    {
+        // The defaults on IJobStore list the matching keys and then delete them, which is correct but
+        // is two operations: a job stored in between survives a call the caller believes emptied the
+        // group. Both shipped stores resolve the keys inside the same lock or transaction that
+        // removes them, and that difference is invisible from the outside - which is why it is
+        // asserted structurally, here, rather than by trying to lose the race on purpose.
+        System.Reflection.InterfaceMapping map = Store.GetType().GetInterfaceMap(typeof(IJobStore));
+
+        for (int i = 0; i < map.InterfaceMethods.Length; i++)
+        {
+            System.Reflection.MethodInfo declared = map.InterfaceMethods[i];
+            if (declared.Name is not (nameof(IJobStore.DeleteJobs) or nameof(IJobStore.DeleteTriggers))
+                || declared.GetParameters()[0].ParameterType.GetGenericTypeDefinition() != typeof(GroupMatcher<>))
+            {
+                continue;
+            }
+
+            map.TargetMethods[i].DeclaringType.Should().NotBe(typeof(IJobStore),
+                $"{Store.GetType().Name}.{declared.Name} must resolve the group and delete it in one "
+                + "pass rather than inherit the list-then-delete default");
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
     // Error state
     //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
+++ b/src/Quartz.Tests.Unit/Core/BulkKeySetOperationsTest.cs
@@ -30,15 +30,23 @@ using Quartz.Listeners;
 namespace Quartz.Tests.Unit.Core;
 
 /// <summary>
-/// What a key-set pause, resume, error-state reset, delete or unschedule tells the outside world.
+/// What a bulk pause, resume, error-state reset, delete or unschedule tells the outside world —
+/// whether the bulk was named as a key set or as a group matcher.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The answers themselves belong to the job store contract; what belongs here is the part only the
 /// scheduler can get wrong. A key set is neither one key nor one group, so the notification shape
 /// had to be chosen: the events stay per key, because <c>TriggersPaused(null)</c> means every group
 /// and would read to a monitoring listener as a total outage. The scheduling change, in contrast, is
 /// raised once for the call — the scheduler thread treats it as a level, not an edge, so one signal
 /// covers the whole set. That is why the scheduler must reach the store once, and never loop.
+/// </para>
+/// <para>
+/// The group-matcher delete and unschedule answer the same way, and for a reason of their own: a
+/// group event says which group changed, and a delete leaves no group behind to say anything about.
+/// So they too report the keys they removed, one listener event each.
+/// </para>
 /// </remarks>
 [NonParallelizable]
 public class BulkKeySetOperationsTest
@@ -186,6 +194,70 @@ public class BulkKeySetOperationsTest
     }
 
     /// <summary>
+    /// The correlation case: everything scheduled for one saga goes in one call, and the caller is
+    /// told what went rather than which groups it named.
+    /// </summary>
+    [Test]
+    public async Task DeletingAGroupOfJobsAnswersWithTheKeysItDeletedAndRaisesOneEventEach()
+    {
+        await Schedule("first", durable: true, jobGroup: "saga-17");
+        await Schedule("second", durable: true, jobGroup: "saga-17");
+        await Schedule("elsewhere", durable: true, jobGroup: "saga-18");
+
+        JobKey firstJob = new JobKey("first", "saga-17");
+        JobKey secondJob = new JobKey("second", "saga-17");
+        JobKey untouched = new JobKey("elsewhere", "saga-18");
+
+        List<JobKey> deleted = await scheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("saga-17"));
+
+        deleted.Should().BeEquivalentTo([firstJob, secondJob],
+            "the answer is the keys the call removed — a group has nothing left to say about itself "
+            + "once it is empty, which is why this is not the group-name answer that pause gives");
+        listener.DeletedJobs.Should().BeEquivalentTo(deleted,
+            "the events follow the keys, exactly as the key-set form's do");
+
+        store.GroupDeleteJobCalls.Should().Be(1,
+            "one call into the store is what makes one scheduling signal possible");
+        store.BulkDeleteJobCalls.Should().Be(0,
+            "the store resolves the group itself — listing the keys first is the race the group form exists to close");
+        store.SingleDeleteJobCalls.Should().Be(0);
+
+        (await scheduler.Exists(untouched)).Should().BeTrue("a group that was not matched is not touched");
+    }
+
+    [Test]
+    public async Task UnschedulingAGroupOfTriggersAnswersWithTheKeysItRemovedAndRaisesOneEventEach()
+    {
+        TriggerKey first = await Schedule("first", durable: true, triggerGroup: "saga-17");
+        TriggerKey second = await Schedule("second", durable: true, triggerGroup: "saga-17");
+        TriggerKey untouched = await Schedule("elsewhere", durable: true, triggerGroup: "saga-18");
+
+        List<TriggerKey> unscheduled = await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals("saga-17"));
+
+        unscheduled.Should().BeEquivalentTo([first, second]);
+        listener.UnscheduledTriggers.Should().BeEquivalentTo(unscheduled);
+
+        store.GroupDeleteTriggerCalls.Should().Be(1);
+        store.BulkDeleteTriggerCalls.Should().Be(0);
+        store.SingleDeleteTriggerCalls.Should().Be(0);
+
+        (await scheduler.Exists(untouched)).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task AGroupThatMatchedNothingAnnouncesNothing()
+    {
+        await Schedule("kept", durable: true);
+
+        (await scheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("no-such-group"))).Should().BeEmpty();
+        (await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals("no-such-group"))).Should().BeEmpty();
+
+        listener.DeletedJobs.Should().BeEmpty(
+            "an empty group was never deleted, and saying otherwise misinforms every listener");
+        listener.UnscheduledTriggers.Should().BeEmpty();
+    }
+
+    /// <summary>
     /// A key that named nothing used to be announced as deleted anyway.
     /// </summary>
     /// <remarks>
@@ -244,18 +316,41 @@ public class BulkKeySetOperationsTest
         Func<Task> pausingNothing = async () => await scheduler.PauseTriggers((IReadOnlyCollection<TriggerKey>) null!);
         await pausingNothing.Should().ThrowAsync<ArgumentNullException>();
 
-        Func<Task> deletingNothing = async () => await scheduler.DeleteJobs(null!);
+        Func<Task> deletingNothing = async () => await scheduler.DeleteJobs((IReadOnlyCollection<JobKey>) null!);
         await deletingNothing.Should().ThrowAsync<ArgumentNullException>();
 
-        Func<Task> unschedulingNothing = async () => await scheduler.UnscheduleJobs(null!);
+        Func<Task> unschedulingNothing = async () => await scheduler.UnscheduleJobs((IReadOnlyCollection<TriggerKey>) null!);
         await unschedulingNothing.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    private async Task<TriggerKey> Schedule(string name, bool durable = false)
+    /// <summary>
+    /// A group is required too, and for a stronger reason than a key set is.
+    /// </summary>
+    /// <remarks>
+    /// The pause and resume group forms read a <see langword="null" /> matcher as "the default
+    /// group", which is a harmless guess when the operation is reversible. It is not one here: a
+    /// caller whose group variable came back null would silently delete every job in the default
+    /// group instead of being told the call was malformed.
+    /// </remarks>
+    [Test]
+    public async Task AGroupMatcherIsRequired()
     {
-        IJobDetail job = JobBuilder.Create<NoOpBulkJob>().WithIdentity(name, "jobs").StoreDurably(durable).Build();
+        Func<Task> deletingNothing = async () => await scheduler.DeleteJobs((GroupMatcher<JobKey>) null!);
+        await deletingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        Func<Task> unschedulingNothing = async () => await scheduler.UnscheduleJobs((GroupMatcher<TriggerKey>) null!);
+        await unschedulingNothing.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private async Task<TriggerKey> Schedule(
+        string name,
+        bool durable = false,
+        string jobGroup = "jobs",
+        string triggerGroup = "triggers")
+    {
+        IJobDetail job = JobBuilder.Create<NoOpBulkJob>().WithIdentity(name, jobGroup).StoreDurably(durable).Build();
         ITrigger trigger = TriggerBuilder.Create()
-            .WithIdentity(name, "triggers")
+            .WithIdentity(name, triggerGroup)
             .ForJob(job)
             .StartAt(DateTimeOffset.UtcNow.AddYears(1))
             .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
@@ -290,6 +385,8 @@ public class BulkKeySetOperationsTest
         public int BulkResetCalls { get; private set; }
         public int BulkDeleteJobCalls { get; private set; }
         public int BulkDeleteTriggerCalls { get; private set; }
+        public int GroupDeleteJobCalls { get; private set; }
+        public int GroupDeleteTriggerCalls { get; private set; }
 
         public override ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
         {
@@ -313,6 +410,18 @@ public class BulkKeySetOperationsTest
         {
             BulkDeleteTriggerCalls++;
             return base.DeleteTriggers(triggerKeys, cancellationToken);
+        }
+
+        public override ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+        {
+            GroupDeleteJobCalls++;
+            return base.DeleteJobs(matcher, cancellationToken);
+        }
+
+        public override ValueTask<List<TriggerKey>> DeleteTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+        {
+            GroupDeleteTriggerCalls++;
+            return base.DeleteTriggers(matcher, cancellationToken);
         }
 
         public override ValueTask<bool> PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)

--- a/src/Quartz.Tests.Unit/Core/JobStoreKeySetDefaultsTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobStoreKeySetDefaultsTest.cs
@@ -64,6 +64,8 @@ public class JobStoreKeySetDefaultsTest
         A.CallTo(() => store.ResumeJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).CallsBaseMethod();
         A.CallTo(() => store.ResumeTriggers(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
         A.CallTo(() => store.ResetTriggersFromErrorState(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.DeleteJobs(A<GroupMatcher<JobKey>>._, A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => store.DeleteTriggers(A<GroupMatcher<TriggerKey>>._, A<CancellationToken>._)).CallsBaseMethod();
     }
 
     [Test]
@@ -115,6 +117,140 @@ public class JobStoreKeySetDefaultsTest
         (await store.PauseTriggers([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
         (await store.ResumeTriggers([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
         (await store.ResetTriggersFromErrorState([FirstTrigger, MissingTrigger])).Should().Equal([FirstTrigger]);
+    }
+
+    /// <summary>
+    /// The group form's default: list what matches, then delete it by key.
+    /// </summary>
+    /// <remarks>
+    /// A store that overrides nothing still answers a group delete correctly, which is the point of
+    /// giving the member a body at all. What it cannot be is atomic - the listing and the deletion
+    /// are two operations - so the shipped stores override it; this is the other side of that
+    /// promise, and the only place the default runs.
+    /// </remarks>
+    [Test]
+    public async Task TheDefaultGroupDeleteListsTheGroupAndThenDeletesTheKeysItNamed()
+    {
+        GivenTheseJobsExist(FirstJob, SecondJob);
+        GivenTheseJobsAreInTheStore(FirstJob, SecondJob);
+
+        List<JobKey> deleted = await store.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("jobs"));
+
+        deleted.Should().Equal([FirstJob, SecondJob], "the default answers with what the delete deleted");
+
+        A.CallTo(() => store.DeleteJobs(
+                A<IReadOnlyCollection<JobKey>>.That.IsSameSequenceAs(FirstJob, SecondJob),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task TheDefaultGroupUnscheduleListsTheGroupAndThenDeletesTheKeysItNamed()
+    {
+        GivenTheseTriggersExist(FirstTrigger, SecondTrigger);
+        GivenTheseTriggersAreInTheStore(FirstTrigger, SecondTrigger);
+
+        List<TriggerKey> deleted = await store.DeleteTriggers(GroupMatcher<TriggerKey>.GroupEquals("triggers"));
+
+        deleted.Should().Equal([FirstTrigger, SecondTrigger]);
+
+        A.CallTo(() => store.DeleteTriggers(
+                A<IReadOnlyCollection<TriggerKey>>.That.IsSameSequenceAs(FirstTrigger, SecondTrigger),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// The listing the default performs asks for the whole group, not a page of it.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="PagedQuery.Take" /> defaults to 250 precisely so that an unpaged call cannot
+    /// materialize an unbounded result by accident. A delete that inherited that default would empty
+    /// the first 250 of a group and report success, which is the one thing worse than being slow.
+    /// </remarks>
+    [Test]
+    public async Task TheDefaultGroupDeleteAsksForEveryMatchRatherThanAPage()
+    {
+        GivenTheseJobsAreInTheStore(FirstJob);
+        GivenTheseTriggersAreInTheStore(FirstTrigger);
+
+        GroupMatcher<JobKey> jobs = GroupMatcher<JobKey>.GroupStartsWith("jo");
+        GroupMatcher<TriggerKey> triggers = GroupMatcher<TriggerKey>.GroupStartsWith("tri");
+
+        await store.DeleteJobs(jobs);
+        await store.DeleteTriggers(triggers);
+
+        A.CallTo(() => store.QueryJobs(
+                A<JobQuery>.That.Matches(query => query.Group == jobs && query.Take == int.MaxValue),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => store.QueryTriggers(
+                A<TriggerQuery>.That.Matches(query => query.Group == triggers && query.Take == int.MaxValue),
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task ADefaultAnswersNothingForAGroupThatMatchesNothing()
+    {
+        GivenTheseJobsAreInTheStore();
+        GivenTheseTriggersAreInTheStore();
+
+        (await store.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("empty"))).Should().BeEmpty();
+        (await store.DeleteTriggers(GroupMatcher<TriggerKey>.GroupEquals("empty"))).Should().BeEmpty();
+
+        A.CallTo(() => store.DeleteJob(A<JobKey>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => store.DeleteTrigger(A<TriggerKey>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task AGroupMatcherIsRequiredEvenOfADefault()
+    {
+        Func<Task> deletingNothing = async () => await store.DeleteJobs((GroupMatcher<JobKey>) null!);
+        await deletingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        Func<Task> unschedulingNothing = async () => await store.DeleteTriggers((GroupMatcher<TriggerKey>) null!);
+        await unschedulingNothing.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    /// <summary>
+    /// What the listing the group default runs would answer.
+    /// </summary>
+    private void GivenTheseJobsAreInTheStore(params JobKey[] present)
+    {
+        List<JobHeader> headers = [.. present.Select(key => new JobHeader(
+            key,
+            Description: null,
+            JobTypeName: "Quartz.Simpl.NoOpJob, Quartz",
+            Durable: false,
+            ConcurrentExecutionDisallowed: false,
+            PersistJobDataAfterExecution: false,
+            RequestsRecovery: false))];
+
+        A.CallTo(() => store.QueryJobs(A<JobQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<JobHeader>(headers, HasMore: false));
+    }
+
+    /// <inheritdoc cref="GivenTheseJobsAreInTheStore" />
+    private void GivenTheseTriggersAreInTheStore(params TriggerKey[] present)
+    {
+        List<TriggerHeader> headers = [.. present.Select(key => new TriggerHeader(
+            key,
+            JobKey: FirstJob,
+            Description: null,
+            TriggerType: "SIMPLE",
+            State: TriggerState.Normal,
+            StartTimeUtc: DateTimeOffset.UnixEpoch,
+            EndTimeUtc: null,
+            NextFireTimeUtc: null,
+            PreviousFireTimeUtc: null,
+            CalendarName: null,
+            Priority: 5,
+            ExecutionGroup: null))];
+
+        A.CallTo(() => store.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>(headers, HasMore: false));
     }
 
     private void GivenTheseJobsExist(params JobKey[] existing)

--- a/src/Quartz.Tests.Unit/Diagnostics/TracingJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/TracingJobStoreTest.cs
@@ -356,8 +356,10 @@ public sealed class TracingJobStoreTest
         await store.AddCalendar("calendar", new Quartz.Impl.Calendar.BaseCalendar());
         await store.DeleteJob(jobKey);
         await store.DeleteJobs([jobKey]);
+        await store.DeleteJobs(GroupMatcher<JobKey>.AnyGroup());
         await store.DeleteTrigger(triggerKey);
         await store.DeleteTriggers([triggerKey]);
+        await store.DeleteTriggers(GroupMatcher<TriggerKey>.AnyGroup());
         await store.DeleteCalendar("calendar");
         await store.ReplaceTrigger(triggerKey, trigger);
         await store.UpdateTriggerDetails(triggerKey, new TriggerDetailsUpdate());

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerResolutionTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerResolutionTest.cs
@@ -145,6 +145,44 @@ public sealed class SchedulerResolutionTest
         provider.GetRequiredService<IScheduler>().SchedulerName.Should().Be("configured");
     }
 
+    /// <summary>
+    /// The handle replays a group delete onto the scheduler it resolves, rather than answering it.
+    /// </summary>
+    /// <remarks>
+    /// Every member of the handle is a replay, and a member added to <see cref="IScheduler" /> that
+    /// nobody remembers to add here still compiles - the handle would simply not have it, and the
+    /// container would refuse to build. These two are asserted because they are new, and because
+    /// "cancel the whole correlation" is the call an integrator makes through exactly this handle:
+    /// resolved from the container, before anything has started the scheduler.
+    /// </remarks>
+    [Test]
+    public async Task GroupDeletes_AreReplayedOntoTheResolvedScheduler()
+    {
+        JobKey deletedJob = new JobKey("job", "saga-17");
+        TriggerKey removedTrigger = new TriggerKey("trigger", "saga-17");
+
+        IScheduler built = A.Fake<IScheduler>();
+        A.CallTo(() => built.DeleteJobs(A<GroupMatcher<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey> { deletedJob });
+        A.CallTo(() => built.UnscheduleJobs(A<GroupMatcher<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { removedTrigger });
+
+        ISchedulerFactory factory = A.Fake<ISchedulerFactory>();
+        A.CallTo(() => factory.GetScheduler(A<CancellationToken>._)).Returns(new ValueTask<IScheduler>(built));
+
+        DeferredScheduler scheduler = new DeferredScheduler(factory, OptionsFor(new QuartzSchedulerOptions()), new SchedulerKey("reporting"));
+
+        GroupMatcher<JobKey> jobs = GroupMatcher<JobKey>.GroupEquals("saga-17");
+        GroupMatcher<TriggerKey> triggers = GroupMatcher<TriggerKey>.GroupEquals("saga-17");
+
+        (await scheduler.DeleteJobs(jobs)).Should().Equal([deletedJob],
+            "the handle answers with what the scheduler it resolved answered, not with something of its own");
+        (await scheduler.UnscheduleJobs(triggers)).Should().Equal([removedTrigger]);
+
+        A.CallTo(() => built.DeleteJobs(jobs, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => built.UnscheduleJobs(triggers, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
     private static IOptionsMonitor<QuartzSchedulerOptions> OptionsFor(QuartzSchedulerOptions options)
     {
         var monitor = A.Fake<IOptionsMonitor<QuartzSchedulerOptions>>();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoBulkDeleteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoBulkDeleteTest.cs
@@ -128,6 +128,111 @@ public class AdoBulkDeleteTest
         deleted.Should().BeEmpty("nothing was there to delete, which is an answer rather than an error");
     }
 
+    /// <summary>
+    /// The group form resolves the keys itself, inside the lock it deletes them under.
+    /// </summary>
+    /// <remarks>
+    /// That is the whole reason the member exists rather than leaving a caller to list the group and
+    /// hand the keys back: between a listing and a delete another node can schedule one more thing
+    /// into the group, and the delete the caller believes emptied it would miss it. So the assertion
+    /// is not only the answer but where the keys came from - the store asked its delegate, inside the
+    /// same TriggerAccess scope, and made no second one.
+    /// </remarks>
+    [Test]
+    public async Task DeletingAGroupOfJobsResolvesTheKeysInsideTheSameLockThatDeletesThem()
+    {
+        GroupMatcher<JobKey> matcher = GroupMatcher<JobKey>.GroupEquals("jobs");
+        GivenTheseJobsAreInTheGroup(matcher, FirstJob, MissingJob, SecondJob);
+        GivenJobDetailDeleteAffectsRowsFor(FirstJob, SecondJob);
+
+        List<JobKey> deleted = await store.DeleteJobs(matcher);
+
+        deleted.Should().Equal([FirstJob, SecondJob],
+            "the answer is each delete's own outcome, exactly as the key-set form's is");
+
+        A.CallTo(() => driverDelegate.SelectJobKeysInGroup(
+                A<ConnectionAndTransactionHolder>._,
+                matcher,
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        store.LockScopes.Should().Be(1,
+            "resolving the group and emptying it are one scope and one transaction - two would be the "
+            + "race the group form exists to close");
+    }
+
+    [Test]
+    public async Task DeletingAGroupOfTriggersResolvesTheKeysInsideTheSameLockThatDeletesThem()
+    {
+        GroupMatcher<TriggerKey> matcher = GroupMatcher<TriggerKey>.GroupStartsWith("trig");
+        GivenTheseTriggersAreInTheGroup(matcher, FirstTrigger, MissingTrigger, SecondTrigger);
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, A<TriggerKey>._, A<CancellationToken>._))
+            .Returns(0);
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, FirstTrigger, A<CancellationToken>._))
+            .Returns(1);
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, SecondTrigger, A<CancellationToken>._))
+            .Returns(1);
+
+        List<TriggerKey> deleted = await store.DeleteTriggers(matcher);
+
+        deleted.Should().Equal([FirstTrigger, SecondTrigger]);
+
+        A.CallTo(() => driverDelegate.SelectTriggerKeysInGroup(
+                A<ConnectionAndTransactionHolder>._,
+                matcher,
+                A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        store.LockScopes.Should().Be(1);
+    }
+
+    [Test]
+    public async Task AGroupThatResolvedToNothingIsAnEmptyAnswerAndNoDeletes()
+    {
+        GivenTheseJobsAreInTheGroup(GroupMatcher<JobKey>.AnyGroup());
+        GivenTheseTriggersAreInTheGroup(GroupMatcher<TriggerKey>.AnyGroup());
+
+        (await store.DeleteJobs(GroupMatcher<JobKey>.AnyGroup())).Should().BeEmpty();
+        (await store.DeleteTriggers(GroupMatcher<TriggerKey>.AnyGroup())).Should().BeEmpty();
+
+        A.CallTo(() => driverDelegate.DeleteJobDetail(A<ConnectionAndTransactionHolder>._, A<JobKey>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+        A.CallTo(() => driverDelegate.DeleteTrigger(A<ConnectionAndTransactionHolder>._, A<TriggerKey>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task AGroupMatcherIsRequiredBeforeAnyLockIsTaken()
+    {
+        Func<Task> deletingNothing = async () => await store.DeleteJobs((GroupMatcher<JobKey>) null!);
+        await deletingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        Func<Task> unschedulingNothing = async () => await store.DeleteTriggers((GroupMatcher<TriggerKey>) null!);
+        await unschedulingNothing.Should().ThrowAsync<ArgumentNullException>();
+
+        store.LockScopes.Should().Be(0,
+            "a malformed call must not open a transaction, let alone take the scheduler's trigger lock");
+    }
+
+    private void GivenTheseJobsAreInTheGroup(GroupMatcher<JobKey> matcher, params JobKey[] present)
+    {
+        A.CallTo(() => driverDelegate.SelectJobKeysInGroup(
+                A<ConnectionAndTransactionHolder>._,
+                matcher,
+                A<CancellationToken>._))
+            .Returns(new List<JobKey>(present));
+    }
+
+    private void GivenTheseTriggersAreInTheGroup(GroupMatcher<TriggerKey> matcher, params TriggerKey[] present)
+    {
+        A.CallTo(() => driverDelegate.SelectTriggerKeysInGroup(
+                A<ConnectionAndTransactionHolder>._,
+                matcher,
+                A<CancellationToken>._))
+            .Returns(new List<TriggerKey>(present));
+    }
+
     private void GivenJobDetailDeleteAffectsRowsFor(params JobKey[] existing)
     {
         A.CallTo(() => driverDelegate.DeleteJobDetail(A<ConnectionAndTransactionHolder>._, A<JobKey>._, A<CancellationToken>._))

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoGroupDeleteSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoGroupDeleteSqliteTest.cs
@@ -1,0 +1,240 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Deleting a whole group against a real database, and answering the same as the in-memory store does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AdoBulkDeleteTest</c> pins how the group form reaches the database — one lock, keys resolved by
+/// the delegate inside it — over a faked delegate that reaches nothing. What that cannot show is the
+/// cascade actually running: a trigger row taken with its job, a non-durable job taken with its last
+/// trigger, a paused group left recorded. Those are claims about SQL, and SQLite is a file, so they
+/// can be made here rather than only in the container legs.
+/// </para>
+/// <para>
+/// The assertions are deliberately the ones <c>BulkKeySetOperationsTest</c> makes of
+/// <c>RAMJobStore</c>. Two stores answering the same question the same way is the contract; a
+/// divergence found here is a bug in one of them rather than a dialect detail.
+/// </para>
+/// </remarks>
+public sealed class AdoGroupDeleteSqliteTest
+{
+    private const string SagaGroup = "saga-17";
+    private const string OtherGroup = "saga-18";
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-group-delete-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task DeletingAGroupOfJobsTakesTheirTriggersAndLeavesTheOtherGroups()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+        IScheduler scheduler = handle.Scheduler;
+
+        await Schedule(scheduler, "first", SagaGroup);
+        await Schedule(scheduler, "second", SagaGroup);
+        await Schedule(scheduler, "elsewhere", OtherGroup);
+
+        List<JobKey> deleted = await scheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals(SagaGroup));
+
+        deleted.Should().BeEquivalentTo([new JobKey("first", SagaGroup), new JobKey("second", SagaGroup)],
+            "the answer names the jobs the call deleted, as the in-memory store's does");
+
+        (await scheduler.Exists(new JobKey("first", SagaGroup))).Should().BeFalse();
+        (await scheduler.Exists(new JobKey("second", SagaGroup))).Should().BeFalse();
+        (await scheduler.Exists(new TriggerKey("first", SagaGroup))).Should().BeFalse(
+            "a job's triggers go with it, which against a database is a cascade rather than one statement");
+
+        (await scheduler.Exists(new JobKey("elsewhere", OtherGroup))).Should().BeTrue();
+        (await scheduler.Exists(new TriggerKey("elsewhere", OtherGroup))).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task UnschedulingAGroupOfTriggersTakesTheNonDurableJobsItOrphans()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+        IScheduler scheduler = handle.Scheduler;
+
+        await Schedule(scheduler, "perishable", SagaGroup);
+        await Schedule(scheduler, "durable", SagaGroup, durable: true);
+        await Schedule(scheduler, "elsewhere", OtherGroup);
+
+        List<TriggerKey> unscheduled = await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(SagaGroup));
+
+        unscheduled.Should().BeEquivalentTo(
+            [new TriggerKey("perishable", SagaGroup), new TriggerKey("durable", SagaGroup)],
+            "the answer names triggers only — the job an unschedule orphans is deleted, not reported");
+
+        (await scheduler.Exists(new JobKey("perishable", SagaGroup))).Should().BeFalse(
+            "a non-durable job that has lost its last trigger goes with it");
+        (await scheduler.Exists(new JobKey("durable", SagaGroup))).Should().BeTrue(
+            "a durable job survives having no triggers, which is what durable means");
+
+        (await scheduler.Exists(new TriggerKey("elsewhere", OtherGroup))).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Emptying a paused group does not un-pause it.
+    /// </summary>
+    /// <remarks>
+    /// The pause is remembered per group precisely so that a job added to it later is born paused, and
+    /// a delete has no business forgetting that: the group is emptier, not resumed. The in-memory
+    /// store keeps its entry in the paused-group set, and the ADO store must keep its
+    /// <c>PAUSED_JOB_GRPS</c> row — which is asserted against the table itself, because "a group with
+    /// no jobs in it" is exactly the case a listing has an opinion about.
+    /// </remarks>
+    [Test]
+    public async Task EmptyingAPausedJobGroupLeavesThePauseRecorded()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+        IScheduler scheduler = handle.Scheduler;
+
+        await Schedule(scheduler, "first", SagaGroup);
+        await scheduler.PauseJobs(GroupMatcher<JobKey>.GroupEquals(SagaGroup));
+
+        (await CountOfPausedJobGroups()).Should().Be(1, "the pause was recorded before anything was deleted");
+
+        await scheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals(SagaGroup));
+
+        (await CountOfPausedJobGroups()).Should().Be(1,
+            "a delete empties the group; resuming it is a separate decision the caller has not made");
+    }
+
+    [Test]
+    public async Task AGroupThatMatchesNothingDeletesNothing()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+        IScheduler scheduler = handle.Scheduler;
+
+        await Schedule(scheduler, "untouched", SagaGroup);
+
+        (await scheduler.DeleteJobs(GroupMatcher<JobKey>.GroupEquals("no-such-group"))).Should().BeEmpty();
+        (await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals("no-such-group"))).Should().BeEmpty();
+
+        (await scheduler.Exists(new JobKey("untouched", SagaGroup))).Should().BeTrue();
+    }
+
+    private async Task<int> CountOfPausedJobGroups()
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM QRTZ_PAUSED_JOB_GRPS";
+
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
+    private static async Task Schedule(IScheduler scheduler, string name, string group, bool durable = false)
+    {
+        IJobDetail job = JobBuilder.Create<NoOpGroupJob>()
+            .WithIdentity(name, group)
+            .StoreDurably(durable)
+            .Build();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity(name, group)
+            .ForJob(job)
+            // Far enough out that nothing fires while the test drives the store by hand.
+            .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+    }
+
+    private async Task<SchedulerHandle> BuildScheduler()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "group-delete";
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                // #3550: the store creates the schema it needs, so the test needs no script of its own.
+                store.ProvisionSchema();
+            });
+        });
+
+        ServiceProvider container = services.BuildServiceProvider();
+
+        // Never started: the scheduler thread would acquire the triggers this test deletes underneath it.
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        return new SchedulerHandle(container, scheduler);
+    }
+
+    private sealed class SchedulerHandle : IAsyncDisposable
+    {
+        private readonly ServiceProvider container;
+
+        public SchedulerHandle(ServiceProvider container, IScheduler scheduler)
+        {
+            this.container = container;
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Scheduler.Shutdown(waitForJobsToComplete: false);
+            await container.DisposeAsync();
+        }
+    }
+
+    public sealed class NoOpGroupJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/DelegatingSchedulerForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DelegatingSchedulerForwardingTest.cs
@@ -1,0 +1,93 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using FakeItEasy;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// <see cref="DelegatingScheduler" /> hands a call on unchanged, which is the whole of its job.
+/// </summary>
+/// <remarks>
+/// It is the base class an application writes a decorator over — counting, tracing, guarding — and a
+/// decorator is only safe if the members it does not override behave as if it were not there. A
+/// forwarding member that dropped an argument, or answered instead of asking, would be invisible to
+/// every test of the scheduler itself.
+/// </remarks>
+public sealed class DelegatingSchedulerForwardingTest
+{
+    [Test]
+    public async Task DeletingAGroupOfJobsIsHandedOnWithItsMatcherAndItsAnswer()
+    {
+        JobKey deleted = new JobKey("job", "saga-17");
+
+        IScheduler inner = A.Fake<IScheduler>();
+        A.CallTo(() => inner.DeleteJobs(A<GroupMatcher<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey> { deleted });
+
+        DelegatingScheduler scheduler = new DelegatingScheduler(inner);
+        GroupMatcher<JobKey> matcher = GroupMatcher<JobKey>.GroupEquals("saga-17");
+
+        (await scheduler.DeleteJobs(matcher)).Should().Equal([deleted],
+            "the wrapper answers with what it was told, rather than with a list of its own");
+
+        A.CallTo(() => inner.DeleteJobs(matcher, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task UnschedulingAGroupOfTriggersIsHandedOnWithItsMatcherAndItsAnswer()
+    {
+        TriggerKey removed = new TriggerKey("trigger", "saga-17");
+
+        IScheduler inner = A.Fake<IScheduler>();
+        A.CallTo(() => inner.UnscheduleJobs(A<GroupMatcher<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { removed });
+
+        DelegatingScheduler scheduler = new DelegatingScheduler(inner);
+        GroupMatcher<TriggerKey> matcher = GroupMatcher<TriggerKey>.GroupEquals("saga-17");
+
+        (await scheduler.UnscheduleJobs(matcher)).Should().Equal([removed]);
+
+        A.CallTo(() => inner.UnscheduleJobs(matcher, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// The token travels too, which a wrapper that wrote <c>default</c> would quietly stop doing.
+    /// </summary>
+    [Test]
+    public async Task TheCancellationTokenTravelsWithTheCall()
+    {
+        IScheduler inner = A.Fake<IScheduler>();
+        A.CallTo(() => inner.DeleteJobs(A<GroupMatcher<JobKey>>._, A<CancellationToken>._))
+            .Returns(new List<JobKey>());
+
+        using CancellationTokenSource cancellation = new();
+        DelegatingScheduler scheduler = new DelegatingScheduler(inner);
+
+        await scheduler.DeleteJobs(GroupMatcher<JobKey>.AnyGroup(), cancellation.Token);
+
+        A.CallTo(() => inner.DeleteJobs(A<GroupMatcher<JobKey>>._, cancellation.Token)).MustHaveHappenedOnceExactly();
+    }
+}

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -109,6 +109,11 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        public ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask<ICalendar> GetCalendar(string calendarName, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
@@ -375,6 +380,11 @@ public class QuartzHostedServiceTests
         }
 
         public ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -28,6 +28,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -79,6 +80,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default) { }
     }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -692,6 +692,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -742,6 +743,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default);
     }
@@ -1999,8 +2001,10 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -2310,10 +2314,12 @@ namespace Quartz.Impl.AdoJobStore
         protected System.Threading.Tasks.ValueTask<bool> DeleteCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, bool activeDeleteSafe, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.IJobDetail? job, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask ExecuteInLocalTransactionLock(Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, System.Threading.Tasks.ValueTask> txCallback, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<T> ExecuteInLocalTransactionLock<T>(Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, System.Threading.Tasks.ValueTask<T>> txCallback, System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, T, System.Threading.Tasks.ValueTask<bool>>? txValidator = null, System.Guid? requestorId = default, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3338,8 +3344,10 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3402,6 +3410,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3453,6 +3462,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask StartDelayed(System.TimeSpan delay, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask TriggerJob(Quartz.JobKey jobKey, Quartz.JobDataMap? data = null, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> UnscheduleJob(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> UnscheduleJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> UpdateTriggerDetails(Quartz.TriggerKey triggerKey, Quartz.TriggerDetailsUpdate update, System.Threading.CancellationToken cancellationToken = default) { }
     }
@@ -3528,8 +3538,10 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(Quartz.GroupMatcher<Quartz.JobKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -859,7 +859,30 @@ internal sealed class QuartzScheduler
         List<JobKey> deleted = await resources.JobStore.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
         if (deleted.Count > 0)
         {
-            NotifySchedulerThread(null);
+            NotifySchedulerThread(candidateNewNextFireTimeUtc: null);
+            foreach (JobKey key in deleted)
+            {
+                await NotifySchedulerListenersJobDeleted(key, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return deleted;
+    }
+
+    /// <summary>
+    /// Delete every job in the matching groups, signalling the change once and announcing each key.
+    /// </summary>
+    public async ValueTask<List<JobKey>> DeleteJobs(
+        GroupMatcher<JobKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+        ValidateState();
+
+        List<JobKey> deleted = await resources.JobStore.DeleteJobs(matcher, cancellationToken).ConfigureAwait(false);
+        if (deleted.Count > 0)
+        {
+            NotifySchedulerThread(candidateNewNextFireTimeUtc: null);
             foreach (JobKey key in deleted)
             {
                 await NotifySchedulerListenersJobDeleted(key, cancellationToken).ConfigureAwait(false);
@@ -972,7 +995,30 @@ internal sealed class QuartzScheduler
         List<TriggerKey> unscheduled = await resources.JobStore.DeleteTriggers(triggerKeys, cancellationToken).ConfigureAwait(false);
         if (unscheduled.Count > 0)
         {
-            NotifySchedulerThread(null);
+            NotifySchedulerThread(candidateNewNextFireTimeUtc: null);
+            foreach (TriggerKey key in unscheduled)
+            {
+                await NotifySchedulerListenersUnscheduled(key, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        return unscheduled;
+    }
+
+    /// <summary>
+    /// Remove every trigger in the matching groups, signalling the change once and announcing each key.
+    /// </summary>
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(
+        GroupMatcher<TriggerKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+        ValidateState();
+
+        List<TriggerKey> unscheduled = await resources.JobStore.DeleteTriggers(matcher, cancellationToken).ConfigureAwait(false);
+        if (unscheduled.Count > 0)
+        {
+            NotifySchedulerThread(candidateNewNextFireTimeUtc: null);
             foreach (TriggerKey key in unscheduled)
             {
                 await NotifySchedulerListenersUnscheduled(key, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Diagnostics/TracingJobStore.cs
+++ b/src/Quartz/Diagnostics/TracingJobStore.cs
@@ -247,6 +247,19 @@ internal sealed class TracingJobStore : DelegatingJobStore
             static s => s.InnerJobStore.DeleteJobs(s.jobKeys, s.cancellationToken));
     }
 
+    public override ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        StoreOperation operation = Begin(OperationName.JobStore.DeleteJobs);
+        if (!operation.IsRecording)
+        {
+            return InnerJobStore.DeleteJobs(matcher, cancellationToken);
+        }
+
+        operation.Start();
+        return Complete(operation, (InnerJobStore, matcher, cancellationToken),
+            static s => s.InnerJobStore.DeleteJobs(s.matcher, s.cancellationToken));
+    }
+
     public override ValueTask<bool> DeleteTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         StoreOperation operation = Begin(OperationName.JobStore.DeleteTrigger);
@@ -271,6 +284,19 @@ internal sealed class TracingJobStore : DelegatingJobStore
         operation.Start();
         return Complete(operation, (InnerJobStore, triggerKeys, cancellationToken),
             static s => s.InnerJobStore.DeleteTriggers(s.triggerKeys, s.cancellationToken));
+    }
+
+    public override ValueTask<List<TriggerKey>> DeleteTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        StoreOperation operation = Begin(OperationName.JobStore.DeleteTriggers);
+        if (!operation.IsRecording)
+        {
+            return InnerJobStore.DeleteTriggers(matcher, cancellationToken);
+        }
+
+        operation.Start();
+        return Complete(operation, (InnerJobStore, matcher, cancellationToken),
+            static s => s.InnerJobStore.DeleteTriggers(s.matcher, s.cancellationToken));
     }
 
     public override ValueTask<bool> DeleteCalendar(string calendarName, CancellationToken cancellationToken = default)

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -175,6 +175,28 @@ public interface IJobStore
     }
 
     /// <summary>
+    /// Remove (delete) every <see cref="IJob" /> in the matching groups, and any
+    /// <see cref="ITrigger" />s that reference them.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation lists the matching keys and then deletes them, which is two
+    /// operations and so lets a job added in between escape. A store overrides it to resolve the
+    /// keys and delete them under the same lock or connection scope; the answer must not change
+    /// when it does.
+    /// </remarks>
+    /// <returns>
+    /// The keys this call removed. A group that matched nothing contributes nothing — an empty
+    /// list is the plural of the single-key <see langword="false" />, not a failure.
+    /// </returns>
+    /// <seealso cref="DeleteJobs(IReadOnlyCollection{JobKey}, CancellationToken)" />
+    ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        return DeleteMatchingJobs(this, matcher, cancellationToken);
+    }
+
+    /// <summary>
     /// Retrieve the <see cref="IJobDetail" /> for the given
     /// <see cref="IJob" />.
     /// </summary>
@@ -232,6 +254,27 @@ public interface IJobStore
     ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         return ApplyToEach(triggerKeys, DeleteTrigger, cancellationToken);
+    }
+
+    /// <summary>
+    /// Remove (delete) every <see cref="ITrigger" /> in the matching groups.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation lists the matching keys and then deletes them, which is two
+    /// operations and so lets a trigger added in between escape. A store overrides it to resolve
+    /// the keys and delete them under the same lock or connection scope; the answer must not change
+    /// when it does.
+    /// </remarks>
+    /// <returns>
+    /// The keys this call removed. A job left orphaned and non-durable by the removal is deleted
+    /// too, as in the single-key form, but the answer names triggers only.
+    /// </returns>
+    /// <seealso cref="DeleteTriggers(IReadOnlyCollection{TriggerKey}, CancellationToken)" />
+    ValueTask<List<TriggerKey>> DeleteTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        return DeleteMatchingTriggers(this, matcher, cancellationToken);
     }
 
     /// <summary>
@@ -819,5 +862,51 @@ public interface IJobStore
         }
 
         return applied;
+    }
+
+    /// <summary>
+    /// Lists the jobs in the matching groups and deletes them, for a store that has not overridden
+    /// the group form.
+    /// </summary>
+    /// <remarks>
+    /// Correct for any store and atomic for none: the listing and the deletion are two operations,
+    /// so a job stored between them is not deleted. Every shipped store resolves the keys inside
+    /// the same lock the deletion takes, which is the difference this default cannot express.
+    /// </remarks>
+    private static async ValueTask<List<JobKey>> DeleteMatchingJobs(
+        IJobStore store,
+        GroupMatcher<JobKey> matcher,
+        CancellationToken cancellationToken)
+    {
+        PagedResult<JobHeader> matching = await store.QueryJobs(
+            new JobQuery { Group = matcher, Take = int.MaxValue },
+            cancellationToken).ConfigureAwait(false);
+
+        List<JobKey> keys = new List<JobKey>(matching.Items.Count);
+        foreach (JobHeader header in matching.Items)
+        {
+            keys.Add(header.Key);
+        }
+
+        return await store.DeleteJobs(keys, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc cref="DeleteMatchingJobs" />
+    private static async ValueTask<List<TriggerKey>> DeleteMatchingTriggers(
+        IJobStore store,
+        GroupMatcher<TriggerKey> matcher,
+        CancellationToken cancellationToken)
+    {
+        PagedResult<TriggerHeader> matching = await store.QueryTriggers(
+            new TriggerQuery { Group = matcher, Take = int.MaxValue },
+            cancellationToken).ConfigureAwait(false);
+
+        List<TriggerKey> keys = new List<TriggerKey>(matching.Items.Count);
+        foreach (TriggerHeader header in matching.Items)
+        {
+            keys.Add(header.Key);
+        }
+
+        return await store.DeleteTriggers(keys, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -459,6 +459,32 @@ public interface IScheduler : IAsyncDisposable
     ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Remove every <see cref="ITrigger" /> in the matching groups from the scheduler.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The group is the correlation axis: everything scheduled for one saga, one tenant or one
+    /// conversation shares a trigger group, and this is how the whole of it is called off in one
+    /// call rather than one round trip per key — and without first listing the keys, which is a
+    /// window in which another node can add one more.
+    /// </para>
+    /// <para>A job left with no triggers by the removal is deleted too if it is not durable,
+    /// exactly as the single-key <see cref="UnscheduleJob" /> does, but the answer names triggers
+    /// only.</para>
+    /// <para>One <see cref="ISchedulerListener.JobUnscheduled" /> is raised per removed key, and the
+    /// scheduling change is signalled once for the whole call. A matcher that matched nothing raises
+    /// nothing.</para>
+    /// </remarks>
+    /// <param name="matcher">
+    /// Selects the trigger groups to empty. Required — there is no "unschedule the default group"
+    /// reading of <see langword="null" /> worth risking on a destructive call.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The keys of the triggers this call removed.</returns>
+    /// <seealso cref="UnscheduleJobs(IReadOnlyCollection{TriggerKey}, CancellationToken)" />
+    ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Remove (delete) the <see cref="ITrigger" /> with the
     /// given key, and store the new given one - which must be associated
     /// with the same job (the new trigger must have the job name &amp; group specified)
@@ -570,6 +596,32 @@ public interface IScheduler : IAsyncDisposable
     /// </returns>
     /// <seealso cref="DeleteJob" />
     ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete every <see cref="IJobDetail" /> in the matching groups from the Scheduler - and any
+    /// associated <see cref="ITrigger" />s.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The group is the correlation axis: everything belonging to one tenant, one saga or one
+    /// import shares a job group, and this is how the whole of it goes in one call rather than one
+    /// round trip per key — and without first listing the keys, which is a window in which another
+    /// node can add one more.
+    /// </para>
+    /// <para>Unlike <see cref="PauseJobs(GroupMatcher{JobKey}, CancellationToken)" />, nothing is
+    /// remembered about the groups: a delete has no state to impose on a job added afterwards.</para>
+    /// <para>One <see cref="ISchedulerListener.JobDeleted" /> is raised per deleted key, and the
+    /// scheduling change is signalled once for the whole call. A matcher that matched nothing raises
+    /// nothing.</para>
+    /// </remarks>
+    /// <param name="matcher">
+    /// Selects the job groups to empty. Required — there is no "delete the default group" reading of
+    /// <see langword="null" /> worth risking on a destructive call.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The keys of the jobs this call deleted.</returns>
+    /// <seealso cref="DeleteJobs(IReadOnlyCollection{JobKey}, CancellationToken)" />
+    ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Trigger the identified <see cref="IJobDetail" /> (Execute it now).

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
@@ -249,7 +249,42 @@ public abstract partial class AdoJobStoreBase
                 List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
                 foreach (JobKey jobKey in jobKeys)
                 {
-                    if (await DeleteJob(conn, jobKey, true, cancellationToken).ConfigureAwait(false))
+                    if (await DeleteJob(conn, jobKey, activeDeleteSafe: true, cancellationToken).ConfigureAwait(false))
+                    {
+                        deleted.Add(jobKey);
+                    }
+                }
+
+                return deleted;
+            }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Delete the jobs in the matching groups, and the triggers that reference them, in one lock and
+    /// one transaction.
+    /// </summary>
+    /// <remarks>
+    /// The matching keys are resolved inside the lock rather than by the caller, which is the whole
+    /// point of the group form: a job stored between a listing and a deletion would survive a call
+    /// the caller believes emptied the group. Once the keys are in hand the walk is the one
+    /// <see cref="DeleteJobs(IReadOnlyCollection{JobKey}, CancellationToken)" /> does, for the reason
+    /// given there — the answer has to name the keys it hit, and a set-based delete reports a row
+    /// count instead.
+    /// </remarks>
+    public ValueTask<List<JobKey>> DeleteJobs(
+        GroupMatcher<JobKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        return ExecuteInLock(
+            SchedulerLock.TriggerAccess, async conn =>
+            {
+                List<JobKey> matching = await Delegate.SelectJobKeysInGroup(conn, matcher, cancellationToken).ConfigureAwait(false);
+                List<JobKey> deleted = new List<JobKey>(matching.Count);
+                foreach (JobKey jobKey in matching)
+                {
+                    if (await DeleteJob(conn, jobKey, activeDeleteSafe: true, cancellationToken).ConfigureAwait(false))
                     {
                         deleted.Add(jobKey);
                     }
@@ -263,7 +298,7 @@ public abstract partial class AdoJobStoreBase
     /// Delete the identified triggers in one lock and one transaction.
     /// </summary>
     /// <remarks>
-    /// Per key for the same reason <see cref="DeleteJobs" /> is: removing a trigger also removes its
+    /// Per key for the same reason <see cref="DeleteJobs(IReadOnlyCollection{JobKey}, CancellationToken)" /> is: removing a trigger also removes its
     /// sub-table row, its fired-trigger rows, and the job it orphans when that job is not durable.
     /// </remarks>
     public ValueTask<List<TriggerKey>> DeleteTriggers(
@@ -276,6 +311,30 @@ public abstract partial class AdoJobStoreBase
             {
                 List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
                 foreach (TriggerKey triggerKey in triggerKeys)
+                {
+                    if (await DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false))
+                    {
+                        deleted.Add(triggerKey);
+                    }
+                }
+
+                return deleted;
+            }, cancellationToken);
+    }
+
+    /// <inheritdoc cref="DeleteJobs(GroupMatcher{JobKey}, CancellationToken)" />
+    public ValueTask<List<TriggerKey>> DeleteTriggers(
+        GroupMatcher<TriggerKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        return ExecuteInLock(
+            SchedulerLock.TriggerAccess, async conn =>
+            {
+                List<TriggerKey> matching = await Delegate.SelectTriggerKeysInGroup(conn, matcher, cancellationToken).ConfigureAwait(false);
+                List<TriggerKey> deleted = new List<TriggerKey>(matching.Count);
+                foreach (TriggerKey triggerKey in matching)
                 {
                     if (await DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false))
                     {

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -225,6 +225,12 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.UnscheduleJobs(triggerKeys, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.UnscheduleJobs(matcher, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);
@@ -265,6 +271,12 @@ internal sealed class DeferredScheduler : IScheduler
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);
         return await target.DeleteJobs(jobKeys, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.DeleteJobs(matcher, cancellationToken).ConfigureAwait(false);
     }
 
     public async ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -116,6 +116,11 @@ public class DelegatingJobStore : IJobStore
         return jobStore.DeleteJobs(jobKeys, cancellationToken);
     }
 
+    public virtual ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return jobStore.DeleteJobs(matcher, cancellationToken);
+    }
+
     public virtual ValueTask<IJobDetail?> GetJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         return jobStore.GetJob(jobKey, cancellationToken);
@@ -134,6 +139,11 @@ public class DelegatingJobStore : IJobStore
     public virtual ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         return jobStore.DeleteTriggers(triggerKeys, cancellationToken);
+    }
+
+    public virtual ValueTask<List<TriggerKey>> DeleteTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return jobStore.DeleteTriggers(matcher, cancellationToken);
     }
 
     public virtual ValueTask<bool> ReplaceTrigger(TriggerKey triggerKey, IOperableTrigger trigger, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -115,6 +115,11 @@ public class DelegatingScheduler : IScheduler
         return scheduler.UnscheduleJobs(triggerKeys, cancellationToken);
     }
 
+    public virtual ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.UnscheduleJobs(matcher, cancellationToken);
+    }
+
     public virtual ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
     {
         return scheduler.RescheduleJob(triggerKey, newTrigger, cancellationToken);
@@ -148,6 +153,11 @@ public class DelegatingScheduler : IScheduler
     public virtual ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         return scheduler.DeleteJobs(jobKeys, cancellationToken);
+    }
+
+    public virtual ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        return scheduler.DeleteJobs(matcher, cancellationToken);
     }
 
     public virtual ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -411,6 +411,39 @@ public sealed class RAMJobStore : IJobStore
         return deleted;
     }
 
+    /// <summary>
+    /// Deletes the jobs in the matching groups, resolving the keys under the same lock that removes
+    /// them so that a job stored meanwhile cannot slip through the gap.
+    /// </summary>
+    public async ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        PendingSignals pending = default;
+        List<JobKey> deleted;
+
+        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            List<JobKey> matching = GetJobKeysNoLock(matcher);
+            deleted = new List<JobKey>(matching.Count);
+            foreach (JobKey key in matching)
+            {
+                if (RemoveJobNoLock(key, ref pending))
+                {
+                    deleted.Add(key);
+                }
+            }
+        }
+        finally
+        {
+            lockObject.Release();
+        }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
+    }
+
     public async ValueTask<List<TriggerKey>> DeleteTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         PendingSignals pending = default;
@@ -420,6 +453,36 @@ public sealed class RAMJobStore : IJobStore
         try
         {
             foreach (TriggerKey key in triggerKeys)
+            {
+                if (RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, ref pending))
+                {
+                    deleted.Add(key);
+                }
+            }
+        }
+        finally
+        {
+            lockObject.Release();
+        }
+
+        await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
+        return deleted;
+    }
+
+    /// <inheritdoc cref="DeleteJobs(GroupMatcher{JobKey}, CancellationToken)" />
+    public async ValueTask<List<TriggerKey>> DeleteTriggers(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        PendingSignals pending = default;
+        List<TriggerKey> deleted;
+
+        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            List<TriggerKey> matching = GetTriggerKeysNoLock(matcher);
+            deleted = new List<TriggerKey>(matching.Count);
+            foreach (TriggerKey key in matching)
             {
                 if (RemoveTriggerNoLock(key, removeOrphanedJob: true, keepExecutions: false, ref pending))
                 {

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -238,6 +238,13 @@ internal sealed class StdScheduler : IScheduler
         return scheduler.DeleteJobs(jobKeys, cancellationToken);
     }
 
+    public ValueTask<List<JobKey>> DeleteJobs(
+        GroupMatcher<JobKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.DeleteJobs(matcher, cancellationToken);
+    }
+
     public ValueTask ScheduleJobs(
         IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs,
         ScheduleJobOptions options = default,
@@ -260,6 +267,13 @@ internal sealed class StdScheduler : IScheduler
         CancellationToken cancellationToken = default)
     {
         return scheduler.UnscheduleJobs(triggerKeys, cancellationToken);
+    }
+
+    public ValueTask<List<TriggerKey>> UnscheduleJobs(
+        GroupMatcher<TriggerKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.UnscheduleJobs(matcher, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
Pause has had a group form since 1.x and delete has not, so calling off everything that belonged to
one saga, one tenant or one import meant listing the keys and then deleting them. That is two calls
with a window between them: a trigger scheduled into the group by another node after the listing
survives a delete the caller believes emptied it. Cancel-by-correlation is the one operation a
message bus needs that Quartz had no counterpart for, which is why every integration invents a key
scheme it can reconstruct later instead of asking Quartz to remember one.

## The scheduler

```csharp
ValueTask<List<JobKey>>     DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default);
ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default);
```

Both take the matcher the pause forms take and answer with the **keys they removed**, not the group
names `PauseJobs(matcher)` returns. A pause has something to remember per group — the group stays
paused and a job added later is born paused — and a delete has nothing; what a caller can still act
on is what went.

A `null` matcher is an `ArgumentNullException` rather than "the default group", which is what the
pause and resume group forms read it as. A pause taken by mistake can be resumed. This also means a
`null` literal now needs a cast to pick an overload, exactly as it did when the key-set forms
arrived; the two lines in `BulkKeySetOperationsTest` that did so are the only call sites in the tree.

One `NotifySchedulerThread(null)` per call and one `JobDeleted` / `JobUnscheduled` per removed key —
the key-set shape. A non-durable job orphaned by `UnscheduleJobs(matcher)` is deleted and is not
named; the answer is about triggers, as `DeleteTriggers(keys)` already had it.

## The store

`IJobStore` gains the pair as **default interface members** that list the matching keys and then
delete them, so a store outside this repository keeps compiling and stays correct. What that default
cannot be is atomic, so both shipped stores override it:

* `RAMJobStore` resolves the matcher with `GetJobKeysNoLock` / `GetTriggerKeysNoLock` inside the lock
  that then walks the existing remove path, and raises one batch of pending signals after releasing it.
* `AdoJobStoreBase` resolves it with `SelectJobKeysInGroup` / `SelectTriggerKeysInGroup` — already on
  `IDriverDelegate` — inside one `SchedulerLock.TriggerAccess` scope and one transaction. No new
  delegate member, no `DbBatch`, no set-based `DELETE`: the per-key cascade stays per key for the
  reason `DeleteJobs(keys)` gives at `AdoJobStoreBase.Store.cs`, that the answer has to name the keys
  it hit and a row count cannot.

`TracingJobStore` reuses `OperationName.JobStore.DeleteJobs` / `DeleteTriggers`, so
`TracingJobStoreTest_SpanNames.verified.txt` does not move — and `ExerciseEveryTracedOperation` now
calls the group forms, which is what pins that.

## Over the wire

`POST …/jobs/delete-by-group` and `POST …/triggers/unschedule-by-group`, taking `PauseJobs`'s four
`group*` query parameters and answering with the existing `AppliedJobKeysResponse` /
`AppliedTriggerKeysResponse`. They carry the suffix because the plain `delete` and `unschedule` paths
were taken by the key-set forms before there was a group form to give them to. Both handlers are
RDG-compatible; `RequestDelegatesAreSourceGeneratedTest`'s per-file route counts go 20 → 21 on each
endpoint class. The dashboard is untouched, per the issue's ruling.

## Tests

* `JobStoreContractTest` — four new cases plus a structural one, so RAM and all six dialects assert
  the same answer: the group empties and names its keys; unscheduling a group takes the non-durable
  jobs it orphans and still names only triggers; every matcher operator selects what a listing would
  (the in-memory store compares strings and the ADO store writes a `LIKE`, so "the same groups" is a
  real claim about two implementations); an unmatched group is an empty list, not a failure; and the
  group members are overridden rather than left to the list-then-delete default.
* `BulkKeySetOperationsTest` — one store call, one signal, one listener event per key, nothing for an
  empty group, and `ArgumentNullException` for a null matcher.
* `JobEndpointsTest` / `TriggerEndpointsTest` — every matcher operator round-trips through
  `MatcherUrlExtensions.ToUrlParameters`, and an empty answer stays empty.

## Baselines and docs

`PublicApiTest_Quartz.verified.txt` (+12 lines) and `PublicApiTest_Quartz.HttpClient.verified.txt`
(+2), regenerated through Verify — the members on `IScheduler`, `IJobStore`, `RAMJobStore`,
`DelegatingJobStore`, `DelegatingScheduler`, `TracingJobStore` and `HttpScheduler`, nothing else.
The migration guide gains "Jobs and triggers can be removed by group", the HTTP API page gains the
two rows and a "A whole group in one call" section, and the one-off-job how-to gains a
`sample_one_off_job_cancel_by_group` region showing the cancel that answers the `Group = customerId`
one-liner two sections above it.

## For a reviewer to decide

The `null` matcher throws here where `PauseJobs(null)` defaults to the default group. That is a
deliberate inconsistency between two group-form families, argued in the XML docs, the guide and a
test; if you would rather have the consistency than the guard, it is one line in each of the four
implementations.

Closes #3523
