### PR TITLE
Wolverine has no cron, and a runnable example says what Quartz supplies

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -42,7 +42,8 @@
         "UnitTest",
         "VerifyDocsSnippets",
         "VerifyMigrations",
-        "VerifySchema"
+        "VerifySchema",
+        "WolverineSmoke"
       ]
     },
     "Verbosity": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,12 @@ updates:
       aspire:
         patterns:
           - "Aspire.*"
+      # Wolverine, used by the Wolverine example. The core package and its extensions ship as one
+      # version on JasperFx's own cadence, and a mismatched pair fails at startup rather than at
+      # restore, so they move together.
+      wolverine:
+        patterns:
+          - "WolverineFx*"
       # Everything else shipped out of dotnet/runtime and dotnet/aspnetcore.
       microsoft:
         patterns:

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -48,8 +48,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -62,8 +62,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
@@ -76,5 +76,5 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -109,6 +109,11 @@ jobs:
           # analysis, so the bug and code-smell rules still apply to code people paste into their
           # own applications.
           #
+          # Quartz.Examples.Wolverine is excused for a third reason again: it *is* exercised, by the
+          # WolverineSmoke target on the pull-request leg, which runs it end to end and fails on a
+          # non-zero exit. That run happens out of process and under no coverage collector, so the
+          # gate would read a project with a working liveness check as a project with none.
+          #
           # The older src/Quartz.Examples.* projects are not listed, and that is not an oversight:
           # they carry no coverage either, but the condition that fails here measures new code, so
           # the gate has never asked about them. Adding a new example is what surfaces it. Listing
@@ -153,7 +158,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml" \
             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**,src/Quartz/Impl/AdoJobStore/Schema/**" \
             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**,src/Quartz/Impl/AdoJobStore/Schema/**,database/**" \
-            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Trimming.Canary/**,src/Quartz.Examples.Aspire.AppHost/**,src/Quartz.Examples.Aspire.Worker/**" \
+            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Trimming.Canary/**,src/Quartz.Examples.Aspire.AppHost/**,src/Quartz.Examples.Aspire.Worker/**,src/Quartz.Examples.Wolverine/**" \
             /d:sonar.issue.ignore.multicriteria="generatedOracleGuards,wholeTableByDesign" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.ruleKey="plsql:S1523" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.resourceKey="database/migrations/**/*.sql" \

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,6 +89,9 @@
     <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
     <PackageVersion Include="Topshelf" Version="4.3.0" />
     <PackageVersion Include="Verify.NUnit" Version="32.0.0" />
+    <PackageVersion Include="WolverineFx" Version="6.30.3" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="6.30.3" />
+    <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.30.3" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -4,6 +4,7 @@
     <Project Path="src/Quartz.Examples.Aspire.Worker/Quartz.Examples.Aspire.Worker.csproj" />
     <Project Path="src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj" />
     <Project Path="src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj" />
+    <Project Path="src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj" />
     <Project Path="src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj" />
     <Project Path="src/Quartz.Examples/Quartz.Examples.csproj" />
   </Folder>

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -21,10 +21,10 @@ using Quartz.Build;
     // line tools ILCompiler links with, so there is nothing to install, and if that stops being true the
     // leg says so out loud rather than the claim going unchecked on a third platform.
     //
-    // BenchmarkSmoke is on this workflow alone. Every change reaches main through a pull request, so
-    // this is where a broken benchmark is caught while somebody is still looking; the push and release
-    // legs have ten-minute budgets and nothing to do with the benchmarks.
-    InvokedTargets = [nameof(VerifyMigrations), nameof(VerifySchema), nameof(ICompile.Compile), nameof(UnitTest), nameof(BenchmarkSmoke), nameof(PublishTrimmed), nameof(PublishAot)],
+    // BenchmarkSmoke and WolverineSmoke are on this workflow alone. Every change reaches main through a
+    // pull request, so this is where a broken benchmark or a broken example is caught while somebody is
+    // still looking; the push and release legs have ten-minute budgets and nothing to do with either.
+    InvokedTargets = [nameof(VerifyMigrations), nameof(VerifySchema), nameof(ICompile.Compile), nameof(UnitTest), nameof(BenchmarkSmoke), nameof(WolverineSmoke), nameof(PublishTrimmed), nameof(PublishAot)],
     CacheKeyFiles = [],
     // Generating native code is minutes rather than seconds, and it happens after everything else here.
     TimeoutMinutes = 20,

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -442,6 +442,44 @@ partial class Build : FalloutBuild, ICompile, IPack
             );
         });
 
+    /// <summary>
+    /// Runs the Wolverine example end to end, so a recipe that compiles is also a recipe that works.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Quartz.Examples.Wolverine</c> is in the solution, so <c>Compile</c> catches the calls it makes
+    /// going away. What compiling cannot catch is the part of the integration that is about two runtimes
+    /// agreeing: hosted-service ordering, a scheduler started by something other than its own hosted
+    /// service, a trigger group used as a correlation axis, and a serialized envelope handed back to a
+    /// message bus. <c>--smoke</c> asserts each of those produced its effect and returns non-zero when
+    /// one did not; <c>src/Quartz.Examples.Wolverine/Smoke.cs</c> is the list.
+    /// </para>
+    /// <para>
+    /// Nothing external is needed — Wolverine's in-memory local transport and Quartz's in-memory store.
+    /// The example's Postgres mode is reached through an environment variable and is deliberately not
+    /// exercised here; it needs a database, which is what the <c>pr-integration-*</c> workflows are for.
+    /// </para>
+    /// <para>
+    /// Beside <see cref="BenchmarkSmoke" /> and after the unit tests, for the same reason: both want the
+    /// machine, and a failing test is the one worth reading first.
+    /// </para>
+    /// </remarks>
+    Target WolverineSmoke => _ => _
+        .DependsOn<ICompile>()
+        .After(UnitTest)
+        .Before<IPack>()
+        .Executes(() =>
+        {
+            var solution = ((IHasSolution) this).Solution;
+            var configuration = ((ICompile) this).Configuration;
+
+            DotNetRun(s => s
+                .SetProjectFile(solution.AllProjects.First(x => x.Name == "Quartz.Examples.Wolverine"))
+                .SetConfiguration(configuration)
+                .SetApplicationArguments("--smoke")
+            );
+        });
+
     static readonly string[] DatabaseCategories =
         ["db-postgres", "db-sqlserver", "db-mysql", "db-oracle", "db-firebird", "db-sqlite", "db-redis"];
 

