### PR TITLE
A firing is linked to the activity that scheduled it

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1810,6 +1810,70 @@ conversation can share a group and be listed, paused or unscheduled together. Ca
 
 See [One-Off Job](how-tos/one-off-job.md#a-payload-and-a-time-in-one-call).
 
+## A scheduled job links back to the trace that scheduled it
+
+New in 4.0, and on by default: when a scheduling call is made inside an `Activity`, the scheduler
+records that activity's W3C trace context on the trigger, and the firing's `Quartz.Job.Execute` span
+carries an `ActivityLink` back to it. Nothing has to be configured, and no code changes.
+
+3.x propagated nothing, so every integrator that cared reached into the trigger's `JobDataMap` and
+invented a key of its own:
+
+```diff
+- trigger.UsingJobData("traceparent", Activity.Current?.Id);   // and a job that read it back by hand
++ // nothing — the scheduler writes it, and the execute span links to it
+```
+
+**A link, not a parent.** A job scheduled for next Tuesday runs a week after the request that asked for
+it, quite possibly on another node. Making the firing a *child* of the scheduling span would produce a
+trace that stays open for a week, which no backend can render and no operator can read. The firing is
+its own trace root and the link is how you walk back — the shape OpenTelemetry gives an asynchronous
+producer and the consumer that eventually picks the work up. The span name is unchanged.
+
+**The API added.** In `Quartz`: `SchedulerConstants.TraceParent` (`"QRTZ_TRACEPARENT"`),
+`SchedulerConstants.TraceState` (`"QRTZ_TRACESTATE"`), and
+`QuartzSchedulerOptions.PropagateTraceContext`, which defaults to `true`. There is no flat `quartz.*`
+key for it: nothing on 3.x did this, so there is no configuration to migrate — and `LegacyPropertyKeys`
+correctly rejects an invented one.
+
+```csharp
+q.ConfigureScheduler(options => options.PropagateTraceContext = false);
+```
+
+**Where it is written.** On the **trigger's** data map, by the scheduler, at every entry point that
+stores a trigger — both `ScheduleJob` overload pairs, `ScheduleJobs`, both `TriggerJob` forms and
+`RescheduleJob`. A reschedule counts because it is the call that decided when the firing happens, so the
+link follows the move: a replacement trigger rebuilt from the original carries the original's data map,
+reserved keys included, and the new context overwrites the old one rather than being kept beside it.
+
+`UpdateTriggerDetails` deliberately writes **no** trace context. It changes metadata on a trigger that
+stays scheduled and keeps its fire times, so the trace that asked for the firing is still the one that
+scheduled it — re-pointing the link at whoever later edited a description would make it say something
+false. (It does normalize a typed input in the map it is given, because that is about what a store can
+hold rather than about what scheduled anything.)
+
+Two consequences worth knowing:
+
+- **Two more entries per trigger row.** They are ordinary string job data, so they travel through
+  `StoreJobDataAsStrings`, the System.Text.Json write gate, the Newtonsoft serializer, the binary blob
+  column and the HTTP wire without any of them knowing about it — and they are visible in
+  `MergedJobDataMap`, in the dashboard and in `GET /triggers`, like every other `QRTZ_*` reserved key.
+  Turn the option off if that is not wanted.
+- **The trigger's map, never the job's.** `[PersistJobDataAfterExecution]` writes back only the job's
+  map, so the two never meet and a persisted job cannot carry a `traceparent` forward into its next
+  firing.
+
+**A stale context is removed rather than kept.** The scheduler stores the trigger object it was handed
+rather than a copy of it, so a trigger scheduled once inside a request and again outside one has the key
+*removed* on the second call. A stale link reads exactly like a true one, which makes leaving it the
+worst of the three answers.
+
+**Over HTTP it is free.** `POST /jobs/{group}/{name}/trigger` and the scheduling endpoints run inside
+ASP.NET Core's own server span, so the request's trace reaches the trigger without `Quartz.AspNetCore`
+mentioning tracing at all.
+
+See [Observability](packages/opentelemetry-integration.md#linking-a-firing-to-what-scheduled-it).
+
 ## A component of your own is chosen the same way a shipped one is
 
 Three seams that had no code-first spelling at all, and one that only worked through a type-name string:

--- a/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
+++ b/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
@@ -75,6 +75,31 @@ and are constants on `Quartz.Diagnostics.ActivityTags`:
 | `quartz.jobstore.trigger.count` | `Quartz.JobStore.AcquireNextTriggers` (how many came back) and `.TriggersFired` (how many were fired) |
 | `error.type` | any span that ended in a failure |
 
+### Linking a firing to what scheduled it
+
+A job runs minutes, hours or days after the call that scheduled it, quite possibly on another node. When
+that call was made inside an `Activity`, the scheduler records its W3C trace context on the trigger — under
+the reserved keys `SchedulerConstants.TraceParent` and `SchedulerConstants.TraceState` — and the firing's
+`Quartz.Job.Execute` span carries an `ActivityLink` back to it. Nothing needs configuring, and an HTTP API
+request gets it without asking, because the endpoint runs inside ASP.NET Core's server span.
+
+It is a **link** rather than a parent on purpose: the firing is its own trace root, so a trace never has to
+stay open across the wait. That is the shape OpenTelemetry gives an asynchronous producer and the consumer
+that eventually picks the work up, and every backend that renders links will walk from the firing back to
+the request that asked for it.
+
+The cost is two string entries on each trigger's data map, visible wherever trigger data is —
+`MergedJobDataMap`, the dashboard, `GET /triggers`. Turn it off with:
+
+```csharp
+q.ConfigureScheduler(options => options.PropagateTraceContext = false);
+```
+
+::: tip The trigger's map, never the job's
+`[PersistJobDataAfterExecution]` writes back only the job's map, so the two never interact — a persisted
+job cannot carry a `traceparent` forward into its next firing.
+:::
+
 ## Metrics
 
 Eight instruments, all on the `Quartz` meter. **Every measurement carries `quartz.scheduler.name` and

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TraceContextOverHttpTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TraceContextOverHttpTest.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Json;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// The HTTP API gets trace propagation for nothing, because the endpoint runs inside the request's own
+/// span and the scheduler reads <see cref="Activity.Current" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the arrangement the feature was written for: a request arrives carrying a
+/// <c>traceparent</c>, asks for a job to be fired, and returns long before the job runs. Nothing in
+/// <c>Quartz.AspNetCore</c> mentions tracing — the whole of the connection is that ASP.NET Core has made
+/// the server span current by the time the endpoint calls the scheduler — so this test exists to keep
+/// that free ride from quietly ending.
+/// </para>
+/// <para>
+/// The scheduler behind the API is a real one rather than this folder's fake, because a fake would
+/// record the call without any of the code under test running. It is bound into the application's
+/// repository the same way the fake is, and is deliberately never started: the trigger has to still be
+/// there to be read back.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class TraceContextOverHttpTest
+{
+    private const string CallerTraceId = "0af7651916cd43dd8448eb211c80319c";
+
+    private WebApplicationFactory<Program> factory;
+    private ServiceProvider provider;
+    private IScheduler scheduler;
+    private ActivityListener listener;
+    private string schedulerName;
+    private JobKey jobKey;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        // ASP.NET Core only creates the request activity when something is listening, so this listener
+        // is what makes Activity.Current non-null inside the endpoint. Listening to every source rather
+        // than to one name keeps the test from depending on what the hosting layer calls its own.
+        listener = new ActivityListener
+        {
+            ShouldListenTo = static _ => true,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        TestContentRoot.Apply();
+        factory = new WebApplicationFactory<Program>();
+
+        schedulerName = $"trace-over-http-{Guid.NewGuid():N}";
+        jobKey = new JobKey("fire-me", "http");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = schedulerName);
+            quartz.AddJob<DummyJob>(job => job.WithIdentity(jobKey).StoreDurably());
+        });
+
+        provider = services.BuildServiceProvider();
+        scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        factory.Services.GetRequiredService<ISchedulerRepository>().Bind(scheduler);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (factory is not null)
+        {
+            factory.Services.GetRequiredService<ISchedulerRepository>().Remove(schedulerName);
+            await factory.DisposeAsync();
+        }
+
+        if (scheduler is not null)
+        {
+            await scheduler.Shutdown();
+        }
+
+        if (provider is not null)
+        {
+            await provider.DisposeAsync();
+        }
+
+        listener?.Dispose();
+    }
+
+    [Test]
+    public async Task TriggeringAJobOverHttpCarriesTheRequestsTraceOntoTheTrigger()
+    {
+        using HttpClient client = factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            $"schedulers/{schedulerName}/jobs/{jobKey.Group}/{jobKey.Name}/trigger");
+
+        // The caller's own span, spelled the way it goes on the wire.
+        string callerSpanId = "b7ad6b7169203331";
+        request.Headers.Add("traceparent", $"00-{CallerTraceId}-{callerSpanId}-01");
+        request.Content = JsonContent.Create(new { });
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK, await response.Content.ReadAsStringAsync());
+
+        ITrigger trigger = (await scheduler.GetTriggersOfJob(jobKey)).Should().ContainSingle(
+            "the request asked for one firing").Subject;
+
+        string traceParent = trigger.JobDataMap.Should().ContainKey(SchedulerConstants.TraceParent)
+            .WhoseValue.Should().BeOfType<string>().Subject;
+
+        ActivityContext.TryParse(traceParent, traceState: null, isRemote: true, out ActivityContext scheduledBy)
+            .Should().BeTrue("what is stored is a W3C traceparent, readable by anything that reads the header");
+
+        scheduledBy.TraceId.ToHexString().Should().Be(CallerTraceId,
+            "the caller's trace reaches the trigger through the server span the endpoint runs inside — "
+            + "that is the whole of what makes the HTTP API traceable across the scheduled gap");
+        scheduledBy.SpanId.ToHexString().Should().NotBe(callerSpanId,
+            "the firing links back to the server span that handled the request, not to the client span "
+            + "that sent it, so the link points at work this process actually did");
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/TraceContextThroughAdoStoreTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/TraceContextThroughAdoStoreTest.cs
@@ -1,0 +1,248 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The link from a firing back to the call that scheduled it, across an actual database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The unit tests for this run against the in-memory store, where the trigger the scheduler was handed
+/// is the trigger the job is fired from — so they cannot tell a value that was stored from one that was
+/// merely still in memory. Here the trigger is written to a SQLite file as job data, read back out by
+/// the scheduler thread as a row, and the firing's span still carries the link. That is the round trip
+/// the feature is actually for: the node that schedules the job and the node that runs it are usually
+/// not the same process, and everything they share went through the store.
+/// </para>
+/// <para>
+/// SQLite on a file needs no container, so this runs wherever the unit tests do.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class TraceContextThroughAdoStoreTest
+{
+    private string databaseFile;
+    private ActivityListener listener;
+    private readonly List<Activity> stoppedActivities = [];
+
+    [SetUp]
+    public void SetUp()
+    {
+        RecordingJob.Reset();
+
+        lock (stoppedActivities)
+        {
+            stoppedActivities.Clear();
+        }
+
+        listener = new ActivityListener
+        {
+            ShouldListenTo = static source => source.Name == QuartzInstrumentation.ActivitySourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                lock (stoppedActivities)
+                {
+                    stoppedActivities.Add(activity);
+                }
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        listener?.Dispose();
+
+        // Pools first, or the handle the store left behind keeps the file locked on Windows.
+        SqliteConnection.ClearAllPools();
+
+        if (databaseFile is not null && File.Exists(databaseFile))
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                // scratch space; leaving one behind is not worth failing a passing test over
+            }
+        }
+    }
+
+    [Test]
+    public async Task TheLinkToTheSchedulingActivitySurvivesTheStore()
+    {
+        await PrepareDatabase();
+
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"traced-{id}", "trace");
+        TriggerKey triggerKey = new($"traced-{id}", "trace");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"trace-ado-{id}");
+            quartz.UsePersistentStore(store => store.UseSqlite(ConnectionString));
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            IJobDetail job = JobBuilder.Create<RecordingJob>()
+                .WithIdentity(jobKey)
+                .StoreDurably()
+                .Build();
+
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .StartAt(DateTimeOffset.UtcNow.AddSeconds(1))
+                .Build();
+
+            // Started rather than merely constructed, because Activity.Current refuses a finished
+            // activity — and put back to null as soon as the scheduling calls are done, so that the
+            // scheduler's worker cannot inherit it and make the firing a child instead of a link.
+            using Activity scheduling = new Activity("caller.schedules").SetIdFormat(ActivityIdFormat.W3C).Start();
+            try
+            {
+                await scheduler.AddJob(job);
+                await scheduler.ScheduleJob(trigger);
+            }
+            finally
+            {
+                Activity.Current = null;
+            }
+
+            // Read back from the store rather than from the object that was handed to it: everything
+            // between here and the firing is rows.
+            ITrigger stored = await scheduler.GetTrigger(triggerKey);
+            stored.Should().NotBeSameAs(trigger, "the store returns a trigger it materialized from a row");
+            stored.JobDataMap.Should().ContainKey(SchedulerConstants.TraceParent)
+                .WhoseValue.Should().Be(scheduling.Id,
+                    "the traceparent is an ordinary job data value, so it goes through whatever the store "
+                    + "does with job data — including StoreJobDataAsStrings and the JSON write gate");
+
+            await scheduler.Start();
+
+            (await RecordingJob.Fired.WaitAsync(TimeSpan.FromSeconds(60))).Should().Be(jobKey);
+
+            Activity execute = await WaitForExecuteActivity(jobKey);
+
+            ActivityLink link = execute.Links.Should().ContainSingle(
+                "the firing links back to the one call that scheduled it").Subject;
+            link.Context.TraceId.Should().Be(scheduling.TraceId,
+                "the whole point is walking from a firing back to the request that asked for it, and the "
+                + "trace id is what a backend searches by");
+            link.Context.SpanId.Should().Be(scheduling.SpanId);
+            link.Context.IsRemote.Should().BeTrue(
+                "the context came out of storage rather than being created in this process");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private async Task<Activity> WaitForExecuteActivity(JobKey jobKey)
+    {
+        // The job signals from inside Execute, and the span is closed after Execute returns.
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(30);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            lock (stoppedActivities)
+            {
+                Activity found = stoppedActivities.Find(a =>
+                    a.OperationName == OperationName.Job.Execute
+                    && Equals(a.GetTagItem(ActivityTags.JobName), jobKey.Name));
+
+                if (found is not null)
+                {
+                    return found;
+                }
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"No {OperationName.Job.Execute} activity was recorded for {jobKey}.");
+        return null;
+    }
+
+    private string ConnectionString => $"Data Source={databaseFile};";
+
+    private async Task PrepareDatabase()
+    {
+        databaseFile = $"trace-context-{Guid.NewGuid():N}.db";
+
+        await using SqliteConnection connection = new SqliteConnection(ConnectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = new SqliteCommand(LoadTableScript(), connection);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static string LoadTableScript()
+    {
+        DirectoryInfo directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, "database", "tables", "tables_sqlite.sql");
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate database/tables/tables_sqlite.sql from " + AppContext.BaseDirectory);
+    }
+
+    /// <summary>
+    /// Reports that it ran, so the assertions never race the firing they are about.
+    /// </summary>
+    public sealed class RecordingJob : IJob
+    {
+        private static volatile TaskCompletionSource<JobKey> fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task<JobKey> Fired => fired.Task;
+
+        public static void Reset() => fired = new TaskCompletionSource<JobKey>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            fired.TrySetResult(context.JobDetail.Key);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/JobExecutionObservabilityTest.cs
@@ -503,6 +503,280 @@ public sealed class JobExecutionObservabilityTest
             + "of them being silent");
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // The gap between scheduling a job and running it
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The whole of #3524: a firing can be walked back to the call that asked for it, however long ago
+    /// that was and whichever node it happened on.
+    /// </summary>
+    [Test]
+    public async Task TheExecuteSpan_LinksBackToTheActivityThatScheduledTheTrigger()
+    {
+        using Activity scheduling = StartDetachedActivity();
+        scheduling.TraceStateString = "quartz=alpha4";
+
+        Execution execution = await RunJob<SucceedingJob>(scheduledUnder: scheduling);
+
+        Activity activity = ActivityFor(execution.JobKey);
+
+        ActivityLink link = activity.Links.Should().ContainSingle(
+            "one scheduling call produced this firing, so there is exactly one thing to link back to")
+            .Subject;
+
+        link.Context.TraceId.Should().Be(scheduling.TraceId,
+            "walking from the firing to the request that asked for it is the point, and the trace id is "
+            + "what a backend searches by");
+        link.Context.SpanId.Should().Be(scheduling.SpanId,
+            "the link names the scheduling span itself, not merely its trace");
+        link.Context.TraceState.Should().Be("quartz=alpha4",
+            "tracestate is vendor routing information that travels with the context, and dropping it "
+            + "silently sends the linked span to a different backend than the one that recorded it");
+        link.Context.IsRemote.Should().BeTrue(
+            "the context was parsed from stored data rather than created in this process — the same "
+            + "thing a server span's context is when it came off the wire");
+
+        activity.ParentSpanId.Should().NotBe(scheduling.SpanId,
+            "the scheduling call and the firing are separated by however long the schedule said, and a "
+            + "span whose parent is a week away makes a trace no backend can render");
+    }
+
+    /// <summary>
+    /// The trigger's map, never the job's — so a <c>[PersistJobDataAfterExecution]</c> job can never
+    /// write a <c>traceparent</c> forward into its next firing.
+    /// </summary>
+    [Test]
+    public async Task TheTraceContext_IsWrittenOntoTheTriggerUnderTheReservedKeys()
+    {
+        using Activity scheduling = StartDetachedActivity();
+
+        Execution execution = await RunJob<SucceedingJob>(scheduledUnder: scheduling);
+
+        execution.MergedJobData.Should().ContainKey(SchedulerConstants.TraceParent)
+            .WhoseValue.Should().Be(scheduling.Id,
+                "the stored value is the W3C traceparent verbatim, so anything that can parse a "
+                + "traceparent header can read it");
+        execution.MergedJobData.Should().NotContainKey(SchedulerConstants.TraceState,
+            "the scheduling activity carried no tracestate, and an empty entry per trigger would be "
+            + "storage spent on nothing");
+    }
+
+    [Test]
+    public async Task AJobScheduledOutsideAnyActivity_CarriesNoLinkAndNoReservedKeys()
+    {
+        Execution execution = await RunJob<SucceedingJob>();
+
+        Activity activity = ActivityFor(execution.JobKey);
+
+        activity.Links.Should().BeEmpty(
+            "there was nothing to link to — a link to a context nobody recorded is worse than none");
+        execution.MergedJobData.Should().NotContainKey(SchedulerConstants.TraceParent,
+            "an application that never traces must not pay two map entries per trigger for the feature");
+    }
+
+    [Test]
+    public async Task TurningPropagationOff_LeavesTheTriggerAndTheSpanAlone()
+    {
+        using Activity scheduling = StartDetachedActivity();
+
+        Execution execution = await RunJob<SucceedingJob>(propagateTraceContext: false, scheduledUnder: scheduling);
+
+        execution.MergedJobData.Should().NotContainKey(SchedulerConstants.TraceParent,
+            "opting out is about what reaches the store, so the key is never written in the first place");
+        ActivityFor(execution.JobKey).Links.Should().BeEmpty(
+            "with nothing stored there is nothing to link to, and the execute span is emitted either way");
+    }
+
+    /// <summary>
+    /// The reason the write is a write-<em>or-remove</em>.
+    /// </summary>
+    /// <remarks>
+    /// <c>AsOperableTrigger</c> hands the store the very object the caller passed rather than a copy of
+    /// it, so a trigger scheduled once inside a request and again outside one would otherwise keep
+    /// pointing at the first request's trace — and a stale link reads exactly like a true one.
+    /// </remarks>
+    [Test]
+    public async Task ReschedulingTheSameTriggerObjectOutsideAnActivity_DropsTheStaleTraceParent()
+    {
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"job-{id}", $"job-group-{id}");
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"stale-traceparent-{id}");
+            quartz.AddJob<SucceedingJob>(job => job.WithIdentity(jobKey).StoreDurably());
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        // Never started: this is about what the scheduling call writes, and a firing would delete the
+        // one-shot trigger out from under the second half of the test.
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity($"trigger-{id}", $"trigger-group-{id}")
+            .ForJob(jobKey)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
+
+        using (Activity scheduling = StartDetachedActivity())
+        {
+            Activity previous = Activity.Current;
+            Activity.Current = scheduling;
+            try
+            {
+                await scheduler.ScheduleJob(trigger);
+            }
+            finally
+            {
+                Activity.Current = previous;
+            }
+
+            trigger.JobDataMap.Should().ContainKey(SchedulerConstants.TraceParent)
+                .WhoseValue.Should().Be(scheduling.Id, "the first scheduling call happened inside a trace");
+        }
+
+        await scheduler.ScheduleJob(trigger, new ScheduleJobOptions { Replace = true });
+
+        trigger.JobDataMap.Should().NotContainKey(SchedulerConstants.TraceParent,
+            "the second call was made outside any activity, and the scheduler stores the trigger object "
+            + "it was handed rather than a copy — leaving the old value would link every future firing "
+            + "back to a trace that has nothing to do with it");
+    }
+
+    /// <summary>
+    /// Rescheduling is a scheduling call, so the firing links to the call that moved it rather than to
+    /// the one that first put it there.
+    /// </summary>
+    [Test]
+    public async Task ReschedulingInsideAnActivity_LinksTheFiringToTheReschedule()
+    {
+        using Activity first = StartDetachedActivity();
+        using Activity second = StartDetachedActivity();
+
+        Execution execution = await RescheduleAndRun(scheduledUnder: first, rescheduledUnder: second);
+
+        ActivityLink link = ActivityFor(execution.JobKey).Links.Should().ContainSingle(
+            "one call decided when this firing happens, so there is one thing to link back to").Subject;
+
+        link.Context.SpanId.Should().Be(second.SpanId,
+            "the reschedule is what decided when this firing happens, and that is the call worth "
+            + "walking back to");
+        link.Context.TraceId.Should().NotBe(first.TraceId,
+            "a replacement trigger rebuilt from the original carries the original's job data map, "
+            + "reserved keys included — so the traceparent the first call left has to be overwritten "
+            + "rather than kept, or the firing points at a trace that did not schedule it");
+    }
+
+    [Test]
+    public async Task ReschedulingOutsideAnyActivity_DropsTheLinkTheFirstSchedulingLeft()
+    {
+        using Activity first = StartDetachedActivity();
+
+        Execution execution = await RescheduleAndRun(scheduledUnder: first, rescheduledUnder: null);
+
+        ActivityFor(execution.JobKey).Links.Should().BeEmpty(
+            "nothing traced the call that decided when this firing happens, and inheriting the earlier "
+            + "call's trace would be a link that reads true and is not");
+        execution.MergedJobData.Should().NotContainKey(SchedulerConstants.TraceParent,
+            $"the replacement carried the first call's key over, so {nameof(SchedulerConstants.TraceParent)} has to be removed rather than left");
+    }
+
+    /// <summary>
+    /// Schedules a trigger for an hour away under one activity, moves it to now under another, and runs
+    /// the firing that results.
+    /// </summary>
+    /// <remarks>
+    /// The replacement is rebuilt from the original with <c>GetTriggerBuilder</c>, which is how an
+    /// application reschedules one — and which copies the original's job data map, reserved keys
+    /// included. That copy is what makes these tests about overwriting a stale context rather than about
+    /// writing to an empty map.
+    /// </remarks>
+    private static async Task<Execution> RescheduleAndRun(Activity scheduledUnder, Activity rescheduledUnder)
+    {
+        string id = Guid.NewGuid().ToString("N");
+        JobKey jobKey = new($"job-{id}", $"job-group-{id}");
+        TriggerKey triggerKey = new($"trigger-{id}", $"trigger-group-{id}");
+
+        ExecutionCompletionListener completion = new();
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options => options.InstanceName = $"reschedule-{id}");
+            quartz.AddJobListener(completion);
+            quartz.AddJob<SucceedingJob>(job => job.WithIdentity(jobKey).StoreDurably());
+        });
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        try
+        {
+            ITrigger original = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+                .Build();
+
+            await Under(scheduledUnder, () => scheduler.ScheduleJob(original).AsTask());
+
+            ITrigger replacement = original.GetTriggerBuilder().StartNow().Build();
+
+            await Under(rescheduledUnder, () => scheduler.RescheduleJob(triggerKey, replacement).AsTask());
+
+            await scheduler.Start();
+
+            Task finished = await Task.WhenAny(completion.Executed, Task.Delay(TimeSpan.FromSeconds(30)));
+            finished.Should().BeSameAs(completion.Executed, "the rescheduled job should have run");
+
+            return new Execution(
+                jobKey,
+                triggerKey,
+                scheduler.SchedulerName,
+                scheduler.SchedulerInstanceId,
+                await completion.Executed,
+                completion.MergedJobData);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Runs one call with a chosen ambient activity, and nothing else with it.
+    /// </summary>
+    /// <remarks>
+    /// An <c>AsyncLocal</c> written inside an async method does not escape it, so the assignment reaches
+    /// everything this awaits and nothing the caller goes on to do — which is what keeps the activity
+    /// from being current when the scheduler is started.
+    /// </remarks>
+    private static async Task Under(Activity activity, Func<Task> call)
+    {
+        Activity.Current = activity;
+        await call();
+    }
+
+    /// <summary>
+    /// A running W3C activity that is deliberately not ambient.
+    /// </summary>
+    /// <remarks>
+    /// It is the shape a caller's span has from the scheduler's point of view: the worker threads that
+    /// run the job never captured the caller's execution context, so nothing but the stored
+    /// <c>traceparent</c> connects the two. Starting an activity makes it current, so this puts
+    /// <see cref="Activity.Current" /> straight back — it cannot simply be stopped instead, because a
+    /// finished activity is one <see cref="Activity.Current" /> refuses to be set to.
+    /// </remarks>
+    private static Activity StartDetachedActivity()
+    {
+        Activity activity = new Activity("caller.schedules").SetIdFormat(ActivityIdFormat.W3C).Start();
+        Activity.Current = null;
+        return activity;
+    }
+
     /// <summary>
     /// Builds a scheduler the way an application does, runs the job its trigger fires exactly once, and
     /// shuts everything down before returning — so an assertion never races the execution it is about.
@@ -510,7 +784,9 @@ public sealed class JobExecutionObservabilityTest
     private static async Task<Execution> RunJob<TJob>(
         bool veto = false,
         string executionGroup = null,
-        IJobExecutionMiddleware middleware = null) where TJob : IJob
+        IJobExecutionMiddleware middleware = null,
+        bool propagateTraceContext = true,
+        Activity scheduledUnder = null) where TJob : IJob
     {
         string id = Guid.NewGuid().ToString("N");
         JobKey jobKey = new($"job-{id}", $"job-group-{id}");
@@ -523,7 +799,11 @@ public sealed class JobExecutionObservabilityTest
         ServiceCollection services = new();
         services.AddQuartz(quartz =>
         {
-            quartz.ConfigureScheduler(options => options.InstanceName = $"observability-{id}");
+            quartz.ConfigureScheduler(options =>
+            {
+                options.InstanceName = $"observability-{id}";
+                options.PropagateTraceContext = propagateTraceContext;
+            });
             quartz.AddJobListener(completion);
             if (veto)
             {
@@ -544,7 +824,7 @@ public sealed class JobExecutionObservabilityTest
 
         await using ServiceProvider provider = services.BuildServiceProvider();
 
-        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        IScheduler scheduler = await CreateScheduler(provider, scheduledUnder);
         try
         {
             await scheduler.Start();
@@ -558,11 +838,36 @@ public sealed class JobExecutionObservabilityTest
                 triggerKey,
                 scheduler.SchedulerName,
                 scheduler.SchedulerInstanceId,
-                await completion.Executed);
+                await completion.Executed,
+                completion.MergedJobData);
         }
         finally
         {
             await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// Resolves the scheduler — which is when the container's declared jobs and triggers are scheduled —
+    /// under a chosen ambient activity.
+    /// </summary>
+    /// <remarks>
+    /// Assigning <see cref="Activity.Current" /> around this one call rather than wrapping the whole of
+    /// <c>RunJob</c> in a <c>using</c> is what keeps the scheduling activity out of the execution: an
+    /// activity that was still current at <c>Start()</c> would be captured by the scheduler's worker and
+    /// become the execute span's *parent*, which is the very thing this feature refuses to do.
+    /// </remarks>
+    private static async Task<IScheduler> CreateScheduler(ServiceProvider provider, Activity scheduledUnder)
+    {
+        Activity previous = Activity.Current;
+        Activity.Current = scheduledUnder;
+        try
+        {
+            return await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        }
+        finally
+        {
+            Activity.Current = previous;
         }
     }
 
@@ -627,7 +932,8 @@ public sealed class JobExecutionObservabilityTest
         TriggerKey TriggerKey,
         string SchedulerName,
         string SchedulerInstanceId,
-        string FireInstanceId);
+        string FireInstanceId,
+        JobDataMap MergedJobData);
 
     /// <summary>
     /// Signals once the shell has finished with the execution, which is after both the activity and the
@@ -642,16 +948,24 @@ public sealed class JobExecutionObservabilityTest
 
         public Task<string> Executed => executed.Task;
 
+        /// <summary>
+        /// What the firing actually carried, which is how a test asserts on the reserved keys a scheduler
+        /// wrote onto the trigger without having to reach back into the store for the row.
+        /// </summary>
+        public JobDataMap MergedJobData { get; private set; }
+
         public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
         public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
+            MergedJobData = context.MergedJobDataMap;
             executed.TrySetResult(context.FireInstanceId);
             return default;
         }
 
         public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException, CancellationToken cancellationToken = default)
         {
+            MergedJobData = context.MergedJobDataMap;
             executed.TrySetResult(context.FireInstanceId);
             return default;
         }

