### PR TITLE
A trigger retries its failed job on the policy it carries

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4334,6 +4334,43 @@ and no attempt.
 A string that is not a policy is refused where the file is read, rather than scheduling a trigger that
 would never retry.
 
+### What happens when a job fails
+
+A job fails, for retry purposes, when `Execute` throws anything other than a `JobExecutionException`
+that asks for something itself. On failure with attempts left the scheduler sets the trigger's next
+fire time to `now + policy.DelayFor(attempt + 1)`, increments the attempt and hands the job store a new
+instruction, `SchedulerInstruction.RetryTrigger`. Everything else about the trigger is untouched.
+
+| Member | What it is |
+|---|---|
+| `SchedulerInstruction.RetryTrigger` | New enum member, appended — no existing value moved. `ITriggerListener.TriggerComplete` sees it; there is no new listener member |
+| `IJobExecutionContext.RetryAttempt` | `0` on a regular fire, *n* on the *n*-th retry |
+| `TriggerBase.RetryFired(ICalendar?)` | `public virtual`, and only on `TriggerBase` — `IOperableTrigger` is unchanged |
+| `IDriverDelegate.UpdateTriggerForRetry` / `ClearTriggerRetryAttempt` | **Breaking for anything implementing `IDriverDelegate`**; `StdAdoDelegate` implements both `virtual` |
+
+Four rules are worth knowing:
+
+* **A retry never displaces the next scheduled occurrence.** If `retryAt + 1s >= NextFireTimeUtc` the
+  retry is dropped and the occurrence supersedes it, attempt reset. The one-second margin exists because
+  `CalendarIntervalTriggerImpl.GetFireTimeAfter` and `DailyTimeIntervalTriggerImpl.GetFireTimeAfter` add
+  a second before searching. A retry is also never scheduled past the trigger's `EndTimeUtc`.
+* **A retry fire is not a `Triggered()` call.** `RetryFired` advances past the retry instant with the
+  same calendar-skip loop, but touches no counter and leaves `PreviousFireTimeUtc` alone — so a retry
+  burns no repeat count and no RRULE `COUNT` slot, and reports the *original* occurrence as its
+  `ScheduledFireTimeUtc`.
+* **Exhausted attempts go back to the ordinary schedule, not to `TriggerState.Error`.** One bad hour
+  must not kill a cron trigger. A misfired retry gets the trigger's own misfire instruction and the
+  attempt is cleared; there is no retry-specific misfire policy.
+* **`RefireImmediately` is not a zero-delay retry.** It re-runs the job on the same thread inside the
+  same firing, with no delay, no ceiling, nothing persisted and no slot released, and it does not touch
+  `RetryAttempt`. An explicit `RefireImmediately` or `Unschedule*` wins over the trigger's policy. An
+  `OperationCanceledException` from the scheduler's own token never retries — shutdown and interrupt are
+  operator decisions, and a node vanishing mid-execution is what `RequestsRecovery` is for.
+
+One meter, `quartz.trigger.retry`, counts each retry the scheduler schedules, tagged like
+`quartz.trigger.misfire`. Log event `1056` reports the trigger, the attempt and the retry instant at
+`Information`.
+
 ## Trimming annotations
 
 `ScheduleJob<T>`, `AddTrigger<TJob>` and `TriggerBuilder.Create<TJob>()` gained

--- a/src/Quartz.Tests.Unit/Impl/RetryStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RetryStoreTest.cs
@@ -1,0 +1,149 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using FakeItEasy;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// What the in-memory store does with a retry: the round trip from the completion that schedules one
+/// to the acquisition that picks it up, which is where the attempt has to survive.
+/// </summary>
+/// <remarks>
+/// Driven against the store directly rather than through a scheduler, so a failure says which of the
+/// two halves lost the value.
+/// </remarks>
+[TestFixture]
+public class RetryStoreTest
+{
+    private RAMJobStore store;
+    private IJobExecutionContext context;
+
+    [SetUp]
+    public void SetUp()
+    {
+        store = TestJobStores.Ram();
+        context = A.Fake<IJobExecutionContext>();
+    }
+
+    private static JobExecutionException Failure() => new JobExecutionException(new InvalidOperationException("boom"));
+
+    private static IJobDetail Job() => JobBuilder.Create<RetryStoreJob>().WithIdentity("job", "jobs").Build();
+
+    /// <summary>Never executed: these tests drive the store, not a scheduler.</summary>
+    private sealed class RetryStoreJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    private static IOperableTrigger Trigger(RetryPolicy policy)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .StartAt(DateTimeOffset.UtcNow.AddMilliseconds(-10))
+            .WithRetryPolicy(policy)
+            .Build();
+
+        // The scheduler does this when it schedules a job; a test driving the store does it itself, or
+        // the trigger has no fire time and nothing acquires it.
+        trigger.ComputeFirstFireTimeUtc(null);
+        return trigger;
+    }
+
+    private async Task<IOperableTrigger> Fire()
+    {
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = DateTimeOffset.UtcNow.AddHours(2),
+            MaxCount = 1,
+        });
+
+        acquired.Should().ContainSingle("the trigger under test is the only one due");
+
+        List<TriggerFiredResult> results = await store.TriggersFired(acquired);
+        results.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull();
+
+        return acquired[0];
+    }
+
+    [Test]
+    public async Task TheAttemptSurvivesTheCompletionAndComesBackOnTheNextAcquisition()
+    {
+        IJobDetail job = Job();
+        IOperableTrigger trigger = Trigger(RetryPolicy.Fixed(3, TimeSpan.FromMilliseconds(1)));
+        await store.ScheduleJob(job, trigger);
+
+        IOperableTrigger firing = await Fire();
+        firing.RetryAttempt.Should().Be(0, "the first firing is the scheduled occurrence");
+
+        SchedulerInstruction instruction = firing.ExecutionComplete(context, Failure());
+        instruction.Should().Be(SchedulerInstruction.RetryTrigger);
+
+        await store.TriggeredJobComplete(firing, job, instruction);
+
+        (await store.GetTrigger(trigger.Key))!.RetryAttempt.Should().Be(1,
+            "the store writes the attempt it was handed, or a retry restarts from the first wait every time");
+
+        IOperableTrigger retryFiring = await Fire();
+        retryFiring.RetryAttempt.Should().Be(1,
+            "the firing the scheduler is handed carries the attempt, which is what the execution context reports");
+    }
+
+    [Test]
+    public async Task ASuccessfulRetryPutsTheAttemptBackInTheStore()
+    {
+        IJobDetail job = Job();
+        IOperableTrigger trigger = Trigger(RetryPolicy.Fixed(3, TimeSpan.FromMilliseconds(1)));
+        await store.ScheduleJob(job, trigger);
+
+        IOperableTrigger firing = await Fire();
+        await store.TriggeredJobComplete(firing, job, firing.ExecutionComplete(context, Failure()));
+
+        IOperableTrigger retryFiring = await Fire();
+        SchedulerInstruction instruction = retryFiring.ExecutionComplete(context, result: null);
+        instruction.Should().Be(SchedulerInstruction.NoInstruction);
+
+        await store.TriggeredJobComplete(retryFiring, job, instruction);
+
+        (await store.GetTrigger(trigger.Key))!.RetryAttempt.Should().Be(0,
+            "the occurrence is done with, so the next failure starts from the first wait again");
+    }
+
+    [Test]
+    public async Task ARetryFireDoesNotBurnARepeatCount()
+    {
+        IJobDetail job = Job();
+        IOperableTrigger trigger = Trigger(RetryPolicy.Fixed(3, TimeSpan.FromMilliseconds(1)));
+        await store.ScheduleJob(job, trigger);
+
+        IOperableTrigger firing = await Fire();
+        int afterFirstFire = ((ISimpleTrigger) (await store.GetTrigger(trigger.Key))!).TimesTriggered;
+
+        await store.TriggeredJobComplete(firing, job, firing.ExecutionComplete(context, Failure()));
+        await Fire();
+
+        ((ISimpleTrigger) (await store.GetTrigger(trigger.Key))!).TimesTriggered.Should().Be(afterFirstFire,
+            "a retry is a second go at an occurrence that has already been counted");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
@@ -89,6 +89,11 @@ public sealed class TriggeredJobCompleteTest
             FiredTriggerState = TriggerState.None,
             DeletesTrigger = true,
         };