--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -145,6 +145,7 @@ export const sidebarEn: SidebarConfig = [
               "/documentation/quartz-4.x/how-tos/multiple-triggers",
               "/documentation/quartz-4.x/how-tos/job-template",
               "/documentation/quartz-4.x/how-tos/aspire",
+              "/documentation/quartz-4.x/how-tos/wolverine",
               "/documentation/quartz-4.x/how-tos/trimming-and-native-aot",
               "/documentation/quartz-4.x/how-tos/custom-job-store",
               "/documentation/quartz-4.x/how-tos/dialect-delegate",

--- a/docs/documentation/quartz-4.x/how-tos/README.md
+++ b/docs/documentation/quartz-4.x/how-tos/README.md
@@ -15,6 +15,7 @@ Short, task-shaped recipes. Each page answers one question; the
 * [Multiple Triggers](multiple-triggers.md) — drive one job from several triggers, and give each its own data
 * [Job Template](job-template.md) — the recommended skeleton for a job class
 * [Running Quartz under Aspire](aspire.md) — telemetry, health and the database, wired to an AppHost
+* [Quartz.NET with Wolverine](wolverine.md) — cron-publishing into a message bus, cancelling by correlation, and sharing the outbox's transaction
 * [Publishing Trimmed and Native AOT](trimming-and-native-aot.md) — what each package claims, what still warns, and what to do about it
 
 Extending Quartz — the four seams the `Quartz.Impl.AdoJobStore` types exist for:

--- a/docs/documentation/quartz-4.x/how-tos/wolverine.md
+++ b/docs/documentation/quartz-4.x/how-tos/wolverine.md
@@ -1,0 +1,641 @@
+---
+
+title: 'Quartz.NET with Wolverine'
+---
+
+# Quartz.NET with Wolverine
+
+[Wolverine](https://wolverinefx.net) can deliver a message later. It cannot say "every weekday at
+03:00", and its maintainer has said it never will: the request for cron scheduling,
+[JasperFx/wolverine#1403](https://github.com/JasperFx/wolverine/issues/1403), was closed the day it was
+opened with "We're not doing this, ever. *Maybe* there'll be a move to integrate Quartz.net or Hangfire
+*with* Wolverine, but it's not something I'm interested in having to support." That position has since
+turned into a plan rather than a refusal. Wolverine 6's
+[master issue](https://github.com/JasperFx/wolverine/issues/2715) lists "Scheduler integrations —
+Quartz.Net + TickerQ" among its goals, its
+[migration-guide tracker](https://github.com/JasperFx/wolverine/issues/2717) says the integrations get
+"opt-in package references and configuration" documented, the
+[release punchlist](https://github.com/JasperFx/wolverine/issues/2745) records that the maintainer
+"wants involvement before this lands", and the
+[Critter Stack roadmap post of 24 July 2026](https://jeremydmiller.com/2026/07/24/critter-stack-roadmap-for-the-rest-of-2026/)
+says "It's quite possible that Wolverine gets first class documentation and integration for Quartz.Net
+and TickerQ first". Wolverine has already shipped the hook the integration needs:
+["Sending Raw Message Data"](https://wolverinefx.net/guide/messaging/message-bus.html) exists, in its
+own words, for "integrating scheduling libraries like Quartz.NET or Hangfire where you might be
+persisting a `byte[]` for a message to be sent via Wolverine at a certain time".
+
+Nothing has shipped on either side. There is no `WolverineFx.Quartz` package and no `Quartz.Wolverine`
+package; this page is a recipe, not an announcement, and it is written against Wolverine 6.30.3.
+
+::: tip A working copy of all of this
+`src/Quartz.Examples.Wolverine` in the
+[Quartz.NET repository](https://github.com/quartznet/quartznet/tree/main/src/Quartz.Examples.Wolverine)
+is this page as one console application that builds and runs. It is in the solution, so a call on this
+page that stops compiling fails the build, and every C# block below is checked against it line for
+line. `dotnet run --project src/Quartz.Examples.Wolverine -- --smoke` exercises all six parts against
+the in-memory store and exits non-zero if any of them stops working; the `WolverineSmoke` build target
+runs exactly that on every pull request, on all three operating systems, with no database involved.
+:::
+
+## Which library should own the schedule
+
+Before wiring anything together it is worth being clear about what is genuinely missing, because most
+of what a bus calls "scheduling" is not what a scheduler does.
+
+A transport's delay is a property of one message. Azure Service Bus says so outright: "Because the
+feature is anchored on individual messages and messages can only be enqueued once, Service Bus doesn't
+support recurring schedules for messages"
+([message sequencing](https://learn.microsoft.com/en-us/azure/service-bus-messaging/message-sequencing)).
+Amazon SQS caps delayed delivery at
+[15 minutes](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html)
+and tells you to reach for EventBridge Scheduler beyond that. RabbitMQ's delayed-message-exchange
+plugin, which several buses lean on, keeps its schedule in a single unreplicated table, is documented as
+being for "a number of seconds, minutes, or hours — a day or two at most", and
+[is no longer maintained](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange): Mnesia was
+removed in RabbitMQ 4.3.0 and took the plugin with it.
+
+A recurrence is not a message. It is a rule that outlives every message it produces, and it brings a
+tail of decisions with it: which time zone the expression is read in, what happens to a firing the
+process was down for, which node in a cluster owns it, and how it is cancelled after the fact. NServiceBus
+built a scheduler, ran it for years, and then removed it, publishing an unusually candid list of why:
+the schedule was not durable across a restart, tasks "cannot be canceled or modified after creation",
+an interval could be specified but not an execution time, and on a scaled-out endpoint a task could be
+dequeued by an instance that had never created it, so it was "not executed but also not rescheduled".
+Their conclusion was to
+[deprecate the API](https://docs.particular.net/nservicebus/upgrades/7to8/) "in favor of options like
+sagas and production-grade schedulers such as Hangfire, Quartz, and FluentScheduler". Rebus never
+offered recurrence at all, consistent with its self-description as a "message bus without smarts", and
+[Brighter](https://brightercommand.gitbook.io/paramore-brighter-documentation/scheduler/brighterschedulersupport)
+defines a scheduler abstraction whose whole surface is "at this time" and "after this delay", with cron
+left to whichever backend it is pointed at — Quartz being one.
+
+The honest counter-example is MassTransit, which went the other way. Having relied on Quartz for
+recurring messages for years — and it still ships `MassTransit.Quartz` — it grew a cron parser of
+its own inside its Job Service in 2024, and now
+[tells users](https://masstransit.io/documentation/patterns/job-consumers) that "Quartz.NET or Hangfire
+are NOT required". So this is a live disagreement, not settled practice.
+
+The axis that decides it, in four questions:
+
+* Does the schedule outlive any individual message? A rule that keeps producing work is not a delayed
+  send, however many times you re-arm one.
+* Does a missed firing need a defined outcome rather than a silent drop? That decision is a misfire
+  policy, and something has to own it.
+* Must the schedule be inspectable, re-schedulable and cancellable after the fact, by something other
+  than the code that created it?
+* Who is on the hook when a cron expression turns out to be wrong across a daylight-saving transition?
+  That is the maintenance surface Wolverine's maintainer declined to take on, and it is a real one.
+
+Where the answers are yes, a scheduler earns its place beside the bus. Where they are no — a saga
+timeout, a retry in ten minutes, a delayed reply — Wolverine's own `ScheduleAsync` is the right tool
+and adding Quartz buys nothing.
+
+## Setting the two up
+
+Both runtimes are ordinary hosted services in one host. Wolverine goes first, so that its runtime is
+started before anything that might publish into it:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Program.cs:22 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+builder.UseWolverine(opts =>
+{
+    // Handlers live in this assembly. Setting it explicitly rather than letting Wolverine walk the
+    // stack is what keeps discovery working under a test runner and under a second host in the same
+    // process (JasperFx/wolverine#3776, #3778).
+    opts.ApplicationAssembly = typeof(OrderPlaced).Assembly;
+
+    // Part 3 sends raw bytes to an endpoint by name, and a name is the whole of what it can address —
+    // there is no live message for Wolverine to route on. A local queue keeps that free of a broker.
+    opts.PublishMessage<ArchiveOrders>().ToLocalQueue(Part3RawMessageData.EndpointName);
+
+    if (options.HasDatabase)
+    {
+        // The outbox, the inbox and the node table part 5's agent needs. Quartz's own tables go in the
+        // same database, because part 6's single transaction cannot span two servers.
+        opts.PersistMessagesWithPostgresql(options.PostgresConnectionString!);
+    }
+});
+```
+
+`WolverineFx.RuntimeCompilation` is not optional in Wolverine 6: the core package no longer ships
+Roslyn, and a host left in the default `TypeLoadMode.Dynamic` throws at startup with "no
+`IAssemblyGenerator` (Roslyn) is registered" unless either that package is referenced or handlers were
+pre-generated with `codegen write`.
+
+Quartz is registered the way it always is. The in-memory store is the fallback, so `UseInMemoryStore()`
+would only restate the default; the persistent branch is what the last two sections need:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Program.cs:41 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    Part1RecurringPublishing.Register(q, options.ReconciliationCron);
+    Part4TunedLatency.Register(q);
+
+    if (options.HasDatabase)
+    {
+        q.UsePersistentStore(store =>
+        {
+            store.UsePostgres(options.PostgresConnectionString!);
+            store.UseSystemTextJsonSerializer();
+
+            // Development convenience. A production account is usually right not to hold DDL rights;
+            // database/migrations/ is what moves a real schema forward.
+            store.ProvisionSchema();
+
+            // Part 6 throws without this, rather than silently scheduling outside the caller's
+            // transaction.
+            store.ConfigureStore(o => o.AcceptEnlistedTransactions = true);
+        });
+    }
+
+    // Nothing else: the in-memory store is what a scheduler falls back to, so UseInMemoryStore() would
+    // only restate the default.
+});
+```
+
+## Publishing on a cron schedule
+
+This is the capability Wolverine does not have, and it is a job like any other. Take `IMessageBus` in
+the constructor — Quartz resolves the job from a fresh scope per firing, so a scoped `IMessageBus` is
+exactly right — and publish:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part1RecurringPublishing.cs:34 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public sealed class ReconciliationJob : IJob<ReconciliationWindow>
+{
+    private readonly IMessageBus bus;
+    private readonly ILogger<ReconciliationJob> logger;
+
+    public ReconciliationJob(IMessageBus bus, ILogger<ReconciliationJob> logger)
+    {
+        this.bus = bus;
+        this.logger = logger;
+    }
+
+    public async ValueTask Execute(
+        IJobExecutionContext context,
+        ReconciliationWindow input,
+        CancellationToken cancellationToken = default)
+    {
+        // The scheduler's own clock, not DateTimeOffset.UtcNow: a trigger that misfired and is firing
+        // late still reports the time it was scheduled for, which is the window the run is about.
+        DateTimeOffset to = context.ScheduledFireTimeUtc ?? context.FireTimeUtc;
+
+        RunReconciliation message = new(to - input.Length, to);
+        await bus.PublishAsync(message);
+
+        logger.LogInformation("Published {Message} for the window ending {To:O}", nameof(RunReconciliation), to);
+    }
+}
+```
+
+`IJob<TInput>` is the typed-input form: the payload arrives as a parameter rather than as a
+`JobDataMap` lookup. Register it with a cron trigger and `UsingInput`:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part1RecurringPublishing.cs:84 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+q.ScheduleJob<ReconciliationJob>(trigger => trigger
+    .WithIdentity("reconciliation", "recurring")
+    .WithCronSchedule(cron, x => x
+        // The expression is read in this zone, so a deployment that means "03:00 local" says
+        // so here rather than hoping the host agrees.
+        .InTimeZone(TimeZoneInfo.Utc)
+        // What happens when the process was down at 03:00. DoNothing skips to the next
+        // firing; FireAndProceed publishes one catch-up message. Wolverine has no equivalent
+        // decision to make, because it has nothing to miss.
+        .WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
+    .UsingInput(new ReconciliationWindow(TimeSpan.FromDays(1))));
+```
+
+Read `context.ScheduledFireTimeUtc` rather than the clock. A trigger firing late after a misfire still
+reports the time it was scheduled for, and that is the window the run is about.
+
+## Scheduling one firing from a handler
+
+A Wolverine handler can take `IScheduler` as a parameter and arrange a single future firing in one
+call. `OneOffJobOptions.Group` is the interesting argument: it sets the trigger's group, and the group
+is a correlation axis — everything scheduled for one order, one saga or one tenant shares it.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs:41 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public static class OrderPlacedHandler
+{
+    public static async Task Handle(OrderPlaced message, IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        TriggerKey trigger = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+            new PaymentReminder(message.OrderId, message.Amount),
+            ExampleOptions.Current.ReminderDelay,
+            new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
+            cancellationToken);
+
+        Ledger.Record(Events.ReminderScheduled, trigger.ToString());
+    }
+}
+```
+
+The job key is not affected by `Group`. One durable job detail is stored per job type, under the
+`QRTZ_SCHEDULED` group, and each call adds a trigger to it; the group you pass names the trigger.
+
+### Cancelling by correlation
+
+Because the group is part of the trigger's identity, withdrawing everything arranged for one order is
+a single store operation, with the matcher evaluated where the triggers are:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs:58 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public static class OrderPaidHandler
+{
+    public static async Task Handle(OrderPaid message, IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        // The whole cancellation, in one store operation. The matcher is evaluated where the triggers
+        // are, so no key list round-trips through this process and there is no window in which a
+        // trigger listed a moment ago fires before it can be removed. What comes back is the keys that
+        // were actually withdrawn, which is how the caller learns whether it beat the firing.
+        List<TriggerKey> cancelled = await scheduler.UnscheduleJobs(
+            GroupMatcher<TriggerKey>.GroupEquals(OrderGroup.For(message.OrderId)),
+            cancellationToken);
+
+        Ledger.Record(Events.RemindersCancelled, $"{cancelled.Count} for {message.OrderId}");
+    }
+}
+```
+
+This is worth comparing honestly with the alternatives, because "Quartz can cancel and buses cannot"
+would be wrong. Azure Service Bus hands back a sequence number and takes it back through
+`CancelScheduledMessageAsync`; MassTransit gives you a `TokenId` and a `CancelScheduledMessage`
+contract; Hangfire returns a job id for `BackgroundJob.Delete`. What none of them offers is a *set*
+operation. Each cancels exactly one schedule per call, against a handle the application had to keep.
+Quartz's schedule identity is a two-part key, and the scheduler exposes group matchers over it —
+`GetTriggerKeys`, `UnscheduleJobs`, `PauseTriggers`, `DeleteJobs` — so "everything this tenant owns"
+is a query rather than a list you were responsible for not losing. NServiceBus saga timeouts sit at the
+other end: they cannot be cancelled at all, and the documented approach is to let the timeout arrive and
+be ignored because the saga is gone.
+
+## Deferring a serialized envelope
+
+The section of Wolverine's documentation that names Quartz teaches `SendRawMessageAsync`, which takes
+a `byte[]` rather than a message. What it does not show is how to produce the bytes, or where to keep
+them; `WolverineOptions.DefaultSerializer.WriteMessage(message)` is the missing line, and a typed job
+input is the place:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part3RawMessageData.cs:59 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public static async ValueTask<TriggerKey> ScheduleSend<TMessage>(
+    IScheduler scheduler,
+    IWolverineRuntime runtime,
+    TMessage message,
+    TimeSpan delay,
+    CancellationToken cancellationToken = default) where TMessage : notnull
+{
+    // Serialized here, at the moment the decision was made, rather than at fire time.
+    DeferredEnvelope envelope = new(
+        EndpointName,
+        typeof(TMessage).ToMessageTypeName(),
+        runtime.Options.DefaultSerializer.WriteMessage(message));
+
+    return await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
+        envelope,
+        delay,
+        new OneOffJobOptions { Group = "deferred-envelopes" },
+        cancellationToken);
+}
+```
+
+At fire time the job hands the stored bytes back to Wolverine:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part3RawMessageData.cs:92 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public async ValueTask Execute(
+    IJobExecutionContext context,
+    DeferredEnvelope input,
+    CancellationToken cancellationToken = default)
+{
+    IDestinationEndpoint endpoint = bus.EndpointFor(input.EndpointName);
+
+    await endpoint.SendRawMessageAsync(input.Data, configure: envelope =>
+    {
+        // The stored name rather than SetMessageType<T>(): the type this envelope describes is
+        // whatever was serialized, which this job has no static knowledge of.
+        envelope.MessageType = input.MessageTypeName;
+
+        // Setting Destination is not optional, and Wolverine 6.30.3 does not do it for you.
+        // DestinationEndpoint.SendRawMessageAsync assigns Sender but leaves Destination null, and
+        // Executor.ExecuteAsync logs both success and failure through envelope.Destination!, so a
+        // raw message that is handled perfectly still ends the pipeline with a
+        // NullReferenceException out of the logging call. One line here avoids it.
+        envelope.Destination = endpoint.Uri;
+    });
+}
+```
+
+Two things are load-bearing there. `Envelope.MessageType` is set from the stored name rather than from
+`SetMessageType<T>()`, because the job has no static knowledge of what was serialized;
+`typeof(T).ToMessageTypeName()` on the storing side honours a `[MessageIdentity]` alias where a raw
+`FullName` would not. And `Envelope.Destination` has to be set by hand: on Wolverine 6.30.3,
+`SendRawMessageAsync` assigns `Sender` but leaves `Destination` null, while `Executor.ExecuteAsync`
+logs both success and failure through `envelope.Destination!` — so a raw message that is handled
+perfectly still ends its pipeline with a `NullReferenceException` out of the logging call.
+
+Why bother, when the previous section publishes a live object instead? Because the envelope is
+serialized at the moment the decision was made. A payload stored as bytes is not re-derived from
+application state that has since moved on, and the message contract can change under it without the
+stored firing changing meaning. It is the outbox argument, applied to a schedule.
+
+## What the latency settings actually do
+
+Reading Quartz's 30-second `IdleWaitTime` beside Wolverine's 5-second `ScheduledJobPollingTime`
+invites the conclusion that Quartz is six times slower to deliver a due message. That is not what the
+numbers mean.
+
+`QuartzSchedulerThread` acquires triggers due within the next `IdleWaitTime`, not triggers due now, and
+having acquired one it waits out the exact fire time rather than sleeping the interval. More
+importantly, every in-process mutation — `ScheduleJob`, `AddTrigger`, `RescheduleJob`, `DeleteJob`
+— signals the scheduling loop, which releases the wait immediately. A trigger scheduled from a
+Wolverine handler through this process's own `IScheduler` therefore does not wait for a sweep at all.
+
+`IdleWaitTime` bounds the discovery of work this node did not learn about in process: a trigger another
+node wrote to the shared database, or one recovered from a node that died. It is a cross-node pickup
+bound and the look-ahead horizon of a single acquisition. Lowering it does not make a locally scheduled
+job fire sooner, and the one place it genuinely shows is the last section on this page.
+
+With that said, the three settings that are worth touching in front of a message bus:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part4TunedLatency.cs:49 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+q.ConfigureScheduler(options =>
+{
+    // Default 30 s. Only affects how quickly this node notices triggers it did not schedule
+    // itself, so it is a clustering setting, not a latency setting.
+    options.IdleWaitTime = TimeSpan.FromSeconds(10);
+
+    // Default 1. Must not exceed ThreadPoolOptions.MaxConcurrency, which defaults to 10.
+    options.MaxBatchSize = 10;
+
+    // Default TimeSpan.Zero. Without this, MaxBatchSize above changes nothing for triggers
+    // that are due milliseconds apart rather than at the same instant.
+    options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromMilliseconds(500);
+});
+```
+
+`MaxBatchSize` and `BatchTriggerAcquisitionFireAheadTimeWindow` are one setting in two halves. With the
+default window of `TimeSpan.Zero` only triggers due at the same instant batch together, so raising
+`MaxBatchSize` alone leaves the effective batch at one for any schedule spread over time. Set the
+window to the spread you are willing to fire early by. `MaxBatchSize` must not exceed the thread pool's
+`MaxConcurrency`, and `IdleWaitTime` has a floor of one second.
+
+## Letting Wolverine start the scheduler
+
+`AutoStart = false` leaves the scheduler built, initialized and bound but in `SchedulerStatus.Created`.
+Everything that reads a scheduler still sees it; nothing fires until something calls `Start`. Shutdown
+is unaffected — the hosted service stops every scheduler it created, started or not.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Program.cs:69 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+builder.Services.AddQuartzHostedService(hosted =>
+{
+    hosted.AutoStart = false;
+    hosted.WaitForJobsToComplete = true;
+});
+```
+
+Which "something" presses start depends on whether Wolverine has a message store, and here the tidy
+answer and the true one differ.
+
+**Without persistence**, Wolverine runs no agents at all. `WolverineRuntime.startAgentsAsync` opens with
+`if (Storage is NullMessageStore) { ...; return; }`, so the node agent controller is never built and the
+`IAgentFamily` registrations in the container are never read. `AddSingularAgent<T>()` would compile,
+register, and silently never start. The faithful form is an ordinary `IHostedService` registered after
+`UseWolverine`, since hosted services start in registration order:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part5StartedByWolverine.cs:51 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public sealed class SchedulerStarter : IHostedService
+{
+    private readonly ISchedulerFactory schedulerFactory;
+    private readonly ILogger<SchedulerStarter> logger;
+
+    public SchedulerStarter(ISchedulerFactory schedulerFactory, ILogger<SchedulerStarter> logger)
+    {
+        this.schedulerFactory = schedulerFactory;
+        this.logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        IScheduler scheduler = await schedulerFactory.GetScheduler(cancellationToken);
+        await scheduler.Start(cancellationToken);
+
+        logger.LogInformation("Scheduler '{Name}' started after the Wolverine runtime", scheduler.SchedulerName);
+        Ledger.Record(Events.SchedulerStartedByWolverine, "IHostedService ordered after UseWolverine");
+    }
+
+    // Nothing to do: the Quartz hosted service shuts the scheduler down whether or not it started it.
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+```
+
+**With persistence**, the agent machinery is running and `SingularAgent` is the supported way to say
+"one node in the cluster does this":
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part5StartedByWolverine.cs:96 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+protected override async Task startAsync(CancellationToken cancellationToken)
+{
+    started = await schedulerFactory.GetScheduler(cancellationToken);
+    await started.Start(cancellationToken);
+
+    logger.LogInformation("Scheduler '{Name}' started on this node by Wolverine", started.SchedulerName);
+    Ledger.Record(Events.SchedulerStartedByWolverine, "Wolverine SingularAgent");
+}
+
+protected override async Task stopAsync(CancellationToken cancellationToken)
+{
+    // The scheduler the agent started, not a fresh ISchedulerFactory.GetScheduler(): on host
+    // shutdown Wolverine stops its agents after the Quartz hosted service has already shut the
+    // scheduler down, and asking the factory for it again throws rather than handing back the
+    // shut-down instance. Holding the reference and checking Status keeps the stop quiet.
+    if (started is null || started.Status is SchedulerStatus.ShuttingDown or SchedulerStatus.Shutdown)
+    {
+        return;
+    }
+
+    // Standby rather than Shutdown: the agent may be re-assigned to this node later, and a
+    // shut-down scheduler cannot be started again in the same container.
+    await started.Standby(cancellationToken);
+}
+```
+
+Be precise about what that buys. `SingularAgent` is once-per-cluster but it is *not* leader-pinned: its
+`EvaluateAssignmentsAsync` picks `assignments.Nodes.FirstOrDefault(x => !x.IsLeader) ??
+assignments.Nodes.FirstOrDefault()`, so it prefers a non-leader and falls back to the leader only when
+there is one node. Wolverine's own leader-pinned family is for transport listeners and is registered
+internally; a user cannot add to it. Strictly-leader-only means writing an `IAgentFamily` of your own
+and calling `AssignmentGrid.RunOnLeader`.
+
+Note also what is *not* being asked of Wolverine here: not "which node may fire this trigger". A
+clustered persistent Quartz store already answers that with its own lock, so a scheduler running on
+every node still fires each trigger once. What this arrangement buys is that the scheduler's lifecycle
+is subordinate to the messaging runtime's — the bus is up before the first job can publish into it.
+
+## Sharing the outbox's transaction
+
+A handler that writes a row, sends a message and schedules a follow-up has three writes that can
+disagree. Wolverine's outbox already ties the first two together. `IScheduler.EnlistTransaction` is how
+the third joins them: for the duration of the returned scope, on the current asynchronous flow, the
+persistent job store uses the given transaction and its connection instead of opening its own, so the
+`INSERT` into `QRTZ_TRIGGERS` is a statement in the caller's transaction and a rollback takes the
+trigger with it.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
+     Copied from src/Quartz.Examples.Wolverine/Part6EnlistedTransaction.cs:70 — WolverineHowToTest fails when the two stop
+     matching. -->
+
+```csharp
+public static async Task Handle(
+    ApproveRefund message,
+    MessageContext context,
+    IWolverineRuntime runtime,
+    IScheduler scheduler,
+    CancellationToken cancellationToken)
+{
+    IMessageDatabase database = (IMessageDatabase) runtime.Storage;
+
+    await using NpgsqlConnection connection = new(ExampleOptions.Current.PostgresConnectionString!);
+    await connection.OpenAsync(cancellationToken);
+    await using DbTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+    // Wolverine's outgoing envelopes are now written into this transaction rather than sent
+    // immediately. This is the manual form of what [Transactional] does for a Marten or EF Core
+    // application.
+    await context.EnlistInOutboxAsync(new DatabaseEnvelopeTransaction(database, transaction));
+
+    // 1. the application's own state
+    await using (NpgsqlCommand command = new(
+        "insert into refunds (order_id, amount) values (@order_id, @amount)",
+        connection,
+        (NpgsqlTransaction) transaction))
+    {
+        command.Parameters.AddWithValue("order_id", message.OrderId);
+        command.Parameters.AddWithValue("amount", message.Amount);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    // 2. a message that must not be sent unless the row above survives
+    await context.PublishAsync(new SendPaymentReminder(message.OrderId, message.Amount));
+
+    // 3. the trigger, in the same transaction as both, with the commit inside the scope so the
+    // scheduler is signalled once the trigger is visible to it
+    using (scheduler.EnlistTransaction(transaction))
+    {
+        await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+            new PaymentReminder(message.OrderId, message.Amount),
+            TimeSpan.FromDays(7),
+            new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
+            cancellationToken);
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    // Releases the envelopes the outbox held back. Nothing left the process before the commit.
+    await context.FlushOutgoingMessagesAsync();
+
+    Ledger.Record(Events.RefundApprovedInTransaction, message.OrderId);
+```
+
+The caveats are all in
+[`SchedulerEnlistmentExtensions`](https://github.com/quartznet/quartznet/blob/main/src/Quartz/SchedulerEnlistmentExtensions.cs)'
+own documentation, and every one of them bites here:
+
+* It must be turned on. `ConfigureStore(o => o.AcceptEnlistedTransactions = true)`, or
+  `quartz.jobStore.acceptEnlistedTransactions`. Without it "the job store keeps opening its own
+  connection and managing its own transaction, and enlisting throws rather than being ignored".
+* An ambient `TransactionScope` on its own is not enough, "because a connection the job store opens for
+  itself is deliberately kept out of it". Sharing the one connection is also what keeps the transaction
+  from being promoted to a distributed one, which Npgsql does not support at all.
+* The enlistment "flows with the current asynchronous context, so it must be established in the same
+  scope as the scheduler calls it should cover". Establishing it inside an `async` helper does not carry
+  it back out to the caller.
+* The commit belongs inside the `using` block. Disposing the scope is what signals the scheduling loop
+  that a trigger appeared, so disposing before the commit wakes it to look for a row it cannot yet see
+  — and the trigger then waits for the next acquisition sweep, which is one of the few places
+  `IdleWaitTime` really does bound latency.
+* "While the enlistment is in effect the job store holds its locks in the caller's transaction, so they
+  are only released once that transaction completes. Keep enlisted transactions short: a long running
+  one blocks trigger acquisition, the misfire handler and cluster check-in." A message handler fits
+  that; a batch job that enlists and then works for a minute does not.
+* Both stores must be in one database. Different schemas are fine; one `DbTransaction` cannot span two
+  servers.
+
+The transaction is opened by hand rather than by Wolverine's `[Transactional]` attribute, and that is
+not a stylistic choice. Wolverine's transactional middleware supplies whatever its persistence provider
+supplies, and on 6.30.3 the raw-ADO.NET Postgres package supplies nothing: every
+`IPersistenceFrameProvider` in the tree belongs to Marten, Entity Framework Core, RavenDB, CosmosDB,
+Fisher or Polecat. A handler declaring `[Transactional] Handle(T msg, NpgsqlTransaction tx)` against
+plain `PersistMessagesWithPostgresql` compiles and then fails at runtime with "JasperFx was unable to
+resolve a variable of type Npgsql.NpgsqlTransaction". An application that already has Marten or EF Core
+can use `[Transactional]` and take the provider's own session or `DbContext` — but then the commit
+happens in generated code after the handler returns, so the enlistment scope necessarily disposes
+first, and the signal is spent on a trigger the loop cannot yet see. Nothing is lost; the trigger simply
+waits for the next sweep.
+
+## What this recipe does not do
+
+* **It is not a package.** There is nothing to install beyond `Quartz` and `WolverineFx`, and nothing
+  here is covered by Quartz.NET's API compatibility promises. If JasperFx ships a first-party
+  integration, prefer it.
+* **It does not put Quartz's schedule under Wolverine's leader election.** Trigger ownership is the
+  Quartz cluster's business, and a persistent store with `UseClustering()` already handles it. The
+  agent in the last-but-one section decides which node *runs a scheduler*, not which node fires a
+  trigger.
+* **It does not make in-memory scheduling durable.** With the default in-memory store a restart loses
+  every pending trigger, exactly as it loses Wolverine's in-memory scheduled envelopes. Use a
+  persistent store for anything that must survive.
+* **It does not replace Wolverine's own scheduling.** `ScheduleAsync` and `TimeoutMessage` remain the
+  right answer for a delayed message or a saga timeout. Reach for Quartz when the schedule is a rule
+  rather than a message.
+
+## See also
+
+* [One-Off Job](one-off-job.md) — the `ScheduleJob<TJob, TInput>` one-liner in isolation
+* [Rescheduling Jobs](rescheduling-jobs.md) — changing a live schedule, and recovering a failed trigger
+* [Job Template](job-template.md) — the recommended skeleton for a job class
+* [Running Quartz under Aspire](aspire.md) — telemetry, health and the database, wired to an AppHost
+* [Cron Expression Reference](../cron-expressions.md) — the cron field and special-character syntax
+* [Configuration Reference](../configuration/reference.md) — every option, typed and legacy

--- a/src/Quartz.Examples.Wolverine/ExampleOptions.cs
+++ b/src/Quartz.Examples.Wolverine/ExampleOptions.cs
@@ -1,0 +1,60 @@
+namespace Quartz.Examples.Wolverine;
+
+/// <summary>
+/// The few knobs that differ between a plain <c>dotnet run</c>, the <c>--smoke</c> run that CI could
+/// invoke, and the Postgres mode.
+/// </summary>
+/// <param name="Smoke">
+/// Whether to run every part on a compressed clock, assert each one happened, and exit.
+/// </param>
+/// <param name="ReconciliationCron">
+/// The cron expression part 1 registers. <see cref="Part1RecurringPublishing.NightlyCron" /> is what a
+/// deployment would use; the smoke run needs something that fires while it is watching.
+/// </param>
+/// <param name="ReminderDelay">
+/// How far ahead part 2 schedules its follow-up. Days in a real application, seconds here.
+/// </param>
+/// <param name="PostgresConnectionString">
+/// Set from <c>QUARTZ_WOLVERINE_POSTGRES</c>. When it is absent — which is the case on every CI leg —
+/// parts 5 and 6 fall back to the forms that need no database, and say so.
+/// </param>
+public sealed record ExampleOptions(
+    bool Smoke,
+    string ReconciliationCron,
+    TimeSpan ReminderDelay,
+    string? PostgresConnectionString)
+{
+    /// <summary>
+    /// The environment variable that turns the durable half of the example on.
+    /// </summary>
+    public const string PostgresVariable = "QUARTZ_WOLVERINE_POSTGRES";
+
+    /// <summary>
+    /// The options the running process was started with.
+    /// </summary>
+    /// <remarks>
+    /// A static, for the reason <see cref="Ledger" /> is one: the alternative is threading an options
+    /// record through every handler signature on the page, which would obscure the scheduling.
+    /// </remarks>
+    public static ExampleOptions Current { get; private set; } = FromArguments([]);
+
+    /// <summary>
+    /// Whether the durable parts — Wolverine agents and the shared transaction — are reachable.
+    /// </summary>
+    public bool HasDatabase => !string.IsNullOrWhiteSpace(PostgresConnectionString);
+
+    public static ExampleOptions FromArguments(string[] args)
+    {
+        bool smoke = args.Contains("--smoke", StringComparer.Ordinal);
+
+        Current = new ExampleOptions(
+            Smoke: smoke,
+            // Every two seconds, so a smoke run of a few seconds sees several firings; the nightly
+            // expression otherwise, which is what the page shows.
+            ReconciliationCron: smoke ? "0/2 * * * * ?" : Part1RecurringPublishing.NightlyCron,
+            ReminderDelay: smoke ? TimeSpan.FromSeconds(2) : TimeSpan.FromMinutes(30),
+            PostgresConnectionString: Environment.GetEnvironmentVariable(PostgresVariable));
+
+        return Current;
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Ledger.cs
+++ b/src/Quartz.Examples.Wolverine/Ledger.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+
+namespace Quartz.Examples.Wolverine;
+
+/// <summary>
+/// What the six parts did, so that <c>--smoke</c> can assert each one actually happened rather than
+/// assert that the process survived.
+/// </summary>
+/// <remarks>
+/// A static in an example is a shortcut a real application would not take; it is here because the
+/// alternative — a hosted service, a channel and a result type — is scaffolding that would make every
+/// sample on the page longer without teaching anything about scheduling.
+/// </remarks>
+public static class Ledger
+{
+    private static readonly ConcurrentDictionary<string, List<string>> Entries = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records that something observable happened, and prints it so a plain <c>dotnet run</c> shows
+    /// the same story the smoke run asserts.
+    /// </summary>
+    public static void Record(string what, string detail)
+    {
+        List<string> details = Entries.GetOrAdd(what, static _ => []);
+        lock (details)
+        {
+            details.Add(detail);
+        }
+
+        Console.WriteLine($"  [{what}] {detail}");
+    }
+
+    /// <summary>
+    /// How many times <paramref name="what" /> has been recorded.
+    /// </summary>
+    public static int Count(string what) => Details(what).Count;
+
+    /// <summary>
+    /// What was recorded against <paramref name="what" />, in order.
+    /// </summary>
+    public static List<string> Details(string what)
+    {
+        if (!Entries.TryGetValue(what, out List<string>? details))
+        {
+            return [];
+        }
+
+        lock (details)
+        {
+            return [.. details];
+        }
+    }
+}
+
+/// <summary>
+/// The names the six parts record against, so <c>--smoke</c> and the parts cannot drift apart by a
+/// typo in a string literal.
+/// </summary>
+public static class Events
+{
+    public const string ReconciliationPublished = "part1:reconciliation-published";
+    public const string ReminderScheduled = "part2:reminder-scheduled";
+    public const string ReminderFired = "part2:reminder-fired";
+    public const string RemindersCancelled = "part2:reminders-cancelled";
+    public const string RawEnvelopeStored = "part3:raw-envelope-stored";
+    public const string RawEnvelopeDelivered = "part3:raw-envelope-delivered";
+    public const string SchedulerStartedByWolverine = "part5:scheduler-started";
+    public const string RefundApprovedInTransaction = "part6:refund-approved";
+}

--- a/src/Quartz.Examples.Wolverine/Messages.cs
+++ b/src/Quartz.Examples.Wolverine/Messages.cs
@@ -1,0 +1,40 @@
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * The Wolverine messages this example passes around.
+ *
+ * They are ordinary records that know nothing about a scheduler, which is the point: Quartz publishes
+ * into Wolverine and the handlers read what any other producer would have sent. They are public
+ * because Wolverine compiles its handler dispatch into a dynamic assembly, which cannot see internals.
+ */
+
+/// <summary>
+/// Published by <see cref="ReconciliationJob" /> on a cron schedule.
+/// </summary>
+public sealed record RunReconciliation(DateTimeOffset FromUtc, DateTimeOffset ToUtc);
+
+/// <summary>
+/// An order was placed and is not paid for yet, so a follow-up is due unless payment arrives first.
+/// </summary>
+public sealed record OrderPlaced(string OrderId, decimal Amount);
+
+/// <summary>
+/// Payment arrived, so the follow-up scheduled for <see cref="OrderPlaced" /> is no longer wanted.
+/// </summary>
+public sealed record OrderPaid(string OrderId);
+
+/// <summary>
+/// Published by <see cref="PaymentReminderJob" /> when the reminder falls due.
+/// </summary>
+public sealed record SendPaymentReminder(string OrderId, decimal Amount);
+
+/// <summary>
+/// Sent as raw bytes by <see cref="DeferredEnvelopeJob" />, so it is never re-serialized from a live
+/// object at fire time.
+/// </summary>
+public sealed record ArchiveOrders(string Reason, int OlderThanDays);
+
+/// <summary>
+/// Handled inside the application's own database transaction, in the Postgres mode only.
+/// </summary>
+public sealed record ApproveRefund(string OrderId, decimal Amount);

--- a/src/Quartz.Examples.Wolverine/Part1RecurringPublishing.cs
+++ b/src/Quartz.Examples.Wolverine/Part1RecurringPublishing.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging;
+
+using Wolverine;
+
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 1 — publishing a Wolverine message on a cron schedule.
+ *
+ * What Wolverine lacks: any recurring or cron concept whatsoever. IMessageBus.ScheduleAsync defers one
+ * message to one moment and that is the whole of it; there is no crontab, no calendar, no "every
+ * weekday at 03:00". Wolverine's maintainer closed the request for it — JasperFx/wolverine#1403,
+ * "Lack of recurring (Cron) scheduling" — with "We're not doing this, ever. *Maybe* there'll be a move
+ * to integrate Quartz.net or Hangfire *with* Wolverine". The nearest thing Wolverine ships is
+ * opts.EnableHeartbeats(), a fixed interval, which answers "every N" and not "at 03:00 on weekdays".
+ *
+ * What Quartz supplies: the cron expression, the time zone the expression is read in, what happens
+ * when the process was down at 03:00 (the misfire instruction), and — with a persistent store — the
+ * guarantee that one node in the cluster fires it rather than all of them.
+ *
+ * The job is the only place the two libraries meet: an IJob<TInput> that resolves IMessageBus and
+ * publishes. Nothing downstream can tell the message came from a scheduler.
+ */
+
+/// <summary>
+/// How far back a reconciliation run should look. A record rather than a <c>JobDataMap</c> entry
+/// because <see cref="IJob{TInput}" /> hands it to the job as a typed parameter.
+/// </summary>
+public sealed record ReconciliationWindow(TimeSpan Length);
+
+/// <summary>
+/// Publishes <see cref="RunReconciliation" /> into Wolverine whenever its cron trigger fires.
+/// </summary>
+public sealed class ReconciliationJob : IJob<ReconciliationWindow>
+{
+    private readonly IMessageBus bus;
+    private readonly ILogger<ReconciliationJob> logger;
+
+    public ReconciliationJob(IMessageBus bus, ILogger<ReconciliationJob> logger)
+    {
+        this.bus = bus;
+        this.logger = logger;
+    }
+
+    public async ValueTask Execute(
+        IJobExecutionContext context,
+        ReconciliationWindow input,
+        CancellationToken cancellationToken = default)
+    {
+        // The scheduler's own clock, not DateTimeOffset.UtcNow: a trigger that misfired and is firing
+        // late still reports the time it was scheduled for, which is the window the run is about.
+        DateTimeOffset to = context.ScheduledFireTimeUtc ?? context.FireTimeUtc;
+
+        RunReconciliation message = new(to - input.Length, to);
+        await bus.PublishAsync(message);
+
+        logger.LogInformation("Published {Message} for the window ending {To:O}", nameof(RunReconciliation), to);
+    }
+}
+
+/// <summary>
+/// Consumes what the cron job published, standing in for whatever the application would really do.
+/// </summary>
+public static class RunReconciliationHandler
+{
+    public static void Handle(RunReconciliation message)
+    {
+        Ledger.Record(Events.ReconciliationPublished, $"{message.FromUtc:O} .. {message.ToUtc:O}");
+    }
+}
+
+/// <summary>
+/// Registers the cron trigger. Called from <c>Program.cs</c> inside <c>AddQuartz</c>.
+/// </summary>
+public static class Part1RecurringPublishing
+{
+    /// <summary>
+    /// The expression a real deployment would use: 03:00 on weekdays.
+    /// </summary>
+    public const string NightlyCron = "0 0 3 ? * MON-FRI";
+
+    public static void Register(IQuartzBuilder q, string cron)
+    {
+        q.ScheduleJob<ReconciliationJob>(trigger => trigger
+            .WithIdentity("reconciliation", "recurring")
+            .WithCronSchedule(cron, x => x
+                // The expression is read in this zone, so a deployment that means "03:00 local" says
+                // so here rather than hoping the host agrees.
+                .InTimeZone(TimeZoneInfo.Utc)
+                // What happens when the process was down at 03:00. DoNothing skips to the next
+                // firing; FireAndProceed publishes one catch-up message. Wolverine has no equivalent
+                // decision to make, because it has nothing to miss.
+                .WithMisfireInstruction(CronTriggerMisfireInstruction.DoNothing))
+            .UsingInput(new ReconciliationWindow(TimeSpan.FromDays(1))));
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs
+++ b/src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs
@@ -1,0 +1,104 @@
+using Wolverine;
+
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 2 — a one-off typed job scheduled from a Wolverine handler, and cancelled by correlation.
+ *
+ * What Wolverine lacks: a handle on a scheduled message. IMessageBus.ScheduleAsync returns ValueTask —
+ * no id, no token, nothing to cancel with. Wolverine's saga timeouts (TimeoutMessage) are the same
+ * shape: completing the saga does not withdraw the timeout, the timeout still fires and the generated
+ * handler discards it because the saga is gone. The one cancellation API that does exist,
+ * IScheduledMessages.CancelAsync, filters on message type, execution time or envelope id — there is no
+ * correlation-id filter, so cancelling "everything for order 42" means having stashed each envelope's
+ * Guid yourself, and on a store-less host it is a silent no-op.
+ *
+ * What Quartz supplies: the trigger's group as a correlation axis. OneOffJobOptions.Group sets the
+ * trigger key's group (the job key stays "QRTZ_SCHEDULED"/typeof(TJob).Name, one durable job per job
+ * type, many triggers), so every firing arranged for one order shares a group and the whole group is
+ * listed, paused or unscheduled in one call. That is a first-class store operation, not bookkeeping
+ * the application has to keep.
+ */
+
+/// <summary>
+/// What a payment reminder needs to know. Serialized into the trigger by <c>UsingInput</c> and handed
+/// back to <see cref="PaymentReminderJob" /> as a typed parameter.
+/// </summary>
+public sealed record PaymentReminder(string OrderId, decimal Amount);
+
+/// <summary>
+/// The correlation axis. Every trigger scheduled for one order lives in this group, which is what
+/// makes "cancel everything for order 42" one call.
+/// </summary>
+public static class OrderGroup
+{
+    public static string For(string orderId) => $"order:{orderId}";
+}
+
+/// <summary>
+/// Schedules the follow-up when an order is placed.
+/// </summary>
+public static class OrderPlacedHandler
+{
+    public static async Task Handle(OrderPlaced message, IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        TriggerKey trigger = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+            new PaymentReminder(message.OrderId, message.Amount),
+            ExampleOptions.Current.ReminderDelay,
+            new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
+            cancellationToken);
+
+        Ledger.Record(Events.ReminderScheduled, trigger.ToString());
+    }
+}
+
+/// <summary>
+/// Withdraws every firing arranged for an order once it has been paid for.
+/// </summary>
+public static class OrderPaidHandler
+{
+    public static async Task Handle(OrderPaid message, IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        // The whole cancellation, in one store operation. The matcher is evaluated where the triggers
+        // are, so no key list round-trips through this process and there is no window in which a
+        // trigger listed a moment ago fires before it can be removed. What comes back is the keys that
+        // were actually withdrawn, which is how the caller learns whether it beat the firing.
+        List<TriggerKey> cancelled = await scheduler.UnscheduleJobs(
+            GroupMatcher<TriggerKey>.GroupEquals(OrderGroup.For(message.OrderId)),
+            cancellationToken);
+
+        Ledger.Record(Events.RemindersCancelled, $"{cancelled.Count} for {message.OrderId}");
+    }
+}
+
+/// <summary>
+/// Publishes the reminder back into Wolverine when the trigger fires.
+/// </summary>
+public sealed class PaymentReminderJob : IJob<PaymentReminder>
+{
+    private readonly IMessageBus bus;
+
+    public PaymentReminderJob(IMessageBus bus)
+    {
+        this.bus = bus;
+    }
+
+    public async ValueTask Execute(
+        IJobExecutionContext context,
+        PaymentReminder input,
+        CancellationToken cancellationToken = default)
+    {
+        await bus.PublishAsync(new SendPaymentReminder(input.OrderId, input.Amount));
+    }
+}
+
+/// <summary>
+/// Consumes the reminder, standing in for whatever the application would really do.
+/// </summary>
+public static class SendPaymentReminderHandler
+{
+    public static void Handle(SendPaymentReminder message)
+    {
+        Ledger.Record(Events.ReminderFired, $"{message.OrderId} for {message.Amount}");
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Part3RawMessageData.cs
+++ b/src/Quartz.Examples.Wolverine/Part3RawMessageData.cs
@@ -1,0 +1,124 @@
+using Wolverine;
+using Wolverine.Runtime;
+using Wolverine.Util;
+
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 3 — Wolverine's raw-message-data hook.
+ *
+ * This is the seam Wolverine shipped for exactly this integration. Its own documentation says so, in
+ * the "Sending Raw Message Data" section of guide/messaging/message-bus.html:
+ *
+ *     "An example use case is integrating scheduling libraries like Quartz.NET or Hangfire where you
+ *      might be persisting a byte[] for a message to be sent via Wolverine at a certain time."
+ *
+ * What Wolverine lacks: nothing here — this is the one place Wolverine has already met the scheduler
+ * halfway. What it does not supply is the "at a certain time" half, or the byte[] itself: the section
+ * shows how to send raw data, not how to produce it. Options.DefaultSerializer.WriteMessage(message)
+ * is the missing line.
+ *
+ * What Quartz supplies: the durable place to keep the bytes until they are due. The payload is the
+ * job's typed input, so it lands in the same store, under the same lock and in the same transaction as
+ * the trigger that will send it.
+ *
+ * Why bother, when part 2 publishes a live object instead: the envelope is serialized at the moment
+ * the decision was made. A payload stored as bytes is not re-derived from application state that has
+ * since moved on, and the message contract can change under it without the stored firing changing
+ * meaning. That is the same argument the outbox pattern makes.
+ */
+
+/// <summary>
+/// A Wolverine envelope's payload, kept until the trigger that sends it comes due.
+/// </summary>
+/// <param name="EndpointName">
+/// Which endpoint to send to. <c>SendRawMessageAsync</c> has no routing to fall back on — Wolverine
+/// routes on the message's .NET type and there is no live message here — so the destination is part of
+/// what has to be stored.
+/// </param>
+/// <param name="MessageTypeName">
+/// Wolverine's own name for the message type, which is what the receiving side matches on. Produced by
+/// <c>typeof(T).ToMessageTypeName()</c> so that a <c>[MessageIdentity]</c> alias is honoured rather
+/// than bypassed by a raw <c>FullName</c>.
+/// </param>
+/// <param name="Data">The serialized message body.</param>
+public sealed record DeferredEnvelope(string EndpointName, string MessageTypeName, byte[] Data);
+
+/// <summary>
+/// Stores a Wolverine message as bytes now and sends it later.
+/// </summary>
+public static class Part3RawMessageData
+{
+    /// <summary>
+    /// The named local queue the deferred envelope is addressed to. Any Wolverine endpoint would do —
+    /// a Rabbit queue, an Azure Service Bus topic — but a local queue keeps the example free of a
+    /// broker.
+    /// </summary>
+    public const string EndpointName = "archive";
+
+    public static async ValueTask<TriggerKey> ScheduleSend<TMessage>(
+        IScheduler scheduler,
+        IWolverineRuntime runtime,
+        TMessage message,
+        TimeSpan delay,
+        CancellationToken cancellationToken = default) where TMessage : notnull
+    {
+        // Serialized here, at the moment the decision was made, rather than at fire time.
+        DeferredEnvelope envelope = new(
+            EndpointName,
+            typeof(TMessage).ToMessageTypeName(),
+            runtime.Options.DefaultSerializer.WriteMessage(message));
+
+        return await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
+            envelope,
+            delay,
+            new OneOffJobOptions { Group = "deferred-envelopes" },
+            cancellationToken);
+    }
+}
+
+/// <summary>
+/// Hands the stored bytes to Wolverine when the trigger fires.
+/// </summary>
+public sealed class DeferredEnvelopeJob : IJob<DeferredEnvelope>
+{
+    private readonly IMessageBus bus;
+
+    public DeferredEnvelopeJob(IMessageBus bus)
+    {
+        this.bus = bus;
+    }
+
+    public async ValueTask Execute(
+        IJobExecutionContext context,
+        DeferredEnvelope input,
+        CancellationToken cancellationToken = default)
+    {
+        IDestinationEndpoint endpoint = bus.EndpointFor(input.EndpointName);
+
+        await endpoint.SendRawMessageAsync(input.Data, configure: envelope =>
+        {
+            // The stored name rather than SetMessageType<T>(): the type this envelope describes is
+            // whatever was serialized, which this job has no static knowledge of.
+            envelope.MessageType = input.MessageTypeName;
+
+            // Setting Destination is not optional, and Wolverine 6.30.3 does not do it for you.
+            // DestinationEndpoint.SendRawMessageAsync assigns Sender but leaves Destination null, and
+            // Executor.ExecuteAsync logs both success and failure through envelope.Destination!, so a
+            // raw message that is handled perfectly still ends the pipeline with a
+            // NullReferenceException out of the logging call. One line here avoids it.
+            envelope.Destination = endpoint.Uri;
+        });
+    }
+}
+
+/// <summary>
+/// Receives the message Wolverine rebuilt from the stored bytes.
+/// </summary>
+public static class ArchiveOrdersHandler
+{
+    public static void Handle(ArchiveOrders message)
+    {
+        Ledger.Record(Events.RawEnvelopeDelivered, $"{message.Reason}, older than {message.OlderThanDays} days");
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Part4TunedLatency.cs
+++ b/src/Quartz.Examples.Wolverine/Part4TunedLatency.cs
@@ -1,0 +1,63 @@
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 4 — the three settings people reach for when a scheduler sits in front of a message bus, and
+ * what they actually do.
+ *
+ * The reflex is to see IdleWaitTime's 30-second default beside Wolverine's 5-second
+ * ScheduledJobPollingTime and conclude that Quartz is six times slower at delivering a due message.
+ * That reading is wrong, and the code says why.
+ *
+ *   - QuartzSchedulerThread acquires triggers due within the next IdleWaitTime, not triggers due now:
+ *     `NoLaterThan = now + IdleWaitTime`. Having acquired one it waits out the exact fire time rather
+ *     than sleeping the full interval.
+ *
+ *   - Every in-process mutation — ScheduleJob, AddTrigger, RescheduleJob, DeleteJob — calls
+ *     SignalSchedulingChange, which releases the semaphore the loop is waiting on. A trigger scheduled
+ *     from a Wolverine handler through this process's own IScheduler therefore does not wait for the
+ *     next sweep at all; the loop is woken synchronously by the scheduling call.
+ *
+ *   - So IdleWaitTime bounds *discovery of work this node did not learn about in process*: a trigger
+ *     another node wrote to the shared database, or one recovered from a node that died. It is a
+ *     cross-node pickup bound and the look-ahead horizon of one acquisition. It is not the resolution
+ *     of in-process scheduling, and lowering it does not make a locally scheduled job fire sooner.
+ *
+ * What is worth tuning, and why:
+ *
+ *   - IdleWaitTime, only if a *clustered* deployment needs another node's triggers picked up faster
+ *     than 30 s. The cost is a database round trip per node per interval. The minimum is one second.
+ *
+ *   - MaxBatchSize defaults to 1: one acquisition, one trigger. A bus-facing scheduler that fires
+ *     many small jobs at once wants this raised, bounded by ThreadPoolOptions.MaxConcurrency.
+ *
+ *   - BatchTriggerAcquisitionFireAheadTimeWindow defaults to TimeSpan.Zero, and it is the half that
+ *     makes the other half work: with a zero window only triggers due at the same instant batch
+ *     together, so raising MaxBatchSize alone leaves the effective batch at one for any schedule
+ *     spread over time. Set it to the spread you are willing to fire early by.
+ *
+ * The values below are the ones a Wolverine-facing scheduler plausibly wants, not the ones this
+ * example needs. The example would behave identically on the defaults.
+ */
+
+/// <summary>
+/// The latency settings, as a single call so the page can quote it and the compiler can check it.
+/// </summary>
+public static class Part4TunedLatency
+{
+    public static void Register(IQuartzBuilder q)
+    {
+        q.ConfigureScheduler(options =>
+        {
+            // Default 30 s. Only affects how quickly this node notices triggers it did not schedule
+            // itself, so it is a clustering setting, not a latency setting.
+            options.IdleWaitTime = TimeSpan.FromSeconds(10);
+
+            // Default 1. Must not exceed ThreadPoolOptions.MaxConcurrency, which defaults to 10.
+            options.MaxBatchSize = 10;
+
+            // Default TimeSpan.Zero. Without this, MaxBatchSize above changes nothing for triggers
+            // that are due milliseconds apart rather than at the same instant.
+            options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromMilliseconds(500);
+        });
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Part5StartedByWolverine.cs
+++ b/src/Quartz.Examples.Wolverine/Part5StartedByWolverine.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Wolverine;
+using Wolverine.Runtime.Agents;
+
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 5 — AutoStart = false, and Quartz started by Wolverine's runtime rather than by the host.
+ *
+ * QuartzHostedServiceOptions.AutoStart = false leaves the scheduler built, initialized and bound but
+ * in SchedulerStatus.Created. Everything that reads a scheduler — ISchedulerRegistry, the dashboard,
+ * the HTTP API — still sees it; nothing fires until something calls IScheduler.Start. Shutdown is
+ * unaffected: the hosted service still stops every scheduler it created, started or not. The option's
+ * own documentation names the case this is: "a library that owns its own leader election".
+ *
+ * Which "something" should press start depends on whether Wolverine has a message store, and this is
+ * the part of the integration where the honest answer is not the tidy one.
+ *
+ *   - WITHOUT persistence — the default in this example, and what CI compiles and runs — Wolverine
+ *     runs no agents at all. WolverineRuntime.startAgentsAsync() opens with
+ *     `if (Storage is NullMessageStore) { ...; return; }`, so NodeAgentController is never built and
+ *     the IAgentFamily registrations in the container are never read. AddSingularAgent<T>() would
+ *     compile, register, and silently never start. So the faithful form here is an ordinary
+ *     IHostedService registered after UseWolverine — hosted services start in registration order, so
+ *     WolverineRuntime is up before the scheduler is.
+ *
+ *   - WITH persistence, Wolverine's agent machinery is running and SingularAgent is the supported way
+ *     to say "one node in the cluster does this". It is also the one worth being precise about:
+ *     SingularAgent.EvaluateAssignmentsAsync picks
+ *     `assignments.Nodes.FirstOrDefault(x => !x.IsLeader) ?? assignments.Nodes.FirstOrDefault()`, so
+ *     it is once-per-cluster and *prefers a non-leader*, falling back to the leader only when there is
+ *     one node. It is not leader-pinned. Wolverine's own leader-pinned family,
+ *     LeaderPinnedListenerFamily, is for transport listeners and is registered internally; a user
+ *     cannot add to it. Strictly-leader-only means writing an IAgentFamily and calling
+ *     AssignmentGrid.RunOnLeader, which is more machinery than this example earns.
+ *
+ * Either way, note what is NOT being asked of Wolverine: not "which node may fire this trigger". A
+ * clustered persistent Quartz store already answers that with its own lock, so a scheduler running on
+ * every node still fires each trigger once. What this part buys is that the scheduler's own
+ * lifecycle is subordinate to the messaging runtime's — the bus is up before the first job can
+ * publish into it.
+ */
+
+/// <summary>
+/// Starts the scheduler once Wolverine's runtime is up. Registered after <c>UseWolverine</c>, which is
+/// what puts it after <c>WolverineRuntime</c> in the hosted-service order.
+/// </summary>
+public sealed class SchedulerStarter : IHostedService
+{
+    private readonly ISchedulerFactory schedulerFactory;
+    private readonly ILogger<SchedulerStarter> logger;
+
+    public SchedulerStarter(ISchedulerFactory schedulerFactory, ILogger<SchedulerStarter> logger)
+    {
+        this.schedulerFactory = schedulerFactory;
+        this.logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        IScheduler scheduler = await schedulerFactory.GetScheduler(cancellationToken);
+        await scheduler.Start(cancellationToken);
+
+        logger.LogInformation("Scheduler '{Name}' started after the Wolverine runtime", scheduler.SchedulerName);
+        Ledger.Record(Events.SchedulerStartedByWolverine, "IHostedService ordered after UseWolverine");
+    }
+
+    // Nothing to do: the Quartz hosted service shuts the scheduler down whether or not it started it.
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+/// <summary>
+/// The same job, expressed as a Wolverine agent, for the deployment that has a message store.
+/// </summary>
+/// <remarks>
+/// Registered with <c>services.AddSingularAgent&lt;QuartzSchedulerAgent&gt;()</c>. Wolverine assigns it
+/// to one node and re-assigns it when that node leaves, so the scheduler's <c>Start</c> and
+/// <c>Standby</c> follow the cluster's own view of who is up.
+/// </remarks>
+public sealed class QuartzSchedulerAgent : SingularAgent
+{
+    private readonly ISchedulerFactory schedulerFactory;
+    private readonly ILogger<QuartzSchedulerAgent> logger;
+    private IScheduler? started;
+
+    public QuartzSchedulerAgent(ISchedulerFactory schedulerFactory, ILogger<QuartzSchedulerAgent> logger)
+        : base("quartz-scheduler")
+    {
+        this.schedulerFactory = schedulerFactory;
+        this.logger = logger;
+    }
+
+    protected override async Task startAsync(CancellationToken cancellationToken)
+    {
+        started = await schedulerFactory.GetScheduler(cancellationToken);
+        await started.Start(cancellationToken);
+
+        logger.LogInformation("Scheduler '{Name}' started on this node by Wolverine", started.SchedulerName);
+        Ledger.Record(Events.SchedulerStartedByWolverine, "Wolverine SingularAgent");
+    }
+
+    protected override async Task stopAsync(CancellationToken cancellationToken)
+    {
+        // The scheduler the agent started, not a fresh ISchedulerFactory.GetScheduler(): on host
+        // shutdown Wolverine stops its agents after the Quartz hosted service has already shut the
+        // scheduler down, and asking the factory for it again throws rather than handing back the
+        // shut-down instance. Holding the reference and checking Status keeps the stop quiet.
+        if (started is null || started.Status is SchedulerStatus.ShuttingDown or SchedulerStatus.Shutdown)
+        {
+            return;
+        }
+
+        // Standby rather than Shutdown: the agent may be re-assigned to this node later, and a
+        // shut-down scheduler cannot be started again in the same container.
+        await started.Standby(cancellationToken);
+    }
+}
+
+/// <summary>
+/// Registers whichever of the two forms the running configuration can actually honour.
+/// </summary>
+public static class Part5StartedByWolverine
+{
+    public static void Register(IServiceCollection services, ExampleOptions options)
+    {
+        if (options.HasDatabase)
+        {
+            services.AddSingularAgent<QuartzSchedulerAgent>();
+        }
+        else
+        {
+            services.AddHostedService<SchedulerStarter>();
+        }
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Part6EnlistedTransaction.cs
+++ b/src/Quartz.Examples.Wolverine/Part6EnlistedTransaction.cs
@@ -1,0 +1,120 @@
+using System.Data.Common;
+
+using Npgsql;
+
+using Wolverine.Persistence.Durability;
+using Wolverine.RDBMS;
+using Wolverine.Runtime;
+
+namespace Quartz.Examples.Wolverine;
+
+/*
+ * Part 6 — one transaction holding the application's row, Wolverine's outgoing envelope and Quartz's
+ * trigger.
+ *
+ * The problem is the one every "schedule something as a side effect" integration hits: a handler
+ * writes a row, tells Wolverine to send a message and tells Quartz to schedule a follow-up, and any
+ * two of those three can commit while the third does not. Wolverine's outbox already ties the first
+ * two together. IScheduler.EnlistTransaction is how the third joins them.
+ *
+ * What EnlistTransaction does: for the duration of the returned scope, on the current asynchronous
+ * flow, the persistent job store uses the given transaction and the connection it belongs to instead
+ * of opening its own. Quartz's INSERT into QRTZ_TRIGGERS is then a statement in the caller's
+ * transaction, and a rollback takes the trigger with it.
+ *
+ * The caveats, from SchedulerEnlistmentExtensions' own documentation, all of which bite here:
+ *
+ *   - It has to be turned on. `ConfigureStore(o => o.AcceptEnlistedTransactions = true)` on the
+ *     persistent store builder, or quartz.jobStore.acceptEnlistedTransactions. Without it the store
+ *     keeps opening its own connection, and enlisting throws rather than being quietly ignored.
+ *
+ *   - An ambient TransactionScope on its own is not enough, "because a connection the job store opens
+ *     for itself is deliberately kept out of it". Sharing the one connection is also what keeps the
+ *     transaction from being promoted to a distributed one, which Npgsql does not support at all.
+ *
+ *   - The enlistment flows with the current asynchronous context, so it must be established in the
+ *     same scope as the scheduler calls it should cover. Establishing it inside an async helper does
+ *     not carry it back out to the caller — which is why the `using` below is in the handler body
+ *     rather than hidden behind a "ScheduleTransactionally" method.
+ *
+ *   - The commit belongs INSIDE the using block. Disposing the scope is what signals the scheduling
+ *     loop that a trigger appeared, so disposing before the commit would wake it to look for a row it
+ *     cannot yet see; the trigger would then wait for the next acquisition sweep instead.
+ *
+ *   - "While the enlistment is in effect the job store holds its locks in the caller's transaction, so
+ *     they are only released once that transaction completes. Keep enlisted transactions short: a long
+ *     running one blocks trigger acquisition, the misfire handler and cluster check-in." A message
+ *     handler fits that; a batch job that enlists and then works for a minute does not.
+ *
+ *   - Both stores have to be in one database. Quartz's tables and Wolverine's envelope tables may live
+ *     in different schemas, but one DbTransaction cannot span two servers.
+ *
+ * Why the transaction is opened by hand rather than by [Transactional]: Wolverine's transactional
+ * middleware supplies whatever its persistence provider supplies, and on 6.30.3 the raw-ADO.NET
+ * Postgres package supplies nothing. Every IPersistenceFrameProvider in the tree belongs to Marten,
+ * Entity Framework Core, RavenDB, CosmosDB, Fisher or Polecat; there is none in Wolverine.RDBMS or
+ * Wolverine.Postgresql. A handler declaring `[Transactional] Handle(T msg, NpgsqlTransaction tx)`
+ * against plain PersistMessagesWithPostgresql compiles and then fails at runtime with
+ * "JasperFx was unable to resolve a variable of type Npgsql.NpgsqlTransaction". Adding Marten or EF
+ * Core would fix that and is what most Wolverine applications already have — but doing it by hand is
+ * the version that shows where the outbox actually joins, and it is the version that lets the commit
+ * sit inside the enlistment scope where it belongs.
+ */
+
+/// <summary>
+/// Writes the application's own row, the outgoing message and the follow-up trigger in one
+/// transaction, so that all three commit or none does.
+/// </summary>
+public static class ApproveRefundHandler
+{
+    public static async Task Handle(
+        ApproveRefund message,
+        MessageContext context,
+        IWolverineRuntime runtime,
+        IScheduler scheduler,
+        CancellationToken cancellationToken)
+    {
+        IMessageDatabase database = (IMessageDatabase) runtime.Storage;
+
+        await using NpgsqlConnection connection = new(ExampleOptions.Current.PostgresConnectionString!);
+        await connection.OpenAsync(cancellationToken);
+        await using DbTransaction transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        // Wolverine's outgoing envelopes are now written into this transaction rather than sent
+        // immediately. This is the manual form of what [Transactional] does for a Marten or EF Core
+        // application.
+        await context.EnlistInOutboxAsync(new DatabaseEnvelopeTransaction(database, transaction));
+
+        // 1. the application's own state
+        await using (NpgsqlCommand command = new(
+            "insert into refunds (order_id, amount) values (@order_id, @amount)",
+            connection,
+            (NpgsqlTransaction) transaction))
+        {
+            command.Parameters.AddWithValue("order_id", message.OrderId);
+            command.Parameters.AddWithValue("amount", message.Amount);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        // 2. a message that must not be sent unless the row above survives
+        await context.PublishAsync(new SendPaymentReminder(message.OrderId, message.Amount));
+
+        // 3. the trigger, in the same transaction as both, with the commit inside the scope so the
+        // scheduler is signalled once the trigger is visible to it
+        using (scheduler.EnlistTransaction(transaction))
+        {
+            await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+                new PaymentReminder(message.OrderId, message.Amount),
+                TimeSpan.FromDays(7),
+                new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
+                cancellationToken);
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+
+        // Releases the envelopes the outbox held back. Nothing left the process before the commit.
+        await context.FlushOutgoingMessagesAsync();
+
+        Ledger.Record(Events.RefundApprovedInTransaction, message.OrderId);
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Program.cs
+++ b/src/Quartz.Examples.Wolverine/Program.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Npgsql;
+
+using Quartz;
+using Quartz.Examples.Wolverine;
+
+using Wolverine;
+using Wolverine.Postgresql;
+using Wolverine.Runtime;
+
+ExampleOptions options = ExampleOptions.FromArguments(args);
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+// Wolverine first, so that its runtime is the first hosted service and everything registered below
+// starts after it. The lambda is not optional on IHostApplicationBuilder — unlike the IHostBuilder
+// overload, this one has no default for it.
+builder.UseWolverine(opts =>
+{
+    // Handlers live in this assembly. Setting it explicitly rather than letting Wolverine walk the
+    // stack is what keeps discovery working under a test runner and under a second host in the same
+    // process (JasperFx/wolverine#3776, #3778).
+    opts.ApplicationAssembly = typeof(OrderPlaced).Assembly;
+
+    // Part 3 sends raw bytes to an endpoint by name, and a name is the whole of what it can address —
+    // there is no live message for Wolverine to route on. A local queue keeps that free of a broker.
+    opts.PublishMessage<ArchiveOrders>().ToLocalQueue(Part3RawMessageData.EndpointName);
+
+    if (options.HasDatabase)
+    {
+        // The outbox, the inbox and the node table part 5's agent needs. Quartz's own tables go in the
+        // same database, because part 6's single transaction cannot span two servers.
+        opts.PersistMessagesWithPostgresql(options.PostgresConnectionString!);
+    }
+});
+
+builder.Services.AddQuartz(q =>
+{
+    Part1RecurringPublishing.Register(q, options.ReconciliationCron);
+    Part4TunedLatency.Register(q);
+
+    if (options.HasDatabase)
+    {
+        q.UsePersistentStore(store =>
+        {
+            store.UsePostgres(options.PostgresConnectionString!);
+            store.UseSystemTextJsonSerializer();
+
+            // Development convenience. A production account is usually right not to hold DDL rights;
+            // database/migrations/ is what moves a real schema forward.
+            store.ProvisionSchema();
+
+            // Part 6 throws without this, rather than silently scheduling outside the caller's
+            // transaction.
+            store.ConfigureStore(o => o.AcceptEnlistedTransactions = true);
+        });
+    }
+
+    // Nothing else: the in-memory store is what a scheduler falls back to, so UseInMemoryStore() would
+    // only restate the default.
+});
+
+// AutoStart = false is part 5. The scheduler is built and bound but not running; SchedulerStarter or
+// QuartzSchedulerAgent presses start once Wolverine is up.
+builder.Services.AddQuartzHostedService(hosted =>
+{
+    hosted.AutoStart = false;
+    hosted.WaitForJobsToComplete = true;
+});
+
+Part5StartedByWolverine.Register(builder.Services, options);
+
+using IHost host = builder.Build();
+await host.StartAsync();
+
+IMessageBus bus = host.Services.GetRequiredService<IMessageBus>();
+IScheduler scheduler = await host.Services.GetRequiredService<ISchedulerFactory>().GetScheduler();
+IWolverineRuntime runtime = host.Services.GetRequiredService<IWolverineRuntime>();
+
+if (options.HasDatabase)
+{
+    await Refunds.EnsureTable(options.PostgresConnectionString!);
+}
+
+Console.WriteLine(options.HasDatabase
+    ? $"Quartz.NET + Wolverine, durable mode ({ExampleOptions.PostgresVariable} is set)."
+    : $"Quartz.NET + Wolverine, in-memory mode. Set {ExampleOptions.PostgresVariable} for parts 5 and 6 in full.");
+Console.WriteLine();
+
+// Part 2: a Wolverine handler schedules a one-off typed job, correlated by trigger group.
+await bus.PublishAsync(new OrderPlaced(Smoke.RemindedOrderId, 149.50m));
+
+// Part 2 again, the cancelling half: this order is paid for before its reminder falls due.
+// InvokeAsync rather than PublishAsync, because these two must be handled in this order and a local
+// queue processes in parallel — a cancellation that arrives before the thing it cancels proves
+// nothing. InvokeAsync runs the handler inline on this thread and returns when it is done.
+await bus.InvokeAsync(new OrderPlaced(Smoke.PaidOrderId, 20.00m));
+await bus.InvokeAsync(new OrderPaid(Smoke.PaidOrderId));
+
+// Part 3: a serialized envelope stored now and sent through Wolverine when its trigger fires.
+TriggerKey deferred = await Part3RawMessageData.ScheduleSend(
+    scheduler,
+    runtime,
+    new ArchiveOrders("nightly housekeeping", OlderThanDays: 90),
+    options.Smoke ? TimeSpan.FromSeconds(2) : TimeSpan.FromHours(1));
+
+Ledger.Record(Events.RawEnvelopeStored, deferred.ToString());
+
+if (options.HasDatabase)
+{
+    // Part 6: the application's row, the outgoing envelopes and the trigger, in one transaction.
+    await bus.PublishAsync(new ApproveRefund("A-1003", 42.00m));
+}
+
+if (options.Smoke)
+{
+    int exitCode = await Smoke.RunAsync(options, TimeSpan.FromSeconds(20));
+    await host.StopAsync();
+    return exitCode;
+}
+
+Console.WriteLine("Running. Ctrl+C to stop.");
+await host.WaitForShutdownAsync();
+return 0;

--- a/src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj
+++ b/src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Quartz.NET beside Wolverine, as one runnable console application.
+
+    Wolverine can deliver a message later; it cannot say "every weekday at 03:00", and its maintainer
+    has said it never will (JasperFx/wolverine#1403). The gap is what this project fills, and the
+    accompanying page is docs/documentation/quartz-4.x/how-tos/wolverine.md. It is in Quartz.slnx so
+    that `Compile` fails the moment a call this page teaches stops compiling — which is the only
+    reason an example project exists.
+
+    Everything here runs with no external service: Wolverine's in-memory local transport and Quartz's
+    in-memory store. Set QUARTZ_WOLVERINE_POSTGRES to a connection string and the same program adds
+    the two parts that a durable store is a precondition for — Wolverine agents, and enlisting Quartz
+    in the outbox's transaction. Neither is needed to build, so CI never touches a database.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <!--
+      MA0004 wants ConfigureAwait on every await. Application code does not need it and the samples on
+      the page would carry noise no reader benefits from; the other examples suppress it for the same
+      reason. MA0016 and MA0018 are about API shape in a library, which this is not.
+    -->
+    <NoWarn>$(NoWarn);MA0004</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WolverineFx" />
+    <!--
+      Wolverine 6 moved Roslyn out of the core package: a host in the default TypeLoadMode.Dynamic
+      throws at startup with "no IAssemblyGenerator (Roslyn) is registered" unless this is referenced
+      or handlers were pre-generated with the `codegen write` command (JasperFx/wolverine#2876).
+      An example is better off compiling handlers at startup than carrying generated code nobody reads.
+    -->
+    <PackageReference Include="WolverineFx.RuntimeCompilation" />
+    <!--
+      Only reached when QUARTZ_WOLVERINE_POSTGRES is set. It is an unconditional reference because a
+      conditional one would leave the durable half of the page uncompiled on every CI leg, which is
+      exactly the rot this project exists to catch.
+    -->
+    <PackageReference Include="WolverineFx.Postgresql" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Examples.Wolverine/README.md
+++ b/src/Quartz.Examples.Wolverine/README.md
@@ -1,0 +1,49 @@
+# Quartz.NET with Wolverine
+
+A runnable console application putting Quartz.NET beside the [Wolverine](https://wolverinefx.net)
+message bus. Wolverine can deliver a message later but has no recurring or cron concept at all, and its
+maintainer has said it never will
+([JasperFx/wolverine#1403](https://github.com/JasperFx/wolverine/issues/1403)); this project is the
+recipe for filling that gap, and the prose that goes with it is
+[Quartz.NET with Wolverine](https://www.quartz-scheduler.net/documentation/quartz-4.x/how-tos/wolverine.html).
+
+Every C# block on that page is copied from this project and checked against it by
+`WolverineHowToTest`, so the page cannot drift from code that compiles.
+
+## Running it
+
+```shell
+dotnet run --project src/Quartz.Examples.Wolverine
+```
+
+Nothing external is needed: Wolverine's in-memory local transport and Quartz's in-memory store. Add
+`--smoke` to run every part on a compressed clock, assert each one happened, and exit:
+
+```shell
+dotnet run --project src/Quartz.Examples.Wolverine -- --smoke
+```
+
+Set `QUARTZ_WOLVERINE_POSTGRES` to a connection string and two more parts come to life — Wolverine
+agents, which do not run at all without a message store, and enlisting Quartz in the application's own
+transaction, which needs a persistent job store:
+
+```shell
+QUARTZ_WOLVERINE_POSTGRES="Host=localhost;Database=quartz;Username=quartz;Password=quartz" \
+  dotnet run --project src/Quartz.Examples.Wolverine -- --smoke
+```
+
+The schema is created on startup in that mode, including a small `refunds` table the last part writes
+to.
+
+## The six parts
+
+| File | What it shows |
+|---|---|
+| `Part1RecurringPublishing.cs` | An `IJob<TInput>` publishing a Wolverine message on a cron schedule |
+| `Part2OneOffFromHandler.cs` | Scheduling one firing from a handler, and cancelling every firing for one order by trigger group |
+| `Part3RawMessageData.cs` | Storing a serialized envelope and sending it with `SendRawMessageAsync` at fire time |
+| `Part4TunedLatency.cs` | `IdleWaitTime`, `MaxBatchSize` and `BatchTriggerAcquisitionFireAheadTimeWindow`, and what they really bound |
+| `Part5StartedByWolverine.cs` | `AutoStart = false`, with the scheduler started by Wolverine's runtime |
+| `Part6EnlistedTransaction.cs` | One transaction holding the application's row, Wolverine's outgoing envelope and Quartz's trigger |
+
+Each file opens with a comment saying what Wolverine lacks and what Quartz supplies.

--- a/src/Quartz.Examples.Wolverine/Refunds.cs
+++ b/src/Quartz.Examples.Wolverine/Refunds.cs
@@ -1,0 +1,26 @@
+using Npgsql;
+
+namespace Quartz.Examples.Wolverine;
+
+/// <summary>
+/// The application's own table, so part 6 has something of its own to write beside the trigger and the
+/// outgoing envelope.
+/// </summary>
+/// <remarks>
+/// Created here rather than shipped as a migration because this table exists only to make one
+/// transaction contain three writes. Nothing in the example reads it back.
+/// </remarks>
+public static class Refunds
+{
+    public static async Task EnsureTable(string connectionString)
+    {
+        await using NpgsqlConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using NpgsqlCommand command = new(
+            "create table if not exists refunds (order_id text not null, amount numeric not null)",
+            connection);
+
+        await command.ExecuteNonQueryAsync();
+    }
+}

--- a/src/Quartz.Examples.Wolverine/Smoke.cs
+++ b/src/Quartz.Examples.Wolverine/Smoke.cs
@@ -1,0 +1,84 @@
+namespace Quartz.Examples.Wolverine;
+
+/// <summary>
+/// What <c>--smoke</c> does: waits for every part to have produced its observable effect, then exits
+/// zero or one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The point of the flag is that a build server can prove the six parts still work, not merely that
+/// the process starts. A run that starts, schedules nothing and exits zero would be worse than no
+/// check at all.
+/// </para>
+/// <para>
+/// It is deliberately not a unit test. What it exercises is two hosted runtimes agreeing about
+/// startup order, a scheduling loop, and a message bus — none of which a test double would tell the
+/// truth about.
+/// </para>
+/// </remarks>
+public static class Smoke
+{
+    /// <summary>
+    /// The order the program pays for before its reminder falls due. No reminder may fire for it.
+    /// </summary>
+    public const string PaidOrderId = "A-1002";
+
+    /// <summary>
+    /// The order whose reminder is left to fire.
+    /// </summary>
+    public const string RemindedOrderId = "A-1001";
+
+    public static async Task<int> RunAsync(ExampleOptions options, TimeSpan timeout)
+    {
+        List<string> required =
+        [
+            Events.SchedulerStartedByWolverine,
+            Events.ReconciliationPublished,
+            Events.ReminderScheduled,
+            Events.ReminderFired,
+            Events.RemindersCancelled,
+            Events.RawEnvelopeStored,
+            Events.RawEnvelopeDelivered,
+        ];
+
+        if (options.HasDatabase)
+        {
+            required.Add(Events.RefundApprovedInTransaction);
+        }
+
+        DateTimeOffset deadline = TimeProvider.System.GetUtcNow() + timeout;
+        while (TimeProvider.System.GetUtcNow() < deadline && required.Exists(static x => Ledger.Count(x) == 0))
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+        }
+
+        List<string> missing = required.FindAll(static x => Ledger.Count(x) == 0);
+
+        Console.WriteLine();
+        foreach (string name in required)
+        {
+            Console.WriteLine($"  {(Ledger.Count(name) == 0 ? "MISSING" : "ok     ")}  {name} x{Ledger.Count(name)}");
+        }
+
+        // The cancellation is only proved by the reminder that did not fire. Asserted against the
+        // order rather than against a count, because part 6 publishes a reminder of its own in the
+        // durable mode and a count would then mean two different things in two configurations.
+        bool cancellationHeld = !Ledger.Details(Events.ReminderFired)
+            .Exists(static x => x.Contains(PaidOrderId, StringComparison.Ordinal));
+
+        if (!cancellationHeld)
+        {
+            Console.WriteLine($"  MISSING  no reminder should have fired for {PaidOrderId}, one did");
+        }
+
+        Console.WriteLine();
+        if (missing.Count == 0 && cancellationHeld)
+        {
+            Console.WriteLine("smoke: ok");
+            return 0;
+        }
+
+        Console.WriteLine("smoke: failed");
+        return 1;
+    }
+}

--- a/src/Quartz.Tests.Unit/WolverineHowToTest.cs
+++ b/src/Quartz.Tests.Unit/WolverineHowToTest.cs
@@ -1,0 +1,141 @@
+using System.Text.RegularExpressions;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The C# on the Wolverine how-to page is the C# in <c>src/Quartz.Examples.Wolverine</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other page's samples are generated: they live as <c>#region sample_*</c> blocks in
+/// <c>Quartz.Documentation.Samples</c> and <c>VerifyDocsSnippets</c> fails a page that has drifted from
+/// them. That machinery is not available here, because <c>DocsSnippets</c> reads that one project and
+/// that project may not take a <c>WolverineFx</c> dependency for the sake of a sample — the rule
+/// <c>CONTRIBUTING.md</c> states under "Code samples in the documentation", and the reason the Aspire
+/// how-to's AppHost blocks are hand-written too.
+/// </para>
+/// <para>
+/// So the page carries plain fences, and this test is what <c>VerifyDocsSnippets</c> would otherwise
+/// have been: each fence names the example file and line it was copied from, and the two are compared
+/// verbatim. It is deliberately not the anti-pattern
+/// <see cref="Configuration.DocumentedConfigurationTest" />'s remarks describe — that was a test
+/// holding its own transcription of a page, so that the page and the test were two copies with nothing
+/// comparing them. Here the compiled example is the only copy, and the page is checked against it.
+/// </para>
+/// </remarks>
+public class WolverineHowToTest
+{
+    private const string PagePath = "docs/documentation/quartz-4.x/how-tos/wolverine.md";
+
+    private const string ExampleDirectory = "src/Quartz.Examples.Wolverine";
+
+    /// <summary>
+    /// How many fences the page is expected to carry, so that deleting them all cannot make this test
+    /// pass by having nothing to check.
+    /// </summary>
+    private const int LeastExpectedFences = 6;
+
+    /// <summary>
+    /// The provenance comment and the fence it introduces — <c>Copied from &lt;path&gt;:&lt;line&gt;</c>
+    /// anywhere inside an HTML comment, then a <c>csharp</c> fence.
+    /// </summary>
+    private static readonly Regex AttributedFence = new(
+        @"<!--(?<comment>(?:(?!-->).)*?)Copied from (?<path>src/Quartz\.Examples\.Wolverine/[^\s:]+):(?<line>\d+)(?:(?!-->).)*?-->\s*\r?\n```csharp\r?\n(?<code>.*?)\r?\n```",
+        RegexOptions.Singleline,
+        TimeSpan.FromSeconds(10));
+
+    /// <summary>
+    /// Every fenced C# block on the page, attributed or not.
+    /// </summary>
+    private static readonly Regex CsharpFence = new(
+        @"^```csharp\r?$",
+        RegexOptions.Multiline,
+        TimeSpan.FromSeconds(10));
+
+    [Test]
+    public void EveryFencedSampleAppearsVerbatimInTheExample()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+        string page = ReadPage(root);
+
+        MatchCollection matches = AttributedFence.Matches(page);
+        matches.Count.Should().BeGreaterThanOrEqualTo(LeastExpectedFences,
+            $"{PagePath} teaches the six parts of {ExampleDirectory}, and a page that has stopped quoting them is a page nobody is checking");
+
+        foreach (Match match in matches)
+        {
+            string relative = match.Groups["path"].Value;
+            int firstLine = int.Parse(match.Groups["line"].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+            FileInfo source = new(Path.Combine(root.FullName, relative.Replace('/', Path.DirectorySeparatorChar)));
+            source.Exists.Should().BeTrue($"{PagePath} says it copied a sample from {relative}");
+
+            string[] sourceLines = File.ReadAllLines(source.FullName);
+            string[] pageLines = Dedent(match.Groups["code"].Value.Replace("\r\n", "\n").Split('\n'));
+
+            (firstLine + pageLines.Length - 1).Should().BeLessThanOrEqualTo(sourceLines.Length,
+                $"{relative} is shorter than the block {PagePath} says starts at line {firstLine}");
+
+            string[] candidate = Dedent(sourceLines.Skip(firstLine - 1).Take(pageLines.Length).ToArray());
+
+            for (int i = 0; i < pageLines.Length; i++)
+            {
+                candidate[i].Should().Be(pageLines[i],
+                    $"{PagePath} quotes {relative}:{firstLine + i}. Copy the block again from the example, and correct the line number in the page's provenance comment if it moved: {Locate(sourceLines, pageLines)}");
+            }
+        }
+    }
+
+    [Test]
+    public void EveryFencedSampleSaysWhereItCameFrom()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+        string page = ReadPage(root);
+
+        CsharpFence.Matches(page).Count.Should().Be(AttributedFence.Matches(page).Count,
+            $"every csharp fence on {PagePath} is hand-written, so each one needs the comment naming the {ExampleDirectory} file and line it was copied from — otherwise nothing keeps it honest");
+    }
+
+    private static string ReadPage(DirectoryInfo root)
+    {
+        FileInfo file = new(Path.Combine(root.FullName, PagePath.Replace('/', Path.DirectorySeparatorChar)));
+        file.Exists.Should().BeTrue($"{PagePath} is the page this test exists for");
+
+        return File.ReadAllText(file.FullName);
+    }
+
+    /// <summary>
+    /// Removes the indentation the block carries as a whole, so a method body reads on the page the way
+    /// a generated snippet would.
+    /// </summary>
+    private static string[] Dedent(string[] lines)
+    {
+        string[] trimmed = lines.Select(x => x.TrimEnd()).ToArray();
+
+        int indent = trimmed
+            .Where(x => x.Length > 0)
+            .Select(x => x.Length - x.TrimStart().Length)
+            .DefaultIfEmpty(0)
+            .Min();
+
+        return trimmed.Select(x => x.Length == 0 ? x : x[indent..]).ToArray();
+    }
+
+    /// <summary>
+    /// Where the quoted block really begins, so a failure names the line to write rather than only the
+    /// line that is wrong.
+    /// </summary>
+    private static string Locate(string[] sourceLines, string[] pageLines)
+    {
+        for (int start = 0; start + pageLines.Length <= sourceLines.Length; start++)
+        {
+            string[] candidate = Dedent(sourceLines.Skip(start).Take(pageLines.Length).ToArray());
+            if (candidate.SequenceEqual(pageLines, StringComparer.Ordinal))
+            {
+                return $"the block now starts at line {start + 1}";
+            }
+        }
+
+        return "the block is no longer in that file at all";
+    }
+}


### PR DESCRIPTION
`src/Quartz.Examples.Wolverine` is one console application, in `Quartz.slnx` so that a call it makes
going away fails `Compile`, and its how-to is `docs/documentation/quartz-4.x/how-tos/wolverine.md`.
It runs on Wolverine's in-memory local transport and Quartz's in-memory store, so no CI leg needs a
service; `QUARTZ_WOLVERINE_POSTGRES` turns on the two parts a durable store is a precondition for.

The acceptance criteria are the maintainer's own, and the page opens with them:
[JasperFx/wolverine#1403](https://github.com/JasperFx/wolverine/issues/1403) ("We're not doing this,
ever. *Maybe* there'll be a move to integrate Quartz.net or Hangfire *with* Wolverine"),
[#2715](https://github.com/JasperFx/wolverine/issues/2715) goal 5,
[#2717](https://github.com/JasperFx/wolverine/issues/2717),
[#2745](https://github.com/JasperFx/wolverine/issues/2745) ("Jeremy wants involvement before this
lands") and the [roadmap post of 2026-07-24](https://jeremydmiller.com/2026/07/24/critter-stack-roadmap-for-the-rest-of-2026/).
No outward action was taken on any JasperFx repository.

## The six parts

1. **Recurring/cron publishing** — an `IJob<TInput>` publishing a Wolverine message on a cron
   schedule, registered with `q.ScheduleJob<T>(… .WithCronSchedule(…).UsingInput(…))`, with the time
   zone and misfire instruction spelled out.
2. **A one-off typed job from a handler**, plus **cancel by correlation**.
   `ScheduleJob<TJob, TInput>(input, delay, new OneOffJobOptions { Group = … })` in one handler and
   `UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(…))` — the overload #3558 merged — in another.
3. **The raw-message-data hook** — a serialized envelope kept as the typed job input and handed to
   `SendRawMessageAsync` at fire time, which is the shape Wolverine's own documentation describes as
   being for Quartz.
4. **The latency triple**, with the honest reading: an in-process `ScheduleJob` signals the loop
   synchronously, so `IdleWaitTime` bounds cross-node pickup and the look-ahead of one acquisition,
   not the latency of anything this process scheduled.
5. **`AutoStart = false`**, with Quartz started by Wolverine.
6. **`EnlistTransaction`** with Wolverine's outbox — Postgres mode only.

## Rebased onto `0b98adf6a`

Two things this branch originally carried are now on main in stronger form, and have been dropped:

* The `RescheduleJob` gap — this branch fixed it with a one-line `NormalizeInput`; #3565 landed
  `PrepareTriggerData`, which normalizes the input **and** writes or removes the trace context, and
  calls it from every trigger-storing entry point. Its `TheInputOnARescheduledTriggerIsStoredAsAString`
  asserts exactly what this branch's test asserted, down to the same JSON, and adds
  `AnInputOnARescheduledTriggerReachesTheJob` and `TheInputOnAnUpdatedTriggerIsStoredAsAString` on top.
  Mine pinned nothing main's does not, so it is gone rather than duplicated.
* The `GetTriggerKeys` + `UnscheduleJobs(keys)` workaround — #3558 merged
  `UnscheduleJobs(GroupMatcher<TriggerKey>)`, so part 2 now makes the single call and the "not on this
  base" note is gone from the code and the page. The prose gained the reason it is better rather than
  merely shorter: the matcher is evaluated where the triggers are, so no key list round-trips through
  the process and no trigger fires between being listed and being removed.

## One defect found, worked around not reported

**Wolverine's `SendRawMessageAsync` leaves `Envelope.Destination` null** while `Executor.ExecuteAsync`
logs both success and failure through `envelope.Destination!`, so a raw message that is handled
perfectly still ends its pipeline with a `NullReferenceException` out of the logging call. The example
sets `Destination` and says why. Not reported upstream — outward action was out of scope.

## Deviations from the issue

* **The page's C# is copied, not generated.** The issue asked for `#region sample_*` blocks;
  `DocsSnippets` reads `Quartz.Documentation.Samples` alone and that project may not take a
  `WolverineFx` dependency for a sample's sake — the rule `CONTRIBUTING.md` states, and the reason the
  Aspire how-to's AppHost blocks are hand-written too. So the fences carry a provenance comment naming
  the example file and line, and `WolverineHowToTest` compares them verbatim, reporting the line to
  write when a block moves. `VerifyDocsSnippets` is green because a page with no markers is left alone.
* **The issue's item 2 — replacing `IMessageStore.StartScheduledJobs` — is not implemented.** It would
  mean shipping an `IMessageStore` decorator, which is a package, and packages are out of scope here.
  The page explains what that member does (a 5 s poll under a per-database advisory lock) where it is
  relevant.
* **`SingularAgent` is not leader-pinned**, and the example and page say so rather than implying it.
  It prefers a non-leader node and falls back to the leader only when there is one.

## Verification

`dotnet build Quartz.slnx` (0 warnings), `dotnet test src/Quartz.Tests.Unit` (4115 passed),
`dotnet fallout VerifyDocsSnippets`, `dotnet fallout WolverineSmoke`, `npm run docs:check-links`,
`markdownlint-cli2` on the new pages, and `--smoke` against a real Postgres 17 container for the
durable mode, including a restart against an existing schema.

Closes #3536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