--- a/src/Quartz.Tests.Unit/TypedJobInputTest.cs
+++ b/src/Quartz.Tests.Unit/TypedJobInputTest.cs
@@ -119,6 +119,98 @@ public sealed class TypedJobInputTest
             .Which.Should().Be("""{"To":"someone@example.org","Subject":"hello"}""");
     }
 
+    /// <summary>
+    /// Rescheduling stores a trigger, so it normalizes one.
+    /// </summary>
+    /// <remarks>
+    /// <c>RescheduleJob</c> was the one call that stored a trigger without preparing its data map, so an
+    /// input placed on the replacement reached the store as whatever object the caller built. The
+    /// in-memory store hands the very object back and the job could not tell; a store that serializes
+    /// could, which is the asymmetry <see cref="TheStoredInputIsAString" /> exists to rule out.
+    /// </remarks>
+    [Test]
+    public async Task TheInputOnARescheduledTriggerIsStoredAsAString()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(TheInputOnARescheduledTriggerIsStoredAsAString), start: false);
+
+        TriggerKey key = new("later", "typed");
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>().WithIdentity("email", "typed").Build(),
+            TriggerBuilder.Create().WithIdentity(key).StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+        await harness.Scheduler.RescheduleJob(key, TriggerBuilder.Create<SendEmailJob>()
+            .WithIdentity(key)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(2))
+            .UsingInput(new SendEmail("rescheduled@example.org", "after the move"))
+            .Build());
+
+        ITrigger stored = await harness.Scheduler.GetTrigger(key);
+
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().BeOfType<string>(
+            "a replacement trigger reaches a store by the same road as an original one, so its input has "
+            + "to be the string every store path can carry")
+            .Which.Should().Be("""{"To":"rescheduled@example.org","Subject":"after the move"}""");
+    }
+
+    [Test]
+    public async Task AnInputOnARescheduledTriggerReachesTheJob()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(AnInputOnARescheduledTriggerReachesTheJob));
+
+        TriggerKey key = new("later", "typed");
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>().WithIdentity("email", "typed").Build(),
+            TriggerBuilder.Create().WithIdentity(key).StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+        await harness.Scheduler.RescheduleJob(key, TriggerBuilder.Create<SendEmailJob>()
+            .WithIdentity(key)
+            .StartNow()
+            .UsingInput(new SendEmail("rescheduled@example.org", "after the move"))
+            .Build());
+
+        object received = await recorder.Received;
+
+        received.Should().Be(new SendEmail("rescheduled@example.org", "after the move"),
+            "the firing a reschedule produces reads its input the same way any other firing does");
+    }
+
+    /// <summary>
+    /// Updating a trigger's data map is the third way a map reaches a store.
+    /// </summary>
+    /// <remarks>
+    /// It is not a scheduling call — fire times and trigger state are preserved — so it deliberately
+    /// does not touch the trace-context keys. The input still has to be normalized, because that is
+    /// about what a store can hold rather than about what scheduled anything.
+    /// </remarks>
+    [Test]
+    public async Task TheInputOnAnUpdatedTriggerIsStoredAsAString()
+    {
+        Recorder recorder = new();
+        await using SchedulerHarness harness = await SchedulerHarness.Start(recorder, nameof(TheInputOnAnUpdatedTriggerIsStoredAsAString), start: false);
+
+        TriggerKey key = new("later", "typed");
+
+        await harness.Scheduler.ScheduleJob(
+            JobBuilder.Create<SendEmailJob>().WithIdentity("email", "typed").Build(),
+            TriggerBuilder.Create().WithIdentity(key).StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+        JobDataMap replacement = new();
+        replacement[SchedulerConstants.JobInput] = new SendEmail("updated@example.org", "edited in place");
+
+        (await harness.Scheduler.UpdateTriggerDetails(key, new TriggerDetailsUpdate().WithJobDataMap(replacement)))
+            .Should().BeTrue("the trigger exists, so the update applies");
+
+        ITrigger stored = await harness.Scheduler.GetTrigger(key);
+
+        stored.JobDataMap[SchedulerConstants.JobInput].Should().BeOfType<string>(
+            "UpdateTriggerDetails replaces the whole map, so it is a way into the store like any other")
+            .Which.Should().Be("""{"To":"updated@example.org","Subject":"edited in place"}""");
+    }
+
     [Test]
     public async Task GetInputReadsTheInputFromAnUntypedJob()
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1454,6 +1454,7 @@ namespace Quartz
         public string InstanceId { get; set; }
         public string InstanceName { get; set; }
         public int MaxBatchSize { get; set; }
+        public bool PropagateTraceContext { get; set; }
         public Quartz.ShutdownJobInterruption ShutdownJobInterruption { get; set; }
     }
     public static class QuartzServiceCollectionExtensions
