### PR TITLE
A trigger loaded with its job is scheduled once, and fires once at its start

### DIFF
--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -89,7 +89,12 @@ public class XMLSchedulingDataProcessorTest
 
         await processor.ScheduleJobs(mockScheduler);
 
-        A.CallTo(() => mockScheduler.ScheduleJob(A<ITrigger>.That.Not.IsNull(), A<CancellationToken>._)).MustHaveHappened(7, Times.Exactly);
+        // Five triggers over two schedule elements, and five scheduling calls: the durable job's two
+        // triggers are scheduled on their own, and so are the second and third of the non-durable job's
+        // three, whose first carries its job in. This used to count seven, because every trigger loaded
+        // beside its own job was scheduled again by the trailing loop (#3554).
+        A.CallTo(() => mockScheduler.ScheduleJob(A<ITrigger>.That.Not.IsNull(), A<CancellationToken>._)).MustHaveHappened(4, Times.Exactly);
+        A.CallTo(() => mockScheduler.ScheduleJob(A<IJobDetail>.That.Not.IsNull(), A<ITrigger>.That.Not.IsNull(), A<CancellationToken>._)).MustHaveHappened(1, Times.Exactly);
     }
 
     [Test]
@@ -283,8 +288,16 @@ public class XMLSchedulingDataProcessorTest
 
         await processor.ScheduleJobs(mockScheduler);
 
