### PR TITLE
Schema validation checks QRTZ_SIMPROP_TRIGGERS too

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3253,6 +3253,15 @@ The `Sql*` statement templates on `StdAdoConstants` are not visible at all any m
 statement is not a contract. Build the statement your dialect needs, or override the `GetSelect*Sql` hooks,
 which are unchanged.
 
+`AdoConstants` names **every** table the store reads or writes, which in 3.x it did not:
+`TableSimplePropertiesTriggers` (`"SIMPROP_TRIGGERS"`) was declared `protected` on
+`SimplePropertiesTriggerPersistenceDelegateSupport` and nowhere else. The startup schema validation walks
+the names on `AdoConstants`, so it never asked whether `QRTZ_SIMPROP_TRIGGERS` was there, and a database
+missing only that table started and failed later — on the first calendar-interval, daily-time-interval or
+recurrence trigger written to it. It is `public const` on `AdoConstants` in 4.x and validated with the other
+eleven. The `protected` spelling stays on `SimplePropertiesTriggerPersistenceDelegateBase` for a delegate
+that derives from it, so a subclass compiles unchanged.
+
 `DbLockHandler.AdoUtil` is `private protected` for the same reason, so a lock handler written outside Quartz
 no longer sees it. What such a handler needs from it — preparing a statement and binding a parameter — is
 `protected` on `DbLockHandler` itself:
@@ -8746,7 +8755,7 @@ Parameters and behavior are unchanged:
 | `AdoJobStoreOptions.CommandTimeout` added | Bounds every statement the store issues, the lock handler's included; it reaches them through `DriverDelegateContext.CommandTimeout` and `LockHandlerContext.CommandTimeout`. Unset keeps each provider's own default, so nothing changes for a store that does not set it. 3.x had no way to say this at all — there was no `quartz.*` key for it, so nothing needs translating |
 | `DbMetadataFactory` is internal | Every implementation was already internal and no public member accepted one; describe a driver through `UseGenericDatabase`'s metadata factory |
 | `DbProvider.PropertyDbProvider` and `.DbProviderResourceName` removed | Two `protected const`s nothing read, left over from the process-wide provider registry |