+        // A retry leaves the trigger waiting, exactly as a plain completion does — the difference is
+        // which instant it waits for, and that is written through UpdateTriggerForRetry rather than
+        // through the state transitions this matrix watches. A failed occurrence with attempts left
+        // is not a broken trigger, so nothing here goes to Error or Complete.
+        yield return new CompletionCase(SchedulerInstruction.RetryTrigger);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/RetryEngineTest.cs
+++ b/src/Quartz.Tests.Unit/RetryEngineTest.cs
@@ -1,0 +1,425 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using FakeItEasy;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+using Quartz.Impl.Calendar;
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The retry decision itself: what <c>ExecutionComplete</c> does with a failed job, and what
+/// <c>RetryFired</c> does when the retry it scheduled comes round.
+/// </summary>
+/// <remarks>
+/// Everything here runs against a trigger and a clock, with no store and no scheduler, because the
+/// decision is the trigger's. What the stores do with the instruction is
+/// <see cref="Impl.TriggeredJobCompleteTest" />'s, and the end-to-end behaviour is
+/// <see cref="RetryExecutionTest" />'s.
+/// </remarks>
+[TestFixture]
+public class RetryEngineTest
+{
+    private static readonly DateTimeOffset now = new DateTimeOffset(2026, 3, 1, 10, 0, 0, TimeSpan.Zero);
+
+    private FakeTimeProvider clock;
+    private IJobExecutionContext context;
+
+    [SetUp]
+    public void SetUp()
+    {
+        clock = new FakeTimeProvider(now);
+        context = A.Fake<IJobExecutionContext>();
+    }
+
+    /// <summary>A failure the job did not ask anything about, which is what a thrown exception becomes.</summary>
+    private static JobExecutionException Failure() => new JobExecutionException(new InvalidOperationException("boom"));
+
+    /// <summary>An hourly trigger, fired at 10:00, so its next scheduled occurrence is 11:00.</summary>
+    private IOperableTrigger HourlyTriggerFiredAtTen(RetryPolicy policy)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("hourly", "retries")
+            .ForJob("job", "jobs")
+            .WithCronSchedule("0 0 * * * ?")
+            .StartAt(now.AddDays(-1))
+            .WithRetryPolicy(policy)
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.NextFireTimeUtc = now;
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1), "the fixture is an hourly trigger just fired at 10:00");
+        return trigger;
+    }
+
+    [Test]
+    public void AFailureWithAttemptsLeftSchedulesTheRetry()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, Failure());
+
+        instruction.Should().Be(SchedulerInstruction.RetryTrigger);
+        trigger.NextFireTimeUtc.Should().Be(now.AddMinutes(5), "the retry instant is now plus the policy's first wait");
+        trigger.RetryAttempt.Should().Be(1);
+        trigger.MayFireAgain.Should().BeTrue("a trigger waiting to retry has something left to do");
+    }
+
+    [Test]
+    public void EachFailureTakesTheNextWaitFromThePolicy()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Explicit(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(2), TimeSpan.FromMinutes(4)));
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        trigger.NextFireTimeUtc.Should().Be(now.AddMinutes(1));
+        trigger.RetryAttempt.Should().Be(1);
+
+        // The retry fires, which puts the trigger back on its schedule, and fails again.
+        ((TriggerBase) trigger).RetryFired(null);
+        clock.SetUtcNow(now.AddMinutes(1));
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        trigger.NextFireTimeUtc.Should().Be(now.AddMinutes(3), "the second wait is two minutes, measured from the second failure");
+        trigger.RetryAttempt.Should().Be(2);
+    }
+
+    [Test]
+    public void SuccessPutsTheAttemptBack()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+        trigger.ExecutionComplete(context, Failure());
+        ((TriggerBase) trigger).RetryFired(null);
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, result: null);
+
+        instruction.Should().Be(SchedulerInstruction.NoInstruction);
+        trigger.RetryAttempt.Should().Be(0, "the occurrence is done with, so the next failure starts from the first wait again");
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1), "the schedule is untouched by a retry that worked");
+        ((TriggerBase) trigger).RetryAttemptCleared.Should().BeTrue("the store has a write to make");
+    }
+
+    [Test]
+    public void ExhaustedAttemptsGoBackToTheOrdinaryScheduleAndNotToError()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(2, TimeSpan.FromMinutes(5)));
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        ((TriggerBase) trigger).RetryFired(null);
+        clock.SetUtcNow(now.AddMinutes(5));
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        ((TriggerBase) trigger).RetryFired(null);
+        clock.SetUtcNow(now.AddMinutes(10));
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, Failure());
+
+        instruction.Should().Be(SchedulerInstruction.NoInstruction,
+            "one bad hour must not kill a cron trigger: spent attempts put it back on its schedule, not into Error");
+        trigger.RetryAttempt.Should().Be(0);
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1));
+    }
+
+    [Test]
+    public void ARetryThatWouldPassTheNextOccurrenceIsDropped()
+    {
+        // Ninety minutes is longer than the hour between occurrences, so the 11:00 fire supersedes it.
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(90)));
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, Failure());
+
+        instruction.Should().Be(SchedulerInstruction.NoInstruction);
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1), "the schedule wins; the trigger is not retried twice for one late hour");
+        trigger.RetryAttempt.Should().Be(0);
+    }
+
+    [Test]
+    public void TheSupersedeRuleIsAWholeSecondWideOnBothSides()
+    {
+        // Exactly one second short of the next occurrence: retryAt + 1s == regularNext, which the rule
+        // rejects, because GetFireTimeAfter adds a second before searching and could not tell them apart.
+        IOperableTrigger tooClose = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(60) - TimeSpan.FromSeconds(1)));
+        tooClose.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.NoInstruction);
+        tooClose.RetryAttempt.Should().Be(0);
+
+        // One tick further away, and there is room.
+        IOperableTrigger justFits = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(60) - TimeSpan.FromSeconds(1) - TimeSpan.FromTicks(1)));
+        justFits.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        justFits.RetryAttempt.Should().Be(1);
+    }
+
+    [Test]
+    public void ARetryIsNotScheduledPastTheTriggersEndTime()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("ending", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .StartAt(now)
+            .EndAt(now.AddMinutes(2))
+            .WithRetryPolicy(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, Failure());
+
+        instruction.Should().Be(SchedulerInstruction.DeleteTrigger,
+            "a trigger does not fire after its end time, and a retry is a fire");
+        trigger.RetryAttempt.Should().Be(0);
+    }
+
+    [Test]
+    public void ATriggerWithNoPolicyIsUnchanged()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(policy: null!);
+        trigger.RetryPolicy = null;
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.NoInstruction);
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1));
+        trigger.RetryAttempt.Should().Be(0);
+        ((TriggerBase) trigger).RetryAttemptCleared.Should().BeFalse("nothing was cleared, so the stores have no write to make");
+    }
+
+    [Test]
+    public void ACancellationIsNotAFailureToRetry()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+
+        // What the run shell leaves behind when the job stopped because the scheduler's own token was
+        // cancelled: no JobExecutionException at all. Shutdown and interrupt are operator decisions.
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, result: null);
+
+        instruction.Should().Be(SchedulerInstruction.NoInstruction);
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1));
+        trigger.RetryAttempt.Should().Be(0);
+    }
+
+    [Test]
+    public void RefireImmediatelyWinsAndIsNotARetry()
+    {
+        IOperableTrigger trigger = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, new JobExecutionException { RefireImmediately = true });
+
+        instruction.Should().Be(SchedulerInstruction.ReExecuteJob,
+            "an explicit directive wins over the trigger's policy, and the two are different things");
+        trigger.RetryAttempt.Should().Be(0, "the in-process refire loop is not an attempt at the policy");
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1));
+    }
+
+    [Test]
+    public void UnschedulingWinsOverTheRetryPolicy()
+    {
+        IOperableTrigger firing = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+        firing.ExecutionComplete(context, new JobExecutionException { UnscheduleFiringTrigger = true })
+            .Should().Be(SchedulerInstruction.SetTriggerComplete);
+        firing.RetryAttempt.Should().Be(0);
+
+        IOperableTrigger all = HourlyTriggerFiredAtTen(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)));
+        all.ExecutionComplete(context, new JobExecutionException { UnscheduleAllTriggers = true })
+            .Should().Be(SchedulerInstruction.SetAllJobTriggersComplete);
+        all.RetryAttempt.Should().Be(0);
+    }
+
+    [Test]
+    public void AOneShotTriggerMayStillFireAgainWhileItWaitsToRetry()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("one-shot", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(0))
+            .StartAt(now)
+            .WithRetryPolicy(RetryPolicy.Fixed(1, TimeSpan.FromMinutes(5)))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull("a one-shot trigger has nothing scheduled after its single fire");
+        trigger.MayFireAgain.Should().BeFalse();
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger,
+            "a null next fire time is not the next occurrence winning; there is no occurrence to lose to");
+        trigger.MayFireAgain.Should().BeTrue(
+            "the run shell announces TriggerFinalized off MayFireAgain, and a trigger about to retry is not finished");
+
+        // The retry fires and succeeds, and now it really is finished.
+        ((TriggerBase) trigger).RetryFired(null);
+        trigger.NextFireTimeUtc.Should().BeNull();
+        trigger.ExecutionComplete(context, result: null).Should().Be(SchedulerInstruction.DeleteTrigger);
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // RetryFired
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// <summary>
+    /// Every shipped trigger type, each with a counter or a schedule a retry must not consume.
+    /// </summary>
+    public static IEnumerable<TestCaseData> RetryFiredCases()
+    {
+        DateTimeOffset start = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero);
+
+        yield return new TestCaseData(
+            (Func<TimeProvider, IOperableTrigger>) (clock => (IOperableTrigger) TriggerBuilder.Create(clock)
+                .WithIdentity("simple", "retries").ForJob("job", "jobs")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(5))
+                .StartAt(start).Build())).SetName("SimpleTrigger");
+
+        yield return new TestCaseData(
+            (Func<TimeProvider, IOperableTrigger>) (clock => (IOperableTrigger) TriggerBuilder.Create(clock)
+                .WithIdentity("cron", "retries").ForJob("job", "jobs")
+                .WithCronSchedule("0 0 * * * ?")
+                .StartAt(start).Build())).SetName("CronTrigger");
+
+        yield return new TestCaseData(
+            (Func<TimeProvider, IOperableTrigger>) (clock => (IOperableTrigger) TriggerBuilder.Create(clock)
+                .WithIdentity("calendar", "retries").ForJob("job", "jobs")
+                .WithCalendarIntervalSchedule(x => x.WithInterval(1, IntervalUnit.Hour).InTimeZone(TimeZoneInfo.Utc))
+                .StartAt(start).Build())).SetName("CalendarIntervalTrigger");
+
+        yield return new TestCaseData(
+            (Func<TimeProvider, IOperableTrigger>) (clock => (IOperableTrigger) TriggerBuilder.Create(clock)
+                .WithIdentity("daily", "retries").ForJob("job", "jobs")
+                .WithDailyTimeIntervalSchedule(x => x
+                    .WithInterval(1, IntervalUnit.Hour)
+                    .StartingDailyAt(new TimeOnly(0, 0))
+                    .EndingDailyAt(new TimeOnly(23, 0))
+                    .InTimeZone(TimeZoneInfo.Utc))
+                .StartAt(start).Build())).SetName("DailyTimeIntervalTrigger");
+
+        yield return new TestCaseData(
+            (Func<TimeProvider, IOperableTrigger>) (clock => (IOperableTrigger) TriggerBuilder.Create(clock)
+                .WithIdentity("recurrence", "retries").ForJob("job", "jobs")
+                .WithRecurrenceSchedule("FREQ=HOURLY;COUNT=5", x => x.InTimeZone(TimeZoneInfo.Utc))
+                .StartAt(start).Build())).SetName("RecurrenceTrigger");
+    }
+
+    /// <summary>
+    /// The whole point of <c>RetryFired</c>: a retry is another attempt at an occurrence that has
+    /// already been counted, so firing one must land the trigger back on the very occurrence it was
+    /// already heading for, without burning a repeat count or an RRULE slot.
+    /// </summary>
+    [TestCaseSource(nameof(RetryFiredCases))]
+    public void RetryFiredLandsOnTheSameOccurrenceTriggeredWouldHave(Func<TimeProvider, IOperableTrigger> build)
+    {
+        IOperableTrigger trigger = build(clock);
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        DateTimeOffset regularNext = trigger.NextFireTimeUtc.Should().NotBeNull().And.Subject!.Value;
+        DateTimeOffset? previousFire = trigger.PreviousFireTimeUtc;
+
+        // What a scheduled retry looks like on the trigger, a minute before the occurrence is due.
+        DateTimeOffset retryAt = regularNext.AddMinutes(-1);
+        trigger.NextFireTimeUtc = retryAt;
+
+        ((TriggerBase) trigger).RetryFired(null);
+
+        trigger.NextFireTimeUtc.Should().Be(regularNext,
+            "a retry sits between two occurrences, so the schedule after it is the occurrence that was already due");
+        trigger.PreviousFireTimeUtc.Should().Be(previousFire,
+            "a retry reports the original occurrence as its scheduled fire time, so it does not move the previous fire");
+    }
+
+    [Test]
+    public void RetryFiredBurnsNoRepeatCount()
+    {
+        SimpleTriggerImpl trigger = (SimpleTriggerImpl) TriggerBuilder.Create(clock)
+            .WithIdentity("simple", "retries").ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(5))
+            .StartAt(now).Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        int afterOneFire = trigger.TimesTriggered;
+        trigger.NextFireTimeUtc = now.AddMinutes(30);
+
+        trigger.RetryFired(null);
+
+        trigger.TimesTriggered.Should().Be(afterOneFire,
+            "a repeat count counts occurrences, and a retry is a second go at one that has already been counted");
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1));
+    }
+
+    [Test]
+    public void RetryFiredSkipsAnExcludedOccurrenceTheSameWayTriggeredDoes()
+    {
+        // A calendar that excludes the whole of the hour the next occurrence falls in.
+        DailyCalendar calendar = new DailyCalendar(new TimeOnly(11, 0, 0), new TimeOnly(11, 59, 59))
+        {
+            // The trigger's fire times are UTC, and a calendar reads its range in its own zone: left
+            // at the machine's, this excludes some other hour and the test proves nothing.
+            TimeZone = TimeZoneInfo.Utc,
+            InvertTimeRange = false
+        };
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("cron", "retries").ForJob("job", "jobs")
+            .WithCronSchedule("0 0 * * * ?")
+            .StartAt(now.AddDays(-1))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.NextFireTimeUtc = now;
+        trigger.Triggered(calendar);
+
+        DateTimeOffset regularNext = trigger.NextFireTimeUtc!.Value;
+        regularNext.Should().Be(now.AddHours(2), "11:00 is excluded, so Triggered skipped to 12:00");
+
+        trigger.NextFireTimeUtc = now.AddMinutes(5);
+        ((TriggerBase) trigger).RetryFired(calendar);
+
+        trigger.NextFireTimeUtc.Should().Be(regularNext,
+            "the retry fire applies the calendar exactly as the regular fire did, or the two would disagree about the schedule");
+    }
+
+    [Test]
+    public void ADailyTimeIntervalTriggerThatRunsOutWhileRetryingIsFinished()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("daily", "retries").ForJob("job", "jobs")
+            .WithDailyTimeIntervalSchedule(x => x
+                .WithInterval(1, IntervalUnit.Hour)
+                .StartingDailyAt(new TimeOnly(10, 0))
+                .EndingDailyAt(new TimeOnly(10, 0))
+                .InTimeZone(TimeZoneInfo.Utc))
+            .StartAt(now)
+            .EndAt(now.AddMinutes(30))
+            .WithRetryPolicy(RetryPolicy.Fixed(1, TimeSpan.FromMinutes(5)))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull("the trigger's end time is before its next daily slot");
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        trigger.MayFireAgain.Should().BeTrue();
+
+        ((TriggerBase) trigger).RetryFired(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull();
+        trigger.MayFireAgain.Should().BeFalse(
+            "this trigger records having run out of schedule in a flag of its own, and the retry fire has to set it too");
+    }
+}

