### PR TITLE
An Aspire scheduler creates its schema where that is the right thing to do

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/aspire.md
+++ b/docs/documentation/quartz-4.x/how-tos/aspire.md
@@ -219,14 +219,44 @@ data-source probe entirely — otherwise it would resolve some other database's 
 all, and only find out at the first query. The same shape works for Postgres, and is the right one whenever
 the application has no data source of its own to share.
 
-## The tables are still yours to create
+## Getting the tables there
 
-Quartz does not create or migrate its schema, under Aspire or anywhere else — see
-[Database Schema](../db/) for what has to exist and
-[`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables) for the scripts.
-Aspire's own hooks mostly do not close that gap. `AddDatabase` does create the *database* — on the server
-resource's `ResourceReadyEvent`, once its health check passes — but the two hooks that look like they would
-then run the DDL are narrower than they appear:
+Quartz never migrates its schema, and under Aspire as anywhere else the fresh-install scripts in
+[`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables) are what a
+production database runs — see [Database Schema](../db/) for what has to exist. What is new in 4.0 is
+that a *development* database need not: `store.ProvisionSchema()` has the store create whatever is
+missing as it starts, which is exactly the case an AppHost tearing a Postgres container up and down
+represents. `AddQuartzPersistentStore` asks for it on your behalf, reading `builder.Environment` at the
+call: `CreateIfMissing` under `Development`, and the `Validate` default in every other environment,
+where the account the scheduler connects with usually cannot run DDL and is right not to be able to.
+[Creating the schema](../tutorial/job-stores.md#creating-the-schema) has the setting and its limits.
+
+`QuartzAspireSettings.ProvisionSchema` says it outright when the environment is not the right thing to
+ask — `true` creates in every environment, and `false` in none:
+
+<!-- snippet: sample_aspire_provision_schema -->
+```csharp
+builder.AddQuartzPersistentStore("quartz", settings => settings.ProvisionSchema = true);
+```
+<!-- endSnippet -->
+
+The store still has the last word. A `SchemaProvisioning` the application set itself — through
+`ConfigureStore`, or through `Quartz:JobStore:SchemaProvisioning` — is a decision about this store in
+particular, and this call fills the gap rather than overruling it:
+
+<!-- snippet: sample_aspire_schema_by_hand -->
+```csharp
+builder.AddQuartz(q => q.UsePersistentStore(store =>
+    store.ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.None)));
+```
+<!-- endSnippet -->
+
+The one position that cannot be said that way is `Validate`, which is what an unconfigured store already
+holds and so cannot be told apart from having said nothing. `ProvisionSchema = false` is how to say it.
+
+That leaves the production question, and Aspire's own hooks mostly do not close it. `AddDatabase` does
+create the *database* — on the server resource's `ResourceReadyEvent`, once its health check passes —
+but the two hooks that look like they would then run the DDL are narrower than they appear:
 
 * `WithCreationScript` runs one command against the **server's** default database, on a connection whose
   `Database=postgres`. Its own documentation says it is for statements that apply to that database, such as
@@ -264,11 +294,10 @@ builder.AddProject<Projects.Orders_Worker>("orders")
 is up, not that `QRTZ_TRIGGERS` exists. `WaitForCompletion` waits for the migration project to exit, which
 is the thing the scheduler actually depends on.
 
-The store will eventually be able to do this itself:
-[#3531](https://github.com/quartznet/quartznet/issues/3531) tracks a `SchemaProvisioning` setting that would
-let a persistent store create its own tables. Half of it has landed — the schema each dialect needs is now
-generated as a script a provider can execute — but nothing reads those scripts yet, so the recipe above is
-the answer today.
+Provisioning does not replace that recipe in production, for the two reasons it is opt-in everywhere:
+the scheduler's account would need permission to create tables, and creating a missing schema is not the
+same as moving an existing one forward. `database/migrations/` is still what does that, and the 3.x →
+4.0 upgrade is still mandatory.
 
 ## Health
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -135,6 +135,13 @@ integration: the AppHost still declares its database resources itself. See
 [Aspire Integration](packages/aspire.md) for every setting it reads from `Aspire:Quartz`, and
 [Running Quartz under Aspire](how-tos/aspire.md) for what the call expands to.
 
+One of those settings decides something the rest of Quartz leaves off by default, so it is worth reading
+before the first run:
+
+| Setting | Default | What it decides |
+|---|---|---|
+| `QuartzAspireSettings.ProvisionSchema` | unset — `SchemaProvisioning.CreateIfMissing` under `Development`, the `Validate` default in every other environment | Whether the store creates whatever its schema is missing as it starts. `true` creates in every environment and `false` in none; a `SchemaProvisioning` the application set on the store itself is kept either way. See [`PerformSchemaValidation` became `SchemaProvisioning`](#performschemavalidation-became-schemaprovisioning-which-has-a-third-position) |
+
 ### The health check is in `Quartz`, not `Quartz.AspNetCore`
 
 `Quartz.AspNetCore` carries `<FrameworkReference Include="Microsoft.AspNetCore.App" />` for the HTTP API,

--- a/docs/documentation/quartz-4.x/packages/aspire.md
+++ b/docs/documentation/quartz-4.x/packages/aspire.md
@@ -77,6 +77,7 @@ reads them. What these settings decide is the handful of things that follow from
 | `Provider` | `string?` | inferred from the connection string | Which ADO.NET driver reaches the database |
 | `SchedulerName` | `string?` | every scheduler in the container | Which scheduler this store belongs to |
 | `TablePrefix` | `string?` | whatever `AdoJobStoreOptions.TablePrefix` already had | The prefix on the Quartz table names |
+| `ProvisionSchema` | `bool?` | unset — creates under `Development`, validates everywhere else | Whether the store creates whatever its schema is missing as it starts |
 | `Clustered` | `bool` | `false` | Whether this scheduler joins a cluster on the database, deriving an instance id to do it with |
 | `DisableHealthChecks` | `bool` | `false` | Leaves `AddQuartzHealthChecks()` unregistered |
 | `DisableTracing` | `bool` | `false` | Leaves the `Quartz` activity source unsubscribed |
@@ -86,6 +87,10 @@ The three flags are spelled `Disable*` rather than `Enable*` because Aspire's ru
 that a fresh instance — which is what binding an absent section produces — must already hold the
 recommended values. A `bool` bound from nothing is `false`, so the useful default has to be the `false` one.
 Every first-party integration has been spelled this way since Aspire 8.0.
+
+`ProvisionSchema` is the one `bool?`, for the same rule read the other way: the recommended value is not
+the same in every environment, so no `bool` could hold it. Unset is a third answer rather than a missing
+one — *ask the environment* — and `true` or `false` is how an application that knows better says so.
 
 Every setting here says something or says nothing; none of them says *no*. `TablePrefix` left unset keeps
 whatever `Quartz:JobStore:TablePrefix` or an earlier `ConfigureStore` said, rather than resetting it, and
@@ -217,6 +222,36 @@ implementation at all, and Aspire's SQL Server client integration registers a sc
 instead — so probing for an unkeyed `DbDataSource` would find some *other* database's, or nothing, and would
 fail at first use rather than at startup.
 
+## What happens to the schema
+
+The store is configured with `SchemaProvisioning.CreateIfMissing` when the application is running in
+`Development`, and left at the `Validate` default everywhere else. `builder.Environment` is read at the
+`AddQuartzPersistentStore` call rather than when the scheduler starts, so the answer is the environment
+the container was built in.
+
+| `ProvisionSchema` | `AdoJobStoreOptions.SchemaProvisioning` becomes |
+|---|---|
+| unset (the default) | `CreateIfMissing` under `Development`, `Validate` in every other environment |
+| `true` | `CreateIfMissing`, whatever the environment |
+| `false` | `Validate`, whatever the environment — which is what it already is, so nothing is set |
+
+An AppHost's database container comes up empty whenever its volume is new, which makes a first run that
+fails schema validation the ordinary outcome rather than an edge case; a production account, on the other
+hand, usually holds no DDL permission and is right not to. Neither is a fact about *this* application,
+which is why the environment answers rather than a default that would be wrong on one side.
+
+The store keeps its own word. A `SchemaProvisioning` the application set — through `ConfigureStore`, or
+through `Quartz:JobStore:SchemaProvisioning` — is read as a decision about this store and left alone,
+because this call runs from `ConfigureAllQuartzSchedulers` and would otherwise win merely by being last.
+`Validate` is the exception, being what an unconfigured store already holds and so indistinguishable from
+silence: `ProvisionSchema = false` is how an application in `Development` says it.
+
+Everything else about provisioning is the store's, not this package's:
+[Creating the schema](../tutorial/job-stores.md#creating-the-schema) covers what it runs, why it is safe
+under a cluster starting at once, and the two configurations that cannot provision or would provision the
+wrong schema. [Running Quartz under Aspire](../how-tos/aspire.md#getting-the-tables-there) has the
+production recipe.
+
 ## Clustering
 
 `Clustered = true` calls `UseClustering()`, which turns database locking on with it, **and makes the
@@ -294,9 +329,12 @@ See [Multiple Schedulers](multiple-schedulers.md) for what a named scheduler is 
   and a decision about *this application's* probe, not about Quartz;
   [the how-to](../how-tos/aspire.md#health) explains why the default mapping loses a standby scheduler and
   what to write instead.
-* **It creates no tables.** Quartz does not provision its schema under Aspire or anywhere else — see
-  [the how-to](../how-tos/aspire.md#the-tables-are-still-yours-to-create) for the migration-service recipe,
-  and [#3531](https://github.com/quartznet/quartznet/issues/3531) for the store learning to do it itself.
+* **It creates no tables in production.** The store provisions its own schema under `Development` and
+  validates it everywhere else, because that is what an AppHost's empty container and a production
+  account's permissions respectively call for — and it migrates a schema nowhere, because nothing in a
+  Quartz schema records which version it is.
+  [The how-to](../how-tos/aspire.md#getting-the-tables-there) has the migration-service recipe that
+  answers the production half.
 * **It adds no OpenTelemetry exporter**, for the reason above.
 
 One convention this package knowingly diverges from: Aspire's contributor guidance asks a client

--- a/src/Quartz.Aspire/ConfigurationSchema.json
+++ b/src/Quartz.Aspire/ConfigurationSchema.json
@@ -45,6 +45,10 @@
                 "Firebird"
               ]
             },
+            "ProvisionSchema": {
+              "type": "boolean",
+              "description": "Gets or sets whether the store creates whatever its schema is missing when the scheduler starts. Left unset, the environment decides: it creates under Development, where the AppHost's database container comes up empty, and only validates everywhere else, where the account usually cannot run DDL. A SchemaProvisioning the application set on the job store itself is kept either way."
+            },
             "SchedulerName": {
               "type": "string",
               "description": "Gets or sets which scheduler this store belongs to, for an application that registers more than one. Left unset, every scheduler in the container gets it."

--- a/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
+++ b/src/Quartz.Aspire/QuartzAspireHostApplicationBuilderExtensions.cs
@@ -21,9 +21,9 @@ namespace Quartz;
 /// This is the page <c>how-tos/aspire.md</c> already documented, turned into one call. An Aspire AppHost
 /// declares a database and hands the worker its connection string as <c>ConnectionStrings:&lt;name&gt;</c>;
 /// everything after that — which driver delegate speaks that database's SQL, whether connections come
-/// from a <c>DbDataSource</c> the container holds or from the string itself, and naming Quartz's two
-/// telemetry signals to the pipeline ServiceDefaults built — follows from the name, and is what this
-/// does.
+/// from a <c>DbDataSource</c> the container holds or from the string itself, whether a development
+/// database that came up empty has its tables created, and naming Quartz's two telemetry signals to the
+/// pipeline ServiceDefaults built — follows from the name, and is what this does.
 /// </para>
 /// <para>
 /// It is <em>additive</em> and order-independent. The store is contributed through
@@ -107,6 +107,11 @@ public static class QuartzAspireHostApplicationBuilderExtensions
         bool clustered = settings.Clustered;
         bool healthChecks = !settings.DisableHealthChecks;
 
+        // Decided here rather than in the callback, so that it is the environment the application was
+        // built in that answers, and so that a reader of this method can see what the unset setting
+        // resolved to at the one place the answer is known.
+        bool provisionSchema = settings.ProvisionSchema ?? builder.Environment.IsDevelopment();
+
         builder.Services.ConfigureAllQuartzSchedulers(quartz =>
         {
             // A settings object naming a scheduler is talking about that one. Naming none is the single
@@ -123,6 +128,14 @@ public static class QuartzAspireHostApplicationBuilderExtensions
                 if (tablePrefix is not null)
                 {
                     store.ConfigureStore(options => options.TablePrefix = tablePrefix);
+                }
+
+                // Only one side of this is written. Not provisioning is what an unconfigured store
+                // already does, so saying it would mean overwriting a store the application configured
+                // itself with the value it would have had anyway.
+                if (provisionSchema)
+                {
+                    ProvisionTheSchemaUnlessAPositionWasChosen(store);
                 }
 
                 if (clustered)
@@ -145,6 +158,37 @@ public static class QuartzAspireHostApplicationBuilderExtensions
         AddTelemetry(builder.Services, settings);
 
         return builder;
+    }
+
+    /// <summary>
+    /// Has the store create whatever its schema is missing, unless the application said what the store
+    /// should do about its schema.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IPersistentStoreBuilder.ProvisionSchema"/> as a conditional. That method assigns
+    /// <see cref="SchemaProvisioning.CreateIfMissing"/> outright, and this delegate runs after
+    /// everything the application said — options are last-wins, and
+    /// <c>ConfigureAllQuartzSchedulers</c> is applied after the scheduler's own callback and after the
+    /// configuration binding — so calling it would overrule a store that had been told something else
+    /// rather than answering for one that was told nothing.
+    /// </para>
+    /// <para>
+    /// The gap it fills is <see cref="SchemaProvisioning.Validate"/>, which is what an unconfigured
+    /// store holds. An application that means that under <c>Development</c> says so with
+    /// <see cref="QuartzAspireSettings.ProvisionSchema"/> set to <see langword="false"/>, since setting
+    /// the option to the value it already has cannot be read as a decision.
+    /// </para>
+    /// </remarks>
+    private static void ProvisionTheSchemaUnlessAPositionWasChosen(IPersistentStoreBuilder store)
+    {
+        store.ConfigureStore(options =>
+        {
+            if (options.SchemaProvisioning == SchemaProvisioning.Validate)
+            {
+                options.SchemaProvisioning = SchemaProvisioning.CreateIfMissing;
+            }
+        });
     }
 
     /// <summary>

--- a/src/Quartz.Aspire/QuartzAspireSettings.cs
+++ b/src/Quartz.Aspire/QuartzAspireSettings.cs
@@ -79,6 +79,39 @@ public sealed class QuartzAspireSettings
     public string? TablePrefix { get; set; }
 
     /// <summary>
+    /// Whether the store creates whatever its schema is missing when the scheduler starts.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Left unset — the default — the environment decides, read from
+    /// <see cref="Microsoft.Extensions.Hosting.IHostApplicationBuilder.Environment"/> at the
+    /// <c>AddQuartzPersistentStore</c> call: <see cref="SchemaProvisioning.CreateIfMissing"/> under
+    /// <c>Development</c>, and <see cref="SchemaProvisioning.Validate"/> everywhere else. The two halves
+    /// of that are the same observation from opposite ends — the AppHost's database container comes up
+    /// empty on every start that has no data volume behind it, so a development scheduler that refuses
+    /// to start until somebody applies a script is refusing on every first run; and a production account
+    /// usually cannot run DDL at all, which it is right not to be able to.
+    /// </para>
+    /// <para>
+    /// <see langword="true"/> creates in every environment, <see langword="false"/> in none — which is
+    /// what a deployment that applies its own schema wants to say once, in the shared
+    /// <c>Aspire:Quartz</c> section, rather than per environment. Creating only ever creates: no object
+    /// is altered and none is dropped, so it cannot turn a mis-typed <see cref="TablePrefix"/> into data
+    /// loss, and it is equally not an upgrade — <c>database/migrations/</c> is still what moves a schema
+    /// forward.
+    /// </para>
+    /// <para>
+    /// It fills a gap rather than overruling one. An <c>AdoJobStoreOptions.SchemaProvisioning</c> the
+    /// application set itself — from <c>ConfigureStore</c> or from
+    /// <c>Quartz:JobStore:SchemaProvisioning</c> — is a decision made about this store in particular and
+    /// is kept. The one thing that cannot be said that way is <see cref="SchemaProvisioning.Validate"/>,
+    /// which is what an unconfigured store already holds and so is indistinguishable from having said
+    /// nothing; <see langword="false"/> here is how to say it.
+    /// </para>
+    /// </remarks>
+    public bool? ProvisionSchema { get; set; }
+
+    /// <summary>
     /// Whether this scheduler takes part in a cluster with every other scheduler sharing the database.
     /// </summary>
     /// <remarks>

--- a/src/Quartz.Aspire/README.md
+++ b/src/Quartz.Aspire/README.md
@@ -67,6 +67,7 @@ builder.AddQuartzPersistentStore("quartz", settings =>
 | `Provider` | inferred | Which ADO.NET driver reaches the database |
 | `SchedulerName` | every scheduler | Which scheduler this store belongs to |
 | `TablePrefix` | `QRTZ_` | The prefix on the Quartz table names |
+| `ProvisionSchema` | unset | Whether the store creates whatever its schema is missing as it starts |
 | `Clustered` | `false` | Whether this scheduler joins a cluster on the database, deriving an instance id to do it with |
 | `DisableHealthChecks` | `false` | Leaves `AddQuartzHealthChecks()` unregistered |
 | `DisableTracing` | `false` | Leaves the `Quartz` activity source unsubscribed |
@@ -100,13 +101,19 @@ the drivers above them, so which of each pair to use is the application's choice
 A name Quartz ships no description for works there too — it selects the generic SQL dialect and whatever
 `DbMetadataFactory` you registered.
 
-## The tables are still yours to create
+## Getting the tables there
 
-Quartz does not create or migrate its schema, under Aspire or anywhere else, and neither
-`WithInitFiles` nor `WithCreationScript` closes that gap — both run against the server rather than the
-database. Apply the schema the way you would apply an Entity Framework Core migration: a small project the
-worker waits for with `WaitForCompletion`. The scripts are in
-[`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables).
+Under `Development` the store creates whatever its schema is missing as it starts, because an AppHost's
+database container comes up empty whenever its volume is new. Everywhere else it validates the schema and
+creates nothing, because creating tables needs DDL permission a production account is usually right not to
+hold. `ProvisionSchema` set to `true` or `false` says it outright, and a `SchemaProvisioning` the
+application set on the store itself is kept either way.
+
+Nothing migrates a schema, here or anywhere else. In production apply it the way you would apply an Entity
+Framework Core migration — a small project the worker waits for with `WaitForCompletion` — from the scripts
+in [`database/tables`](https://github.com/quartznet/quartznet/tree/main/database/tables); neither
+`WithInitFiles` nor `WithCreationScript` closes that gap, as both run against the server rather than the
+database.
 
 ## Documentation
 

--- a/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs
@@ -47,6 +47,25 @@ public static class AspireSamples
         #endregion
     }
 
+    public static void ProvisionTheSchemaInEveryEnvironment(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_provision_schema
+
+        builder.AddQuartzPersistentStore("quartz", settings => settings.ProvisionSchema = true);
+
+        #endregion
+    }
+
+    public static void ChooseWhatHappensToTheSchemaByHand(IHostApplicationBuilder builder)
+    {
+        #region sample_aspire_schema_by_hand
+
+        builder.AddQuartz(q => q.UsePersistentStore(store =>
+            store.ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.None)));
+
+        #endregion
+    }
+
     public static void TwoDatabasesOnTwoSchedulers(IHostApplicationBuilder builder)
     {
         #region sample_aspire_two_schedulers

--- a/src/Quartz.Examples.Aspire.Worker/Program.cs
+++ b/src/Quartz.Examples.Aspire.Worker/Program.cs
@@ -15,6 +15,11 @@ builder.AddNpgsqlDataSource("quartz");
 
 // Everything the Aspire connection named "quartz" is evidence of: which database it is, the driver
 // delegate that speaks its SQL, where connections come from, and the scheduler's health check.
+//
+// The tables come with it here. This profile runs in Development, where the store creates whatever
+// its schema is missing rather than refusing to start against the empty database a fresh Postgres
+// volume hands it. Anywhere else it would validate instead, and something else would apply the
+// schema; settings.ProvisionSchema says which without asking the environment.
 builder.AddQuartzPersistentStore("quartz");
 
 builder.AddQuartz(q => q.ScheduleJob<HeartbeatJob>(trigger => trigger

--- a/src/Quartz.Tests.Unit/Aspire/AspireApplication.cs
+++ b/src/Quartz.Tests.Unit/Aspire/AspireApplication.cs
@@ -64,6 +64,30 @@ internal static class AspireApplication
     }
 
     /// <summary>
+    /// A worker running in a named environment, with one Postgres connection string.
+    /// </summary>
+    /// <remarks>
+    /// The environment is named rather than left to the default, on both sides of every test that reads
+    /// it: what <see cref="Host.CreateEmptyApplicationBuilder"/> falls back to when nothing names one is
+    /// not the subject, and a test that relied on it would be asserting the host's default rather than
+    /// Quartz's.
+    /// </remarks>
+    public static HostApplicationBuilder WorkerIn(
+        string environmentName,
+        params (string Key, string? Value)[] configuration)
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(
+            new HostApplicationBuilderSettings { EnvironmentName = environmentName });
+
+        builder.Configuration.AddInMemoryCollection(
+            configuration
+                .Select(entry => new KeyValuePair<string, string?>(entry.Key, entry.Value))
+                .Prepend(new KeyValuePair<string, string?>("ConnectionStrings:quartz", Postgres)));
+
+        return builder;
+    }
+
+    /// <summary>
     /// The data source settings the scheduler ended up with.
     /// </summary>
     /// <remarks>

--- a/src/Quartz.Tests.Unit/Aspire/AspireSchemaProvisioningTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/AspireSchemaProvisioningTest.cs
@@ -1,0 +1,162 @@
+#nullable enable
+
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Tests.Unit.Aspire;
+
+/// <summary>
+/// What the store does about its schema when an Aspire connection wired it, and who gets to say so.
+/// </summary>
+/// <remarks>
+/// The unset default is the interesting one: it is the only setting on
+/// <see cref="QuartzAspireSettings"/> whose answer depends on something outside the settings, so both
+/// branches of it are pinned here rather than one branch and a comment.
+/// </remarks>
+public class AspireSchemaProvisioningTest
+{
+    [Test]
+    public void DevelopmentCreatesWhateverTheSchemaIsMissing()
+    {
+        Provisioning(Environments.Development).Should().Be(SchemaProvisioning.CreateIfMissing,
+            "the AppHost's database container comes up empty, so a scheduler that refuses to start "
+            + "until somebody applies a script refuses on every first run");
+    }
+
+    [Test]
+    public void EveryOtherEnvironmentValidatesAndCreatesNothing()
+    {
+        Provisioning(Environments.Production).Should().Be(SchemaProvisioning.Validate,
+            "creating tables needs DDL permission that a production account is usually right not to "
+            + "have, so the default there is the one that only reads");
+
+        Provisioning(Environments.Staging).Should().Be(SchemaProvisioning.Validate,
+            "Development is the environment this is safe in, not merely the one it is most useful in, "
+            + "so everything that is not Development gets the careful answer");
+    }
+
+    [Test]
+    public void ProvisionSchemaTrueCreatesInEveryEnvironment()
+    {
+        Provisioning(Environments.Production, settings => settings.ProvisionSchema = true)
+            .Should().Be(SchemaProvisioning.CreateIfMissing,
+                "an application that says it outright has said it about this deployment, whatever the "
+                + "environment name happens to be");
+    }
+
+    [Test]
+    public void ProvisionSchemaFalseCreatesInNone()
+    {
+        Provisioning(Environments.Development, settings => settings.ProvisionSchema = false)
+            .Should().Be(SchemaProvisioning.Validate,
+                "a deployment whose schema is applied by something else says so once, and the "
+                + "development database is the same schema as the production one");
+    }
+
+    /// <summary>
+    /// An <c>AdoJobStoreOptions.SchemaProvisioning</c> the application set is a decision about this
+    /// store, and this call fills gaps rather than overruling decisions.
+    /// </summary>
+    /// <remarks>
+    /// Options are last-wins and <c>ConfigureAllQuartzSchedulers</c> is applied after the scheduler's
+    /// own callback, so what this call contributes would win by position if it were written as an
+    /// assignment. Reading the value first is what keeps the application's word — the same shape that
+    /// leaves an explicit <c>InstanceId</c> alone.
+    /// </remarks>
+    [Test]
+    public void AStoreTaughtToLeaveItsSchemaAloneIsLeftAlone()
+    {
+        using IHost host = Host(Environments.Development, builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz");
+            builder.AddQuartz(q => q.UsePersistentStore(store =>
+                store.ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.None)));
+        });
+
+        AspireApplication.StoreOf(host.Services).SchemaProvisioning.Should().Be(SchemaProvisioning.None,
+            "a store told to assume its schema is there has been told, and an environment name is not "
+            + "an argument against it");
+    }
+
+    [Test]
+    public void AStoreTaughtToCreateItsSchemaKeepsThatOutsideDevelopment()
+    {
+        using IHost host = Host(Environments.Production, builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", settings => settings.ProvisionSchema = false);
+            builder.AddQuartz(q => q.UsePersistentStore(store => store.ProvisionSchema()));
+        });
+
+        AspireApplication.StoreOf(host.Services).SchemaProvisioning.Should().Be(SchemaProvisioning.CreateIfMissing,
+            "ProvisionSchema = false is this call declining to decide, not an instruction to undo what "
+            + "the application decided for itself");
+    }
+
+    [Test]
+    public void ConfigurationSaysItAsWellAsCodeDoes()
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerIn(
+            Environments.Development,
+            ("Quartz:JobStore:SchemaProvisioning", "None"));
+
+        builder.AddQuartzPersistentStore("quartz");
+        builder.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        AspireApplication.StoreOf(host.Services).SchemaProvisioning.Should().Be(SchemaProvisioning.None,
+            "this runs from ConfigureAllQuartzSchedulers, which AddQuartz applies after the "
+            + "configuration binding, so Quartz:JobStore is read as something the application said");
+    }
+
+    [Test]
+    public void TheSettingIsBoundFromTheSharedSectionAndTheConnectionsOwn()
+    {
+        HostApplicationBuilder shared = AspireApplication.WorkerIn(
+            Environments.Production,
+            ("Aspire:Quartz:ProvisionSchema", "true"));
+
+        shared.AddQuartzPersistentStore("quartz");
+        shared.AddQuartz();
+
+        using IHost sharedHost = shared.Build();
+
+        AspireApplication.StoreOf(sharedHost.Services).SchemaProvisioning.Should().Be(SchemaProvisioning.CreateIfMissing,
+            "every setting is bound from Aspire:Quartz, and one that is only reachable from code would "
+            + "be one an appsettings.json cannot say");
+
+        HostApplicationBuilder own = AspireApplication.WorkerIn(
+            Environments.Development,
+            ("Aspire:Quartz:ProvisionSchema", "true"),
+            ("Aspire:Quartz:quartz:ProvisionSchema", "false"));
+
+        own.AddQuartzPersistentStore("quartz");
+        own.AddQuartz();
+
+        using IHost ownHost = own.Build();
+
+        AspireApplication.StoreOf(ownHost.Services).SchemaProvisioning.Should().Be(SchemaProvisioning.Validate,
+            "the connection's own section is bound over the shared one, so it wins where the two "
+            + "disagree - which is what an application with one provisioned database and one it may "
+            + "not touch writes");
+    }
+
+    private static SchemaProvisioning Provisioning(
+        string environmentName,
+        Action<QuartzAspireSettings>? configureSettings = null)
+    {
+        using IHost host = Host(environmentName, builder =>
+        {
+            builder.AddQuartzPersistentStore("quartz", configureSettings);
+            builder.AddQuartz();
+        });
+
+        return AspireApplication.StoreOf(host.Services).SchemaProvisioning;
+    }
+
+    private static IHost Host(string environmentName, Action<HostApplicationBuilder> configure)
+    {
+        HostApplicationBuilder builder = AspireApplication.WorkerIn(environmentName);
+        configure(builder);
+        return builder.Build();
+    }
+}

--- a/src/Quartz.Tests.Unit/Aspire/QuartzAspireSettingsBindingTest.cs
+++ b/src/Quartz.Tests.Unit/Aspire/QuartzAspireSettingsBindingTest.cs
@@ -49,6 +49,33 @@ public class QuartzAspireSettingsBindingTest
             + "about keeps the shared value");
     }
 
+    /// <summary>
+    /// The one setting that is <see langword="null"/> rather than <see langword="false"/> when nothing
+    /// says anything, so binding has three answers to carry rather than two.
+    /// </summary>
+    [Test]
+    public void ATriStateSettingBindsAllThreeOfItsAnswers()
+    {
+        Capture(AspireApplication.WorkerWith(AspireApplication.Postgres), "quartz")
+            .ProvisionSchema.Should().BeNull(
+                "unset is what asks the environment, and a bool that bound to false could not say it");
+
+        Capture(
+            AspireApplication.Worker(
+                ("ConnectionStrings:quartz", AspireApplication.Postgres),
+                ("Aspire:Quartz:ProvisionSchema", "true")),
+            "quartz").ProvisionSchema.Should().BeTrue();
+
+        Capture(
+            AspireApplication.Worker(
+                ("ConnectionStrings:quartz", AspireApplication.Postgres),
+                ("Aspire:Quartz:ProvisionSchema", "true"),
+                ("Aspire:Quartz:quartz:ProvisionSchema", "false")),
+            "quartz").ProvisionSchema.Should().BeFalse(
+                "one database whose schema this creates and one it may not touch is exactly what the "
+                + "per-connection section is for");
+    }
+
     [Test]
     public void TheOverrideSectionIsThisConnectionsAlone()
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Aspire.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Aspire.verified.txt
@@ -15,6 +15,7 @@ namespace Quartz
         public bool DisableMetrics { get; set; }
         public bool DisableTracing { get; set; }
         public string? Provider { get; set; }
+        public bool? ProvisionSchema { get; set; }
         public string? SchedulerName { get; set; }
         public string? TablePrefix { get; set; }
     }


### PR DESCRIPTION
The follow-up recorded on #3533 and #3531, now that both have landed:
`QuartzAspireSettings.ProvisionSchema`.

## Why

An AppHost's database container comes up empty whenever its volume is new, so a development
scheduler on the `Validate` default refuses to start on nearly every first run until somebody
applies a script by hand — which is the failure the [example
worker](https://github.com/quartznet/quartznet/blob/main/src/Quartz.Examples.Aspire.Worker/Program.cs)
in this repository would have hit. A production account, meanwhile, usually cannot run DDL at all,
and is right not to be able to. Neither of those is a fact about any particular application, so
the environment answers rather than a default that would be wrong on one side of it.

## What changed

`public bool? ProvisionSchema { get; set; }` on `QuartzAspireSettings`, bound from `Aspire:Quartz`
and `Aspire:Quartz:<connection name>` like every other setting:

| `ProvisionSchema` | `AdoJobStoreOptions.SchemaProvisioning` becomes |
|---|---|
| unset (the default) | `CreateIfMissing` under `Development`, `Validate` in every other environment |
| `true` | `CreateIfMissing`, whatever the environment |
| `false` | `Validate`, whatever the environment |

`builder.Environment.IsDevelopment()` is read at the `AddQuartzPersistentStore` call, and the store
is configured from the same `ConfigureAllQuartzSchedulers` callback the rest of the call uses.

It **fills a gap rather than overruling one**. Options are last-wins and that callback runs after
everything the application said, so `store.ProvisionSchema()` written outright would beat a store
that had been told something else. The delegate reads the value first instead, so an explicit
`None` or `CreateIfMissing` — from `ConfigureStore` or from `Quartz:JobStore:SchemaProvisioning` —
is kept, the same shape that leaves an explicit `InstanceId` alone. `Validate` is the one position
that cannot be said that way, being what an unconfigured store already holds; `ProvisionSchema =
false` is what says it.

Documentation: the how-to's schema section is rewritten as **Getting the tables there** — provisioned
by default under `Development`, the `Validate` default elsewhere, the migration-service recipe kept
as the production path, and a pointer to
[Creating the schema](https://github.com/quartznet/quartznet/blob/main/docs/documentation/quartz-4.x/tutorial/job-stores.md)
from #3561 for the setting's own limits. The package page gains a settings row and a
**What happens to the schema** section, the package readme and the migration guide a row each, and
the example worker a comment saying why its tables are there. Both C# blocks are new
`sample_aspire_*` regions in `src/Quartz.Documentation.Samples/HowTos/AspireSamples.cs`.

## For a reviewer to decide

* **The gap-filling rule versus `ProvisionSchema = true`.** An application that sets `true` *and* an
  explicit `SchemaProvisioning.None` on the store gets `None`: the store-level setting is the more
  specific of the two. That is what the brief asked for and matches `Clustered`, but both are
  explicit, so it is a judgement rather than a derivation. `AStoreTaughtToLeaveItsSchemaAloneIsLeftAlone`
  pins it.
* **An explicitly-set `Validate` is invisible.** It is the default, so a store configured with it in
  `Development` still provisions. Documented on the property, on the page and in the readme; the
  alternative would be a second sentinel on `AdoJobStoreOptions`, which seems worse than a sentence.
* **The public-API baseline moved by one line**, accepted through Verify:
  `        public bool? ProvisionSchema { get; set; }` in
  `src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Aspire.verified.txt`.

## Verification

* `dotnet build Quartz.slnx` — 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — 4062 passed, 0 failed
* `dotnet test src/Quartz.Tests.AspNetCore` — 537 passed, 0 failed
* `dotnet pack src/Quartz.Aspire -c Release` — packed
* `dotnet fallout DocsSnippets` and `VerifyDocsSnippets` — up to date, 97 markdown files
* `npm ci && npm run docs:check-links` — 216 pages, 957 internal links, 580 fragments, no dead links or anchors

Part of #3533 and #3531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