-| `SimplePropertiesTriggerPersistenceDelegateBase`'s four SQL statements are private | `SelectSimplePropsTrigger`, `DeleteSimplePropsTrigger`, `InsertSimplePropsTrigger` and `UpdateSimplePropsTrigger` name every column the base class binds, so replacing one could not work. The table and column name constants stay `protected` — they are the schema contract |
+| `SimplePropertiesTriggerPersistenceDelegateBase`'s four SQL statements are private | `SelectSimplePropsTrigger`, `DeleteSimplePropsTrigger`, `InsertSimplePropsTrigger` and `UpdateSimplePropsTrigger` name every column the base class binds, so replacing one could not work. The column name constants stay `protected` — they are the schema contract — and `TableSimplePropertiesTriggers` is `protected` still, now aliasing the `public` `AdoConstants.TableSimplePropertiesTriggers` that schema validation walks |
 | `RAMJobStore` is `sealed` and has no `virtual` members | Wrap it in a store deriving from the new `DelegatingJobStore` instead of deriving from it — see [`RAMJobStore` is sealed](#ramjobstore-is-sealed) |
 | `Quartz.Impl.DelegatingJobStore` added | Forwards every `IJobStore` member to a wrapped store, each one `virtual`, so a decorating store overrides only what it changes — see [`DelegatingJobStore` decorates a store](#delegatingjobstore-decorates-a-store) |
 | `HostnameInstanceIdGenerator` is `HostNameInstanceIdGenerator` | Casing matched to `HostNameBasedIdGenerator`. The type is internal; a `quartz.scheduler.instanceIdGenerator.type` still naming the old spelling resolves, with a warning |

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -212,12 +212,9 @@ they have no delegate of their own, so a store configured for either still provi
 schema, which is not what you asked for. Both are deliberate departures a person chose for a particular
 deployment. Run those by hand and leave `SchemaProvisioning` at `Validate`.
 
-Validation, whichever position you leave the setting at, checks *tables* — not columns. A database
-missing only a column gets past startup and fails on the first statement that names it, which is the
-other half of why the 4.0 migration is mandatory rather than merely recommended. It is eleven of the
-twelve tables, too: `QRTZ_SIMPROP_TRIGGERS` is not among the ones it queries, so a schema missing only
-that one starts and fails later, when something schedules a calendar-interval, daily-time-interval or
-recurrence trigger.
+Validation, whichever position you leave the setting at, checks *tables* — all twelve of them, and not
+their columns. A database missing only a column gets past startup and fails on the first statement that
+names it, which is the other half of why the 4.0 migration is mandatory rather than merely recommended.
 
 ### Storing job data as strings
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaScriptTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaScriptTest.cs
@@ -23,6 +23,8 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 
+using Quartz.Impl.AdoJobStore;
+
 namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 
 /// <summary>
@@ -66,6 +68,26 @@ public class SchemaScriptTest
             $"a table in database/tables/tables_{dialect}.sql and not in the generated script is one "
             + "SchemaProvisioning.CreateIfMissing leaves out, and one the store validates for immediately "
             + "afterwards");
+    }
+
+    /// <summary>
+    /// The third file in the pair's conversation: the list the store probes at startup.
+    /// </summary>
+    /// <remarks>
+    /// The two scripts agreeing with each other is not enough, because both can create a table the
+    /// store never asks about. <c>AdoConstants.AllTableNames</c> is what
+    /// <see cref="SchemaProvisioning.Validate" /> runs a <c>SELECT 1</c> against, so a table in the
+    /// scripts and not in that list is one a database can be missing while startup reports the schema
+    /// good — which is what #3564 was, about <c>QRTZ_SIMPROP_TRIGGERS</c>.
+    /// </remarks>
+    [TestCaseSource(nameof(Dialects))]
+    public void EveryTableTheFreshInstallScriptCreatesIsOneTheStoreValidates(string dialect)
+    {
+        SqlObjects fresh = SqlObjects.Parse(FreshInstallScript(dialect));
+
+        fresh.Tables.Keys.Should().BeEquivalentTo(AdoConstants.AllTableNames,
+            $"database/tables/tables_{dialect}.sql and AdoConstants.AllTableNames describe the same "
+            + "schema — one creates it, the other is the whole of what startup checks is there");
     }
 
     [TestCaseSource(nameof(Dialects))]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