@@ -1529,6 +1530,8 @@ namespace Quartz
         public const string ForceJobDataMapDirty = "QRTZ_FORCE_JOB_DATAMAP_DIRTY";
         public const string JobInput = "QRTZ_JOB_INPUT";
         public const string ScheduledJobGroup = "QRTZ_SCHEDULED";
+        public const string TraceParent = "QRTZ_TRACEPARENT";
+        public const string TraceState = "QRTZ_TRACESTATE";
     }
     public sealed class SchedulerContext : System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IDictionary<string, object?>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, object?>>, System.Collections.Generic.IReadOnlyDictionary<string, object?>, System.Collections.IEnumerable
     {

--- a/src/Quartz/Configuration/QuartzSchedulerOptions.cs
+++ b/src/Quartz/Configuration/QuartzSchedulerOptions.cs
@@ -93,6 +93,28 @@ public sealed class QuartzSchedulerOptions
     public ShutdownJobInterruption ShutdownJobInterruption { get; set; }
 
     /// <summary>
+    /// Whether the scheduler records the trace context of the call that scheduled a trigger, so that the
+    /// firing links back to it. On by default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A scheduled job runs minutes, hours or days after the call that asked for it, quite possibly on
+    /// another node. With this on, a scheduling call made inside an activity leaves the W3C
+    /// <c>traceparent</c> on the trigger — under <see cref="SchedulerConstants.TraceParent" /> and
+    /// <see cref="SchedulerConstants.TraceState" /> — and the firing's <c>Quartz.Job.Execute</c> span
+    /// carries an <see cref="System.Diagnostics.ActivityLink" /> to it. A link and not a parent: the
+    /// firing is its own trace root, because a trace spanning the wait would be a trace nothing could
+    /// display.
+    /// </para>
+    /// <para>
+    /// Turn it off to keep the two reserved keys out of trigger data entirely — for a store whose rows
+    /// are read by something that does not expect them, or where the extra two entries per trigger are
+    /// not worth what they buy. Nothing else changes: the execute span is emitted either way.
+    /// </para>
+    /// </remarks>
+    public bool PropagateTraceContext { get; set; } = true;
+
+    /// <summary>
     /// Values seeded into <see cref="SchedulerContext"/> when the scheduler is created.
     /// </summary>
     /// <remarks>Replaces the <c>quartz.context.key.*</c> property keys.</remarks>

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -213,6 +213,7 @@ internal static class QuartzServiceRegistration
                 MaxBatchSize = options.MaxBatchSize,
                 BatchTimeWindow = options.BatchTriggerAcquisitionFireAheadTimeWindow,
                 ShutdownJobInterruption = options.ShutdownJobInterruption,
+                PropagateTraceContext = options.PropagateTraceContext,
                 TimeProvider = timeProvider,
                 LoggerFactory = provider.GetSchedulerLoggerFactory(),
                 Meters = meters,

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -21,6 +21,7 @@
 
 #pragma warning disable CA2012
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -689,8 +690,8 @@ internal sealed class QuartzScheduler
         AdjustSimpleTriggerStartTimeIfInPast(trig);
         trig.Validate();
 
-        NormalizeInput(jobDetail.JobDataMap);
-        NormalizeInput(trig.JobDataMap);
+        PrepareJobData(jobDetail.JobDataMap);
+        PrepareTriggerData(trig);
 
         ICalendar? calendar = null;
         if (trigger.CalendarName is not null)
@@ -750,7 +751,7 @@ internal sealed class QuartzScheduler
         AdjustSimpleTriggerStartTimeIfInPast(trig);
         trig.Validate();
 
-        NormalizeInput(trig.JobDataMap);
+        PrepareTriggerData(trig);
 
         ICalendar? calendar = null;
         if (trigger.CalendarName is not null)
@@ -802,7 +803,7 @@ internal sealed class QuartzScheduler
             Throw.SchedulerException("Jobs added with no trigger must be durable.");
         }
 