--- a/src/Quartz.Tests.Unit/RetryExecutionTest.cs
+++ b/src/Quartz.Tests.Unit/RetryExecutionTest.cs
@@ -1,0 +1,253 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// A job that actually fails and is actually retried, through a real scheduler and the in-memory
+/// store — the decision, the store write, the second firing and what an operator sees.
+/// </summary>
+/// <remarks>
+/// The waits are short enough for a test to sit through, which is the only concession made: nothing
+/// here fakes a clock, because the point is that the scheduling loop picks the retry up on its own.
+/// </remarks>
+[NonParallelizable]
+public sealed class RetryExecutionTest
+{
+    // Spelled out rather than read from the constant the product publishes it from: the wire name is
+    // what a dashboard is written against, and reading both sides from one constant would let a
+    // rename pass unnoticed.
+    private const string RetryCounter = "quartz.trigger.retry";
+
+    private readonly ConcurrentBag<RetryMeasurement> measurements = [];
+    private MeterListener meterListener;
+
+    private sealed record RetryMeasurement(string Instrument, string Unit, long Value, Dictionary<string, object> Tags);
+
+    [SetUp]
+    public void SetUp()
+    {
+        measurements.Clear();
+
+        meterListener = new MeterListener
+        {
+            InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == QuartzInstrumentation.MeterName && instrument.Name == RetryCounter)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, _) =>
+        {
+            Dictionary<string, object> copy = new(tags.Length, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, object> tag in tags)
+            {
+                copy[tag.Key] = tag.Value;
+            }
+
+            measurements.Add(new RetryMeasurement(instrument.Name, instrument.Unit, value, copy));
+        });
+        meterListener.Start();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        meterListener?.Dispose();
+    }
+
+    /// <summary>
+    /// A job that throws the first <c>failures</c> times it is asked, and records what it was told
+    /// about each firing.
+    /// </summary>
+    private sealed class FlakyJob : IJob
+    {
+        internal static readonly ConcurrentQueue<(int RetryAttempt, int RefireCount, DateTimeOffset? ScheduledFireTimeUtc)> Firings = new();
+        internal static readonly SemaphoreSlim Succeeded = new(0);
+        internal static int RemainingFailures;
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Firings.Enqueue((context.RetryAttempt, context.RefireCount, context.ScheduledFireTimeUtc));
+
+            if (Interlocked.Decrement(ref RemainingFailures) >= 0)
+            {
+                throw new InvalidOperationException("not this time");
+            }
+
+            Succeeded.Release();
+            return default;
+        }
+    }
+
+    [Test]
+    public async Task AFailedJobIsRetriedOnItsPolicyAndTheContextSaysWhichAttemptItIs()
+    {
+        FlakyJob.Firings.Clear();
+        FlakyJob.RemainingFailures = 2;
+
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"flaky-{id}", "retries");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"retry-{id}");
+            quartz.AddJob<FlakyJob>(job => job.WithIdentity(jobKey));
+            quartz.AddTrigger<FlakyJob>(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity($"trigger-{id}", "retries")
+                // Exactly one scheduled occurrence, so every firing after the first is a retry and
+                // nothing else. A repeating trigger started with StartNow fires twice here before any
+                // retry is involved, which would make the count ambiguous.
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(0))
+                .StartNow()
+                .WithRetryPolicy(RetryPolicy.Fixed(3, TimeSpan.FromMilliseconds(300))));
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        try
+        {
+            await scheduler.Start();
+
+            (await FlakyJob.Succeeded.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the job should have failed twice, been retried twice, and then succeeded");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        (int RetryAttempt, int RefireCount, DateTimeOffset? ScheduledFireTimeUtc)[] firings = [.. FlakyJob.Firings];
+
+        firings.Should().HaveCount(3, "one regular fire and two retries");
+        firings.Select(x => x.RetryAttempt).Should().Equal([0, 1, 2],
+            "the context reports which attempt at this occurrence the firing is: 0 on the regular fire, n on the n-th retry");
+        firings.Select(x => x.RefireCount).Should().AllBeEquivalentTo(0,
+            "a retry is a fresh firing, not an iteration of the in-process refire loop, so RefireCount stays where it was");
+        firings.Select(x => x.ScheduledFireTimeUtc).Distinct().Should().ContainSingle(
+            "a retry is another attempt at one occurrence, so all three firings report the occurrence the schedule "
+            + "called for - which is what leaving PreviousFireTimeUtc alone buys");
+    }
+
+    [Test]
+    public async Task EachScheduledRetryIsCounted()
+    {
+        FlakyJob.Firings.Clear();
+        FlakyJob.RemainingFailures = 1;
+
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"counted-{id}", "retries");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"retry-meter-{id}");
+            quartz.AddJob<FlakyJob>(job => job.WithIdentity(jobKey));
+            quartz.AddTrigger<FlakyJob>(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity($"trigger-{id}", "retries")
+                .WithExecutionGroup("heavy")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(0))
+                .StartNow()
+                .WithRetryPolicy(RetryPolicy.Fixed(2, TimeSpan.FromMilliseconds(300))));
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        try
+        {
+            await scheduler.Start();
+            (await FlakyJob.Succeeded.WaitAsync(TimeSpan.FromSeconds(30))).Should().BeTrue();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        RetryMeasurement retry = measurements
+            .Where(m => Equals(m.Tags.GetValueOrDefault("quartz.scheduler.id"), scheduler.SchedulerInstanceId))
+            .Should().ContainSingle("one retry was scheduled, so one measurement was published")
+            .Subject;
+
+        retry.Value.Should().Be(1);
+        retry.Unit.Should().Be("{trigger}");
+        retry.Tags.Should().Contain(new KeyValuePair<string, object>("quartz.trigger.group", "retries"))
+            .And.Contain(new KeyValuePair<string, object>("quartz.execution.group", "heavy"));
+        retry.Tags.Should().NotContainKey("quartz.trigger.name",
+            "a job limping along on its retries is a property of a group, and one series per trigger is a "
+            + "cardinality no alert can be built on");
+    }
+
+    [Test]
+    public async Task ATriggerWithNoPolicyIsNotRetriedAndNothingIsCounted()
+    {
+        FlakyJob.Firings.Clear();
+
+        // Fails every time it is asked. Without a policy it is fired once and that is that.
+        FlakyJob.RemainingFailures = int.MaxValue;
+
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"unpolicied-{id}", "retries");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"retry-none-{id}");
+            quartz.AddJob<FlakyJob>(job => job.WithIdentity(jobKey));
+            quartz.AddTrigger<FlakyJob>(trigger => trigger
+                .ForJob(jobKey)
+                .WithIdentity($"trigger-{id}", "retries")
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(0))
+                .StartNow());
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        string instanceId = scheduler.SchedulerInstanceId;
+
+        try
+        {
+            await scheduler.Start();
+
+            // Long enough that a retry on any plausible policy would have fired by now.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        FlakyJob.Firings.Should().HaveCount(1, "a trigger with no retry policy fires once and reports the failure");
+        measurements.Where(m => Equals(m.Tags.GetValueOrDefault("quartz.scheduler.id"), instanceId))
+            .Should().BeEmpty("nothing was retried, so nothing was counted");
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -64,6 +64,8 @@
     "Trigger instruction : {InstructionCode}"
 1055  Debug  CoreLog.TriggerRefiring
     "Rescheduling trigger to reexecute"
+1056  Information  CoreLog.TriggerRetryScheduled
+    "Job of trigger {TriggerKey} failed; retry {Attempt} of {MaxAttempts} scheduled for {RetryTimeUtc}"
 1070  Information  CoreLog.SchedulerSignalerInitialized
     "Initialized Scheduler Signaller of type: {Type}"
 1071  Error  CoreLog.ListenerNotificationOfMisfireFailed

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -524,6 +524,7 @@ namespace Quartz
         Quartz.TriggerKey? RecoveringTriggerKey { get; }
         int RefireCount { get; }
         object? Result { get; set; }
+        int RetryAttempt { get; }
         System.DateTimeOffset? ScheduledFireTimeUtc { get; }
         Quartz.IScheduler Scheduler { get; }
         Quartz.ITrigger Trigger { get; }
@@ -1581,6 +1582,7 @@ namespace Quartz
         SetAllJobTriggersComplete = 4,
         SetAllJobTriggersError = 5,
         SetTriggerError = 6,
+        RetryTrigger = 7,
     }
     public static class SchedulerJobExtensions
     {
@@ -2574,6 +2576,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask<bool> CalendarIsReferenced(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ClearData(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ClearMisfireOriginalFireTime(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> ClearTriggerRetryAttempt(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountTriggersForJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask CreateSchema(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default);
@@ -2648,6 +2651,7 @@ namespace Quartz.Impl.AdoJobStore
         System.Threading.Tasks.ValueTask UpdateMisfiredTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Collections.Generic.IReadOnlyList<Quartz.Impl.AdoJobStore.MisfiredTriggerUpdate> updates, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> UpdateSchedulerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string instanceId, System.DateTimeOffset checkInTime, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> UpdateTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> UpdateTriggerForRetry(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState newState, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> UpdateTriggerGroupStateFromOtherState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.GroupMatcher<Quartz.TriggerKey> matcher, Quartz.Extensibility.StoredTriggerState newState, Quartz.Extensibility.StoredTriggerState oldState, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> UpdateTriggerGroupStateFromOtherStates(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.GroupMatcher<Quartz.TriggerKey> matcher, Quartz.Extensibility.StoredTriggerState newState, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.StoredTriggerState> oldStates, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> UpdateTriggerPreferredNodeConditional(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.Impl.AdoJobStore.PreferredNodeTransition transition, System.Threading.CancellationToken cancellationToken = default);
@@ -2924,6 +2928,7 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask<bool> CalendarIsReferenced(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ClearData(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ClearMisfireOriginalFireTime(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<int> ClearTriggerRetryAttempt(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected virtual System.Collections.Generic.Dictionary<string, object?> ConvertFromProperty(System.Collections.Specialized.NameValueCollection properties) { }
         protected virtual System.Collections.Specialized.NameValueCollection ConvertToProperty(System.Collections.Generic.IDictionary<string, object?> data) { }
         public virtual System.Threading.Tasks.ValueTask<int> CountMisfiredTriggersInState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.StoredTriggerState state, System.DateTimeOffset misfireTime, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3031,6 +3036,7 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask UpdateMisfiredTriggers(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Collections.Generic.IReadOnlyList<Quartz.Impl.AdoJobStore.MisfiredTriggerUpdate> updates, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> UpdateSchedulerState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string instanceId, System.DateTimeOffset checkInTime, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> UpdateTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState state, Quartz.IJobDetail jobDetail, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<int> UpdateTriggerForRetry(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger trigger, Quartz.Extensibility.StoredTriggerState newState, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> UpdateTriggerGroupStateFromOtherState(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.GroupMatcher<Quartz.TriggerKey> matcher, Quartz.Extensibility.StoredTriggerState newState, Quartz.Extensibility.StoredTriggerState oldState, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> UpdateTriggerGroupStateFromOtherStates(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.GroupMatcher<Quartz.TriggerKey> matcher, Quartz.Extensibility.StoredTriggerState newState, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.StoredTriggerState> oldStates, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<int> UpdateTriggerPreferredNodeConditional(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, Quartz.Impl.AdoJobStore.PreferredNodeTransition transition, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3490,6 +3496,7 @@ namespace Quartz.Impl
         public Quartz.TriggerKey? RecoveringTriggerKey { get; }
         public int RefireCount { get; }
         public object? Result { get; set; }
+        public int RetryAttempt { get; }
         public System.DateTimeOffset? ScheduledFireTimeUtc { get; }
         public Quartz.IScheduler Scheduler { get; }
         public Quartz.ITrigger Trigger { get; }
@@ -3726,6 +3733,7 @@ namespace Quartz.Impl.Triggers
         public override System.DateTimeOffset? ComputeFirstFireTimeUtc(Quartz.ICalendar? calendar) { }
         public override System.DateTimeOffset? GetFireTimeAfter(System.DateTimeOffset? afterTime) { }
         public override Quartz.IScheduleBuilder GetScheduleBuilder() { }
+        public override void RetryFired(Quartz.ICalendar? calendar) { }
         public override void Triggered(Quartz.ICalendar? calendar) { }
         public override void UpdateAfterMisfire(Quartz.ICalendar? calendar) { }
         public override void UpdateWithNewCalendar(Quartz.ICalendar calendar, System.TimeSpan misfireThreshold) { }
@@ -3815,6 +3823,7 @@ namespace Quartz.Impl.Triggers
         public override int GetHashCode() { }
         public abstract Quartz.IScheduleBuilder GetScheduleBuilder();
         public Quartz.TriggerBuilder<Quartz.IJob> GetTriggerBuilder() { }
+        public virtual void RetryFired(Quartz.ICalendar? calendar) { }
         public override string ToString() { }
         public abstract void Triggered(Quartz.ICalendar? calendar);
         public abstract void UpdateAfterMisfire(Quartz.ICalendar? calendar);

--- a/src/Quartz/Core/CoreLog.cs
+++ b/src/Quartz/Core/CoreLog.cs
@@ -136,6 +136,9 @@ internal static partial class CoreLog
     [LoggerMessage(EventId = 1055, Level = LogLevel.Debug, Message = "Rescheduling trigger to reexecute")]
     public static partial void TriggerRefiring(this ILogger logger);
 
+    [LoggerMessage(EventId = 1056, Level = LogLevel.Information, Message = "Job of trigger {TriggerKey} failed; retry {Attempt} of {MaxAttempts} scheduled for {RetryTimeUtc}")]
+    public static partial void TriggerRetryScheduled(this ILogger logger, TriggerKey triggerKey, int attempt, int maxAttempts, DateTimeOffset retryTimeUtc);
+
     [LoggerMessage(EventId = 1070, Level = LogLevel.Information, Message = "Initialized Scheduler Signaller of type: {Type}")]
     public static partial void SchedulerSignalerInitialized(this ILogger logger, Type type);
 

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -274,6 +274,20 @@ internal sealed class JobRunShell
                     {
                         logger.TriggerInstructionDecided(instructionCode);
                     }
+
+                    if (instructionCode == SchedulerInstruction.RetryTrigger)
+                    {
+                        // Reported at Information, unlike the instruction itself: a job that keeps
+                        // failing and retrying is the thing an operator wants in the log without
+                        // turning Debug on, and the retry instant is what tells them when to look.
+                        logger.TriggerRetryScheduled(
+                            trigger.Key,
+                            trigger.RetryAttempt,
+                            trigger.RetryPolicy?.MaxAttempts ?? 0,
+                            trigger.NextFireTimeUtc.GetValueOrDefault());
+
+                        qs.resources.Meters.TriggerRetryScheduled(qs.resources.Name, qs.resources.InstanceId, trigger);
+                    }
                 }
                 catch (Exception e)
                 {

--- a/src/Quartz/Diagnostics/Meters.cs
+++ b/src/Quartz/Diagnostics/Meters.cs
@@ -34,6 +34,7 @@ internal sealed class Meters
     private readonly UpDownCounter<long> jobExecuteInProgress;
     private readonly Histogram<double> jobExecuteDuration;
     private readonly Counter<long> triggerMisfires;
+    private readonly Counter<long> triggerRetries;
     private readonly Histogram<double> triggerAcquisitionDuration;
     private readonly Counter<long> triggersAcquired;
     private readonly Histogram<double> clusterCheckinDuration;
@@ -61,6 +62,12 @@ internal sealed class Meters
         // wants an alert on. Counted once per trigger the scheduler is told misfired, wherever the store
         // noticed it: the notification is what every store has in common.
         triggerMisfires = meter.CreateCounter<long>("quartz.trigger.misfire", "{trigger}", "Number of trigger misfires the scheduler was notified of");
+
+        // A retry is a fire that happened, failed, and is being attempted again — the other half of the
+        // picture a misfire count gives, and the number that says whether a job is limping along on its
+        // retries rather than working. Counted once per retry the scheduler schedules, not per attempt
+        // configured, so a policy that never has to be used contributes nothing.
+        triggerRetries = meter.CreateCounter<long>("quartz.trigger.retry", "{trigger}", "Number of trigger retries the scheduler scheduled after a job failed");
 
         // How long the scheduling loop waits on its store for the next batch. This is the round trip the
         // loop cannot overlap with anything, so it is what a slow or contended store shows up as.
@@ -160,6 +167,33 @@ internal sealed class Meters
         }
 
         triggerMisfires.Add(1, tags);
+    }
+
+    /// <summary>
+    /// One retry the scheduler has just scheduled for a trigger whose job failed.
+    /// </summary>
+    internal void TriggerRetryScheduled(string schedulerName, string schedulerId, ITrigger trigger)
+    {
+        if (!triggerRetries.Enabled)
+        {
+            return;
+        }
+
+        // The same tags a misfire carries, and for the same reason: one series per trigger is a
+        // cardinality nobody can alert on, and retries cluster by group and by execution group.
+        TagList tags = new()
+        {
+            { ActivityTags.SchedulerName, schedulerName },
+            { ActivityTags.SchedulerId, schedulerId },
+            { ActivityTags.TriggerGroup, trigger.Key.Group },
+        };
+
+        if (trigger.ExecutionGroup is { } executionGroup)
+        {
+            tags.Add(ActivityTags.ExecutionGroup, executionGroup);
+        }
+
+        triggerRetries.Add(1, tags);
     }
 
     /// <summary>

--- a/src/Quartz/IJobExecutionContext.cs
+++ b/src/Quartz/IJobExecutionContext.cs
@@ -52,6 +52,25 @@ public interface IJobExecutionContext
     int RefireCount { get; }
 
     /// <summary>
+    /// How many times this occurrence has already been retried under the trigger's
+    /// <see cref="ITrigger.RetryPolicy" />: <c>0</c> on a regular fire, <c>n</c> on the <c>n</c>-th
+    /// retry.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Distinct from <see cref="RefireCount" />, which counts iterations of the in-process refire
+    /// loop within a single firing — same context, same thread, nothing persisted. A retry is a
+    /// fresh firing at a later instant, recorded in the job store, and it releases the execution
+    /// slot while it waits.
+    /// </para>
+    /// <para>
+    /// <c>0</c> for every trigger with no retry policy, which is the default.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Quartz.RetryPolicy" />
+    int RetryAttempt { get; }
+
+    /// <summary>
     /// Get the convenience <see cref="JobDataMap" /> of this execution context.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Acquisition.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Acquisition.cs
@@ -574,8 +574,18 @@ public abstract partial class AdoJobStoreBase
 
         DateTimeOffset? prevFireTime = trigger.PreviousFireTimeUtc;
 
-        // call triggered - to update the trigger's next-fire-time state...
-        trigger.Triggered(calendar);
+        // call triggered - to update the trigger's next-fire-time state. A trigger carrying a retry
+        // attempt is being fired for a retry rather than for a scheduled occurrence, so it advances
+        // past the retry instant without burning a count or moving its previous fire time - the same
+        // dispatch on TriggerBase the misfire original fire time above uses.
+        if (trigger.RetryAttempt > 0 && trigger is TriggerBase retryingTrigger)
+        {
+            retryingTrigger.RetryFired(calendar);
+        }
+        else
+        {
+            trigger.Triggered(calendar);
+        }
 
         StoredTriggerState state2 = StoredTriggerState.Waiting;
         bool force = true;

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Completion.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Completion.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using Quartz.Extensibility;
+using Quartz.Impl.Triggers;
 
 namespace Quartz.Impl.AdoJobStore;
 
@@ -135,6 +136,24 @@ public abstract partial class AdoJobStoreBase
                     await Delegate.UpdateTriggerStatesForJob(conn, trigger.JobKey, StoredTriggerState.Error, cancellationToken).ConfigureAwait(false);
                     conn.SignalSchedulingChangeOnTxCompletion = SchedulerConstants.SchedulingSignalDateTime;
                 }
+                else if (triggerInstructionCode == SchedulerInstruction.RetryTrigger)
+                {
+                    // The occurrence failed and the trigger has attempts left, so its next fire time is
+                    // the retry instant ExecutionComplete put on it. The row goes back to waiting - or
+                    // to paused, if the group is, because a retry waits with everything else in it.
+                    //
+                    // Written before the DisallowConcurrentExecution unblock below, which transitions
+                    // from BLOCKED and PAUSED_BLOCKED and so leaves this row alone now that it holds
+                    // the state it is going to wait in.
+                    StoredTriggerState retryState = await ApplyPausedTriggerGroupState(
+                        conn,
+                        trigger.Key.Group,
+                        StoredTriggerState.Waiting,
+                        cancellationToken).ConfigureAwait(false);
+
+                    await Delegate.UpdateTriggerForRetry(conn, trigger, retryState, cancellationToken).ConfigureAwait(false);
+                    conn.SignalSchedulingChangeOnTxCompletion = SchedulerConstants.SchedulingSignalDateTime;
+                }
                 else if (!trigger.NextFireTimeUtc.HasValue)
                 {
                     // Every instruction that settles the trigger is above, so what reaches here is a
@@ -155,6 +174,14 @@ public abstract partial class AdoJobStoreBase
                         // trigger with a fire time ahead of it is nobody's leftover.
                         await DeleteTrigger(conn, trigger.Key, jobDetail, cancellationToken).ConfigureAwait(false);
                     }
+                }
+
+                // The occurrence is done with its retries — it succeeded, spent them, or was never going
+                // to get one — so the row stops counting. Only when the count was actually non-zero,
+                // which is what RetryAttemptCleared says, so an ordinary completion costs no statement.
+                if (trigger is TriggerBase completed && completed.RetryAttemptCleared)
+                {
+                    await Delegate.ClearTriggerRetryAttempt(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
                 }
 
                 if (jobDetail.ConcurrentExecutionDisallowed)

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Misfire.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Misfire.cs
@@ -185,6 +185,12 @@ public abstract partial class AdoJobStoreBase
 
         trigger.UpdateAfterMisfire(calendar);
 
+        // The occurrence that was waiting to be retried has been missed, and misfire handling has just
+        // recomputed the trigger from its schedule. Whatever it fires next is a fresh occurrence, so it
+        // starts with no retries behind it; the trigger's own misfire instruction decides what that
+        // fire is, and there is deliberately no retry-specific misfire policy.
+        trigger.RetryAttempt = 0;
+
         // Determine new state.
         DateTimeOffset? newFireTime = trigger.NextFireTimeUtc;
         StoredTriggerState newState = newFireTime.HasValue ? newStateIfNotComplete : StoredTriggerState.Complete;

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -1318,6 +1318,47 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Writes the retry a completing trigger has just scheduled for itself: where it fires next, how
+    /// many attempts at the current occurrence are behind it, and the state it waits in.
+    /// </summary>
+    /// <remarks>
+    /// Narrow on purpose. The trigger's schedule has not changed — only which instant it fires at
+    /// next — so the generic trigger UPDATE would write a row's worth of columns to move one, and
+    /// would write back a preferred node and a job data map this path has no business touching.
+    /// </remarks>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="trigger">
+    /// The completing trigger, carrying the retry instant as its next fire time and the incremented
+    /// attempt.
+    /// </param>
+    /// <param name="newState">The state to leave the trigger in — waiting, or paused if its group is.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>How many rows were updated.</returns>
+    /// <seealso cref="SchedulerInstruction.RetryTrigger" />
+    ValueTask<int> UpdateTriggerForRetry(
+        ConnectionAndTransactionHolder conn,
+        IOperableTrigger trigger,
+        StoredTriggerState newState,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Puts a trigger's retry attempt back to zero, leaving everything else about the row alone.
+    /// </summary>
+    /// <remarks>
+    /// The other end of <see cref="UpdateTriggerForRetry" />: the occurrence is done with, whether it
+    /// succeeded or spent its attempts. Issued only when the attempt was actually non-zero, so an
+    /// ordinary completion still costs no extra statement.
+    /// </remarks>
+    /// <param name="conn">The DB connection.</param>
+    /// <param name="triggerKey">The trigger to clear.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>How many rows were updated.</returns>
+    ValueTask<int> ClearTriggerRetryAttempt(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Selects the misfired triggers to recover as fully populated triggers, rather than as keys that the
     /// caller then has to read back one at a time. Same predicate and ordering as
     /// <see cref="CountMisfiredTriggersInState" />.

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -1047,14 +1047,26 @@ internal static class StdAdoConstants
     public static readonly string SqlUpdateTriggerStatesFromOtherStatesPrefix =
         Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnTriggerState} = @{SqlParameters.NewState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
+    // A retry, written at completion. Narrow on purpose: the trigger's schedule has not changed, only
+    // where it fires next and how many attempts at the current occurrence are behind it. The state
+    // goes with them because the completing trigger is leaving whatever state its firing left it in.
+    public static readonly string SqlUpdateTriggerForRetry =
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnRetryAttempt} = @{SqlParameters.TriggerRetryAttempt}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
+
+    // The other end of a retry: the occurrence is done with, so the count goes back to zero and
+    // nothing else about the trigger is touched — its state and fire times are whatever its firing
+    // already made them.
+    public static readonly string SqlClearTriggerRetryAttempt =
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnRetryAttempt} = 0 WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
+
     public static readonly string SqlUpdateMisfireOrigFireTime =
         Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnMisfireOriginalFireTime} = @{SqlParameters.MisfireOrigFireTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     // Targeted misfire recovery UPDATE — only touches columns that change during UpdateAfterMisfire.
     // START_TIME is included because SimpleTrigger's RescheduleNowWith* policies modify it.
     public static readonly string SqlUpdateTriggerMisfire =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnRetryAttempt} = @{SqlParameters.TriggerRetryAttempt} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 
     public static readonly string SqlUpdateTriggerMisfireWithOrigFireTime =
-        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnMisfireOriginalFireTime} = @{SqlParameters.TriggerMisfireOrigFireTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
+        Invariant($"UPDATE {TablePrefixSubst}{AdoConstants.TableTriggers} SET {AdoConstants.ColumnNextFireTime} = @{SqlParameters.TriggerNextFireTime}, {AdoConstants.ColumnPreviousFireTime} = @{SqlParameters.TriggerPreviousFireTime}, {AdoConstants.ColumnTriggerState} = @{SqlParameters.TriggerState}, {AdoConstants.ColumnStartTime} = @{SqlParameters.TriggerStartTime}, {AdoConstants.ColumnRetryAttempt} = @{SqlParameters.TriggerRetryAttempt}, {AdoConstants.ColumnMisfireOriginalFireTime} = @{SqlParameters.TriggerMisfireOrigFireTime} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND {AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup}");
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -2141,6 +2141,41 @@ public partial class StdAdoDelegate
         }
     }
 
+    /// <inheritdoc />
+    public virtual async ValueTask<int> UpdateTriggerForRetry(
+        ConnectionAndTransactionHolder conn,
+        IOperableTrigger trigger,
+        StoredTriggerState newState,
+        CancellationToken cancellationToken = default)
+    {
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerForRetry));
+
+        // Statement order.
+        AddCommandParameter(cmd, SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc));
+        AddCommandParameter(cmd, SqlParameters.TriggerRetryAttempt, trigger.RetryAttempt);
+        AddCommandParameter(cmd, SqlParameters.TriggerState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
+
+        return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public virtual async ValueTask<int> ClearTriggerRetryAttempt(
+        ConnectionAndTransactionHolder conn,
+        TriggerKey triggerKey,
+        CancellationToken cancellationToken = default)
+    {
+        using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlClearTriggerRetryAttempt));
+
+        AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
+        AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
+        AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
+
+        return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
     //---------------------------------------------------------------------------
     // batched misfire recovery
     //---------------------------------------------------------------------------
@@ -2493,7 +2528,10 @@ public partial class StdAdoDelegate
             new(SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
             new(SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
             new(SqlParameters.TriggerState, update.NewState.ToStoredValue()),
-            new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc))
+            new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc)),
+            // Misfire handling recomputed the trigger from its schedule, so the occurrence that was
+            // waiting to be retried is gone and the attempt goes with it.
+            new(SqlParameters.TriggerRetryAttempt, trigger.RetryAttempt)
         ];
 
         if (writeMisfireOrigFireTime)

--- a/src/Quartz/Impl/JobExecutionContextImpl.cs
+++ b/src/Quartz/Impl/JobExecutionContextImpl.cs
@@ -172,6 +172,16 @@ public sealed class JobExecutionContextImpl : IInterruptableJobExecutionContext,
     public int RefireCount => numRefires;
 
     /// <summary>
+    /// How many times this occurrence has already been retried under the trigger's retry policy.
+    /// </summary>
+    /// <remarks>
+    /// Read from the trigger this firing was handed, which is the copy the job store fired: the store
+    /// wrote the attempt when it scheduled the retry and read it back when it acquired the trigger, so
+    /// this is the count as the store has it and not something the run shell keeps.
+    /// </remarks>
+    public int RetryAttempt => Trigger.RetryAttempt;
+
+    /// <summary>
     /// Get the convenience <see cref="JobDataMap" /> of this execution context.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -569,8 +569,7 @@ public sealed class RAMJobStore : IJobStore
         // add to triggers by FQN map
         triggersByKey[tw.TriggerKey] = tw;
 
-        if (pausedTriggerGroups.Contains(tw.TriggerKey.Group) ||
-            (pausedJobGroups.Contains(tw.JobKey.Group) && !resumedJobsInPausedGroups.Contains(tw.JobKey)))
+        if (IsTriggerGroupPausedNoLock(tw))
         {
             tw.state = StoredTriggerState.Paused;
             if (blockedJobs.Contains(tw.JobKey))
@@ -586,6 +585,19 @@ public sealed class RAMJobStore : IJobStore
         {
             timeTriggers.Add(tw);
         }
+    }
+
+    /// <summary>
+    /// Whether the trigger is in a group that is paused, either directly or through its job's group.
+    /// </summary>
+    /// <remarks>
+    /// A job group resumed for this particular job does not count as paused, which is what
+    /// <c>resumedJobsInPausedGroups</c> records.
+    /// </remarks>
+    private bool IsTriggerGroupPausedNoLock(TriggerWrapper tw)
+    {
+        return pausedTriggerGroups.Contains(tw.TriggerKey.Group)
+               || (pausedJobGroups.Contains(tw.JobKey.Group) && !resumedJobsInPausedGroups.Contains(tw.JobKey));
     }
 
     /// <summary>
@@ -2536,6 +2548,12 @@ public sealed class RAMJobStore : IJobStore
 
         tw.Trigger.UpdateAfterMisfire(calendar);
 
+        // The occurrence that was waiting to be retried has been missed, and misfire handling has just
+        // recomputed the trigger from its schedule. Whatever it fires next is a fresh occurrence, so
+        // it starts with no retries behind it; the trigger's own misfire instruction decides what that
+        // fire is, and there is deliberately no retry-specific misfire policy.
+        tw.Trigger.RetryAttempt = 0;
+
         // Only save for "fire now" misfire policies (FireOnceNow, FireNow, RescheduleNowWith*).
         // These set nextFireTimeUtc to ~now. "Reschedule next" policies (DoNothing,
         // RescheduleNextWith*) set it to a future schedule time where the existing code
@@ -2856,9 +2874,21 @@ public sealed class RAMJobStore : IJobStore
                 // execution listing reports it, and Triggered() is about to move it on.
                 DateTimeOffset? firingScheduledTime = trigger.NextFireTimeUtc;
 
-                // call triggered on our copy, and the scheduler's copy
-                tw.Trigger.Triggered(calendar);
-                trigger.Triggered(calendar);
+                // call triggered on our copy, and the scheduler's copy. A trigger carrying a retry
+                // attempt is being fired for a retry rather than for a scheduled occurrence, so it
+                // advances past the retry instant without burning a count or moving its previous fire
+                // time - the same dispatch on TriggerBase the misfire original fire time uses above.
+                bool firingRetry = trigger.RetryAttempt > 0 && tw.Trigger is TriggerBase && trigger is TriggerBase;
+                if (firingRetry)
+                {
+                    ((TriggerBase) tw.Trigger).RetryFired(calendar);
+                    ((TriggerBase) trigger).RetryFired(calendar);
+                }
+                else
+                {
+                    tw.Trigger.Triggered(calendar);
+                    trigger.Triggered(calendar);
+                }
                 // Deliberately not an "executing" state: this field decides whether the trigger can be
                 // acquired and fired again, and TriggersFired/ReleaseAcquiredTrigger/the blocking fan-out
                 // below all depend on it being Waiting or Blocked here. Executions are tracked separately,
@@ -3043,6 +3073,14 @@ public sealed class RAMJobStore : IJobStore
             // check for trigger deleted during execution...
             if (triggersByKey.TryGetValue(trigger.Key, out var tw))
             {
+                // The occurrence is done with its retries — it succeeded, spent them, or was never
+                // going to get one — so the stored trigger stops counting. Only when the count was
+                // actually non-zero, which is what RetryAttemptCleared says.
+                if (trigger is TriggerBase completed && completed.RetryAttemptCleared)
+                {
+                    tw.Trigger.RetryAttempt = 0;
+                }
+
                 if (triggerInstructionCode == SchedulerInstruction.DeleteTrigger)
                 {
                     logger.TriggerDeleting();
@@ -3090,6 +3128,32 @@ public sealed class RAMJobStore : IJobStore
                 else if (triggerInstructionCode == SchedulerInstruction.SetAllJobTriggersComplete)
                 {
                     SetAllTriggersOfJobToState(trigger.JobKey, StoredTriggerState.Complete);
+                    pending.RecordSchedulingChange();
+                }
+                else if (triggerInstructionCode == SchedulerInstruction.RetryTrigger)
+                {
+                    // The stored trigger is written, not the clone the scheduler was handed: reads
+                    // hand out clones of this instance, and the retry has to be what every later
+                    // reader — and the next acquisition — sees.
+                    //
+                    // Removed from the sorted set before its fire time moves and re-added after,
+                    // because the set is ordered by that time and mutating a member in place would
+                    // leave it in the wrong place. It may already be in there: the unblock loop above
+                    // puts a DisallowConcurrentExecution trigger back when its job finishes.
+                    timeTriggers.Remove(tw);
+
+                    tw.Trigger.NextFireTimeUtc = trigger.NextFireTimeUtc;
+                    tw.Trigger.RetryAttempt = trigger.RetryAttempt;
+
+                    // Whatever the trigger was, it is waiting for the retry now — unless its group is
+                    // paused, in which case a retry waits with everything else in the group.
+                    tw.state = IsTriggerGroupPausedNoLock(tw) ? StoredTriggerState.Paused : StoredTriggerState.Waiting;
+
+                    if (tw.state == StoredTriggerState.Waiting)
+                    {
+                        timeTriggers.Add(tw);
+                    }
+
                     pending.RecordSchedulingChange();
                 }
                 else if (tw.Trigger.NextFireTimeUtc is null)

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -392,6 +392,23 @@ public class DailyTimeIntervalTriggerImpl : TriggerBase, IDailyTimeIntervalTrigg
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Overridden for the same reason <see cref="Triggered" /> ends the way it does: this trigger
+    /// records having run out of schedule in a flag of its own, which <see cref="GetFireTimeAfter" />
+    /// then short-circuits on. Without setting it here, a trigger whose last occurrence failed and
+    /// then retried would go on answering as though it had a schedule left.
+    /// </remarks>
+    public override void RetryFired(ICalendar? calendar)
+    {
+        base.RetryFired(calendar);
+
+        if (NextFireTimeUtc is null)
+        {
+            complete = true;
+        }
+    }
+
     /// <summary>
     ///
     /// </summary>

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -92,6 +92,12 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     private string? retryPolicy;
     private int retryAttempt;
 
+    // Whether ExecutionComplete has just cleared a non-zero attempt, so the stores know they have a
+    // write to make on a completion that otherwise writes nothing. Not serialized: it says something
+    // about this completion, not about the trigger.
+    [NonSerialized]
+    private bool retryAttemptCleared;
+
     // Parsing the stored form once per trigger rather than once per read. Not serialized: it is
     // derived from the field above, which is.
     [NonSerialized]
@@ -599,6 +605,9 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     {
         if (result is not null && result.RefireImmediately)
         {
+            // An explicit directive wins over the trigger's retry policy, and the two are different
+            // things: this re-runs the job on the same thread inside the same firing, with no delay,
+            // no ceiling and nothing persisted. It does not touch the retry attempt.
             return SchedulerInstruction.ReExecuteJob;
         }
 
@@ -612,12 +621,141 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
             return SchedulerInstruction.SetAllJobTriggersComplete;
         }
 
+        // The retry decision sits after the explicit directives, which win, and before the
+        // nothing-left-to-fire check below, which a scheduled retry has to be able to postpone: a
+        // one-shot trigger waiting to retry may still fire again, and announcing it as finalized
+        // here would be announcing it twice.
+        if (result is not null && RetryPolicy is { } policy && RetryAttempt < policy.MaxAttempts && TryScheduleRetry(policy))
+        {
+            return SchedulerInstruction.RetryTrigger;
+        }
+
+        // Everything else settles the occurrence: it succeeded, the trigger has no policy, its
+        // attempts are spent, or the retry would have landed on top of the next scheduled
+        // occurrence. All of them go back to the ordinary schedule, and none of them is an error —
+        // one bad hour must not kill a cron trigger.
+        ClearRetryAttempt();
+
         if (!MayFireAgain)
         {
             return SchedulerInstruction.DeleteTrigger;
         }
 
         return SchedulerInstruction.NoInstruction;
+    }
+
+    /// <summary>
+    /// How close to the next scheduled occurrence a retry may be scheduled before the occurrence
+    /// supersedes it.
+    /// </summary>
+    /// <remarks>
+    /// One second, because <c>CalendarIntervalTriggerImpl.GetFireTimeAfter</c> and
+    /// <c>DailyTimeIntervalTriggerImpl.GetFireTimeAfter</c> both add a second before searching: a
+    /// retry closer than that to the next occurrence could not be told apart from it, and
+    /// <see cref="RetryFired" /> would answer with the occurrence after it instead — losing a fire.
+    /// </remarks>
+    internal static readonly TimeSpan RetrySupersedeMargin = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Moves the trigger's next fire time to the retry instant, if there is room for one before the
+    /// next scheduled occurrence.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> when the retry was scheduled, and the trigger now carries its instant
+    /// and the incremented attempt.
+    /// </returns>
+    private bool TryScheduleRetry(RetryPolicy policy)
+    {
+        // The trigger's own clock, so a retry instant and the fire times it is compared with are two
+        // readings of the same one.
+        DateTimeOffset retryAt = TimeProvider.GetUtcNow() + policy.DelayFor(RetryAttempt + 1);
+
+        // What the schedule says comes next, which the fire that just completed advanced this to.
+        DateTimeOffset? regularNext = NextFireTimeUtc;
+
+        if (regularNext is not null && retryAt + RetrySupersedeMargin >= regularNext.Value)
+        {
+            // The occurrence wins. Retrying at or beside it would fire the job twice for what is
+            // really one late attempt, and a policy whose waits are longer than the gap between
+            // occurrences would do that on every failure.
+            return false;
+        }
+
+        if (EndTimeUtc is not null && retryAt > EndTimeUtc.Value)
+        {
+            // A trigger does not fire after its end time, and a retry is a fire.
+            return false;
+        }
+
+        NextFireTimeUtc = retryAt;
+        RetryAttempt++;
+        retryAttemptCleared = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Puts the occurrence's retry count back to zero, recording whether that changed anything so a
+    /// job store knows whether it has a write to make.
+    /// </summary>
+    private void ClearRetryAttempt()
+    {
+        if (retryAttempt != 0)
+        {
+            retryAttempt = 0;
+            retryAttemptCleared = true;
+        }
+    }
+
+    /// <summary>
+    /// Whether <see cref="ExecutionComplete" /> has just put a non-zero <see cref="RetryAttempt" />
+    /// back to zero, and so left the trigger's stored attempt behind.
+    /// </summary>
+    /// <remarks>
+    /// The job stores write the attempt only when it changed. A completion that settles an
+    /// occurrence which was never retried is by far the common case, and it costs nothing.
+    /// </remarks>
+    internal bool RetryAttemptCleared => retryAttemptCleared;
+
+    /// <summary>
+    /// This method should not be used by the Quartz client.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Called by a job store when it is firing a retry rather than a scheduled occurrence — that is,
+    /// when the trigger's next fire time is a retry instant <see cref="ExecutionComplete" /> put
+    /// there. It advances <see cref="NextFireTimeUtc" /> past the retry to the occurrence the
+    /// schedule actually calls for, applying the trigger's calendar exactly as
+    /// <see cref="Triggered" /> does.
+    /// </para>
+    /// <para>
+    /// Unlike <see cref="Triggered" /> it touches no counter and does not move
+    /// <see cref="PreviousFireTimeUtc" />: a retry is another attempt at an occurrence that has
+    /// already been counted, so it must not burn a repeat count or a recurrence rule's <c>COUNT</c>
+    /// slot, and it reports the original occurrence as its scheduled fire time.
+    /// </para>
+    /// </remarks>
+    /// <param name="calendar">The calendar the trigger observes, if any.</param>
+    /// <seealso cref="Triggered" />
+    public virtual void RetryFired(ICalendar? calendar)
+    {
+        NextFireTimeUtc = GetFireTimeAfter(NextFireTimeUtc);
+
+        while (NextFireTimeUtc is not null && calendar is not null && !calendar.IsTimeIncluded(NextFireTimeUtc.Value))
+        {
+            NextFireTimeUtc = GetFireTimeAfter(NextFireTimeUtc);
+
+            if (NextFireTimeUtc is null)
+            {
+                break;
+            }
+
+            // avoid infinite loop
+            if (NextFireTimeUtc.Value.Year > TriggerConstants.YearToGiveUpSchedulingAt)
+            {
+                NextFireTimeUtc = null;
+                break;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Quartz/SchedulerInstruction.cs
+++ b/src/Quartz/SchedulerInstruction.cs
@@ -70,5 +70,25 @@ public enum SchedulerInstruction
     /// Instructs the <see cref="IScheduler" /> that the <see cref="ITrigger" />
     /// should be put in the <see cref="TriggerState.Error" /> state.
     /// </summary>
-    SetTriggerError
+    SetTriggerError,
+
+    /// <summary>
+    /// Instructs the <see cref="IScheduler" /> that the <see cref="ITrigger" /> has scheduled a
+    /// retry of the occurrence that just failed, and that the job store should store the retry
+    /// instant and the attempt count it now carries.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A retry needs an instruction of its own because <see cref="NoInstruction" /> means the
+    /// opposite: neither store writes the trigger at completion, since the regular next fire time
+    /// was already written when the trigger fired. A retry moves that time, so it has to be said.
+    /// </para>
+    /// <para>
+    /// The trigger is left waiting, not in error — a failed occurrence with attempts left is not a
+    /// broken trigger. It is decided by <c>TriggerBase.ExecutionComplete</c> from the trigger's
+    /// <see cref="ITrigger.RetryPolicy" />, and never returned by a trigger that has none.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Quartz.RetryPolicy" />
+    RetryTrigger
 }


### PR DESCRIPTION
R4 of #3520 — the engine. A trigger carrying a retry policy now actually retries its failed job.

**Stacked on #3555 (R3), which is stacked on the merged R2.** Base is `main` at `4aec95a7b`; the diff against #3555 is this commit alone. R3 → R4 → R5 merge as a set.

## The decision

`TriggerBase.ExecutionComplete` gains one branch, placed after the explicit `JobExecutionException` directives (which win) and before the nothing-left-to-fire check (which a scheduled retry must be able to postpone). On a failure with attempts left it sets the next fire time to `now + policy.DelayFor(attempt + 1)`, increments the attempt, and returns the new `SchedulerInstruction.RetryTrigger`.

`NoInstruction` could not carry this: it means the opposite — neither store writes the trigger at completion, because the regular next fire time was already written when the trigger fired. A retry moves that time, so it has to be said out loud.

Four rules, each with a test that fails without it:

* **A retry never displaces the schedule.** `retryAt + 1s >= NextFireTimeUtc` → dropped, occurrence wins, attempt reset. The one-second margin is `CalendarIntervalTriggerImpl.GetFireTimeAfter` and `DailyTimeIntervalTriggerImpl.GetFireTimeAfter`, which each add a second before searching. `TheSupersedeRuleIsAWholeSecondWideOnBothSides` pins both sides of the boundary to the tick.
* **Firing a retry is not `Triggered()`.** `TriggerBase.RetryFired(ICalendar?)` — `public virtual`, on `TriggerBase` only, no `IOperableTrigger` change — advances past the retry instant with the same calendar-skip loop but touches no counter and leaves `PreviousFireTimeUtc` alone. So a retry burns no repeat count and no RRULE `COUNT` slot, and reports the *original* occurrence as its `ScheduledFireTimeUtc`. Asserted for all five shipped trigger types.
* **Exhausted → ordinary schedule, not `Error`.** One bad hour must not kill a cron trigger. A misfired retry gets the trigger's own misfire instruction and the attempt is cleared by the two paths that recompute a trigger from its schedule; there is no retry-specific misfire policy.
* **`RefireImmediately` is not a zero-delay retry.** It re-runs the job on the same thread in the same firing and does not touch `RetryAttempt`. `Unschedule*` likewise wins. A cancellation on the scheduler's own token leaves no exception behind (`JobRunShell` sets no `jobExEx`) and so never retries.

## The stores

Both dispatch on the attempt being non-zero *and* on `TriggerBase`, exactly as they already do for the misfire original fire time.

* `RAMJobStore.TriggeredJobComplete` writes **`tw.Trigger`, not the clone it was handed** — reads hand out clones of that instance. It removes the wrapper from `timeTriggers` before moving the fire time and re-adds it after, because the set is ordered by that time and the `[DisallowConcurrentExecution]` unblock above may already have put it back.
* `AdoJobStoreBase.Completion` writes through one narrow statement (`NEXT_FIRE_TIME`, `RETRY_ATTEMPT`, `TRIGGER_STATE`), before the unblock transitions so they leave the row alone, with the state from `ApplyPausedTriggerGroupState` so a retry in a paused group waits with the group.
* **The attempt is written only when it changes.** Clearing is a second, narrower statement issued only when the completing trigger actually had a non-zero attempt — which is what the new internal `TriggerBase.RetryAttemptCleared` records. An ordinary completion still costs no extra round trip.

## Public API delta

`src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt`, accepted through Verify. Every moved line:

```
+ SchedulerInstruction:  RetryTrigger = 7,                       ← appended; no existing value moved
+ IJobExecutionContext:  int RetryAttempt { get; }
+ JobExecutionContextImpl: public int RetryAttempt { get; }
+ TriggerBase:           public virtual void RetryFired(Quartz.ICalendar? calendar) { }
+ DailyTimeIntervalTriggerImpl: public override void RetryFired(Quartz.ICalendar? calendar) { }
+ IDriverDelegate:       ValueTask<int> UpdateTriggerForRetry(ConnectionAndTransactionHolder, IOperableTrigger, StoredTriggerState, CancellationToken = default);
+ IDriverDelegate:       ValueTask<int> ClearTriggerRetryAttempt(ConnectionAndTransactionHolder, TriggerKey, CancellationToken = default);
+ StdAdoDelegate:        public virtual … UpdateTriggerForRetry(…) { }
+ StdAdoDelegate:        public virtual … ClearTriggerRetryAttempt(…) { }
```

`src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt`, one added line:

```
+ 1056  Information  CoreLog.TriggerRetryScheduled
+     "Job of trigger {TriggerKey} failed; retry {Attempt} of {MaxAttempts} scheduled for {RetryTimeUtc}"
```

**Breaking for anything implementing `IDriverDelegate`** — two new members, no default implementations, matching how `UpdateTriggerPreferredNodeConditional` and the listing members were added. `StdAdoDelegate` implements both `virtual`. Called out in the migration guide.

One meter, `quartz.trigger.retry`, tagged like `quartz.trigger.misfire` (scheduler, group, execution group — deliberately not the trigger name, which is a cardinality no alert can be built on).

## Tests

* `RetryEngineTest` (20) — the decision and `RetryFired`, against a trigger and a fake clock, no store.
* `RetryStoreTest` (3) — the store round trip: completion → acquisition, which is where the attempt has to survive. Driven against `RAMJobStore` directly so a failure says which half lost it.
* `RetryExecutionTest` (3) — a real scheduler, a job that really fails, the meter, and `IJobExecutionContext.RetryAttempt` reading `0, 1, 2` across three firings that all report the **same** `ScheduledFireTimeUtc`, which is what leaving `PreviousFireTimeUtc` alone buys.
* `TriggeredJobCompleteTest` — its `EveryInstructionHasACase` guard caught the new enum member; the matrix now covers `RetryTrigger` on both stores.

The full `RetryMatrixTest` (the 15 mandatory cases) is R5.

## Found while writing the tests, and deliberately left alone

A trigger built with `.WithSimpleSchedule(x => x.WithInterval(1h).RepeatForever()).StartNow()` **fires twice at scheduler startup**, milliseconds apart, with two distinct fire-instance ids and two distinct scheduled fire times (`…:26.752` and `…:26.760`, 8 ms apart — the second being the trigger's real start time). Reproduced with **no retry policy at all**, so it predates this change and is not caused by it. It is why the end-to-end tests here use a one-shot schedule: the retry count would otherwise be ambiguous. Worth its own issue; I have not opened one.

## Verification

```
dotnet build Quartz.slnx                                   ->  0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                          ->  Passed!  Failed: 0, Passed: 4105
dotnet test src/Quartz.Tests.AspNetCore                    ->  Passed!  Failed: 0, Passed: 537
dotnet test src/Quartz.Tests.Integration                   ->  Passed!  Failed: 0, Passed: 174
  --filter RAMJobStoreContractTest|SQLiteJobStoreContractTest|SqliteFileJobStoreContractTest
dotnet test src/Quartz.Tests.Integration                   ->  Passed!  Failed: 0, Passed: 87
  --filter PostgresJobStoreContractTest                         (postgres:15.1 container)
dotnet fallout PublishTrimmed                              ->  Succeeded; no new TrimAnalysisBaseline entry
dotnet fallout VerifyDocsSnippets                          ->  Succeeded (96 markdown files checked)
```

SQLite plus one Docker dialect locally; CI runs the rest of the matrix.

Part of #3520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