@@ -1,0 +1,218 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// What a store checks is there before it starts, and what it does when one of them is not.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The database is a real one: SQLite is a file, so a schema installed from
+/// <c>database/tables/tables_sqlite.sql</c> — the script a reader is told to run — costs a temporary
+/// path, and the store that validates it runs in this process. Nothing here needs a container, which
+/// is why the case is a unit test rather than one more dialect in <c>SchemaProvisioningTest</c>.
+/// </para>
+/// <para>
+/// Installing the script and then dropping one table is the shape of the real failure this guards
+/// against: a database that is almost right. <c>SchemaScriptTest</c> is the other half, and compares
+/// the list against every dialect's script without needing a database at all.
+/// </para>
+/// </remarks>
+public sealed class SchemaValidationTest
+{
+    /// <summary>The tables the cases below drop one at a time.</summary>
+    private static readonly string[] EveryValidatedTable = AdoConstants.AllTableNames;
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+    private ServiceProvider? container;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-validation-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public async Task DeleteDatabase()
+    {
+        if (container is not null)
+        {
+            await container.DisposeAsync();
+            container = null;
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    /// <summary>
+    /// The twelve tables, spelled out rather than counted.
+    /// </summary>
+    /// <remarks>
+    /// A count would have passed all along: <c>QRTZ_SIMPROP_TRIGGERS</c> was missing from the list
+    /// because its name lived on the delegate that writes it rather than on <c>AdoConstants</c>, and
+    /// eleven was what everything downstream agreed the answer was (#3564). Naming them is what makes
+    /// a thirteenth table, or a twelfth that goes missing again, a failing test here rather than an
+    /// insert against a table nobody checked for.
+    /// </remarks>
+    [Test]
+    public void TheStoreValidatesEveryTableOfTheSchema()
+    {
+        AdoConstants.AllTableNames.Should().Equal(
+            [
+                "JOB_DETAILS",
+                "TRIGGERS",
+                "SIMPLE_TRIGGERS",
+                "SIMPROP_TRIGGERS",
+                "CRON_TRIGGERS",
+                "BLOB_TRIGGERS",
+                "FIRED_TRIGGERS",
+                "CALENDARS",
+                "PAUSED_TRIGGER_GRPS",
+                "PAUSED_JOB_GRPS",
+                "LOCKS",
+                "SCHEDULER_STATE"
+            ],
+            "these are the tables the schema has, in the order the scripts create them, and the list is "
+            + "the whole of what SchemaProvisioning.Validate probes at startup");
+    }
+
+    /// <summary>
+    /// The control: an untouched schema starts.
+    /// </summary>
+    /// <remarks>
+    /// Without it, a harness that installed nothing — a script that failed to run, a path that moved —
+    /// would make every case below pass for the wrong reason, since a database with no tables at all
+    /// also refuses to start.
+    /// </remarks>
+    [Test]
+    public async Task AStoreStartsAgainstTheSchemaTheFreshInstallScriptCreates()
+    {
+        InstallSchemaFromFreshInstallScript();
+
+        Func<Task> act = async () => await (await GetScheduler(
+            nameof(AStoreStartsAgainstTheSchemaTheFreshInstallScriptCreates))).Shutdown();
+
+        await act.Should().NotThrowAsync(
+            "the twelve tables database/tables/tables_sqlite.sql creates are the twelve the store "
+            + "validates, so a schema installed straight from it needs nothing else");
+    }
+
+    /// <summary>
+    /// Every table on the list is one a database can be missing and be refused for.
+    /// </summary>
+    /// <remarks>
+    /// Running the case for all twelve is what makes the list mean something: a name added to
+    /// <c>AllTableNames</c> that no statement can query — a view, a misspelling, a table only some
+    /// dialects have — would pass the two tests above and fail here.
+    /// </remarks>
+    [TestCaseSource(nameof(EveryValidatedTable))]
+    public async Task AStoreRefusesToStartWhenATableIsMissing(string table)
+    {
+        InstallSchemaFromFreshInstallScript();
+        Execute($"DROP TABLE QRTZ_{table}");
+
+        Func<Task> act = () => GetScheduler(nameof(AStoreRefusesToStartWhenATableIsMissing));
+
+        SchedulerException failure = (await act.Should().ThrowAsync<SchedulerException>(
+                "a database missing a table Quartz writes to has to be a startup failure, not a "
+                + "scheduler that runs until something schedules the trigger type that needs it"))
+            .WithMessage("*schema validation failed*")
+            .Which;
+
+        MessagesOf(failure).Should().ContainMatch($"*QRTZ_{table}*",
+            "the message names the table that is missing, since the reader's next move is to run the "
+            + "migration or the fresh-install script that creates it");
+    }
+
+    /// <summary>
+    /// Runs <c>database/tables/tables_sqlite.sql</c>, the script the documentation tells a reader to
+    /// run, against the empty file.
+    /// </summary>
+    /// <remarks>
+    /// The whole text goes to one command: SQLite's own parser splits it, which is the only splitter
+    /// that gets the <c>CREATE TRIGGER … BEGIN … END;</c> blocks right.
+    /// </remarks>
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        string path = Path.Combine(RepositoryRoot.Find().FullName, "database", "tables", "tables_sqlite.sql");
+
+        Execute(File.ReadAllText(path));
+    }
+
+    private void Execute(string sql)
+    {
+        using SqliteConnection connection = new(connectionString);
+        connection.Open();
+
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.ExecuteNonQuery();
+    }
+
+    private async Task<IScheduler> GetScheduler(string schedulerName)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = schedulerName;
+                options.InstanceId = "one";
+            });
+
+            // No ProvisionSchema(): SchemaProvisioning.Validate is the default, and validating what
+            // somebody else installed is the whole subject here.
+            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, connectionString));
+        });
+
+        container = services.BuildServiceProvider();
+
+        return await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+    }
+
+    /// <summary>Every message in an exception chain, outermost first.</summary>
+    private static List<string> MessagesOf(Exception exception)
+    {
+        List<string> messages = [];
+
+        for (Exception? current = exception; current is not null; current = current.InnerException)
+        {
+            messages.Add(current.Message);
+        }
+
+        return messages;
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -2249,6 +2249,7 @@ namespace Quartz.Impl.AdoJobStore
         public const string TablePausedJobs = "PAUSED_JOB_GRPS";
         public const string TablePausedTriggers = "PAUSED_TRIGGER_GRPS";
         public const string TableSchedulerState = "SCHEDULER_STATE";
+        public const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
         public const string TableSimpleTriggers = "SIMPLE_TRIGGERS";
         public const string TableTriggers = "TRIGGERS";
         public const string TriggerTypeBlob = "BLOB";

--- a/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
@@ -35,11 +35,23 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma(.NET)</author>
 public static class AdoConstants
 {
+    /// <summary>
+    /// Every table the store reads or writes, in the order the schema scripts create them.
+    /// </summary>
+    /// <remarks>
+    /// This is what <see cref="IDriverDelegate.ValidateSchema" /> probes at startup, so a table
+    /// missing from here is a table a database can be missing and still start — the failure moves to
+    /// the first statement that names it, which is what validation exists to prevent. Every table
+    /// name therefore belongs on this class, whichever delegate writes to it. <c>SchemaScriptTest</c>
+    /// holds this list to what each dialect's fresh-install script creates, and
+    /// <c>SchemaValidationTest</c> drops each of them from a real database in turn.
+    /// </remarks>
     internal static readonly string[] AllTableNames =
     [
         TableJobDetails,
         TableTriggers,
         TableSimpleTriggers,
+        TableSimplePropertiesTriggers,
         TableCronTriggers,
         TableBlobTriggers,
         TableFiredTriggers,
@@ -54,6 +66,7 @@ public static class AdoConstants
     public const string TableJobDetails = "JOB_DETAILS";
     public const string TableTriggers = "TRIGGERS";
     public const string TableSimpleTriggers = "SIMPLE_TRIGGERS";
+    public const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
     public const string TableCronTriggers = "CRON_TRIGGERS";
     public const string TableBlobTriggers = "BLOB_TRIGGERS";
     public const string TableFiredTriggers = "FIRED_TRIGGERS";

--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateBase.cs
@@ -38,12 +38,22 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma (.NET)</author>
 public abstract class SimplePropertiesTriggerPersistenceDelegateBase : ITriggerPersistenceDelegate
 {
-    // The table and column names are the schema contract a derived delegate reads its own values back
-    // from, so they stay protected. The four statements below are not: they name every column this base
-    // class writes, so a subclass replacing one would either be writing the same statement again or
-    // writing a statement this class's parameter binding does not match.
-    protected const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
+    /// <summary>
+    /// The table this delegate persists into, kept here as the spelling a derived delegate writes.
+    /// </summary>
+    /// <remarks>
+    /// The value belongs to <see cref="AdoConstants" />, where every table the store reads or writes
+    /// is named, because that list is what startup schema validation probes. Declared only here, it
+    /// was a table validation did not know about: a database missing this one alone started, and
+    /// failed on the first calendar-interval, daily-time-interval or recurrence trigger written to
+    /// it (#3564).
+    /// </remarks>
+    protected const string TableSimplePropertiesTriggers = AdoConstants.TableSimplePropertiesTriggers;
 
+    // The column names are the schema contract a derived delegate reads its own values back from, so
+    // they stay protected. The four statements below are not: they name every column this base class
+    // writes, so a subclass replacing one would either be writing the same statement again or writing
+    // a statement this class's parameter binding does not match.
     protected const string ColumnStrProp1 = "STR_PROP_1";
     protected const string ColumnStrProp2 = "STR_PROP_2";
     protected const string ColumnStrProp3 = "STR_PROP_3";

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -177,7 +177,7 @@ internal static class StdAdoConstants
     /// single query covers them all — the per-row discriminator comes from TRIGGERS.TRIGGER_TYPE.
     /// </summary>
     public static readonly string SqlSelectSimpropTriggersByKeysPrefix =
-        Invariant($"SELECT {SimplePropertiesTriggerPersistenceDelegateBase.SelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
+        Invariant($"SELECT {SimplePropertiesTriggerPersistenceDelegateBase.SelectColumns}, {TriggerKeySelectColumns} FROM {TablePrefixSubst}{AdoConstants.TableSimplePropertiesTriggers} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND ");
 
     public static readonly string SqlSelectCalendar =
         Invariant($"SELECT {AdoConstants.ColumnCalendar} FROM {TablePrefixSubst}{AdoConstants.TableCalendars} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnCalendarName} = @{SqlParameters.CalendarName}");


### PR DESCRIPTION
`AdoConstants.AllTableNames` listed eleven of the schema's twelve tables. `QRTZ_SIMPROP_TRIGGERS` was missing because its name lived on `SimplePropertiesTriggerPersistenceDelegateBase` as a `protected const` rather than on `AdoConstants` — and `AllTableNames` is exactly what `SchemaProvisioning.Validate` probes with `SELECT 1` at startup, and what `CreateIfMissing` validates after provisioning. A database missing only that one table passed validation, the scheduler started, and the failure surfaced later as the first `INSERT` from a calendar-interval, daily-time-interval or recurrence trigger.

## What changed

- The name is `AdoConstants.TableSimplePropertiesTriggers` now, beside the other eleven, and joins `AllTableNames` in schema order (after `SIMPLE_TRIGGERS`, matching the order the scripts create the tables in).
- `SimplePropertiesTriggerPersistenceDelegateBase.TableSimplePropertiesTriggers` stays `protected`, aliasing the new constant, so a delegate deriving from the base compiles unchanged. `StdAdoConstants.SqlSelectSimpropTriggersByKeysPrefix` stops spelling the table literally.
- No change to the `SELECT 1` statement was needed: `QRTZ_SIMPROP_TRIGGERS` is an ordinary table carrying the configured prefix in all eight `database/tables/*.sql` and all six generated `create_<dialect>.sql`, so it validates like the rest.

## Tests

Three, at different distances from a database:

- `SchemaScriptTest.EveryTableTheFreshInstallScriptCreatesIsOneTheStoreValidates` compares `AllTableNames` with the tables each of the six dialects' fresh-install script creates. **This is the guard that catches this class of bug** — a hand-written list of twelve would not have, since whoever wrote it would have written eleven.
- `SchemaValidationTest.TheStoreValidatesEveryTableOfTheSchema` names the twelve in order, as the tripwire the issue asked for.
- `SchemaValidationTest.AStoreRefusesToStartWhenATableIsMissing` installs `database/tables/tables_sqlite.sql` into a temporary file and drops each table in turn, checking the store refuses to start and names the missing table. SQLite is a file, so this needs no Docker. A control case asserts the untouched schema starts, so a harness that installed nothing could not make the twelve pass for the wrong reason.

With the `AllTableNames` entry removed, seven of these fail (six dialects plus the explicit list).

## For a reviewer to decide

**The constant is public twice, in a sense.** `AdoConstants.TableSimplePropertiesTriggers` is `public const`; the `protected const` on the delegate base remains, now aliasing it. That is one added line in `PublicApiTest_Quartz.verified.txt` and nothing removed. The alternative — deleting the protected spelling — is tidier against the migration guide's own "One spelling per constant" section, but it breaks source compatibility for a delegate written against the documented `SimplePropertiesTriggerPersistenceDelegateBase` extension point, including the `BusinessDayTriggerPersistenceDelegate` sample. I kept the alias; say the word and I will drop it.

The baseline was accepted through Verify (received moved over verified, BOM intact) and the delta is carried into `docs/documentation/quartz-4.x/migration-guide.md` in two places.

## Docs

The `### Creating the schema` paragraph in `tutorial/job-stores.md` documented the gap; it now says validation checks tables and not columns, without the "eleven of the twelve" caveat. `database/README.md` needed no change — it has no such sentence, and its one line about startup validation (in "Upgrading 3.x → 4.x is mandatory") was already accurate.

## `3.x` has the same bug — not fixed here

`git show origin/3.x:src/Quartz/Impl/AdoJobStore/AdoConstants.cs` lists **ten** names, and 3.x's schema has eleven tables (`QRTZ_PAUSED_JOB_GRPS` is 4.x-only). The missing one is `SIMPROP_TRIGGERS`, for the same reason: `origin/3.x:src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs:44` declares it `protected const`. `JobStoreSupport.PerformSchemaValidation` defaults to `true` there, so 3.x users are exposed the same way. Left alone deliberately, per the brief — a companion PR is worth opening.

Closes #3564

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
