### PR TITLE
A one-word question does not need a query object

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4283,6 +4283,7 @@ already have them.
 * **A calendar can have dependencies** — `AddCalendar(name, serviceProvider => …)` builds the calendar from the container, which the `where T : ICalendar, new()` generic overloads cannot (see [A calendar can be built from the container](#a-calendar-can-be-built-from-the-container))
 * **A `quartz.*` key that lost its prefix is refused** — `QuartzOptions.Properties` is read only through the `quartz.` prefix, so a key without one produced no symptom at all; it now fails options validation at startup (see [A property key without the `quartz.` prefix is refused](#a-property-key-without-the-quartz-prefix-is-refused))
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
+* **A one-word question needs no query object** — `QueryJobs()`, `QueryTriggers()`, `QueryFireInstances()`, `QueryFireInstancesOfJob(jobKey)` and `QueryTriggersInError()` are the query members with the query record filled in, `ResetTriggersFromErrorState(GroupMatcher<TriggerKey>)` resets the failed triggers of a group, `Exists(string calendarName)` answers whether a calendar is there without deserializing it, and `ISchedulerFactory.GetRequiredScheduler(name)` throws where `LookupScheduler` returns null (see [Asking a one-word question does not need a query object](#asking-a-one-word-question-does-not-need-a-query-object))
 * **Pause, resume and reset a set of keys in one call** — `PauseTriggers`, `ResumeTriggers`, `PauseJobs`, `ResumeJobs` and `ResetTriggersFromErrorState` take a key collection, do the whole set in one lock and one transaction, and answer with the keys they applied to (see [A set of keys pauses, resumes or resets in one call](#a-set-of-keys-pauses-resumes-or-resets-in-one-call))
 * **`TriggerDetailsUpdate.WithExecutionGroup`** — move a stored trigger into an execution group, or out of every group, without rescheduling it. `QRTZ_TRIGGERS.EXECUTION_GROUP` was already written by the generic trigger update, and `RAMJobStore` applies it in place the same way it applies a preferred node, so both stores behave alike
 * **A chain can fan out** — `JobChainingJobListener` takes more than one follow-up for a job, either by calling `AddJobChainLink` again with the same first job or with the new `AddJobChainLinks(firstJob, followUpJobs)`. Each follow-up is triggered as its own firing, so they run concurrently rather than one after another, and one that cannot be triggered is logged without costing its siblings theirs. On 3.x the second link threw, so a chain could only be sequential (see [How do I chain Job execution?](../faq.md#how-do-i-chain-job-execution-or-how-do-i-create-a-workflow))
@@ -4599,7 +4600,7 @@ that this process happened to be holding, so it could only ever answer for one n
 
 ```diff
 - List<IJobExecutionContext> running = await scheduler.GetCurrentlyExecutingJobs();
-+ PagedResult<FireInstance> running = await scheduler.QueryFireInstances(new FireInstanceQuery());
++ PagedResult<FireInstance> running = await scheduler.QueryFireInstances();
 ```
 
 With a persistent job store the answer now covers the whole cluster, because a firing is a row rather
@@ -4707,9 +4708,11 @@ The scheduler body's `statistics` object gained `localExecutingJobs`, mirroring 
 
 ### If you implement `IJobStore`
 
-Three members. `QueryFireInstances(FireInstanceQuery, CancellationToken)` is the listing, abstract like
+Four members. `QueryFireInstances(FireInstanceQuery, CancellationToken)` is the listing, abstract like
 the rest of the query family; `QueryClusterNodes(CancellationToken)` is the node listing described in
-[The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing). And `Initialize` takes a
+[The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing);
+`Exists(string calendarName, CancellationToken)` is what replaced `CalendarExists` and is meant to be
+answered without materializing the calendar. And `Initialize` takes a
 `SchedulerIdentity`, which is the whole of what it takes — see
 [SPI changes](#spi-changes) for what its 3.x parameters became:
 
@@ -5069,7 +5072,7 @@ soften it — if you implement a job store, you implement the query members:
 | `GetCalendarNames` | `QueryCalendarNames` |
 | `IsJobGroupPaused`, `IsTriggerGroupPaused` | the matching `Query*Groups` with `Name` and `Paused = true` |
 | `GetNumberOfJobs`, `GetNumberOfTriggers`, `GetNumberOfCalendars` | the matching query with `Take = 0, IncludeTotalCount = true` |
-| `CalendarExists(name)` | `await GetCalendar(name) is not null` — `GetCalendar` returns `ICalendar?` and answers `null` for a name that is not there |
+| `CalendarExists(name)` | `Exists(string calendarName)`, which is the same question under the name the job and trigger overloads already use — see [Asking a one-word question does not need a query object](#asking-a-one-word-question-does-not-need-a-query-object) |
 
 Two members are new on both interfaces: **`GetJobDetails(jobKeys)`** and **`GetTriggers(triggerKeys)`**
 retrieve many by key in one round trip. Keys that do not exist are simply absent, duplicates fold away, and
@@ -5263,6 +5266,88 @@ detected such an override; 4.0 removes the half-open door). A delegate for a dat
 Finally, `ITriggerPersistenceDelegate` gained a batch `LoadExtendedTriggerProperties` taking several trigger
 keys. It is a **default interface method** that loops the single-key overload, so a third-party trigger
 persistence delegate needs no change; override it only to turn a batch into one round trip.
+
+## Asking a one-word question does not need a query object
+
+The paged query objects are the right primitive for a listing, and they are staying. What they cost is
+the trivial case, where the replacement for a parameterless call was
+`QueryFireInstances(new FireInstanceQuery())` — a record whose only job was to be the shape the member
+takes. Five shorthands close that, and none of them changes what the member behind it does.
+
+| Instead of | Write |
+|---|---|
+| `QueryJobs(new JobQuery())` | `QueryJobs()` |
+| `QueryTriggers(new TriggerQuery())` | `QueryTriggers()` |
+| `QueryFireInstances(new FireInstanceQuery())` | `QueryFireInstances()` |
+| `QueryFireInstances(new FireInstanceQuery { Job = jobKey })` | `QueryFireInstancesOfJob(jobKey)` |
+| `QueryTriggers(new TriggerQuery { State = TriggerState.Error })` | `QueryTriggersInError()` |
+
+They are extension methods in `SchedulerQueryExtensions`, beside the 3.x-compatible listings — but they
+belong to the *other* family in that class, and page the way the member they call pages:
+`PagedQuery.DefaultTake` items, with `HasMore` reporting the rest. Name the query record when you want a
+different page, a total count, or a filter.
+
+### Resetting the triggers that failed is one call each way
+
+`ResetTriggerFromErrorState(TriggerKey)` and `ResetTriggersFromErrorState(IReadOnlyCollection<TriggerKey>)`
+were already there, and `TriggerQuery.State` could already select the failed ones. What was missing was a
+way to say "the ones in this group":
+
+```csharp
+// Before
+PagedResult<TriggerHeader> failed = await scheduler.QueryTriggers(new TriggerQuery
+{
+    Group = GroupMatcher<TriggerKey>.GroupEquals("imports"),
+    State = TriggerState.Error,
+    Take = int.MaxValue
+});
+await scheduler.ResetTriggersFromErrorState(failed.Items.Select(x => x.Key).ToList());
+
+// After
+await scheduler.ResetTriggersFromErrorState(GroupMatcher<TriggerKey>.GroupEquals("imports"));
+```
+
+It is that pair of calls, not a new store operation: two round trips, not one transaction, and a trigger
+that enters the error state between them is left for the next call. What resetting a trigger *does* is
+unchanged. Passing `null` throws rather than quietly meaning every group.
+
+### `Exists` has a calendar overload
+
+`IScheduler.Exists` and `IJobStore.Exists` took a `JobKey` or a `TriggerKey`. Asking the same question
+about a calendar meant loading it:
+
+```diff
+- bool exists = await scheduler.GetCalendar("holidays") is not null;
++ bool exists = await scheduler.Exists("holidays");
+```
+
+The difference is not spelling. `GetCalendar` reads the stored blob and deserializes it — an
+`AnnualCalendar` holding a decade of excluded days, materialized to be thrown away. The overload asks the
+store for the name: `RAMJobStore` looks it up without cloning, and the ADO.NET store runs the existence
+statement that selects a constant rather than the calendar column. **No new `IDriverDelegate` member** —
+`CalendarExists` has been on that interface all along, used by `AddCalendar` and by the trigger update
+that validates a calendar reference; it simply had nothing above it.
+
+Over HTTP it is `GET {ApiPath}/schedulers/{name}/calendars/{calendarName}/exists`, answering
+`{ "exists": … }` like the job and trigger routes it mirrors.
+
+### A scheduler can be required rather than looked up
+
+`ISchedulerFactory.LookupScheduler` answers `null` for a name this container does not know, so every
+caller that treats absence as a bug wrote the same throw:
+
+```diff
+- IScheduler scheduler = await factory.LookupScheduler("reporting")
+-     ?? throw new InvalidOperationException("No scheduler named 'reporting'");
++ IScheduler scheduler = await factory.GetRequiredScheduler("reporting");
+```
+
+`GetRequiredScheduler` throws `SchedulerNotFoundException`, which is a `SchedulerException` carrying the
+`SchedulerName` that was asked for. It is an extension method rather than a member of `ISchedulerFactory`,
+for two reasons: it is composition over `LookupScheduler` that no factory could implement better, and an
+extension also resolves on a concrete receiver such as `StandaloneSchedulerFactory`, where a default
+interface method would need a cast. `LookupScheduler` is unchanged and stays the right call when a
+missing scheduler is an answer rather than a failure.
 
 ## Trigger states are typed on the driver delegate
 

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -70,7 +70,7 @@ validated against.
 
 ## Every endpoint
 
-Fifty-seven routes in four groups. `{ApiPath}` is `/quartz-api` unless you said otherwise, and
+Sixty routes in four groups. `{ApiPath}` is `/quartz-api` unless you said otherwise, and
 `{name}` is the scheduler the request is for — every route but the first carries one, and every route
 that carries one is subject to
 [`SchedulerAuthorizationPolicy`](#authorizing-per-scheduler) when it is set.
@@ -153,12 +153,13 @@ Every path below is prefixed `{ApiPath}/schedulers/{name}`.
 | `POST` | `…/triggers/unschedule-by-group` | `{ triggers }` — selects by group matcher in the query string |
 | `POST` | `…/triggers/{triggerGroup}/{triggerName}/reschedule` | `{ firstFireTimeUtc }`, **`null`** when the trigger did not exist |
 
-### Calendars — 4
+### Calendars — 5
 
 | Method | Path | Answers |
 |---|---|---|
 | `GET` | `…/calendars` | paged calendar names |
 | `GET` | `…/calendars/{calendarName}` | The calendar |
+| `GET` | `…/calendars/{calendarName}/exists` | `{ exists }` |
 | `POST` | `…/calendars` | empty — adds or replaces; `replace` and `updateTriggers` are body fields |
 | `DELETE` | `…/calendars/{calendarName}` | `{ applied }` |
 

--- a/docs/documentation/quartz-4.x/tutorial/querying-jobs-and-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/querying-jobs-and-triggers.md
@@ -321,6 +321,46 @@ public sealed class TriggerListModel(IScheduler scheduler)
 
 Nothing here loops over keys, and nothing loads a `JobDataMap` the list does not show.
 
+## Shorthands for the query nobody wants to name
+
+A query record that filters nothing is noise, so the five commonest ones have a name of their own. Each
+is the query member with the record filled in, and each pages exactly as the member does — the first
+`PagedQuery.DefaultTake` items, with `HasMore` reporting the rest:
+
+<!-- snippet: sample_querying_shorthands -->
+```csharp
+PagedResult<JobHeader> jobs = await scheduler.QueryJobs();
+PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers();
+PagedResult<FireInstance> running = await scheduler.QueryFireInstances();
+PagedResult<FireInstance> runningOneJob = await scheduler.QueryFireInstancesOfJob(jobKey);
+PagedResult<TriggerHeader> failed = await scheduler.QueryTriggersInError();
+```
+<!-- endSnippet -->
+
+Two more sit beside them. Resetting the failed triggers of a group was a listing plus a key-set reset;
+it is one call:
+
+<!-- snippet: sample_querying_reset_group_from_error -->
+```csharp
+List<TriggerKey> reset = await scheduler.ResetTriggersFromErrorState(
+    GroupMatcher<TriggerKey>.GroupEquals("imports"));
+```
+<!-- endSnippet -->
+
+That is still the two calls underneath — a listing filtered by `State = TriggerState.Error` and the
+group, then `ResetTriggersFromErrorState(keys)` — so it is not one atomic operation, and a trigger that
+fails between them is left for the next call. What resetting a trigger does is unchanged.
+
+And asking whether a calendar is registered no longer means loading it. `GetCalendar` deserializes the
+stored blob to hand you an `ICalendar` you were going to throw away; `Exists` asks the store for the
+name:
+
+<!-- snippet: sample_querying_calendar_exists -->
+```csharp
+bool haveHolidays = await scheduler.Exists("holidays");
+```
+<!-- endSnippet -->
+
 ## The compatibility layer
 
 The old call shapes still compile. `SchedulerQueryExtensions` puts eight of them back as extension

--- a/docs/documentation/quartz-4.x/tutorial/testing.md
+++ b/docs/documentation/quartz-4.x/tutorial/testing.md
@@ -258,12 +258,11 @@ shipped listeners is `Quartz.Listeners`, plural.
 
 ```csharp
 // what state did the trigger end in?
-PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers(
-    new TriggerQuery { State = TriggerState.Error });
+PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggersInError();
 triggers.Items.Should().BeEmpty();
 
 // what is running right now?
-PagedResult<FireInstance> running = await scheduler.QueryFireInstances(new FireInstanceQuery());
+PagedResult<FireInstance> running = await scheduler.QueryFireInstances();
 
 // what did the job produce?
 context.Result.Should().Be(42);
@@ -274,8 +273,8 @@ Remember that a query pages: `Take` defaults to 250, so an assertion on a large 
 [Querying Jobs and Triggers](querying-jobs-and-triggers.md#paging).
 
 ::: warning Changed in 4.x
-`GetCurrentlyExecutingJobs()` is gone; `QueryFireInstances(new FireInstanceQuery())` is the replacement,
-and it lists firings across the cluster rather than only on the node that answered.
+`GetCurrentlyExecutingJobs()` is gone; `QueryFireInstances()` is the replacement, and it lists firings
+across the cluster rather than only on the node that answered.
 :::
 
 ### Controlling time

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/CalendarEndpoints.cs
@@ -21,6 +21,9 @@ internal static class CalendarEndpoints
         yield return builder.MapGet(patternPrefix + "/{calendarName}", GetCalendar)
             .WithQuartzDefaults(nameof(GetCalendar), "Get calendar details");
 
+        yield return builder.MapGet(patternPrefix + "/{calendarName}/exists", CheckCalendarExists)
+            .WithQuartzDefaults(nameof(CheckCalendarExists), "Check calendar exists");
+
         yield return builder.MapPost(patternPrefix, AddCalendar)
             .WithQuartzDefaults(nameof(AddCalendar), "Add new calendar");
 
@@ -75,6 +78,21 @@ internal static class CalendarEndpoints
         {
             var calendar = await scheduler.GetCalendarOrThrow(calendarName, cancellationToken).ConfigureAwait(false);
             return calendar;
+        });
+    }
+
+    [ProducesResponseType(typeof(ExistsResponse), StatusCodes.Status200OK)]
+    private static Task<IResult> CheckCalendarExists(
+        EndpointHelper endpointHelper,
+        ISchedulerRepository schedulerRepository,
+        string schedulerName,
+        string calendarName,
+        CancellationToken cancellationToken = default)
+    {
+        return endpointHelper.ExecuteWithJsonResponse(schedulerName, schedulerRepository, async scheduler =>
+        {
+            bool exists = await scheduler.Exists(calendarName, cancellationToken).ConfigureAwait(false);
+            return new ExistsResponse(exists);
         });
     }
 

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -192,6 +192,11 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
+        public ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask Clear(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Quartz.Documentation.Samples/Tutorial/QueryingJobsAndTriggersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/QueryingJobsAndTriggersSamples.cs
@@ -113,6 +113,38 @@ public static class QueryingJobsAndTriggersSamples
         #endregion
     }
 
+    public static async ValueTask Shorthands(IScheduler scheduler, JobKey jobKey)
+    {
+        #region sample_querying_shorthands
+
+        PagedResult<JobHeader> jobs = await scheduler.QueryJobs();
+        PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers();
+        PagedResult<FireInstance> running = await scheduler.QueryFireInstances();
+        PagedResult<FireInstance> runningOneJob = await scheduler.QueryFireInstancesOfJob(jobKey);
+        PagedResult<TriggerHeader> failed = await scheduler.QueryTriggersInError();
+
+        #endregion
+    }
+
+    public static async ValueTask ResettingAGroupFromError(IScheduler scheduler)
+    {
+        #region sample_querying_reset_group_from_error
+
+        List<TriggerKey> reset = await scheduler.ResetTriggersFromErrorState(
+            GroupMatcher<TriggerKey>.GroupEquals("imports"));
+
+        #endregion
+    }
+
+    public static async ValueTask CalendarExists(IScheduler scheduler)
+    {
+        #region sample_querying_calendar_exists
+
+        bool haveHolidays = await scheduler.Exists("holidays");
+
+        #endregion
+    }
+
     public static void ReservedVersusRunning()
     {
         #region sample_querying_fire_instance_state

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -842,6 +842,12 @@ public sealed class HttpScheduler : IScheduler
         return result.Exists;
     }
 
+    public async ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.Get<ExistsResponse>($"{CalendarEndpointUrl(calendarName)}/exists", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result.Exists;
+    }
+
     public ValueTask Clear(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/clear", jsonSerializerOptions, cancellationToken);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/CalendarEndpointsTest.cs
@@ -127,4 +127,29 @@ public class CalendarEndpointsTest : WebApiTest
         await HttpScheduler.DeleteCalendar("MyOldCalendar");
         A.CallTo(() => FakeScheduler.DeleteCalendar("MyOldCalendar", A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
     }
+
+    /// <summary>
+    /// The calendar existence route mirrors the job and trigger ones, and — the point of the member —
+    /// it asks the scheduler the existence question rather than fetching the calendar to look at it.
+    /// </summary>
+    [Test]
+    public async Task CalendarExistsShouldRoundTripTheAnswerWithoutFetchingTheCalendar()
+    {
+        A.CallTo(() => FakeScheduler.Exists("AnnualCalendar", A<CancellationToken>._)).Returns(true);
+        A.CallTo(() => FakeScheduler.Exists("NonExistingCalendar", A<CancellationToken>._)).Returns(false);
+
+        (await HttpScheduler.Exists("AnnualCalendar")).Should().BeTrue();
+        (await HttpScheduler.Exists("NonExistingCalendar")).Should().BeFalse();
+
+        A.CallTo(() => FakeScheduler.GetCalendar(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task CalendarExistsShouldRejectABlankNameBeforeTheRequestIsMade()
+    {
+        Func<Task> blank = async () => await HttpScheduler.Exists("  ");
+
+        await blank.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("calendarName", "a blank name would produce a URL that means a different route");
+    }
 }

--- a/src/Quartz.Tests.AspNetCore/HttpApi/QueryEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/QueryEndpointsTest.cs
@@ -310,6 +310,43 @@ public class QueryEndpointsTest : WebApiTest
         }
     }
 
+    /// <summary>
+    /// The parameterless shorthands are extension methods, so nothing about them is remote — what has
+    /// to hold is that the query record they default to is the one that goes on the wire, and that the
+    /// answer comes back the same as the spelled-out call's.
+    /// </summary>
+    [Test]
+    public async Task QueryShorthandsShouldRunOnTheQueryWire()
+    {
+        using (new AssertionScope())
+        {
+            (await client.QueryJobs()).Items.Select(x => x.Key).Should().Equal(
+                (await client.QueryJobs(new JobQuery())).Items.Select(x => x.Key));
+
+            (await client.QueryTriggers()).Items.Select(x => x.Key).Should().Equal(
+                alphaTriggerOne, alphaTriggerTwo, alphaTriggerThree, alphaTriggerFour, betaTriggerOne, betaTriggerTwo);
+
+            (await client.QueryTriggersInError()).Items.Should().BeEmpty(
+                "nothing in the seed has failed, and the state filter reached the server to say so");
+
+            (await client.QueryFireInstances()).Items.Should().BeEmpty(
+                "no job is running, and the fire instance query record's own default is Executing");
+
+            (await client.QueryFireInstancesOfJob(alphaJobOne)).Items.Should().BeEmpty();
+        }
+    }
+
+    [Test]
+    public async Task CalendarExistenceShouldBeAnsweredOverTheWire()
+    {
+        using (new AssertionScope())
+        {
+            (await client.Exists("cal-a")).Should().BeTrue();
+            (await client.Exists("cal-missing")).Should().BeFalse(
+                "a name nothing was stored under is an answer, not a 404");
+        }
+    }
+
     [Test]
     public async Task LegacyListingMembersShouldRunOnTheQueryWire()
     {

--- a/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/RequestDelegatesAreSourceGeneratedTest.cs
@@ -33,7 +33,7 @@ public class RequestDelegatesAreSourceGeneratedTest
     /// </summary>
     private static readonly Dictionary<string, int> mappedRoutes = new(StringComparer.Ordinal)
     {
-        ["CalendarEndpoints.cs"] = 4,
+        ["CalendarEndpoints.cs"] = 5,
         ["JobEndpoints.cs"] = 21,
         ["SchedulerEndpoints.cs"] = 13,
         ["TriggerEndpoints.cs"] = 21

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TriggerEndpointsTest.cs
@@ -727,6 +727,50 @@ public class TriggerEndpointsTest : WebApiTest
             .WithMessage("*HttpScheduler.UpdateTriggerDetails*");
     }
 
+    /// <summary>
+    /// The group-matcher reset is an extension over two routes that already exist, so what has to hold
+    /// remotely is that both halves reach the server: the listing that names the set, with the error
+    /// state and the group on it, and the key-set reset that acts on what came back.
+    /// </summary>
+    [Test]
+    public async Task ResetTriggersFromErrorStateByGroupShouldRunOnTheRoutesItComposes()
+    {
+        GroupMatcher<TriggerKey> matcher = GroupMatcher<TriggerKey>.GroupEquals("group1");
+
+        A.CallTo(() => FakeScheduler.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>([HeaderFor(triggerKeyOne)], HasMore: false));
+        A.CallTo(() => FakeScheduler.ResetTriggersFromErrorState(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .Returns(new List<TriggerKey> { triggerKeyOne });
+
+        List<TriggerKey> reset = await HttpScheduler.ResetTriggersFromErrorState(matcher);
+
+        reset.Should().Equal([triggerKeyOne]);
+
+        A.CallTo(() => FakeScheduler.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((TriggerQuery query, CancellationToken _) =>
+                query.State == TriggerState.Error && Equals(query.Group, matcher))
+            .MustHaveHappened(1, Times.Exactly);
+
+        A.CallTo(() => FakeScheduler.ResetTriggersFromErrorState(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .WhenArgumentsMatch((IReadOnlyCollection<TriggerKey> keys, CancellationToken _) => keys.SequenceEqual([triggerKeyOne]))
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task ResetTriggersFromErrorStateByGroupShouldNotPostWhenNothingIsInError()
+    {
+        A.CallTo(() => FakeScheduler.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>([], HasMore: false));
+
+        List<TriggerKey> reset = await HttpScheduler.ResetTriggersFromErrorState(GroupMatcher<TriggerKey>.AnyGroup());
+
+        reset.Should().BeEmpty();
+
+        // An empty set is not a request worth making, remotely least of all.
+        A.CallTo(() => FakeScheduler.ResetTriggersFromErrorState(A<IReadOnlyCollection<TriggerKey>>._, A<CancellationToken>._))
+            .MustNotHaveHappened();
+    }
+
     private static TriggerHeader HeaderFor(TriggerKey triggerKey) => new(
         triggerKey,
         JobKey: new JobKey("job_of_" + triggerKey.Name, triggerKey.Group),

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -1086,6 +1086,31 @@ public abstract class JobStoreContractTest
     }
 
     /// <summary>
+    /// Whether a calendar is there is a question every store answers the same way, and answers without
+    /// materializing the calendar — the ADO store selects a constant instead of the blob, and
+    /// <c>RAMJobStore</c> looks the name up instead of cloning what it finds. Only the answer is
+    /// observable through the contract, so what this pins is that the cheap path is also the correct
+    /// one on every dialect.
+    /// </summary>
+    [Test]
+    public async Task CalendarExistenceIsAnsweredByName()
+    {
+        AnnualCalendar calendar = new AnnualCalendar();
+        calendar.AddExcludedDay(new MonthDay(12, 25));
+
+        (await Store.Exists("holidays")).Should().BeFalse("nothing has been stored under that name yet");
+
+        await Store.AddCalendar("holidays", calendar);
+
+        (await Store.Exists("holidays")).Should().BeTrue();
+        (await Store.Exists(MissingCalendarName)).Should().BeFalse();
+
+        (await Store.DeleteCalendar("holidays")).Should().BeTrue();
+
+        (await Store.Exists("holidays")).Should().BeFalse("a deleted calendar stops existing for this member too");
+    }
+
+    /// <summary>
     /// Replacing a calendar and asking for its triggers to be updated moves the next fire time of a
     /// trigger the new calendar has just excluded, and leaves the trigger's state alone.
     /// </summary>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -949,9 +949,60 @@ public class AdoJobStoreBaseTest
             .WithMessage("db error");
     }
 
+    /// <summary>
+    /// Asking whether a calendar exists reads no calendar. The whole point of the member is that
+    /// <c>GetCalendar(name) is not null</c> — the answer before it existed — selects the blob and
+    /// deserializes it to throw the result away.
+    /// </summary>
+    [Test]
+    public async Task CalendarExistence_IsAnsweredWithoutSelectingTheCalendar()
+    {
+        ConnectionExecutingAdoJobStore store = new() { DirectDelegate = driverDelegate };
+
+        A.CallTo(() => driverDelegate.CalendarExists(A<ConnectionAndTransactionHolder>.Ignored, "holidays", A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<bool>(true));
+
+        bool exists = await store.Exists("holidays");
+
+        exists.Should().BeTrue();
+
+        A.CallTo(() => driverDelegate.CalendarExists(A<ConnectionAndTransactionHolder>.Ignored, "holidays", A<CancellationToken>.Ignored))
+            .MustHaveHappened(1, Times.Exactly);
+        A.CallTo(() => driverDelegate.SelectCalendar(A<ConnectionAndTransactionHolder>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task CalendarExistence_ReportsAbsenceRatherThanFailing()
+    {
+        ConnectionExecutingAdoJobStore store = new() { DirectDelegate = driverDelegate };
+
+        A.CallTo(() => driverDelegate.CalendarExists(A<ConnectionAndTransactionHolder>.Ignored, "gone", A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<bool>(false));
+
+        (await store.Exists("gone")).Should().BeFalse();
+    }
+
     private static RetryTestAdoJobStoreBase CreateRetryTestStore(int maxTransientRetries = 3)
     {
         return new RetryTestAdoJobStoreBase(maxTransientRetries);
+    }
+
+    /// <summary>
+    /// <see cref="TestAdoJobStoreBase" /> answers every locked call with <c>default</c> without running
+    /// the callback, which is what most of this fixture wants. A read whose point is <em>which</em>
+    /// statement it runs needs the callback to actually run, so this one hands it the fake connection.
+    /// </summary>
+    private sealed class ConnectionExecutingAdoJobStore : TestAdoJobStoreBase
+    {
+        protected override async ValueTask<T> ExecuteInLock<T>(
+            SchedulerLock? lockKind,
+            Func<ConnectionAndTransactionHolder, ValueTask<T>> txCallback,
+            CancellationToken cancellationToken = default)
+        {
+            ConnectionAndTransactionHolder conn = await GetLocalTransactionConnection(cancellationToken);
+            return await txCallback(conn);
+        }
     }
 
     public class TestAdoJobStoreBase : AdoJobStoreBase

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -89,6 +89,11 @@ public class QuartzHostedServiceTests
             throw new NotImplementedException();
         }
 
+        public ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
         public ValueTask Clear(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();

--- a/src/Quartz.Tests.Unit/SchedulerFactoryExtensionsTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerFactoryExtensionsTest.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// <see cref="SchedulerFactoryExtensions.GetRequiredScheduler" /> is the throw every caller of
+/// <see cref="ISchedulerFactory.LookupScheduler" /> was writing for itself.
+/// </summary>
+[NonParallelizable]
+public class SchedulerFactoryExtensionsTest
+{
+    [Test]
+    public async Task ANameTheContainerKnowsIsTheSameSchedulerLookupWouldHaveFound()
+    {
+        await using ServiceProvider provider = Container("reporting");
+        ISchedulerFactory factory = provider.GetRequiredKeyedService<ISchedulerFactory>("reporting");
+
+        IScheduler required = await factory.GetRequiredScheduler("reporting");
+
+        try
+        {
+            required.Should().BeSameAs(await factory.LookupScheduler("reporting"),
+                "the throwing form differs from the lookup only in what it does with absence");
+        }
+        finally
+        {
+            await required.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ANameTheContainerDoesNotKnowThrowsAnExceptionThatNamesIt()
+    {
+        await using ServiceProvider provider = Container("reporting");
+        ISchedulerFactory factory = provider.GetRequiredKeyedService<ISchedulerFactory>("reporting");
+
+        Func<Task> missing = async () => await factory.GetRequiredScheduler("imports");
+
+        SchedulerNotFoundException thrown = (await missing.Should().ThrowAsync<SchedulerNotFoundException>(
+            "a caller that treats absence as a bug should not have to test for null to say so"))
+            .Which;
+
+        thrown.SchedulerName.Should().Be("imports",
+            "the name is on the exception so a report does not have to parse the message");
+        thrown.Should().BeAssignableTo<SchedulerException>(
+            "everything Quartz throws for a scheduling failure is catchable as one");
+    }
+
+    [Test]
+    public async Task LookupStillAnswersNullForTheSameName()
+    {
+        await using ServiceProvider provider = Container("reporting");
+        ISchedulerFactory factory = provider.GetRequiredKeyedService<ISchedulerFactory>("reporting");
+
+        (await factory.LookupScheduler("imports")).Should().BeNull(
+            "the shorthand is additive: the nullable form keeps answering the way it did");
+    }
+
+    [Test]
+    public async Task ABlankNameIsRejectedBeforeTheContainerIsAsked()
+    {
+        await using ServiceProvider provider = Container("reporting");
+        ISchedulerFactory factory = provider.GetRequiredKeyedService<ISchedulerFactory>("reporting");
+
+        Func<Task> blank = async () => await factory.GetRequiredScheduler("   ");
+
+        await blank.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("schedulerName", "a name that is only whitespace is a caller's mistake, not a missing scheduler");
+    }
+
+    private static ServiceProvider Container(string schedulerName)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(schedulerName);
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Quartz.Tests.Unit/SchedulerQueryShorthandTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerQueryShorthandTest.cs
@@ -1,0 +1,237 @@
+using Quartz.Extensibility;
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The <c>Query*</c> shorthands on <see cref="SchedulerQueryExtensions" />: each one is the query
+/// member called with a query record the caller did not have to name.
+/// </summary>
+/// <remarks>
+/// What is worth pinning is not that a shorthand compiles but that it keeps the member's contract —
+/// the same page size, the same filters, and in the reset companion's case the same effect on a
+/// trigger. A shorthand that quietly became unbounded, or that reset a trigger some other way, would
+/// be a different feature wearing a convenient name.
+/// </remarks>
+[NonParallelizable]
+public class SchedulerQueryShorthandTest
+{
+    private IScheduler scheduler = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        scheduler = await QuartzSchedulerBuilder.Create().BuildScheduler();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await scheduler.Shutdown(waitForJobsToComplete: false);
+    }
+
+    [Test]
+    public async Task TheJobAndTriggerShorthandsListWhatTheQueryRecordWouldHave()
+    {
+        await Schedule("alpha", "j1", "t1");
+        await Schedule("beta", "j2", "t2");
+
+        PagedResult<JobHeader> jobs = await scheduler.QueryJobs();
+        PagedResult<JobHeader> spelledOut = await scheduler.QueryJobs(new JobQuery());
+
+        jobs.Items.Select(x => x.Key).Should().Equal(spelledOut.Items.Select(x => x.Key),
+            "the shorthand is the member with a query record that filters nothing");
+
+        PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers();
+
+        triggers.Items.Select(x => x.Key).Should().Equal(
+            [new TriggerKey("t1", "alpha"), new TriggerKey("t2", "beta")]);
+    }
+
+    /// <summary>
+    /// The shorthand takes the query record's default page size, not everything. A shorthand that
+    /// materialized the whole store would be the trap <see cref="PagedQuery.DefaultTake" /> exists to
+    /// close, and it would be invisible until the store was big.
+    /// </summary>
+    [Test]
+    public async Task TheShorthandsPageLikeTheMemberTheyCall()
+    {
+        for (int i = 0; i <= PagedQuery.DefaultTake; i++)
+        {
+            await scheduler.AddJob(JobBuilder.Create<NoOpJob>()
+                .WithIdentity($"job-{i:D4}", "bulk")
+                .StoreDurably()
+                .Build());
+        }
+
+        PagedResult<JobHeader> page = await scheduler.QueryJobs();
+
+        page.Items.Should().HaveCount(PagedQuery.DefaultTake);
+        page.HasMore.Should().BeTrue("the shorthand pages exactly as the member does");
+        page.TotalCount.Should().BeNull("a total count costs a second query and stays opt-in");
+    }
+
+    [Test]
+    public async Task TheFireInstanceShorthandsListWhatIsRunning()
+    {
+        GatedJob.Reset();
+
+        JobKey running = new("running", "gated");
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<GatedJob>().WithIdentity(running).Build(),
+            TriggerBuilder.Create().WithIdentity("now", "gated").StartNow().Build());
+
+        await scheduler.AddJob(JobBuilder.Create<NoOpJob>().WithIdentity("idle", "gated").StoreDurably().Build());
+
+        await scheduler.Start();
+        GatedJob.Started.Wait(TimeSpan.FromSeconds(30)).Should().BeTrue("the assertions are about a firing that exists");
+
+        try
+        {
+            PagedResult<FireInstance> everything = await scheduler.QueryFireInstances();
+            everything.Items.Should().ContainSingle()
+                .Which.JobKey.Should().Be(running, "the query record's own default state is Executing");
+
+            PagedResult<FireInstance> ofRunning = await scheduler.QueryFireInstancesOfJob(running);
+            ofRunning.Items.Should().ContainSingle().Which.JobKey.Should().Be(running);
+
+            PagedResult<FireInstance> ofIdle = await scheduler.QueryFireInstancesOfJob(new JobKey("idle", "gated"));
+            ofIdle.Items.Should().BeEmpty("a job that is not running has no firing to list");
+        }
+        finally
+        {
+            GatedJob.Release.Set();
+        }
+    }
+
+    [Test]
+    public async Task TriggersInErrorAreListedAndResetByGroup()
+    {
+        IScheduler failing = await QuartzSchedulerBuilder.Create()
+            .UseJobFactory(new ThrowingJobFactory())
+            .BuildScheduler();
+
+        try
+        {
+            await ScheduleFailing(failing, "alpha", "t1");
+            await ScheduleFailing(failing, "alpha", "t2");
+            await ScheduleFailing(failing, "beta", "t3");
+
+            await failing.Start();
+            await WaitUntilInError(failing, expected: 3);
+
+            PagedResult<TriggerHeader> failed = await failing.QueryTriggersInError();
+            failed.Items.Select(x => x.Key).Should().Equal(
+                [new TriggerKey("t1", "alpha"), new TriggerKey("t2", "alpha"), new TriggerKey("t3", "beta")],
+                "the shorthand is the trigger query with the error state filter");
+
+            await failing.Standby();
+
+            List<TriggerKey> reset = await failing.ResetTriggersFromErrorState(GroupMatcher<TriggerKey>.GroupEquals("alpha"));
+
+            reset.Should().BeEquivalentTo([new TriggerKey("t1", "alpha"), new TriggerKey("t2", "alpha")],
+                "the companion names the set by group and resets exactly that set");
+
+            (await failing.GetTriggerState(new TriggerKey("t1", "alpha"))).Should().Be(TriggerState.Normal);
+            (await failing.GetTriggerState(new TriggerKey("t2", "alpha"))).Should().Be(TriggerState.Normal);
+            (await failing.GetTriggerState(new TriggerKey("t3", "beta"))).Should().Be(TriggerState.Error,
+                "a group the matcher did not name is not touched");
+        }
+        finally
+        {
+            await failing.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    [Test]
+    public async Task ResettingAGroupWithNothingInErrorAnswersEmpty()
+    {
+        await Schedule("alpha", "j1", "t1");
+
+        List<TriggerKey> reset = await scheduler.ResetTriggersFromErrorState(GroupMatcher<TriggerKey>.AnyGroup());
+
+        reset.Should().BeEmpty("a healthy trigger is not in the set the companion names");
+        (await scheduler.GetTriggerState(new TriggerKey("t1", "alpha"))).Should().Be(TriggerState.Normal);
+    }
+
+    [Test]
+    public async Task ANullMatcherIsRejectedRatherThanTreatedAsEveryGroup()
+    {
+        Func<Task> reset = async () => await scheduler.ResetTriggersFromErrorState((GroupMatcher<TriggerKey>) null!);
+
+        await reset.Should().ThrowAsync<ArgumentNullException>(
+            "silently widening a reset to every group is the mistake this argument can make");
+    }
+
+    private async Task Schedule(string group, string jobName, string triggerName)
+    {
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<NoOpJob>().WithIdentity(jobName, group).Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(triggerName, group)
+                .StartAt(DateTimeOffset.UtcNow.AddDays(1))
+                .Build());
+    }
+
+    private static async Task ScheduleFailing(IScheduler target, string group, string triggerName)
+    {
+        await target.ScheduleJob(
+            JobBuilder.Create<NoOpJob>().WithIdentity("job-" + triggerName, group).Build(),
+            TriggerBuilder.Create().WithIdentity(triggerName, group).StartNow().Build());
+    }
+
+    /// <summary>
+    /// The job factory throws for every firing, which moves each trigger to
+    /// <see cref="TriggerState.Error" /> — but on the scheduler's own thread, so the test waits for the
+    /// state rather than assuming it has already been reached.
+    /// </summary>
+    private static async Task WaitUntilInError(IScheduler target, int expected)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+        while (DateTime.UtcNow < deadline)
+        {
+            PagedResult<TriggerHeader> failed = await target.QueryTriggersInError();
+            if (failed.Items.Count >= expected)
+            {
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"only {(await target.QueryTriggersInError()).Items.Count} of {expected} triggers reached the error state");
+    }
+
+    private sealed class ThrowingJobFactory : IJobFactory
+    {
+        public ValueTask<JobScope> CreateJob(TriggerFiredBundle bundle, IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("no job for you");
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// Runs until the test lets it go, so that a firing is observably in flight while the fire instance
+    /// listing is read.
+    /// </summary>
+    public sealed class GatedJob : IJob
+    {
+        public static readonly ManualResetEventSlim Started = new(false);
+        public static readonly ManualResetEventSlim Release = new(false);
+
+        public static void Reset()
+        {
+            Started.Reset();
+            Release.Reset();
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Started.Set();
+            Release.Wait(TimeSpan.FromSeconds(30));
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -33,6 +33,7 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -696,6 +696,7 @@ namespace Quartz
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.JobKey>> DeleteJobs(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
@@ -1576,6 +1577,10 @@ namespace Quartz
         public SchedulerException(string message, System.Exception? innerException) { }
         public override string ToString() { }
     }
+    public static class SchedulerFactoryExtensions
+    {
+        public static System.Threading.Tasks.ValueTask<Quartz.IScheduler> GetRequiredScheduler(this Quartz.ISchedulerFactory schedulerFactory, string schedulerName, System.Threading.CancellationToken cancellationToken = default) { }
+    }
     public enum SchedulerInstruction
     {
         NoInstruction = 0,
@@ -1613,6 +1618,10 @@ namespace Quartz
         public required string ThreadPoolTypeName { get; init; }
         public required string Version { get; init; }
     }
+    public sealed class SchedulerNotFoundException : Quartz.SchedulerException
+    {
+        public string SchedulerName { get; }
+    }
     public enum SchedulerOrigin
     {
         Container = 0,
@@ -1629,6 +1638,12 @@ namespace Quartz
         public static System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ITrigger>> GetTriggersOfJob(this Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.ValueTask<bool> IsJobGroupPaused(this Quartz.IScheduler scheduler, string groupName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.ValueTask<bool> IsTriggerGroupPaused(this Quartz.IScheduler scheduler, string groupName, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstances(this Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.FireInstance>> QueryFireInstancesOfJob(this Quartz.IScheduler scheduler, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.JobHeader>> QueryJobs(this Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.TriggerHeader>> QueryTriggers(this Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.TriggerHeader>> QueryTriggersInError(this Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResetTriggersFromErrorState(this Quartz.IScheduler scheduler, Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public sealed class SchedulerRegistration : System.IEquatable<Quartz.SchedulerRegistration>
     {
@@ -2013,6 +2028,7 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.TimeSpan GetAcquireRetryDelay(int failureCount);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
@@ -2334,6 +2350,7 @@ namespace Quartz.Impl.AdoJobStore
         protected System.Threading.Tasks.ValueTask<T> ExecuteWithoutLock<T>(System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, System.Threading.Tasks.ValueTask<T>> txCallback, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> Exists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<bool> Exists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Impl.AdoJobStore.SchedulerStateRecord>> FindFailedInstances(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3357,6 +3374,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.TimeSpan GetAcquireRetryDelay(int failureCount) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3421,6 +3439,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask DisposeAsync() { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ExecutionLimits?> GetExecutionLimits(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3551,6 +3570,7 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> DeleteTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> Exists(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<bool> Exists(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.TimeSpan GetAcquireRetryDelay(int failureCount) { }
         public System.Threading.Tasks.ValueTask<Quartz.ICalendar?> GetCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -1946,6 +1946,25 @@ internal sealed class QuartzScheduler
     }
 
     /// <summary>
+    /// Determine whether an <see cref="ICalendar" /> with the given name already exists within the
+    /// scheduler.
+    /// </summary>
+    /// <param name="calendarName">the name to check for</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>true if a calendar is registered under the given name</returns>
+    public ValueTask<bool> Exists(
+        string calendarName,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateState();
+
+        // A name nobody registered answers false, and a blank name is one of those — the same shape
+        // GetCalendar and DeleteCalendar have, which is what "a blank calendar name is no calendar
+        // name" means on this side of the store.
+        return resources.JobStore.Exists(calendarName, cancellationToken);
+    }
+
+    /// <summary>
     /// Clears (deletes!) all scheduling data - all <see cref="IJob"/>s, <see cref="ITrigger" />s
     /// <see cref="ICalendar" />s.
     /// </summary>

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -336,6 +336,20 @@ public interface IJobStore
     ValueTask<bool> Exists(TriggerKey triggerKey, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Determine whether an <see cref="ICalendar" /> with the given name already exists within the
+    /// store.
+    /// </summary>
+    /// <remarks>
+    /// Answer this without materializing the calendar. <see cref="GetCalendar" /> can answer it too, but
+    /// only by reading the stored blob and deserializing it to throw it away — which is what a store
+    /// implementing this member as <c>GetCalendar(name) is not null</c> would go on doing.
+    /// </remarks>
+    /// <param name="calendarName">the name to check for</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>true if a calendar is stored under the given name</returns>
+    ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Clear (delete!) all scheduling data - all <see cref="IJob"/>s, <see cref="ITrigger" />s
     /// <see cref="ICalendar" />s.
     /// </summary>

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -1123,6 +1123,20 @@ public interface IScheduler : IAsyncDisposable
     ValueTask<bool> Exists(TriggerKey triggerKey, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Determine whether an <see cref="ICalendar" /> with the given name already exists within the
+    /// scheduler.
+    /// </summary>
+    /// <remarks>
+    /// Asks the store for the name alone. <see cref="GetCalendar" /> answers the same question, but only
+    /// by loading and deserializing the calendar — an exclusion set that can run to thousands of dates —
+    /// to throw it away again.
+    /// </remarks>
+    /// <param name="calendarName">the name to check for</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>true if a calendar is registered under the given name</returns>
+    ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Clears (deletes!) all scheduling data - all <see cref="IJob"/>s, <see cref="ITrigger" />s
     /// <see cref="ICalendar"/>s.
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Query.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Query.cs
@@ -218,6 +218,28 @@ public abstract partial class AdoJobStoreBase
             "check for existence of trigger");
     }
 
+    /// <summary>
+    /// Determine whether an <see cref="ICalendar" /> with the given name already exists within the
+    /// store.
+    /// </summary>
+    /// <remarks>
+    /// Runs <c>CalendarExists</c>, which selects a constant rather than the calendar blob, so the answer
+    /// costs an index probe instead of a read and a deserialization. The calendar cache is deliberately
+    /// not consulted: it holds what <see cref="GetCalendar(string, CancellationToken)" /> loaded, so it can answer "yes" but never
+    /// "no", and a member that had to fall through to the database half the time would be two code paths
+    /// where one indexed statement does.
+    /// </remarks>
+    /// <param name="calendarName">the name to check for</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>true if a calendar is stored under the given name</returns>
+    public ValueTask<bool> Exists(
+        string calendarName,
+        CancellationToken cancellationToken = default)
+    {
+        return ExecuteWithoutLock( // no locks necessary for read...
+            conn => CalendarExists(conn, calendarName, cancellationToken), cancellationToken);
+    }
+
     protected ValueTask<List<string>> GetTriggerGroupNames(ConnectionAndTransactionHolder conn, CancellationToken cancellationToken = default)
     {
         return Guarded(

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -483,6 +483,12 @@ internal sealed class DeferredScheduler : IScheduler
         return await target.Exists(triggerKey, cancellationToken).ConfigureAwait(false);
     }
 
+    public async ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.Exists(calendarName, cancellationToken).ConfigureAwait(false);
+    }
+
     public async ValueTask Clear(CancellationToken cancellationToken = default)
     {
         var target = await Resolve(cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -171,6 +171,11 @@ public class DelegatingJobStore : IJobStore
         return jobStore.Exists(triggerKey, cancellationToken);
     }
 
+    public virtual ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    {
+        return jobStore.Exists(calendarName, cancellationToken);
+    }
+
     public virtual ValueTask Clear(CancellationToken cancellationToken = default)
     {
         return jobStore.Clear(cancellationToken);

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -330,6 +330,11 @@ public class DelegatingScheduler : IScheduler
         return scheduler.Exists(triggerKey, cancellationToken);
     }
 
+    public virtual ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    {
+        return scheduler.Exists(calendarName, cancellationToken);
+    }
+
     public virtual ValueTask Clear(CancellationToken cancellationToken = default)
     {
         return scheduler.Clear(cancellationToken);

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -959,6 +959,28 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <summary>
+    /// Determine whether an <see cref="ICalendar" /> with the given name already exists within the
+    /// store.
+    /// </summary>
+    /// <param name="calendarName">the name to check for</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>true if a calendar is stored under the given name</returns>
+    public async ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    {
+        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Deliberately not GetCalendar: that clones the calendar, which for an AnnualCalendar with a
+            // decade of excluded days copies every one of them to answer a yes-or-no question.
+            return calendarsByName.ContainsKey(calendarName);
+        }
+        finally
+        {
+            lockObject.Release();
+        }
+    }
+
+    /// <summary>
     /// Get the current state of the identified <see cref="ITrigger" />.
     /// </summary>
     /// <seealso cref="TriggerState.Normal" />

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -371,6 +371,16 @@ internal sealed class StdScheduler : IScheduler
     /// <summary>
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
     /// </summary>
+    public ValueTask<bool> Exists(
+        string calendarName,
+        CancellationToken cancellationToken = default)
+    {
+        return scheduler.Exists(calendarName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
+    /// </summary>
     public ValueTask<bool> PauseTrigger(
         TriggerKey triggerKey,
         CancellationToken cancellationToken = default)

--- a/src/Quartz/SchedulerFactoryExtensions.cs
+++ b/src/Quartz/SchedulerFactoryExtensions.cs
@@ -1,0 +1,64 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Convenience calls over the <see cref="ISchedulerFactory" /> members.
+/// </summary>
+public static class SchedulerFactoryExtensions
+{
+    /// <summary>
+    /// Finds the scheduler with the given name, throwing when this container has none.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ISchedulerFactory.LookupScheduler" /> answers <see langword="null" /> for a name it
+    /// does not know, and a caller that treats absence as a bug writes the same throw around it every
+    /// time. This is that throw. What it deliberately does not do is list the schedulers that
+    /// <em>are</em> there: the repository holds the ones that have been built, so a named scheduler
+    /// registered but not yet asked for would be missing from that list and the report would be
+    /// confidently wrong about what the container holds.
+    /// </remarks>
+    /// <param name="schedulerFactory">The factory to ask.</param>
+    /// <param name="schedulerName">The scheduler's name. Matched ignoring case, as the repository indexes it.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <exception cref="SchedulerNotFoundException">No scheduler of that name is registered in this container.</exception>
+    public static async ValueTask<IScheduler> GetRequiredScheduler(
+        this ISchedulerFactory schedulerFactory,
+        string schedulerName,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(schedulerFactory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedulerName);
+
+        IScheduler? scheduler = await schedulerFactory.LookupScheduler(schedulerName, cancellationToken).ConfigureAwait(false);
+        if (scheduler is not null)
+        {
+            return scheduler;
+        }
+
+        throw new SchedulerNotFoundException(
+            schedulerName,
+            $"No scheduler named '{schedulerName}' is registered in this container. Register it with "
+            + "AddQuartz(\"" + schedulerName + "\", …), or call LookupScheduler if a missing scheduler is "
+            + "an answer rather than a failure. Only schedulers from the same container are visible: one "
+            + "built by a QuartzSchedulerBuilder of its own is not in this container's repository and is "
+            + "reported as absent.");
+    }
+}

--- a/src/Quartz/SchedulerNotFoundException.cs
+++ b/src/Quartz/SchedulerNotFoundException.cs
@@ -1,0 +1,44 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Thrown by <see cref="SchedulerFactoryExtensions.GetRequiredScheduler" /> when the container the
+/// factory belongs to has no scheduler of the requested name.
+/// </summary>
+/// <remarks>
+/// A type of its own rather than a bare <see cref="SchedulerException" />, because "the name is not
+/// registered here" is the one failure a caller of that method can act on — retrying a different name,
+/// or reporting the one that was misspelled — and telling it apart by message text is not a contract.
+/// <see cref="ISchedulerFactory.LookupScheduler" /> is the form that answers <see langword="null" />
+/// for the same question.
+/// </remarks>
+public sealed class SchedulerNotFoundException : SchedulerException
+{
+    internal SchedulerNotFoundException(string schedulerName, string message) : base(message)
+    {
+        SchedulerName = schedulerName;
+    }
+
+    /// <summary>
+    /// The name that was asked for, so a caller can report it without parsing the message.
+    /// </summary>
+    public string SchedulerName { get; }
+}

--- a/src/Quartz/SchedulerQueryExtensions.cs
+++ b/src/Quartz/SchedulerQueryExtensions.cs
@@ -21,17 +21,165 @@
 namespace Quartz;
 
 /// <summary>
-/// Convenience listings built on the <see cref="IScheduler" /> query members.
+/// Convenience calls built on the <see cref="IScheduler" /> query members.
 /// </summary>
 /// <remarks>
-/// Every method here enumerates the whole result — there is no paging, and a scheduler with
-/// many jobs, triggers or groups will pay for all of them on each call. Use the underlying
-/// query member with <see cref="PagedQuery.Skip" /> and <see cref="PagedQuery.Take" /> when
-/// the result may be large, and note that the query members return richer items than the
-/// bare keys and names returned here.
+/// <para>
+/// Two families live here, and they page differently. The <c>Get*</c> listings are the members the
+/// query members replaced: each enumerates the whole result — there is no paging, and a scheduler
+/// with many jobs, triggers or groups will pay for all of them on each call. Use the underlying
+/// query member with <see cref="PagedQuery.Skip" /> and <see cref="PagedQuery.Take" /> when the
+/// result may be large, and note that the query members return richer items than the bare keys and
+/// names returned here.
+/// </para>
+/// <para>
+/// The <c>Query*</c> shorthands are the opposite: each one is the query member called with a query
+/// record the caller did not have to name, so it pages exactly as the member does —
+/// <see cref="PagedQuery.DefaultTake" /> items, with <see cref="PagedResult{T}.HasMore" /> saying
+/// whether anything was left out. Name the query record when you want a different page, a filter or
+/// a total count.
+/// </para>
 /// </remarks>
 public static class SchedulerQueryExtensions
 {
+    /// <summary>
+    /// Lists the first page of jobs.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IScheduler.QueryJobs" /> with a <see cref="JobQuery" /> that filters nothing, which is
+    /// the whole of what the query object says for a caller who only wants "the jobs". Pages like every
+    /// other query: <see cref="PagedQuery.DefaultTake" /> items, and <see cref="PagedResult{T}.HasMore" />
+    /// reports the rest.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler to query.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static ValueTask<PagedResult<JobHeader>> QueryJobs(
+        this IScheduler scheduler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return scheduler.QueryJobs(new JobQuery(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists the first page of triggers.
+    /// </summary>
+    /// <inheritdoc cref="QueryJobs(IScheduler, CancellationToken)" path="/remarks" />
+    /// <param name="scheduler">The scheduler to query.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static ValueTask<PagedResult<TriggerHeader>> QueryTriggers(
+        this IScheduler scheduler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return scheduler.QueryTriggers(new TriggerQuery(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists the first page of firings.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IScheduler.QueryFireInstances" /> with a <see cref="FireInstanceQuery" /> that filters
+    /// nothing further. That record's own default is <see cref="FireInstanceState.Executing" />, so this
+    /// is "what is running", cluster-wide on a persistent store.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler to query.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static ValueTask<PagedResult<FireInstance>> QueryFireInstances(
+        this IScheduler scheduler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return scheduler.QueryFireInstances(new FireInstanceQuery(), cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists the first page of firings of one job.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IScheduler.QueryFireInstances" /> with <see cref="FireInstanceQuery.Job" /> set. A
+    /// firing that is only <see cref="FireInstanceState.Acquired" /> has no job recorded yet and so is
+    /// never selected by a job filter, which is why this lists what is executing rather than everything
+    /// in flight.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler to query.</param>
+    /// <param name="jobKey">The job whose firings to list.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static ValueTask<PagedResult<FireInstance>> QueryFireInstancesOfJob(
+        this IScheduler scheduler,
+        JobKey jobKey,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(jobKey);
+
+        return scheduler.QueryFireInstances(new FireInstanceQuery { Job = jobKey }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Lists the first page of triggers that are in <see cref="TriggerState.Error" />.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IScheduler.QueryTriggers" /> with <see cref="TriggerQuery.State" /> set. Name the
+    /// query record instead to count them without reading them —
+    /// <c>new TriggerQuery { State = TriggerState.Error, Take = 0, IncludeTotalCount = true }</c> — or to
+    /// narrow the listing to one group.
+    /// </remarks>
+    /// <param name="scheduler">The scheduler to query.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static ValueTask<PagedResult<TriggerHeader>> QueryTriggersInError(
+        this IScheduler scheduler,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+
+        return scheduler.QueryTriggers(new TriggerQuery { State = TriggerState.Error }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Resets every trigger in the matching groups that is in <see cref="TriggerState.Error" />, and
+    /// returns the keys it moved.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The companion of <see cref="QueryTriggersInError" />: it names the set the same way, and hands it
+    /// to <see cref="IScheduler.ResetTriggersFromErrorState(IReadOnlyCollection{TriggerKey}, CancellationToken)" />,
+    /// which is what decides what resetting a trigger does. Nothing about a trigger's reset changes here
+    /// — only how the caller names the set.
+    /// </para>
+    /// <para>
+    /// Two round trips, and the listing between them is deliberately unbounded: the set is "every
+    /// trigger in error", and a page of it would silently reset some and leave the rest. They are not
+    /// one atomic operation, so a trigger that enters the error state between the two calls is left for
+    /// the next one — which is also true of a caller who writes the two calls by hand.
+    /// </para>
+    /// </remarks>
+    /// <param name="scheduler">The scheduler to act on.</param>
+    /// <param name="matcher">Limits the reset to triggers whose group matches.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    public static async ValueTask<List<TriggerKey>> ResetTriggersFromErrorState(
+        this IScheduler scheduler,
+        GroupMatcher<TriggerKey> matcher,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(matcher);
+
+        TriggerQuery query = new() { Group = matcher, State = TriggerState.Error, Take = int.MaxValue };
+        PagedResult<TriggerHeader> failed = await scheduler.QueryTriggers(query, cancellationToken).ConfigureAwait(false);
+        if (failed.Items.Count == 0)
+        {
+            return [];
+        }
+
+        return await scheduler.ResetTriggersFromErrorState(
+            Project(failed.Items, static header => header.Key),
+            cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Get the keys of all the <see cref="IJobDetail" />s in the matching groups.
     /// </summary>


### PR DESCRIPTION
Five listing calls that needed a query object to ask a one-word question, from #3529. Everything here is additive — no query object changes shape, no `Take` default moves, and no query-object overload is removed.

## What changed

**Parameterless query shorthands** (L2, L8, L15) — extensions in `SchedulerQueryExtensions`:

| Instead of | Write |
|---|---|
| `QueryJobs(new JobQuery())` | `QueryJobs()` |
| `QueryTriggers(new TriggerQuery())` | `QueryTriggers()` |
| `QueryFireInstances(new FireInstanceQuery())` | `QueryFireInstances()` |
| `QueryFireInstances(new FireInstanceQuery { Job = jobKey })` | `QueryFireInstancesOfJob(jobKey)` |
| `QueryTriggers(new TriggerQuery { State = TriggerState.Error })` | `QueryTriggersInError()` |

They page the way the member they call pages — `PagedQuery.DefaultTake`, `HasMore` for the rest — which is *not* how the `Get*` compatibility listings in that class behave. The class remark said "every method here enumerates the whole result"; it now names the two families and says which is which.

`ResetTriggersFromErrorState(GroupMatcher<TriggerKey>)` is the companion: the listing that names the failed triggers of a group, then `ResetTriggersFromErrorState(keys)`. Two round trips, not a transaction, and what resetting a trigger does is unchanged — the shorthand only changes how the caller names the set. A null matcher throws rather than quietly meaning every group.

**`Exists(string calendarName)`** (L11) on `IScheduler` and `IJobStore`. The old answer, `GetCalendar(name) is not null`, reads the stored blob and deserializes it to throw the result away. `RAMJobStore` looks the name up without cloning; `AdoJobStoreBase` runs the existence statement. Over HTTP: `GET …/calendars/{calendarName}/exists`, mirroring the job and trigger routes.

**`ISchedulerFactory.GetRequiredScheduler(name)`** (L13), throwing a new `SchedulerNotFoundException : SchedulerException` that carries `SchedulerName`.

## Corrections to the issue's assumptions

- **L11 needs no new `IDriverDelegate` member.** The issue allowed for one (with the `UpdateTriggerPreferredNodeConditional` precedent). `IDriverDelegate.CalendarExists` and `StdAdoConstants.SqlSelectCalendarExistence` — literally `SELECT 1 FROM …CALENDARS WHERE …` — have been there all along, used by `AddCalendar` and by the trigger update that validates a calendar reference. They simply had nothing above them. `AdoJobStoreBase.Exists(string)` is `ExecuteWithoutLock(conn => CalendarExists(conn, …))`.
- **L15 needs no new endpoint.** The trigger query route already takes `state`, and `POST …/triggers/keys/reset-from-error-state` already exists, so the extension composes over the wire for free. L2 and L8 likewise map onto existing routes.
- **L11 does need one.** Jobs and triggers have `/exists`; calendars did not. Rather than approximate it with `QueryCalendarNames(nameEquals=…)`, the calendar route is added in the family's shape — same `ExistsResponse`, same path suffix.

## For a reviewer to decide

1. **L13 is an extension, not a DIM.** The issue says "on `ISchedulerFactory`"; the brief said to pick whichever does not break implementers, and both qualify. I chose the extension because it is composition over `LookupScheduler` that no factory could implement better, and because an extension also resolves on a concrete receiver such as the public `StandaloneSchedulerFactory`, where a default interface method would need a cast to be callable. If you would rather it were a DIM on the interface, it is a small change and the baseline row moves.
2. **The shorthands live in `SchedulerQueryExtensions` rather than a class of their own.** The issue said "beside `SchedulerQueryExtensions`". One discoverable class of query conveniences on `IScheduler` seemed better than two, at the cost of the class holding two families that page differently — which the class doc now spells out.
3. **`Exists(calendarName)` does not validate a blank name**, matching `GetCalendar`/`DeleteCalendar` on the same type: a name nobody registered answers `false`. `HttpScheduler` still rejects a blank name client-side, because it cannot build the URL.
4. **`IJobStore` gains a required member**, so a custom store must implement it. Migration guide updated: the "If you implement `IJobStore`" section now says four members, and the removed-members table's `CalendarExists(name)` row points at the new overload instead of at `GetCalendar(name) is not null`.

## Tests

- `SchedulerQueryShorthandTest` — the shorthands list what the spelled-out query would, still page at `DefaultTake` (251 jobs, `HasMore`), list a gated job's firing, and reset only the matching group's failed triggers while leaving another group's alone (triggers driven into `TriggerState.Error` by a throwing job factory).
- `SchedulerFactoryExtensionsTest` — the required form is the lookup's answer, the missing name throws with `SchedulerName` on it, `LookupScheduler` still answers `null` for the same name.
- `AdoJobStoreBaseTest` — calendar existence calls `IDriverDelegate.CalendarExists` and never `SelectCalendar`.
- `JobStoreContractTest.CalendarExistenceIsAnsweredByName` — every store, run here against `RAMJobStore` and SQLite.
- `QueryEndpointsTest`, `TriggerEndpointsTest`, `CalendarEndpointsTest` — the shorthands over the wire, the group reset hitting both routes it composes (and posting nothing when the listing is empty), and the calendar existence route not fetching the calendar.

Baselines regenerated through Verify; the delta is the four `Exists(string calendarName)` rows per implementer, the six shorthands, `SchedulerFactoryExtensions` and `SchedulerNotFoundException`.

Closes #3529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
