### PR TITLE
The documentation teaches a store to create its own schema

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,7 +1,9 @@
 # Quartz.NET database scripts
 
-Quartz.NET does not create or migrate its schema automatically. Creating the tables and applying
-schema changes is a manual, deliberate step.
+These are the scripts a person runs against a database with a database client. Since 4.0 a scheduler
+can also create a missing schema for itself, if it is asked to — see
+[What the scheduler runs](#what-the-scheduler-runs) below — but **migrating** an existing schema is
+still a manual, deliberate step, and nothing in Quartz does it for you.
 
 A migration **both branches can run** is kept byte-identical on `3.x` and `main`, so its path
 resolves whichever branch you land on. The `4.0` folder is the exception and **lives on `main`
@@ -40,6 +42,45 @@ none: the `CREATE TABLE` statements are not guarded and fail against a schema th
 | Oracle | [`tables/tables_oracle.sql`](tables/tables_oracle.sql) |
 | SQLite | [`tables/tables_sqlite.sql`](tables/tables_sqlite.sql) |
 | Firebird | [`tables/tables_firebird.sql`](tables/tables_firebird.sql) |
+
+## What the scheduler runs
+
+A store configured with `SchemaProvisioning.CreateIfMissing` — `store.ProvisionSchema()` in code —
+creates a missing schema itself at startup. It does **not** run the scripts above. It runs a second
+set, embedded in `Quartz.dll` and living in the source tree at
+[`src/Quartz/Impl/AdoJobStore/Schema/create_<dialect>.sql`](../src/Quartz/Impl/AdoJobStore/Schema):
+
+| Database | Script |
+|---|---|
+| SQL Server | [`create_sqlServer.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_sqlServer.sql) |
+| PostgreSQL | [`create_postgres.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_postgres.sql) |
+| MySQL / MariaDB | [`create_mysql_innodb.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_mysql_innodb.sql) |
+| Oracle | [`create_oracle.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_oracle.sql) |
+| SQLite | [`create_sqlite.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_sqlite.sql) |
+| Firebird | [`create_firebird.sql`](../src/Quartz/Impl/AdoJobStore/Schema/create_firebird.sql) |
+
+Six, against `tables/`'s eight: the memory-optimized and pre-2016 SQL Server variants have no
+counterpart here. Both are deliberate departures from the standard schema, chosen by a person for a
+particular deployment, and neither is a decision a scheduler should make for itself. Neither has a
+driver delegate of its own either, so a store pointed at one of them and asked to provision creates the
+**standard** schema instead. Run those two by hand and leave the setting at `Validate`.
+
+**These are not the scripts to run by hand.** They are written for an ADO.NET provider rather than for
+a command-line client: the table prefix is a `{0}` placeholder rather than a literal `QRTZ_`, statements
+are separated by a line reading `--;;` rather than by `GO`, `/` or a `SET TERM` pair, and there is no
+`DECLARE` or variable of any kind because a provider is sent one statement at a time. Paste one into a
+query window and it will not run. Run [`tables/`](tables) instead — that is what those files are for.
+
+They are also **generated**, from the schema model in `build/Build.DatabaseSchema.cs`; `dotnet fallout
+GenerateSchema` emits them and CI's `VerifySchema` fails a build where they are out of step. Editing
+one by hand is pointless. What keeps the two sets honest about each other is `SchemaScriptTest`, which
+parses a `tables/` script and its `create_` counterpart with one parser and compares the tables, columns
+and indexes they name, and `SchemaProvisioningTest`, which provisions a real database of each dialect and
+compares its catalog with one built from `tables/`.
+
+The provisioning script only ever creates. Nothing in it drops or alters, so it is safe against a schema
+that already exists — and it is equally **not** an upgrade: it cannot add a column to a table that is
+already there. Moving an existing schema forward is the `migrations/` folders below, and only those.
 
 ## Upgrading an existing database
 
@@ -113,17 +154,21 @@ Everything under `migrations/` except the `2.0` and `3.0` folders is **generated
 those files by hand, they will be overwritten.
 
 1. Add the change to every `tables/tables_*.sql`, so fresh installs get it.
-2. Describe the change once in `build/Build.DatabaseMigrations.Scripts.cs`, and fold it into the
+2. Add it to the schema model in `build/Build.DatabaseSchema.cs` as well, so a scheduler that
+   provisions its own schema gets it too, and run `dotnet fallout GenerateSchema`. CI runs
+   `VerifySchema`, and `SchemaScriptTest` compares the two sets object by object — a change made in
+   only one of them fails both.
+3. Describe the change once in `build/Build.DatabaseMigrations.Scripts.cs`, and fold it into the
    `4.0` script there too if it is a 3.x change.
-3. Run `dotnet fallout GenerateMigrations` and commit the result. CI runs `VerifyMigrations`, so
+4. Run `dotnet fallout GenerateMigrations` and commit the result. CI runs `VerifyMigrations`, so
    a definition change without a regenerated script fails the build.
-4. If **both branches can run the change**, mirror the new `migrations/` folder and the definition
+5. If **both branches can run the change**, mirror the new `migrations/` folder and the definition
    behind it to `3.x` in a companion pull request — a migration both branches can run must stay
    byte-identical, or a documented path 404s on whichever branch lacks it (#3218). A change that
    exists **only on 4.x** has no companion at all. Either way the `4.0` fold happens here: `3.x`
    does not carry that folder. `tables/` and this README describe their own branch, so neither is
    mirrored verbatim.
-5. Add a section to the schema-changes page in the documentation (docs live on `main` only).
+6. Add a section to the schema-changes page in the documentation (docs live on `main` only).
 
 The `2.0` and `3.0` migrations are hand-written: they are SQL Server-only historical scripts
 that predate this layout and have no per-dialect variants.

--- a/docs/documentation/database/schema-changes.md
+++ b/docs/documentation/database/schema-changes.md
@@ -5,8 +5,11 @@ title: Database Schema Changes
 Every Quartz.NET release that changed the database schema, in order, with the migration to run
 and what happens if you skip it.
 
-Quartz.NET never creates or migrates your schema automatically. Read from your current version
-down to your target version and apply what each section lists.
+Quartz.NET never migrates your schema. A 4.x store asked to
+[provision its own](../quartz-4.x/tutorial/job-stores.md#creating-the-schema) creates a schema that is
+missing, but it cannot move one forward: a guarded `CREATE TABLE` skips a table that is already there
+without looking inside it, so a table short of a column stays short of it. Everything below is yours to
+run. Read from your current version down to your target version and apply what each section lists.
 
 ::: warning
 Always run migration scripts in a test environment against a copy of your production database

--- a/docs/documentation/quartz-4.x/db/index.md
+++ b/docs/documentation/quartz-4.x/db/index.md
@@ -2,7 +2,7 @@
 title: Database Schema
 ---
 
-When using ADO.NET-based job store (the usual being `LocalTransactionJobStore`), Quartz requires the creation of a set of tables. Creating the initial schema or migrating existing one is a manual step, as Quartz.NET does not create or migrate these automatically.
+When using an ADO.NET-based job store (the usual being `LocalTransactionJobStore`), Quartz requires a set of tables. Creating them can be automatic: `ProvisionSchema()` has the store run the DDL for its own database as it starts and create whatever is missing — see [Creating the schema](../tutorial/job-stores.md#creating-the-schema). It is opt-in rather than the default, because creating tables needs a permission a production database is often right not to grant. **Migrating** an existing schema is still a manual step, and nothing in Quartz does it for you.
 
 | Table | Brief Description |
 | -- | -- |
@@ -22,6 +22,27 @@ When using ADO.NET-based job store (the usual being `LocalTransactionJobStore`),
 The scripts to create these tables for various providers can be found [here](https://github.com/quartznet/quartznet/tree/main/database/tables).
 
 Upgrading an existing database instead? See [Database Schema Changes](../../database/schema-changes.md) — upgrading from 3.x to 4.x is **mandatory**, because 4.x no longer probes for the optional 3.x columns.
+
+## Creating it, and why migrating it is different
+
+A store can create a missing schema; nothing in Quartz upgrades one that already exists. The split is
+not arbitrary, and two neighbouring libraries show what decides it.
+[Hangfire](https://docs.hangfire.io/en/latest/configuration/using-sql-server.html) does both, on by
+default — `SqlServerStorageOptions.PrepareSchemaIfNecessary` and its `Hangfire.PostgreSql` namesake both
+default to `true` — and it can, because its schema records its own version: a `Schema` table with a
+single `Version` column that an incremental install script steps forward one release at a time. Even
+there the two expensive migrations of the 1.8 release are
+[held back](https://docs.hangfire.io/en/latest/upgrade-guides/upgrading-to-hangfire-1.8.html) behind
+`EnableHeavyMigrations`, which is off by default, "to prevent uncontrolled upgrades that may lead to
+extended downtime or deadlocks". [TickerQ](https://tickerq.net/docs/entity-framework/migrations) takes
+the opposite route: its schema is Entity Framework Core's, so the application generates the migrations
+with `dotnet ef migrations add` and applies them itself, and the library ships neither DDL nor an
+apply-at-startup switch. Quartz can only do the first of the two because its tables carry no version
+marker of any kind — a guarded `CREATE TABLE` skips a table that is already there without looking
+inside it, and there is nothing to read that would say which columns that table ought to have by now.
+Adding such a marker would itself be a migration, so provisioning stops at creation and
+[`database/migrations/`](https://github.com/quartznet/quartznet/tree/main/database/migrations), whose
+folder names are the version numbers, is what a deployment pipeline runs.
 
 ## Columns 4.x requires
 

--- a/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-3rd-party-plugins.md
@@ -12,6 +12,13 @@ maintained by the Quartz.NET project, and their compatibility with a given Quart
 
 This library handles schema creation and migrations for Quartz.NET using EntityFrameworkCore migrations toolkit with one line of configuration
 
+Since 4.0 the supported way to have a schema created for you is
+[built in](../tutorial/job-stores.md#creating-the-schema). The DDL it runs is compared object by object
+with `database/tables/` in the build, and provisioned against a real database of every dialect in the
+integration tests, so it cannot drift from the schema the release expects. A package that models the
+tables separately tracks them separately, so which Quartz version its schema matches is its own to
+state.
+
 ### [Weasel.Quartz](https://github.com/Hawxy/Weasel.Quartz)
 
 Runtime PostgreSQL migration support for non-EF & Marten projects.

--- a/docs/documentation/quartz-4.x/quick-start.md
+++ b/docs/documentation/quartz-4.x/quick-start.md
@@ -295,15 +295,35 @@ public sealed class HelloJob : IJob
 
 ## Creating and initializing the database
 
-To use SQL persistence, and features such as clustering that depend on it, create a database for Quartz and
-then create its tables and indexes.
+To use SQL persistence, and features such as clustering that depend on it, create a database for Quartz.
+Its tables and indexes can then either be created by the scheduler or created by you.
 
-The DDL scripts are in
-[the Quartz.NET repository](https://github.com/quartznet/quartznet/tree/main/database/tables), one per
+The quickest way to a working database is to let the store do it. `ProvisionSchema()` runs the DDL for
+whichever database you named, creating whatever is missing before the scheduler starts:
+
+<!-- snippet: sample_quick_start_provision_schema -->
+```csharp
+q.UsePersistentStore(store =>
+{
+    store.UseSqlServer("my connection string");
+    store.ProvisionSchema();
+});
+```
+<!-- endSnippet -->
+
+It only ever creates: nothing is dropped and nothing is altered, so it is safe against a database that
+already has the tables, and a second node starting at the same time is fine. It is equally **not** an
+upgrade — a schema built by an earlier Quartz version is moved forward by the migration scripts, not by
+this. It is off by default because creating tables needs a permission a production database is usually
+right not to grant; when the account has none, startup fails naming the script to run instead.
+
+Running that script yourself is the other way, and the one production usually wants. The DDL is in
+[the Quartz.NET repository](https://github.com/quartznet/quartznet/tree/main/database/tables), one file per
 database. Each one drops an existing Quartz schema before it recreates it; the header of every script
 says how to turn that off. Upgrading a schema created by an earlier version is a different script — see
-[Database Schema Changes](../database/schema-changes.md). What the tables hold is described in
-[Database](db/).
+[Database Schema Changes](../database/schema-changes.md). What the tables hold, and why one route is
+automatic and the other is not, is described in [Database Schema](db/); the setting behind the first,
+and which databases can use it, is in [Creating the schema](tutorial/job-stores.md#creating-the-schema).
 
 ## Something to run
 

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -46,7 +46,9 @@ AdoJobStore is also aptly named - it keeps all of its data in a database via ADO
 Because of this it is a bit more complicated to configure than `RAMJobStore`, and it also is not as fast.
 However, the performance draw-back is not terribly bad, especially if you build the database tables with indexes on the primary keys.
 
-To use AdoJobStore, you must first create a set of database tables for Quartz.NET to use.
+AdoJobStore needs its tables to exist before it will start, and there are two ways to get them there. You
+can have the store create them for you — [Creating the schema](#creating-the-schema) below — or you can
+run the DDL yourself, which is what a production database usually wants.
 You can find table-creation SQL scripts in the "[database/tables](https://github.com/quartznet/quartznet/tree/main/database/tables)" directory of the Quartz.NET distribution.
 Each script drops an existing Quartz schema before recreating it, so read its header first — it says how to decline that if you are running it against a database you care about.
 If there is not already a script for your database type, just look at one of the existing ones, and modify it in any way necessary for your DB.
@@ -128,6 +130,94 @@ ADO.NET connection string, not of Quartz.
 Every setting of the store is on `AdoJobStoreOptions`, reached through `store.ConfigureStore(...)` or bound from the
 `Quartz:JobStore` configuration section; they are all tabulated in the
 [configuration reference](../configuration/reference.md#persistent-job-store).
+
+### Creating the schema
+
+A store can create its own tables rather than being handed them. `ProvisionSchema()` asks for it:
+
+<!-- snippet: sample_job_stores_provision_schema -->
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.UsePersistentStore(store =>
+    {
+        store.UsePostgres(connectionString);
+        store.UseSystemTextJsonSerializer();
+
+        // outside production, where whatever applies the rest of the database's
+        // schema applies this one too
+        if (builder.Environment.IsDevelopment())
+        {
+            store.ProvisionSchema();
+        }
+    });
+});
+```
+<!-- endSnippet -->
+
+It is one setting with three positions — `AdoJobStoreOptions.SchemaProvisioning`, bound from
+`Quartz:JobStore:SchemaProvisioning`, or the flat key `quartz.jobStore.schemaProvisioning`:
+
+| Value | What the store does as it initializes |
+|---|---|
+| `None` | Nothing. A missing table surfaces as the first statement that names it, whenever that happens to run. |
+| `Validate` | **The default.** Issues a `SELECT 1` against the store's tables and refuses to start if one is missing, naming it. |
+| `CreateIfMissing` | Runs the DDL for the configured database first, then validates. `ProvisionSchema()` sets this. |
+
+What it runs is not the script you would run by hand. Quartz embeds a second set, one per dialect,
+written for an ADO.NET provider rather than for a command-line client — the table prefix is a
+placeholder rather than a literal `QRTZ_`, and there is no `GO`, no lone `/` and no `SET TERM`, because
+each statement is sent on its own. The build parses the two sets with one parser and compares the
+tables, columns and indexes they name, and the integration tests provision a real database of every
+dialect and compare its catalog with a fresh install's — so the tables a scheduler creates for itself
+are the tables `database/tables/` creates.
+[`database/README.md`](https://github.com/quartznet/quartznet/blob/main/database/README.md#what-the-scheduler-runs)
+has the detail.
+
+Four things are worth knowing before you turn it on.
+
+**It only ever creates.** Every statement in those scripts is guarded and none of them drops or alters
+anything, so it is safe against a database that already has the schema, and safe to run twice. It is
+also safe under a cluster whose nodes all start at once: only one of them can create any given object,
+and a node whose create fails asks the schema rather than the error whether it lost the race — a
+validation that passes means another node got there first. Because the script is guarded throughout, a
+node that arrives while another is half-way through fills in the gaps rather than waiting, and a brief
+retry converges the two. It cannot turn a mis-typed `TablePrefix` into data loss either — but it will
+cheerfully build a second, empty table set under the mis-typed prefix, where refusing to start would
+have told you sooner. Read the prefix twice, and see
+[Shared database](../multi-tenancy.md#shared-database) for what is and is not reported.
+
+**It is not an upgrade.** A schema that has every table but is missing a column a later release added is
+left exactly as it is, because a guarded `CREATE TABLE` skips a table that exists without looking inside
+it. Moving a schema forward is
+[`database/migrations/`](https://github.com/quartznet/quartznet/tree/main/database/migrations) and
+nothing else, and the 3.x → 4.0 upgrade is still mandatory — see
+[Database Schema Changes](../../database/schema-changes.md).
+
+**It is not the default**, because creating tables needs a permission a production database is usually
+right not to grant. That is the case for the shape in the sample above: provision in development and in
+tests, where a database is disposable and nobody wants a DDL step in the way, and let whatever applies
+the rest of your schema apply this one in production. If the account has no such permission, startup
+fails naming the fresh-install script for that database and the setting to drop back to.
+
+**Not every configuration can provision, and one of them can provision the wrong thing.** The six
+databases with a dialect of their own — SQL Server, PostgreSQL, MySQL, Oracle, SQLite and Firebird —
+each carry a script. `UseGenericDatabase` does not, because `StdAdoDelegate` writes portable SQL and
+cannot know what DDL your database accepts; asking it for `CreateIfMissing` throws as the store
+initializes, naming the delegate and the script to run by hand, rather than quietly creating nothing. A
+driver delegate of your own joins in by overriding `StdAdoDelegate.SchemaResourceName` with the name of
+a script embedded in its own assembly. The case to watch is SQL Server's two variant schemas, the
+[memory-optimized one and the pre-2016 one](https://github.com/quartznet/quartznet/tree/main/database/tables):
+they have no delegate of their own, so a store configured for either still provisions the *standard*
+schema, which is not what you asked for. Both are deliberate departures a person chose for a particular
+deployment. Run those by hand and leave `SchemaProvisioning` at `Validate`.
+
+Validation, whichever position you leave the setting at, checks *tables* — not columns. A database
+missing only a column gets past startup and fails on the first statement that names it, which is the
+other half of why the 4.0 migration is mandatory rather than merely recommended. It is eleven of the
+twelve tables, too: `QRTZ_SIMPROP_TRIGGERS` is not among the ones it queries, so a schema missing only
+that one starts and fails later, when something schedules a calendar-interval, daily-time-interval or
+recurrence trigger.
 
 ### Storing job data as strings
 

--- a/src/Quartz.Documentation.Samples/QuickStartSamples.cs
+++ b/src/Quartz.Documentation.Samples/QuickStartSamples.cs
@@ -55,6 +55,22 @@ public static class QuickStartSamples
         #endregion
     }
 
+    public static void ProvisionSchema(IHostApplicationBuilder builder)
+    {
+        builder.AddQuartz(q =>
+        {
+            #region sample_quick_start_provision_schema
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlServer("my connection string");
+                store.ProvisionSchema();
+            });
+
+            #endregion
+        });
+    }
+
     public static async ValueTask WithoutAHost()
     {
         #region sample_quick_start_standalone

--- a/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
@@ -47,6 +47,29 @@ public static class JobStoresSamples
         #endregion
     }
 
+    public static void ProvisionSchema(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_job_stores_provision_schema
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store =>
+            {
+                store.UsePostgres(connectionString);
+                store.UseSystemTextJsonSerializer();
+
+                // outside production, where whatever applies the rest of the database's
+                // schema applies this one too
+                if (builder.Environment.IsDevelopment())
+                {
+                    store.ProvisionSchema();
+                }
+            });
+        });
+
+        #endregion
+    }
+
     public static void StoreJobDataAsStrings(IPersistentStoreBuilder store)
     {
         #region sample_job_stores_store_job_data_as_strings


### PR DESCRIPTION
The fourth and last piece of #3531. #3550 generated the scripts, #3551 wired the store to them, #3552
proved them against every dialect — and between them they renamed `PerformSchemaValidation` on every
page that named it. What none of them did was *teach* the feature: the migration guide is currently
`ProvisionSchema()`'s only prose home, and every page a new reader actually arrives at still opens by
saying Quartz does not create a schema.

## What each page gets

**`quick-start.md`** — "Creating and initializing the database" now leads with `ProvisionSchema()` and
a snippet, and keeps the scripts as the second route, because DDL permission is the whole reason the
setting is opt-in rather than the default.

**`tutorial/job-stores.md`** — a new `### Creating the schema`, which is the page anything else links
to. The three positions as a table, what the store actually runs and why it is not the file you would
paste into a query window, and four things worth knowing before turning it on: it only ever creates
(so a cluster starting together is fine, and a mis-typed prefix cannot lose data but *will* build an
empty second schema); it is not an upgrade; it is not the default; and not every configuration can
provision. The opening at line 49 — "you must first create a set of database tables" — now names both
routes.

**`db/index.md`** — line 5 said creation and migration were both manual. Creation can be automatic
now; migration cannot, and a new short section says what decides that, with two neighbours as the
poles. **This is the one place a comparison earned its keep**, so it is sourced:

* **Hangfire** does both, on by default — `SqlServerStorageOptions.PrepareSchemaIfNecessary` and its
  `Hangfire.PostgreSql` namesake both default to `true` — and it can because its schema records its
  own version, a `Schema` table with a single `Version` column that an incremental install script
  steps forward. Even there the 1.8 release's two expensive migrations are held behind
  `EnableHeavyMigrations`, off by default, "to prevent uncontrolled upgrades that may lead to extended
  downtime or deadlocks".
* **TickerQ** is the opposite: its schema is EF Core's, the application generates the migrations with
  `dotnet ef migrations add` and applies them, and the library ships neither DDL nor an
  apply-at-startup switch.
* **Quartz** can only do the first, because its tables carry no version marker of any kind. Adding one
  would itself be a migration — which is exactly why `CreateOrMigrate` was ruled out of scope on the
  issue, and the page now says so where a reader will ask.

**`database/README.md`** — where the generated `create_<dialect>.sql` live, and, at length, that they
are **not** the scripts to run by hand: `{0}` where `QRTZ_` would be, `--;;` where `GO` would be, and
no variable of any kind. Plus a step in "Adding a migration", because a schema change now has to land
in `Build.DatabaseSchema.cs` as well as in `tables/`.

**`database/schema-changes.md`** — "never creates or migrates" became "never migrates", with the
reason. The SQLite trigger-rename note #3550 added was already there; nothing needed adding.

**`packages/quartz-3rd-party-plugins.md`** — one qualifying sentence on AppAny.

## Three claims the source corrected

Every statement here was checked against this branch's code rather than against the issue or the PR
bodies, and three of them changed as a result.

1. **Validation covers eleven of the twelve tables.** `AdoConstants.AllTableNames` does not include
   `SIMPROP_TRIGGERS`, though the store reads and writes it and every create script makes it. So a
   schema missing only that table starts and fails later. The caveat says that rather than repeating
   `operations.md`'s "every table it needs" — which is now the one page still carrying the imprecise
   form, and is left alone because it is #3551's and the fix belongs with a decision about the gap
   itself. **Worth an issue of its own**: this looks like an oversight in `AllTableNames`, not a
   deliberate exclusion.
2. **`UseGenericDatabase` cannot provision.** It registers `StdAdoDelegate`, whose
   `SchemaResourceName` is `null`, so `CreateIfMissing` throws naming the delegate and the script to
   run. That is the realistic way into that exception and it is documented as such.
3. **The memory-optimized and pre-2016 SQL Server schemas are worse than "not provisionable".** They
   have no delegate of their own — a store using either still uses `SqlServerDelegate` — so asking for
   `CreateIfMissing` does not throw, it creates the **standard** schema instead of the variant you
   chose. That is the one way this feature can quietly do the wrong thing, and both the tutorial and
   `database/README.md` now say it. An earlier draft of this PR had it as "throws", which is what the
   issue's wording implies.

## Verification

```
dotnet build Quartz.slnx                             0 warnings, 0 errors
dotnet fallout DocsSnippets                          2 pages updated
dotnet fallout VerifyDocsSnippets                    up to date, 96 files checked
dotnet test src/Quartz.Tests.Unit                    4046 passed, 0 failed
npm ci && npm run docs:check-links                   215 pages, 934 links, 571 fragments, none dead
npx markdownlint-cli2 <the six touched files>        5 errors, all in database/README.md and all
                                                     byte-identical on 4aec95a7b (MD040 on a fence at
                                                     the top, MD033 on four <br> in a pre-existing
                                                     table)
```

Both C# blocks are generated from new `sample_quick_start_provision_schema` and
`sample_job_stores_provision_schema` regions.

## Not here

`how-tos/aspire.md` has a "The tables are still yours to create" section ending "Half of it has landed
… nothing reads those scripts yet", which is now false. **#3557 is rewriting that page**, so touching
it here would conflict for no gain; the replacement paragraph is in the hand-off notes and should be
applied once #3557 merges.

`configuration/reference.md`'s legacy-key table lists neither `quartz.jobStore.performSchemaValidation`
nor `quartz.jobStore.schemaProvisioning`. Deliberate: that table is headed "Legacy property keys" and
the new key is not one, `LegacyPropertyKeyExhaustivenessTest` already records the migration guide as
their documented home, and the page is #3551's. Easy to add if a reviewer would rather have it.

Closes #3531