-        A.CallTo(() => mockScheduler.ScheduleJob(A<IJobDetail>.That.Matches(p => p.Key.Name == "sched2_job"), A<ITrigger>.Ignored, A<CancellationToken>._));
-        A.CallTo(() => mockScheduler.ScheduleJob(A<ITrigger>.That.Matches(p => p.Key.Name == "sched2_trig"), A<CancellationToken>._)).MustHaveHappened();
+        // The second schedule element's job is not durable, so the first of its triggers is what carries
+        // it into the scheduler - and that is the only time the trigger is handed over. The first of
+        // these two calls asserted nothing at all until now: it was missing its MustHaveHappened.
+        A.CallTo(() => mockScheduler.ScheduleJob(
+            A<IJobDetail>.That.Matches(p => p.Key.Name == "sched2_job"),
+            A<ITrigger>.That.Matches(p => p.Key.Name == "sched2_trig"),
+            A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => mockScheduler.ScheduleJob(
+            A<ITrigger>.That.Matches(p => p.Key.Name == "sched2_trig"),
+            A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/RescheduleJobFireTimeTest.cs
+++ b/src/Quartz.Tests.Unit/Core/RescheduleJobFireTimeTest.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Job;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What rescheduling does with a trigger instance that already carries fire times — the shape a caller
+/// is in after reading a trigger, changing something on it and handing the same object back, and the
+/// one <see cref="Quartz.Xml.XMLSchedulingDataProcessor" /> itself is in.
+/// </summary>
+/// <remarks>
+/// A next fire time the caller set is kept, which is what the clone in
+/// <see cref="Quartz.Core.QuartzScheduler.RescheduleJob" /> is for. One left behind by the start time
+/// rescheduling advances is not: no job store recomputes anything, both of them store the trigger as
+/// handed over, and a simple trigger answers "the start time" for any fire time asked for before it —
+/// so a trigger stored with a next fire time behind its own start fires at both of them, milliseconds
+/// apart (#3554).
+/// </remarks>
+[NonParallelizable]
+public sealed class RescheduleJobFireTimeTest
+{
+    private static readonly DateTimeOffset start = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan interval = TimeSpan.FromMinutes(1);
+
+    private Func<DateTimeOffset> originalUtcNow;
+
+    [SetUp]
+    public void SetUp()
+    {
+        originalUtcNow = SystemTime.UtcNow;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        SystemTime.UtcNow = originalUtcNow;
+    }
+
+    [Test]
+    public async Task AFireTimeLeftBehindByTheAdvancedStartTimeIsRecomputed()
+    {
+        FakeTimeProvider clock = FreezeClock();
+        IScheduler scheduler = await CreateScheduler("reschedule-recomputes");
+        try
+        {
+            ITrigger trigger = RepeatingTrigger();
+            await scheduler.ScheduleJob(Job(), trigger);
+            trigger.GetNextFireTimeUtc().Should().Be(start, "scheduling a trigger that starts now fires it at once");
+
+            clock.Advance(TimeSpan.FromSeconds(30));
+
+            // The same instance back again, exactly as a caller who read it, changed something and returned
+            // it would hand it over - and as the XML processor's own reschedule does.
+            await scheduler.RescheduleJob(trigger.Key, trigger);
+
+            ITrigger stored = await scheduler.GetTrigger(trigger.Key);
+            stored.StartTimeUtc.Should().Be(clock.GetUtcNow(),
+                "a repeating simple trigger that has never fired and whose start is in the past starts from now");
+            stored.GetNextFireTimeUtc().Should().Be(stored.StartTimeUtc,
+                "the fire time computed before the start moved is behind it, and a trigger stored that way "
+                + "fires there and then immediately again at its own start");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task AFireTimeAheadOfTheStartTimeIsKept()
+    {
+        FakeTimeProvider clock = FreezeClock();
+        IScheduler scheduler = await CreateScheduler("reschedule-keeps");
+        try
+        {
+            ITrigger trigger = RepeatingTrigger();
+            await scheduler.ScheduleJob(Job(), trigger);
+
+            clock.Advance(TimeSpan.FromSeconds(30));
+            DateTimeOffset forced = start.AddMinutes(5);
+            ((IOperableTrigger) trigger).SetNextFireTimeUtc(forced);
+
+            await scheduler.RescheduleJob(trigger.Key, trigger);
+
+            ITrigger stored = await scheduler.GetTrigger(trigger.Key);
+            stored.GetNextFireTimeUtc().Should().Be(forced,
+                "a next fire time the caller set is the caller's decision, and rescheduling is how it is "
+                + "made - only one that contradicts the trigger's own start time is replaced");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// Points <see cref="SystemTime" /> at a clock the test moves by hand, so that "the start time is in
+    /// the past" is a decision rather than a race with the machine. Undone by <see cref="TearDown" />.
+    /// </summary>
+    private static FakeTimeProvider FreezeClock()
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(start);
+        SystemTime.UtcNow = () => clock.GetUtcNow();
+        return clock;
+    }
+
+    private static Task<IScheduler> CreateScheduler(string name)
+    {
+        return SchedulerBuilder.Create()
+            .WithName(name)
+            .UseInMemoryStore()
+            .BuildScheduler();
+    }
+
+    private static IJobDetail Job() => JobBuilder.Create<NoOpJob>().WithIdentity("job1").Build();
+
+    private static ITrigger RepeatingTrigger()
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("trigger1")
+            .ForJob("job1")
+            .StartNow()
+            .WithSimpleSchedule(x => x.WithInterval(interval).RepeatForever())
+            .Build();
+    }
+}

--- a/src/Quartz.Tests.Unit/Xml/TriggerScheduledOnceTest.cs
+++ b/src/Quartz.Tests.Unit/Xml/TriggerScheduledOnceTest.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FakeItEasy;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Job;
+using Quartz.Listener;
+using Quartz.Logging;
+using Quartz.Simpl;
+using Quartz.Xml;
+
+namespace Quartz.Tests.Unit.Xml;
+
+/// <summary>
+/// A trigger that arrives together with its own job is applied to the scheduler exactly once, so a
+/// repeating trigger that starts now fires at its start time and then on its interval.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Container registrations and a <c>job_scheduling_data</c> file are the same code from
+/// <see cref="XMLSchedulingDataProcessor.ScheduleJobs" /> downwards, so both front doors are covered
+/// here. The per-job loop used to schedule a trigger and the trailing loop then hand the very same
+/// object back as a reschedule; the second pass restored the next fire time the first had computed and
+/// left the stored trigger with a next fire time behind its own start time, which fires there and then
+/// immediately again at the start — two firings milliseconds apart before the interval took over
+/// (#3554).
+/// </para>
+/// <para>
+/// Non-parallelizable because the container test hands the global <see cref="LogProvider" /> a logger
+/// factory owned by its own container, and because every test here names a scheduler in the process-wide
+/// <see cref="Quartz.Impl.SchedulerRepository" />.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class TriggerScheduledOnceTest
+{
+    /// <summary>
+    /// How long a test waits for firings before deciding the scheduler is stuck. It is never a
+    /// measurement: every assertion here is about the times a trigger computed for itself, not about
+    /// when the notification arrived.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The repeat interval used throughout, short enough to observe three firings quickly and long
+    /// enough that the milliseconds a double scheduling puts between two of them cannot be mistaken
+    /// for it.
+    /// </summary>
+    private static readonly TimeSpan interval = TimeSpan.FromSeconds(1);
+
+    private const string JobType = "Quartz.Job.NoOpJob, Quartz.Jobs";
+
+    [Test]
+    public async Task ATriggerRegisteredWithItsJobFiresAtItsStartAndThenOnItsInterval()
+    {
+        try
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddLogging();
+            services.AddQuartz(q =>
+            {
+                q.SchedulerName = "registered-with-its-job";
+                q.UseInMemoryStore();
+
+                // Deliberately not durable: a durable job is added by itself and its triggers are left to
+                // the trailing loop, which is the one path that never scheduled anything twice.
+                q.AddJob<NoOpJob>(j => j.WithIdentity("job1"));
+                q.AddTrigger(t => t
+                    .WithIdentity("trigger1")
+                    .ForJob("job1")
+                    .StartNow()
+                    .WithSimpleSchedule(x => x.WithInterval(interval).RepeatForever()));
+            });
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+
+            IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+            FiringRecorder recorder = new FiringRecorder(firings: 3);
+            scheduler.ListenerManager.AddJobListener(recorder);
+
+            try
+            {
+                await scheduler.Start();
+                ShouldBeOnTheInterval(await WithinDeadline(recorder.ScheduledFireTimes));
+            }
+            finally
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: true);
+            }
+        }
+        finally
+        {
+            // AddQuartz points the process-wide log provider at this container's logger factory, which
+            // goes away with the container; anything asking for a logger afterwards would get a disposed
+            // one.
+            LogProvider.SetCurrentLogProvider(null);
+        }
+    }
+
+    [Test]
+    public async Task ATriggerLoadedFromAFileWithItsJobFiresAtItsStartAndThenOnItsInterval()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "quartz-scheduled-once-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            string file = Path.Combine(directory, "job_scheduling_data.xml");
+            File.WriteAllText(file, JobWithRepeatingTrigger);
+
+            IScheduler scheduler = await CreateScheduler("loaded-from-a-file");
+            FiringRecorder recorder = new FiringRecorder(firings: 3);
+            scheduler.ListenerManager.AddJobListener(recorder);
+
+            try
+            {
+                await CreateProcessor().ProcessFileAndScheduleJobs(file, scheduler);
+                await scheduler.Start();
+
+                ShouldBeOnTheInterval(await WithinDeadline(recorder.ScheduledFireTimes));
+            }
+            finally
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: true);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task EachTriggerLoadedWithItsJobIsHandedToTheSchedulerExactlyOnce()
+    {
+        // The counting scheduler forwards every call to a real one - the store has to end up holding the
+        // trigger, because a stored trigger is what the second pass used to find and reschedule.
+        IScheduler real = await CreateScheduler("handed-over-once");
+        IScheduler scheduler = A.Fake<IScheduler>(options => options.Wrapping(real));
+        try
+        {
+            await CreateProcessor().ProcessStreamAndScheduleJobs(ToStream(JobWithTwoTriggers), scheduler);
+
+            A.CallTo(() => scheduler.ScheduleJob(
+                A<IJobDetail>.That.Matches(j => j.Key.Name == "job1"),
+                A<ITrigger>.That.Matches(t => t.Key.Name == "trigger1"),
+                A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => scheduler.ScheduleJob(
+                A<ITrigger>.That.Matches(t => t.Key.Name == "trigger2"),
+                A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+
+            // A trigger this call has just scheduled is not something to reschedule; doing so restores
+            // the fire times the scheduling computed and undoes the start time it settled on.
+            A.CallTo(() => scheduler.RescheduleJob(
+                A<TriggerKey>._,
+                A<ITrigger>._,
+                A<CancellationToken>._)).MustNotHaveHappened();
+
+            ITrigger stored = await scheduler.GetTrigger(new TriggerKey("trigger1"));
+            stored.GetNextFireTimeUtc().Should().Be(stored.StartTimeUtc,
+                "a trigger that starts now fires first at its start time, and a next fire time behind the "
+                + "start time is one the scheduler fires twice");
+        }
+        finally
+        {
+            await real.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ATriggerOfADurableJobInTheSameDataIsStillScheduled()
+    {
+        // A durable job is added on its own and its triggers are left to the trailing loop, so this is
+        // what a fix that skipped that loop for every loaded trigger would break.
+        IScheduler real = await CreateScheduler("durable-job-in-the-same-data");
+        IScheduler scheduler = A.Fake<IScheduler>(options => options.Wrapping(real));
+        try
+        {
+            await CreateProcessor().ProcessStreamAndScheduleJobs(ToStream(DurableJobWithTrigger), scheduler);
+
+            // The trailing loop is where a durable job's triggers are scheduled.
+            A.CallTo(() => scheduler.ScheduleJob(
+                A<ITrigger>.That.Matches(t => t.Key.Name == "trigger1"),
+                A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        }
+        finally
+        {
+            await real.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task ATriggerWhoseJobIsNotInTheSameDataIsStillScheduled()
+    {
+        IScheduler real = await CreateScheduler("job-not-in-the-same-data");
+        IScheduler scheduler = A.Fake<IScheduler>(options => options.Wrapping(real));
+        try
+        {
+            await scheduler.AddJob(JobBuilder.Create<NoOpJob>().WithIdentity("job1").StoreDurably().Build(), true);
+
+            await CreateProcessor().ProcessStreamAndScheduleJobs(ToStream(TriggerOnly), scheduler);
+
+            // A trigger loaded without its job is exactly what the trailing loop is for.
+            A.CallTo(() => scheduler.ScheduleJob(
+                A<ITrigger>.That.Matches(t => t.Key.Name == "trigger1"),
+                A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        }
+        finally
+        {
+            await real.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// The firings a repeating trigger that starts now is meant to have: one at the start time, and
+    /// one an interval on from each of those.
+    /// </summary>
+    /// <remarks>
+    /// Asserted on the times the firings were <em>scheduled</em> for rather than on when they arrived,
+    /// so a loaded machine changes nothing: those come from the trigger's own arithmetic.
+    /// </remarks>
+    private static void ShouldBeOnTheInterval(IReadOnlyList<DateTimeOffset> scheduledFireTimes)
+    {
+        scheduledFireTimes[1].Should().Be(scheduledFireTimes[0] + interval,
+            "the firing after the first belongs one interval later; a trigger scheduled twice keeps a "
+            + "next fire time behind the start time the second pass gave it, and fires at both");
+        scheduledFireTimes[2].Should().Be(scheduledFireTimes[1] + interval,
+            "and every firing after that is one interval on from the one before it");
+    }
+
+    /// <summary>
+    /// Gives up on a scheduler that never fires, rather than hanging the run. The deadline is generous
+    /// on purpose — nothing here is timed against it.
+    /// </summary>
+    private static async Task<IReadOnlyList<DateTimeOffset>> WithinDeadline(Task<IReadOnlyList<DateTimeOffset>> firings)
+    {
+        Task finished = await Task.WhenAny(firings, Task.Delay(observationDeadline)).ConfigureAwait(false);
+        if (!ReferenceEquals(finished, firings))
+        {
+            throw new TimeoutException($"The scheduler did not fire often enough within {observationDeadline}.");
+        }
+
+        return await firings.ConfigureAwait(false);
+    }
+
+    private static Task<IScheduler> CreateScheduler(string name)
+    {
+        return SchedulerBuilder.Create()
+            .WithName(name)
+            .UseInMemoryStore()
+            .BuildScheduler();
+    }
+
+    private static XMLSchedulingDataProcessor CreateProcessor()
+    {
+        return new XMLSchedulingDataProcessor(new SimpleTypeLoadHelper());
+    }
+
+    private static Stream ToStream(string xml) => new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+    private static string Document(string body)
+    {
+        return $"""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <job-scheduling-data xmlns="http://quartznet.sourceforge.net/JobSchedulingData" version="2.0">
+                {body}
+                </job-scheduling-data>
+                """;
+    }
+
+    /// <summary>
+    /// A trigger with no start time starts now, which is the case the double scheduling was visible in.
+    /// </summary>
+    private static string Trigger(string name) => $"""
+                                                   <trigger>
+                                                     <simple>
+                                                       <name>{name}</name>
+                                                       <job-name>job1</job-name>
+                                                       <repeat-count>-1</repeat-count>
+                                                       <repeat-interval>{(long) interval.TotalMilliseconds}</repeat-interval>
+                                                     </simple>
+                                                   </trigger>
+                                                   """;
+
+    private static string Job(bool durable) => $"""
+                                                <job>
+                                                  <name>job1</name>
+                                                  <job-type>{JobType}</job-type>
+                                                  <durable>{(durable ? "true" : "false")}</durable>
+                                                </job>
+                                                """;
+
+    private static readonly string JobWithRepeatingTrigger = Document($"""
+        <schedule>
+          {Job(durable: false)}
+          {Trigger("trigger1")}
+        </schedule>
+        """);
+
+    private static readonly string JobWithTwoTriggers = Document($"""
+        <schedule>
+          {Job(durable: false)}
+          {Trigger("trigger1")}
+          {Trigger("trigger2")}
+        </schedule>
+        """);
+
+    private static readonly string DurableJobWithTrigger = Document($"""
+        <schedule>
+          {Job(durable: true)}
+          {Trigger("trigger1")}
+        </schedule>
+        """);
+
+    private static readonly string TriggerOnly = Document($"""
+        <schedule>
+          {Trigger("trigger1")}
+        </schedule>
+        """);
+
+    /// <summary>
+    /// Records the time each firing was scheduled for, and completes once enough of them have arrived.
+    /// </summary>
+    private sealed class FiringRecorder : JobListenerSupport
+    {
+        private readonly TaskCompletionSource<IReadOnlyList<DateTimeOffset>> enough =
+            new TaskCompletionSource<IReadOnlyList<DateTimeOffset>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private readonly List<DateTimeOffset> scheduledFireTimes = new List<DateTimeOffset>();
+        private readonly int firings;
+
+        public FiringRecorder(int firings)
+        {
+            this.firings = firings;
+        }
+
+        public override string Name => nameof(FiringRecorder);
+
+        public Task<IReadOnlyList<DateTimeOffset>> ScheduledFireTimes => enough.Task;
+
+        public override Task JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            lock (scheduledFireTimes)
+            {
+                scheduledFireTimes.Add(context.ScheduledFireTimeUtc.Value);
+                if (scheduledFireTimes.Count >= firings)
+                {
+                    enough.TrySetResult(scheduledFireTimes.ToArray());
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -944,7 +944,7 @@ public class QuartzScheduler :
         }
 
         DateTimeOffset? ft;
-        if (trigger.GetNextFireTimeUtc() != null)
+        if (trigger.GetNextFireTimeUtc() != null && trigger.GetNextFireTimeUtc() >= trigger.StartTimeUtc)
         {
             // use a cloned trigger so that we don't lose possible forcefully set next fire time
             var clonedTrigger = (IOperableTrigger) trigger.Clone();
@@ -952,6 +952,12 @@ public class QuartzScheduler :
         }
         else
         {
+            // Either the trigger carries no fire times yet, or the ones it carries are behind the start
+            // time it now has - which is what AdjustSimpleTriggerStartTimeIfInPast above leaves behind
+            // when the caller passes an instance that was already scheduled once. A trigger stored that
+            // way fires at the stale next fire time and then, because GetFireTimeAfter answers with the
+            // start time for anything before it, immediately again at its own start; the job store keeps
+            // whichever next fire time it is handed, so this is the only place that can say no to it.
             ft = trigger.ComputeFirstFireTimeUtc(cal);
         }
 

--- a/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
+++ b/src/Quartz/Xml/XMLSchedulingDataProcessor.cs
@@ -717,6 +717,13 @@ public class XMLSchedulingDataProcessor
 
         IDictionary<JobKey, List<IMutableTrigger>> triggersByFQJobName = BuildTriggersByFQJobNameMap(triggers);
 
+        // The keys of the triggers the per-job loop below deals with. Those lists are built from
+        // `triggers` but are not backed by it, so taking a trigger out of its job's list leaves it in
+        // `triggers` for the trailing loop to meet a second time - which is how a trigger loaded beside
+        // its own job used to be scheduled and then immediately rescheduled, the reschedule restoring
+        // the fire times the first scheduling had already computed (#3554).
+        HashSet<TriggerKey> handledTriggerKeys = new HashSet<TriggerKey>();
+
         // add each job, and it's associated triggers
         while (jobs.Count > 0)
         {
@@ -808,6 +815,7 @@ public class XMLSchedulingDataProcessor
                     IMutableTrigger trigger = triggersOfJob[0];
                     // remove triggers as we handle them...
                     triggersOfJob.Remove(trigger);
+                    handledTriggerKeys.Add(trigger.Key);
 
                     ITrigger? dupeT = await sched.GetTrigger(trigger.Key, cancellationToken).ConfigureAwait(false);
                     if (dupeT != null)
@@ -872,9 +880,14 @@ public class XMLSchedulingDataProcessor
             }
         }
 
-        // add triggers that weren't associated with a new job... (those we already handled were removed above)
+        // add triggers that weren't associated with a new job... (those we already handled are skipped)
         foreach (IMutableTrigger trigger in triggers)
         {
+            if (handledTriggerKeys.Contains(trigger.Key))
+            {
+                continue;
+            }
+
             ITrigger? dupeT = await sched.GetTrigger(trigger.Key, cancellationToken).ConfigureAwait(false);
             if (dupeT != null)
             {


### PR DESCRIPTION
Companion of #3559 on `3.x`; see #3554

A trigger registered beside its own job was handed to the scheduler twice, and a repeating trigger
that starts now fired twice a few milliseconds apart before settling onto its interval. `3.x` carries
both faults verbatim.

## The two halves

**`XMLSchedulingDataProcessor.ScheduleJobs` schedules each trigger once.** The per-job trigger lists
come from `BuildTriggersByFQJobNameMap`, which is built *from* the loaded triggers but is not backed by
them, so `triggersOfJob.Remove(trigger)` (`src/Quartz/Xml/XMLSchedulingDataProcessor.cs:810` before this
change) left the trigger in `triggers` for the trailing loop at line 875 to meet again. With
`OverWriteExistingData` on — the default for files and for the container processor — that second pass
found the trigger it had just stored and re-applied it through `DoRescheduleJob`, using the very object
the first pass had computed fire times on.

The trailing loop now skips the keys the per-job loop dealt with. Keys rather than a second removal from
`triggers`: trigger equality *is* key equality, so a list removal is that same comparison done in O(n)
with the "by key" part hidden in an override, and it leaves the invariant implicit in two removals
staying in step. The trailing loop is not dead code and is not skipped wholesale — a durable job's
triggers, and a trigger whose job is not in the same data, are still scheduled there, and both cases
have a test. `JsonSchedulingDataProcessor` and `ContainerConfigurationProcessor` both derive from this
processor, so all three front doors are fixed by the one change.

**`QuartzScheduler.RescheduleJob` recomputes a fire time that has fallen behind the start time.** It
advances the start of a never-fired repeating simple trigger whose start is in the past
(`AdjustSimpleTriggerStartTimeIfInPast`), then kept whatever `GetNextFireTimeUtc()` the instance already
carried — so the stored trigger's next fire time was *before* its own start. Neither store corrects
that: `RAMJobStore.ReplaceTrigger` and `JobStoreSupport.ReplaceTrigger` both delete and re-add the
trigger exactly as handed over. `SimpleTriggerImpl.GetFireTimeAfter` answers with the start time for
anything asked before it, so such a trigger fires at the stale time and then immediately again at its
own start — the double firing.

**Recompute, not reject.** `GetTrigger` → mutate → `RescheduleJob` with the same instance is the shape
the API is built around and the one `DoRescheduleJob` itself uses. A next fire time the caller *set* is
still kept — that is what the clone in that method is for, and what
`ScheduleTriggerRelativeToReplacedTrigger` depends on — and only one that contradicts the trigger's own
start time is replaced.

Either half alone stops the double *firing*; both are here because they are different faults. Verified
on this branch by reverting them one at a time:

| Tree | Result |
|---|---|
| Neither fix | 4 of the 7 new tests fail |
| Only the `RescheduleJob` fix | the double scheduling still happens — the counting probe fails |
| Only the loop fix | the incoherent trigger is still storable — the `RescheduleJob` test fails |
| Both | all pass |

## Tests

Seven new tests, in `TriggerScheduledOnceTest` and `RescheduleJobFireTimeTest`, the same set as on
`main`:

- a repeating `StartNow()` trigger registered with `q.AddJob<T>` + `q.AddTrigger` on a non-durable job
  fires at its start and then on its interval, over three firings;
- the same through a `job_scheduling_data` file and `ProcessFileAndScheduleJobs`;
- a counting scheduler over a real in-memory scheduler sees exactly one `ScheduleJob` per trigger and no
  `RescheduleJob`, and the stored trigger's next fire time equals its start time;
- a durable job's trigger, and a trigger whose job is not in the same data, are still scheduled (the
  trailing loop still earns its keep);
- rescheduling recomputes a fire time the advanced start left behind, and keeps one that is still ahead
  of the start.

The firing tests assert on `ScheduledFireTimeUtc` — times the trigger computed for itself — rather than
on when the notifications arrived, so a loaded build agent changes nothing. Waiting is a 30-second
deadline, never a measurement.

**Two existing tests asserted the doubled counts and were corrected** —
`src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs`, exactly as on `main`:

- `TestScheduling_RichConfiguration` expected the single-trigger `ScheduleJob` overload **7** times for
  a file holding **5** triggers. It is 4 now, beside 1 call to the overload that carries the job: five
  calls for five triggers.
- `MultipleScheduleElementsShouldBeSupported` looked for `sched2_trig` in the single-trigger overload,
  where only the second pass ever put it — it is the first trigger of a non-durable job, so it is the
  one that carries the job in. Its companion line asserted nothing at all: it was missing its
  `MustHaveHappened()`. Both are assertions now.

## How this differs from the `main` port

The production change is the same idea in `3.x` spelling: `HashSet<TriggerKey>` built with a constructor
rather than a collection expression, `sched` rather than `scheduler`, and `trigger.GetNextFireTimeUtc()`
rather than the `NextFireTimeUtc` property. The tests needed more adapting, because `3.x` has no
`TimeProvider` plumbing and no `DelegatingScheduler`:

- `RescheduleJobFireTimeTest` drives the clock by pointing `SystemTime.UtcNow` at a `FakeTimeProvider`,
  the pattern `JsonObjectSerializerTest` and `RAMJobStoreTest` already use here, and the fixture is
  `[NonParallelizable]` for it. `main` passes the `TimeProvider` into `QuartzSchedulerBuilder` and
  `TriggerBuilder.Create(clock)`.
- The counting scheduler is a FakeItEasy `Wrapping` fake over a real scheduler, asserted with
  `A.CallTo(...).MustHaveHappenedOnceExactly()`, rather than `main`'s hand-written `DelegatingScheduler`
  subclass — `3.x` has no such base class, and `IScheduler` here is far too wide to delegate by hand for
  one test.
- Schedulers come from `SchedulerBuilder.Create().WithName(...).UseInMemoryStore().BuildScheduler()` and
  the container test resolves `ISchedulerFactory` (`3.x` registers no `IScheduler`), rather than
  `main`'s `StandaloneSchedulerFactory` / `provider.GetRequiredService<IScheduler>()`.
- The container test restores the process-wide `LogProvider` in a `finally`: `AddQuartz` points it at
  the container's `ILoggerFactory`, which is gone once the container is, and leaving it there fails
  every later test that asks for a logger. That is the same guard `DeferredQuartzConfigurationTests`
  uses.
- No `Directory.CreateTempSubdirectory`, `File.WriteAllTextAsync` or `Task.WaitAsync`: the unit tests
  also run on `net472`, so those are a `Path.GetTempPath()` + `Guid` directory, `File.WriteAllText`, and
  a `Task.WhenAny` deadline helper.
- Nothing documentation-side. `main`'s companion added one behaviour row to the 4.x migration guide; the
  docs site is built from `main` only and there is no changelog file here, so the `RescheduleJob` change
  is release-notes material.

## For the reviewer

- **The `RescheduleJob` change is observable to callers who never touch the XML processor**, on a
  maintenance branch. It is narrow — a next fire time is only replaced when it is behind the trigger's
  own start time — but it is a behaviour change and wants a line in the 3.x release notes.
- One corner it does move: `DoRescheduleJob`'s relative-scheduling path sets the next fire time from the
  *replaced* trigger's start, and when that old trigger had never fired,
  `AdjustSimpleTriggerStartTimeIfInPast` then advances the start past it and this change recomputes the
  fire time instead of leaving a deliberately-past one for the misfire machinery. `main` accepted the
  same corner. The case with a previous fire time — the one
  `TestSchedulingWhenUpdatingScheduleBasedOnExistingTrigger` covers — is untouched, because a trigger
  that has a previous fire time is never adjusted.
- The public API baselines did not move: `XMLSchedulingDataProcessor.ScheduleJobs` and
  `QuartzScheduler.RescheduleJob` kept their signatures.