-        NormalizeInput(jobDetail.JobDataMap);
+        PrepareJobData(jobDetail.JobDataMap);
 
         await resources.JobStore.AddJob(jobDetail, options.Replace, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(null);
@@ -887,7 +888,7 @@ internal sealed class QuartzScheduler
             {
                 continue;
             }
-            NormalizeInput(job.JobDataMap);
+            PrepareJobData(job.JobDataMap);
 
             if (triggers is null) // this is possible because the job may be durable, and not yet be having triggers
             {
@@ -904,7 +905,7 @@ internal sealed class QuartzScheduler
                 AdjustSimpleTriggerStartTimeIfInPast(trigger);
                 trigger.Validate();
 
-                NormalizeInput(trigger.JobDataMap);
+                PrepareTriggerData(trigger);
 
                 ICalendar? calendar = null;
                 if (trigger.CalendarName is not null)
@@ -1045,6 +1046,8 @@ internal sealed class QuartzScheduler
         AdjustSimpleTriggerStartTimeIfInPast(trigger);
         trigger.Validate();
 
+        PrepareTriggerData(trigger);
+
         ICalendar? calendar = null;
         if (newTrigger.CalendarName is not null)
         {
@@ -1115,6 +1118,14 @@ internal sealed class QuartzScheduler
         ArgumentNullException.ThrowIfNull(triggerKey);
         ArgumentNullException.ThrowIfNull(update);
 
+        // The input half only. A map that reaches a store has to have its typed input normalized
+        // whichever call carried it there, so this is the same rule as everywhere else — but the trace
+        // context is deliberately not written here, because this is not a scheduling call. It updates
+        // metadata on a trigger that is already scheduled and keeps its fire times, so the trace that
+        // asked for the firing is the one that scheduled it, not the one that later edited its
+        // description. Re-pointing the link at whoever ran an edit would make it say something false.
+        PrepareJobData(update.JobDataMap);
+
         return await resources.JobStore.UpdateTriggerDetails(triggerKey, update, cancellationToken).ConfigureAwait(false);
     }
 
@@ -1132,30 +1143,97 @@ internal sealed class QuartzScheduler
     internal ExecutionLimits? GetExecutionLimits() => executionLimits;
 
     /// <summary>
-    /// The scheduler and the job stores operate on <see cref="IOperableTrigger" />, and Quartz owns
-    /// the implementations of <see cref="ITrigger" /> — so a trigger that implements only the read
-    /// model is rejected with a clear error rather than an invalid-cast exception.
-    /// </summary>
-    /// <summary>
-    /// Turns a job input that is not yet a string into the string a store can hold, on its way in.
+    /// Makes a job's data map ready to be stored.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This is the write half of a typed job's round trip, and it lives here because here is the only
-    /// place the value's <em>runtime</em> type is known — which is what has to be serialized. The read
-    /// half is the default implementation of <see cref="IJob{TInput}" />, where the <em>static</em> type
-    /// is known instead. Neither can do the other's job, which is why they are apart.
+    /// Today that is one thing: turning a job input that is not yet a string into the string a store can
+    /// hold. This is the write half of a typed job's round trip, and it lives here because here is the
+    /// only place the value's <em>runtime</em> type is known — which is what has to be serialized. The
+    /// read half is the default implementation of <see cref="IJob{TInput}" />, where the <em>static</em>
+    /// type is known instead. Neither can do the other's job, which is why they are apart.
     /// </para>
     /// <para>
-    /// Every entry point that takes a <see cref="JobDataMap" /> to be stored passes through here, so an
-    /// input reaches a store as a string whichever way it was scheduled.
+    /// Every entry point that takes a <see cref="JobDataMap" /> to be stored passes through here or
+    /// through <see cref="PrepareTriggerData" />, so an input reaches a store as a string whichever way
+    /// it was scheduled.
     /// </para>
     /// </remarks>
-    private void NormalizeInput(JobDataMap? map)
+    private void PrepareJobData(JobDataMap? map)
     {
         JobInput.Normalize(map, resources.JobInputSerializer);
     }
 
+    /// <summary>
+    /// Makes a trigger's data map ready to be stored: everything <see cref="PrepareJobData" /> does, plus
+    /// the trace context of whoever is scheduling it.
+    /// </summary>
+    /// <remarks>
+    /// The trigger's map and not the job's, because a firing is what the trace is about and a job is
+    /// fired by many triggers. It also keeps the two writes from ever meeting:
+    /// <see cref="PersistJobDataAfterExecutionAttribute" /> writes back the job's map alone, so a
+    /// persisted job can never carry a <c>traceparent</c> forward from the firing that wrote it.
+    /// </remarks>
+    private void PrepareTriggerData(IMutableTrigger trigger)
+    {
+        JobDataMap map = trigger.JobDataMap;
+        JobInput.Normalize(map, resources.JobInputSerializer);
+        WriteTraceContext(map);
+    }
+
+    /// <summary>
+    /// Records the W3C trace context of the activity this trigger is being scheduled from, so that the
+    /// firing — minutes, hours or days later, quite possibly on another node — can link back to it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Write-<em>or-remove</em>: the scheduler stores the trigger object it was handed rather than a copy
+    /// of it, so a trigger re-scheduled outside an activity would otherwise keep pointing at the trace
+    /// that scheduled it the first time — the worst of the three answers, because a stale link is read
+    /// as a true one.
+    /// </para>
+    /// <para>
+    /// An activity whose id is not in the W3C format has no <c>traceparent</c> to record and is treated
+    /// as no activity at all. Opting out with
+    /// <see cref="QuartzSchedulerOptions.PropagateTraceContext" /> leaves the two keys entirely alone,
+    /// including one an application wrote itself.
+    /// </para>
+    /// </remarks>
+    private void WriteTraceContext(JobDataMap map)
+    {
+        if (!resources.PropagateTraceContext)
+        {
+            return;
+        }
+
+        // Read once: Activity.Current is an AsyncLocal, and the traceparent and the tracestate written
+        // below have to come from the same activity.
+        Activity? scheduledFrom = Activity.Current;
+
+        if (scheduledFrom is not { IdFormat: ActivityIdFormat.W3C, Id: { } traceParent })
+        {
+            map.Remove(SchedulerConstants.TraceParent);
+            map.Remove(SchedulerConstants.TraceState);
+            return;
+        }
+
+        map[SchedulerConstants.TraceParent] = traceParent;
+
+        if (scheduledFrom.TraceStateString is { Length: > 0 } traceState)
+        {
+            map[SchedulerConstants.TraceState] = traceState;
+        }
+        else
+        {
+            map.Remove(SchedulerConstants.TraceState);
+        }
+    }
+
+    /// <summary>
+    /// The scheduler and the job stores operate on <see cref="IOperableTrigger" />, and Quartz owns
+    /// the implementations of <see cref="ITrigger" /> — so a trigger that implements only the read
+    /// model is rejected with a clear error rather than an invalid-cast exception.
+    /// </summary>
     private static IOperableTrigger AsOperableTrigger(ITrigger trigger)
     {
         if (trigger is not IOperableTrigger operableTrigger)
@@ -1246,9 +1324,12 @@ internal sealed class QuartzScheduler
         trig.ComputeFirstFireTimeUtc(null);
         if (data is not null)
         {
-            NormalizeInput(data);
             trig.JobDataMap = data;
         }
+
+        // After the map has been attached, and unconditionally: a fire-now with no data of its own is
+        // still a firing worth linking back to whoever asked for it.
+        PrepareTriggerData(trig);
 
         bool collision = true;
         while (collision)
@@ -1279,7 +1360,7 @@ internal sealed class QuartzScheduler
 
         trigger.ComputeFirstFireTimeUtc(null);
 
-        NormalizeInput(trigger.JobDataMap);
+        PrepareTriggerData(trigger);
 
         bool collision = true;
         while (collision)

--- a/src/Quartz/Core/QuartzSchedulerResources.cs
+++ b/src/Quartz/Core/QuartzSchedulerResources.cs
@@ -293,6 +293,13 @@ internal sealed class QuartzSchedulerResources
 
     public ShutdownJobInterruption ShutdownJobInterruption { get; set; }
 
+    /// <summary>
+    /// Whether a trigger carries the trace context of the call that scheduled it. Mirrors
+    /// <see cref="QuartzSchedulerOptions.PropagateTraceContext" />, and defaults to the same value, so a
+    /// scheduler assembled without the container behaves the way one assembled with it does.
+    /// </summary>
+    public bool PropagateTraceContext { get; set; } = true;
+
     public TimeProvider TimeProvider { get; set; }
 
     /// <summary>

--- a/src/Quartz/Diagnostics/QuartzActivitySource.cs
+++ b/src/Quartz/Diagnostics/QuartzActivitySource.cs
@@ -18,9 +18,43 @@ internal static class QuartzActivitySource
 
         activity.SetStartTime(startTime.UtcDateTime);
         activity.EnrichFrom(context);
+        activity.LinkToScheduler(context);
         activity.Start();
 
         return new StartedActivity(activity);
+    }
+
+    /// <summary>
+    /// Links the firing back to the activity that scheduled it, when the trigger recorded one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="ActivityLink" /> and not a parent. The scheduling call and the firing are related but
+    /// separated by however long the schedule said — minutes, days, a cron expression's next Sunday — and
+    /// a span whose parent is that far away makes a trace no backend can render and no operator can
+    /// read. A link is the shape OpenTelemetry gives exactly this: an asynchronous producer and the
+    /// consumer that eventually picks the work up. The firing is its own trace root, and the link is how
+    /// you walk back to the request that asked for it.
+    /// </para>
+    /// <para>
+    /// Added before <see cref="Activity.Start" />, so the link is on the activity by the time a listener
+    /// is told about it — a sampler that reads links reads them at start.
+    /// </para>
+    /// </remarks>
+    private static void LinkToScheduler(this Activity activity, JobExecutionContextImpl context)
+    {
+        if (!context.MergedJobDataMap.TryGetValue(SchedulerConstants.TraceParent, out object? stored)
+            || stored is not string traceParent)
+        {
+            return;
+        }
+
+        context.MergedJobDataMap.TryGetValue(SchedulerConstants.TraceState, out object? state);
+
+        if (ActivityContext.TryParse(traceParent, state as string, isRemote: true, out ActivityContext scheduledBy))
+        {
+            activity.AddLink(new ActivityLink(scheduledBy));
+        }
     }
 
     internal static void EnrichFrom(this Activity activity, IJobExecutionContext context)

--- a/src/Quartz/SchedulerConstants.cs
+++ b/src/Quartz/SchedulerConstants.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System.Diagnostics;
+
 namespace Quartz;
 
 /// <summary>
@@ -131,4 +133,39 @@ public static class SchedulerConstants
     /// dashboard, a query or a clean-up can say which jobs it means without spelling the string.
     /// </remarks>
     public const string ScheduledJobGroup = "QRTZ_SCHEDULED";
+
+    /// <summary>
+    /// The <see cref="JobDataMap" /> key carrying the W3C <c>traceparent</c> of the activity that
+    /// scheduled a trigger, so that the firing can be linked back to it however much later it happens.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Written onto the <em>trigger's</em> map by the scheduler, on every entry point that stores a
+    /// trigger, whenever <see cref="Activity.Current" /> is a W3C activity and
+    /// <see cref="QuartzSchedulerOptions.PropagateTraceContext" /> is on. Read back when the firing's
+    /// span is opened, where it becomes an <see cref="ActivityLink" /> rather than a parent — a job
+    /// scheduled for next Tuesday is its own trace, and a trace that stays open for a week is not a
+    /// trace.
+    /// </para>
+    /// <para>
+    /// A trigger scheduled outside an activity has the key <em>removed</em> rather than left alone,
+    /// because the scheduler stores the trigger object it was handed rather than a copy of it: a trigger
+    /// re-scheduled outside an activity would otherwise keep pointing at the trace that scheduled it the
+    /// first time.
+    /// </para>
+    /// <para>
+    /// This is the trigger's map, never the job's, so
+    /// <see cref="PersistJobDataAfterExecutionAttribute" /> — which writes back only the job's map —
+    /// never sees it and the two cannot interact.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="TraceState" />
+    public const string TraceParent = "QRTZ_TRACEPARENT";
+
+    /// <summary>
+    /// The <see cref="JobDataMap" /> key carrying the W3C <c>tracestate</c> that accompanies
+    /// <see cref="TraceParent" />, present only when the scheduling activity had one.
+    /// </summary>
+    /// <seealso cref="TraceParent" />
+    public const string TraceState = "QRTZ_TRACESTATE";
 }


### PR DESCRIPTION
A scheduled job runs minutes, hours or days after the call that asked for it, on another node, with
no relationship to the trace that wanted it. Every integrator that cared reached into the trigger's
`JobDataMap` and invented a key of its own.

The scheduler now records the W3C trace context of whatever activity is current when a trigger is
stored, and the firing's `Quartz.Job.Execute` span carries an `ActivityLink` back to it.

## What changed

**Two reserved keys and one option**, all in `Quartz`:

```csharp
SchedulerConstants.TraceParent = "QRTZ_TRACEPARENT";
SchedulerConstants.TraceState  = "QRTZ_TRACESTATE";
QuartzSchedulerOptions.PropagateTraceContext { get; set; } = true;
```

Those three lines are the whole of the public API delta, and the only change to
`PublicApiTest_Quartz.verified.txt`. There is no `QuartzPropertyBridge` entry: nothing on 3.x did
this, so there is no flat `quartz.*` key to migrate — and `LegacyPropertyKeys` correctly rejects an
invented one. The value is carried to the scheduler on `QuartzSchedulerResources`, the way
`ShutdownJobInterruption` is.

**Written in `QuartzScheduler`.** The five entry points that already normalized a typed job input now
do both through one `PrepareTriggerData(IMutableTrigger)` / `PrepareJobData(JobDataMap)` pair, so
there is a single place a map is made ready to be stored: both `ScheduleJob` overload pairs,
`AddJob`, `ScheduleJobs`, and both `TriggerJob` forms.

**Read in `QuartzActivitySource.StartJobExecute`**, where `ActivityContext.TryParse` becomes
`activity.AddLink(...)` before `Start()`. The span name is unchanged.

## Three decisions worth a reviewer's attention

**A link, not a parent.** A trace held open from Monday's request to Sunday's firing is a trace no
backend renders and no operator reads. The firing stays its own trace root; the link is how you walk
back to the request. This is the shape OpenTelemetry gives an asynchronous producer and the consumer
that eventually picks the work up.

**The trigger's map, never the job's.** A firing is what the trace is about, and a job is fired by
many triggers. It also keeps the write away from `[PersistJobDataAfterExecution]`, which writes back
only the job's map — so the two can never interact.

**Write-or-remove.** `AsOperableTrigger` hands the store the very object the caller passed rather
than a copy. A trigger scheduled once inside a request and again outside one would otherwise keep
pointing at the first request's trace, and a stale link reads exactly like a true one. Opting out
with `PropagateTraceContext = false` leaves both keys entirely alone, including one an application
wrote itself.

## The default is `true`, and the sweep was empty

The brief said to flip the default to `false` if sweeping the fixtures under an always-on
`ActivityListener` turned out large. It turned out to be **zero assertions**: the write only happens
when `Activity.Current` is set, and neither `JobExecutionObservabilityTest` nor `TracingJobStoreTest`
starts a scheduling activity — their listeners only observe Quartz's own source. The
`WireFormatSnapshotTest_*` trigger snapshots serve canned triggers through a `FakeItEasy` scheduler,
so no `QuartzScheduler` code runs for them at all. The only baseline that moved is the public API
one, by the three lines above. The default therefore ships as `true`.

## Tests

- `JobExecutionObservabilityTest` gains five: the execute span carries exactly one link whose
  context, `tracestate` and `IsRemote` match the scheduling activity's and which is *not* its parent;
  the reserved keys are on the trigger; no link and no keys when there was no activity; opt-out
  honoured; and a stale `traceparent` is dropped when the same trigger object is rescheduled outside
  an activity.
- `TraceContextThroughAdoStoreTest` (new, file-SQLite, no container, runs in the `basic` leg) proves
  the link survives an actual round trip: the trigger is written to a database as job data, read back
  by the scheduler thread as a row, and the firing's span still links back.
- `TraceContextOverHttpTest` (new) confirms the HTTP API gets it for free — a request carrying a
  `traceparent` reaches the trigger through ASP.NET Core's own server span, with a real scheduler
  behind the API rather than this folder's fake.

Both halves were mutation-checked: disabling the link makes exactly one test fail, disabling the
stale-key removal makes exactly one other fail.

## Verification

`dotnet build Quartz.slnx` 0 warnings, 0 errors · `Quartz.Tests.Unit` 4051 passed ·
`Quartz.Tests.AspNetCore` 538 passed · `Quartz.Tests.Integration` (container-free leg) 357 passed ·
`dotnet fallout PublishTrimmed` succeeded · `VerifyDocsSnippets` succeeded ·
`npm run docs:check-links` no dead links or anchors.

## Docs

Migration guide gains "A scheduled job links back to the trace that scheduled it"; the observability
page gains "Linking a firing to what scheduled it".

Closes #3524
