### PR TITLE
The patterns every embedder reinvents are written down

### DIFF
--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -146,6 +146,8 @@ export const sidebarEn: SidebarConfig = [
               "/documentation/quartz-4.x/how-tos/job-template",
               "/documentation/quartz-4.x/how-tos/aspire",
               "/documentation/quartz-4.x/how-tos/wolverine",
+              "/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library",
+              "/documentation/quartz-4.x/how-tos/external-leader",
               "/documentation/quartz-4.x/how-tos/trimming-and-native-aot",
               "/documentation/quartz-4.x/how-tos/custom-job-store",
               "/documentation/quartz-4.x/how-tos/dialect-delegate",

--- a/docs/documentation/quartz-4.x/how-tos/README.md
+++ b/docs/documentation/quartz-4.x/how-tos/README.md
@@ -16,6 +16,8 @@ Short, task-shaped recipes. Each page answers one question; the
 * [Job Template](job-template.md) — the recommended skeleton for a job class
 * [Running Quartz under Aspire](aspire.md) — telemetry, health and the database, wired to an AppHost
 * [Quartz.NET with Wolverine](wolverine.md) — cron-publishing into a message bus, cancelling by correlation, and sharing the outbox's transaction
+* [Embedding Quartz in a Library](embedding-quartz-in-a-library.md) — for a package that has to fit into an application it does not own
+* [Running under an External Leader Election](external-leader.md) — one instance, started and stopped by somebody else's election
 * [Publishing Trimmed and Native AOT](trimming-and-native-aot.md) — what each package claims, what still warns, and what to do about it
 
 Extending Quartz — the four seams the `Quartz.Impl.AdoJobStore` types exist for:

--- a/docs/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library.md
+++ b/docs/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library.md
@@ -1,0 +1,673 @@
+---
+
+title: 'Embedding Quartz in a Library'
+---
+
+# Embedding Quartz in a Library
+
+This page is for the author of a **library** — a message bus integration, an identity server's token
+pruning, a multi-tenant framework, an outbox — rather than the author of an application. The difference is
+ownership: an application decides what the scheduler is and when it starts, and a library has to fit into
+whatever the application decided.
+
+Everything here is one of a handful of questions every embedder answers, usually by inventing something.
+The answers Quartz has are collected here so that you do not have to.
+
+This page is deliberately generic, because the questions are. For the same material worked through
+against one real library — a message bus, with its own scheduling, its own transaction and its own
+lifecycle — read [Quartz.NET with Wolverine](wolverine.md) alongside it.
+
+## Who owns the scheduler
+
+Three arrangements, in the order to consider them:
+
+| Arrangement | Use it when |
+|---|---|
+| **Your own named scheduler** — `AddQuartz("mylib", …)` | The work has a resource profile of its own: its own thread pool, its own store, its own start and stop. Nothing you do can starve the application's jobs, and nothing it does can starve yours. |
+| **Contribute to whatever schedulers exist** — `ConfigureAllQuartzSchedulers(…)` | The work is small, periodic housekeeping that belongs wherever the application already schedules. One scheduler, one thread pool, one set of tables to operate. |
+| **An execution group inside a shared scheduler** | You want the application's scheduler but need a ceiling on how much of it you take. |
+
+The axis is **resource isolation against operational surface**. A second scheduler is a second thread pool,
+a second acquisition loop and a second thing to watch; contributing to the application's is none of those
+and gives you no protection from it. The middle position — one scheduler, a named
+[execution group](../tutorial/execution-groups.md) with a limit — is the one most libraries want and the
+one most libraries do not know exists.
+
+::: warning Never create a scheduler the container does not know about
+Building your own `QuartzSchedulerBuilder` inside a library that is being used from a host means a
+scheduler nothing else can see: not `ISchedulerRegistry`, not the dashboard, not the health check, not the
+host's shutdown. Two libraries doing it against the same tables is worse — each recovers the other's fired
+triggers at start-up. Register through the container the application already has.
+:::
+
+### A scheduler of your own
+
+<!-- snippet: sample_embedding_named_scheduler -->
+```csharp
+// Everything this library registers lands under the scheduler's own service key: its thread
+// pool, its job store, its listeners. Nothing it does can starve the application's scheduler,
+// and nothing the application configures reaches this one.
+services.AddQuartz("acme.outbox", q =>
+{
+    q.UsePersistentStore(store => store.UseSqlServer(connectionString));
+    q.UseDefaultThreadPool(maxConcurrency: 4);
+});
+```
+<!-- endSnippet -->
+
+A named scheduler's whole object graph is keyed by its name, so its thread pool, job store, listeners and
+middleware are its own. Resolve it the way any other keyed service is resolved:
+
+<!-- snippet: sample_embedding_named_scheduler_resolve -->
+```csharp
+IScheduler scheduler = provider.GetRequiredKeyedService<IScheduler>("acme.outbox");
+```
+<!-- endSnippet -->
+
+Name it something an operator will recognise as yours and that nobody else will pick — a reverse-DNS-ish
+prefix works. Registering two schedulers under one name is refused, case-insensitively, at the registration
+site, which is a better failure than two libraries silently sharing one.
+
+[Multiple Schedulers](../packages/multiple-schedulers.md) has the rest: configuration sections, per-scheduler
+listeners, and how the default and named schedulers mix.
+
+### An execution group, if you are sharing
+
+If you use the application's scheduler, an execution group is how you promise not to take all of it. The
+limit is set once, by group name, and every trigger tagged with that group counts against it:
+
+<!-- snippet: sample_embedding_execution_group -->
+```csharp
+services.ConfigureAllQuartzSchedulers(q => q.UseExecutionLimits(limits => limits
+    .ForGroup("acme.outbox", maxConcurrent: 4)
+    .ForOtherGroups(int.MaxValue)));
+```
+<!-- endSnippet -->
+
+Tag your triggers with `WithExecutionGroup("acme.outbox")`, or `OneOffJobOptions.ExecutionGroup`. Read
+[Execution Groups](../tutorial/execution-groups.md) before choosing a number — in particular the difference
+between a node-scoped and a cluster-scoped limit.
+
+## Contributing to a scheduler you do not own
+
+A library cannot know whether the application registers its schedulers before or after calling the
+library's `Add…`, how many there are, or what they are called. `ConfigureAllQuartzSchedulers` is the answer
+to all three: the delegate is recorded, applied to every scheduler already registered, and applied by each
+scheduler registered afterwards as part of its own `AddQuartz`.
+
+<!-- snippet: sample_embedding_contributor -->
+```csharp
+public static IServiceCollection AddAcmeOutbox(this IServiceCollection services)
+{
+    // Contributing twice is contributing twice: Quartz will not apply one delegate instance to one
+    // scheduler more than once, but a second call here creates a second delegate. Guard the
+    // extension method, not the delegate.
+    if (services.Any(descriptor => descriptor.ServiceType == typeof(AcmeOutboxMarker)))
+    {
+        return services;
+    }
+
+    services.AddSingleton<AcmeOutboxMarker>();
+
+    // Applied to every scheduler in the container - those registered before this call, and those
+    // registered after it. The application decides how many schedulers there are and what they are
+    // called; this does not have to know.
+    services.ConfigureAllQuartzSchedulers(q =>
+    {
+        q.AddJob<DrainOutboxJob>(j => j
+            .WithIdentity(DrainOutboxJob.Key)
+            .StoreDurably());
+
+        q.AddTrigger(t => t
+            .WithIdentity("drain", DrainOutboxJob.Key.Group)
+            .ForJob(DrainOutboxJob.Key)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).RepeatForever()));
+    });
+
+    return services;
+}
+
+private sealed class AcmeOutboxMarker;
+```
+<!-- endSnippet -->
+
+The delegate is handed a builder **per scheduler**, so everything it registers lands under that scheduler's
+own service key — exactly as if it had been written inside that scheduler's `AddQuartz(name, q => …)`
+callback. A listener or plugin added this way is one instance per scheduler, not one shared between them.
+It runs after each scheduler's own configuration callback, which is what makes the call order immaterial,
+and the usual precedence follows: registration is first-wins, so a job store the application chose is not
+replaced by one you choose; options are last-wins, so a value you set here overrides the application's.
+
+::: tip This replaces 3.x's `IConfigureOptions<QuartzOptions>`
+On 3.x the way to contribute jobs to somebody else's scheduler was to register an
+`IConfigureOptions<QuartzOptions>` and call `QuartzOptions.AddJob` / `AddTrigger` from it — the shape
+OpenIddict's Quartz integration uses. `QuartzOptions`
+[is no longer a dictionary and no longer holds jobs and triggers](../migration-guide.md#quartzoptions-is-no-longer-a-dictionary),
+so that route is gone. `ConfigureAllQuartzSchedulers` is its replacement, and it is strictly better at the
+job: it reaches named schedulers, which the options route never did, and it hands you a builder rather than
+an options bag.
+:::
+
+**Guard the extension method, not the delegate.** Quartz will not apply one delegate *instance* to one
+scheduler twice, which is what keeps a second `AddQuartz()` for the default scheduler from doubling your
+registrations. It does not make your `AddAcmeOutbox()` idempotent: a lambda that captures anything is a new
+delegate on every call, and two delegates are two contributions. The marker-service check in the sample
+above is the ordinary .NET answer and is what to copy.
+
+If your work belongs to one scheduler rather than all of them, ask which one you are configuring.
+`IQuartzBuilder.SchedulerName` is the empty string for the default scheduler and the registered name
+otherwise:
+
+<!-- snippet: sample_embedding_contributor_scheduler_name -->
+```csharp
+public static IServiceCollection AddAcmeOutboxToOneScheduler(this IServiceCollection services, string schedulerName)
+{
+    services.ConfigureAllQuartzSchedulers(q =>
+    {
+        // "" is the default scheduler; anything else is the name it was registered under.
+        if (!string.Equals(q.SchedulerName, schedulerName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        q.AddJob<DrainOutboxJob>(j => j.WithIdentity(DrainOutboxJob.Key).StoreDurably());
+    });
+
+    return services;
+}
+```
+<!-- endSnippet -->
+
+Remote schedulers registered with `AddQuartzHttpClient` are not built by a builder and are skipped. Calling
+it when no scheduler is registered at all is not an error, so a library may call it unconditionally.
+
+## Deriving keys
+
+A library schedules on behalf of something that has its own identity — a saga, a message, a tenant, an
+import run — and needs to find that work again later. Two keys carry that, and they carry different halves
+of it:
+
+* **The job key says what runs.** One durable job per job type is enough, because a job detail is a
+  definition rather than an occurrence. That is what the typed `ScheduleJob` overloads store, at
+  `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)` — one row per job type, whatever the traffic.
+* **The trigger key says which occurrence.** Its **name** is this one firing and its **group is the
+  correlation id**: the saga, the conversation, the tenant. Everything scheduled for one of those shares a
+  group and can be listed, paused or cancelled together.
+
+<!-- snippet: sample_embedding_typed_job -->
+```csharp
+public sealed record SendReminder(string ConversationId, string MessageId, string Text);
+
+public sealed class SendReminderJob(IReminderSink sink) : IJob<SendReminder>
+{
+    public ValueTask Execute(
+        IJobExecutionContext context,
+        SendReminder input,
+        CancellationToken cancellationToken = default)
+    {
+        return sink.Send(input.ConversationId, input.Text, cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+<!-- snippet: sample_embedding_schedule_correlated -->
+```csharp
+public sealed class Conversations(IScheduler scheduler)
+{
+    public ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
+    {
+        return scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+            reminder,
+            delay,
+            new OneOffJobOptions
+            {
+                // The name is this one firing; the group is what the firing is about. Both are the
+                // library's own identifiers, so nothing has to be looked up to cancel later.
+                Name = reminder.MessageId,
+                Group = reminder.ConversationId,
+                Replace = true
+            },
+            cancellationToken);
+    }
+
+    public ValueTask<bool> Cancel(TriggerKey firing, CancellationToken cancellationToken)
+    {
+        return scheduler.UnscheduleJob(firing, cancellationToken);
+    }
+
+    public ValueTask<List<TriggerKey>> CancelConversation(string conversationId, CancellationToken cancellationToken)
+    {
+        // Everything still scheduled for that conversation, in one store operation, answering with
+        // the keys it removed.
+        return scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(conversationId), cancellationToken);
+    }
+}
+```
+<!-- endSnippet -->
+
+`Replace = true` is what makes scheduling the same name twice an update rather than an
+`ObjectAlreadyExistsException`, which is what a deterministic name is for. Derive the name from something
+the caller already has — the message id, the saga id plus a step — rather than generating one you then have
+to store somewhere to find it again. The whole point of a derived key is that there is nothing to store.
+
+Cancelling by correlation is one call, and it is atomic: listing the group and then deleting the keys is
+two, with a window in which another node can schedule into the group and survive a delete the caller
+believes emptied it.
+
+`DeleteJobs(GroupMatcher<JobKey>)` is the same operation for jobs. Both answer with the keys they actually
+removed, so a caller can act on what went rather than on what it asked for.
+
+::: warning Do not put the correlation id in the job key
+It is the trigger that is the occurrence. A job key per correlation id gives you a job row per saga, a
+delete per saga, and nothing to show for it — the durable job is a definition and there is only one
+definition.
+:::
+
+### Why this is worth using rather than reinventing
+
+A two-level key whose second level is addressable as a *set* is unusual. Most schedulers hand back one
+opaque identifier per scheduled item and leave the caller to keep an index if it ever wants to find a group
+of them again: a Hangfire job id, an Azure Service Bus scheduled-message sequence number, or MassTransit's
+one-shot scheduled-message token, which the sender must have kept in order to cancel by it later.
+NServiceBus goes further and declines the question: a requested saga timeout "cannot be changed (i.e.
+rescheduled) or revoked (i.e. deleted or cancelled)", and its documented answer is to let the timeout
+arrive and have the saga decide, from flags in its own state, whether to act on it. Temporal reaches a set
+through Search Attributes rather than through the workflow id. The nearest thing to Quartz's shape
+elsewhere is MassTransit's *recurring* scheduler, whose `ScheduleId` and `ScheduleGroup` are Quartz's
+trigger name and group surfacing through its API.
+
+That last option — schedule it anyway, decide at the firing — is always available here too, and is worth
+weighing: a cancellation you never have to issue is a cancellation that cannot race. Cancelling by group
+is what you want when the work is expensive or the set is large; a firing that checks whether it is still
+wanted is what you want when it is neither.
+
+Where a platform does let the caller choose the identifier, its documentation says to derive it from the
+business object rather than generate one — Temporal recommends a business-process identifier such as a
+customer or order id, and Hangfire's recurring jobs are keyed by a caller-chosen id that `AddOrUpdate`
+upserts on. No primary source argues for a random id where a stable business key exists.
+
+## A typed input, not a payload bag
+
+A job that reads `context.MergedJobDataMap.GetString("CustomerId")` has a payload contract nothing checks.
+`IJob<TInput>` is the checked version: the input is serialized into the trigger's data under one reserved
+key, and the job is handed it already typed, as the sample above shows.
+
+Two things follow from it being serialized, and they are the same two that apply to any message:
+
+* **Put ids in the payload, not entities.** The payload is read back minutes, hours or days later, by a
+  process that may be running different code. A customer id still means what it meant; a serialized
+  customer may not. Hangfire says the same thing about its argument serialization, and Temporal makes it a
+  named pattern — the claim check, driven there by hard payload size limits.
+* **Evolve it the way you would evolve a message.** Adding an optional member is safe; renaming or removing
+  one breaks every firing already in the store. There is no schema version in the payload unless you put
+  one there.
+
+[A typed input](../tutorial/job-data-map.md#a-typed-input-the-third-read-side) has the mechanism, and
+[What does not belong in job data](../tutorial/job-data-map.md#what-does-not-belong-in-job-data) has the
+rest of the hazards.
+
+## Scheduling over what is already there
+
+The three-call form — check whether it exists, unschedule it, schedule the new one — is the single most
+common thing an embedder writes, and it is wrong twice over: three round trips, and a window between the
+check and the write in which another node does the same thing. Both `ScheduleJob` overloads that take a
+`ScheduleJobOptions` do the whole thing inside the store's own lock:
+
+<!-- snippet: sample_embedding_upsert -->
+```csharp
+ITrigger trigger = TriggerBuilder.Create<SendReminderJob>(scheduler.TimeProvider)
+    .WithIdentity(reminder.MessageId, reminder.ConversationId)
+    .ForJob(new JobKey(nameof(SendReminderJob), SchedulerConstants.ScheduledJobGroup))
+    .StartAt(at)
+    .UsingInput(reminder)
+    .Build();
+
+await scheduler.ScheduleJob(trigger, ScheduleJobOptions.Replacing, cancellationToken);
+```
+<!-- endSnippet -->
+
+`ScheduleJobOptions.Replacing` is the well-known value for the common case; `AddJobOptions.Replacing` is its
+counterpart for `AddJob`. A replaced trigger keeps the previous fire time it had, so a job reading
+`context.PreviousFireTimeUtc` is not told the schedule has never fired merely because its trigger was
+rewritten.
+
+The typed overloads take the same option as `OneOffJobOptions.Replace`, so the one-call path already does
+this. Reach for a hand-built trigger only when you need a schedule the one-call path cannot express.
+
+## Starting at your own moment
+
+A library often cannot let its scheduler start with the host: the bus is not connected, the leader lease is
+not held, the schema is not migrated. `AutoStart = false` builds, initializes and binds the scheduler with
+the host and leaves it in `Created` for you to start:
+
+<!-- snippet: sample_embedding_deferred_start -->
+```csharp
+builder.Services.AddQuartz("acme.outbox", q => q.UseInMemoryStore());
+
+// Built, initialized and bound with the host, and then left in Created. The library starts it
+// when whatever it depends on - a bus connection, a leader lease, a migration - is ready.
+builder.Services.AddQuartzHostedService("acme.outbox", options => options.AutoStart = false);
+```
+<!-- endSnippet -->
+
+Not registering the hosted service at all would also not start it, and would lose the shutdown handling with
+it, which is why this is a setting rather than an omission. The scheduler is still in `ISchedulerRegistry`,
+still on the dashboard, still shut down with the host.
+
+A scheduler waiting like this reports **degraded**, not unhealthy. It is doing what it was configured to
+do, and failing the probe would take a correctly configured node out of rotation for the whole window
+before you press start. The check reads that scheduler's own `QuartzHostedServiceOptions`, so a `Created`
+scheduler that nobody opted out of is still unhealthy, as it should be. See
+[Health checks](../packages/hosted-services-integration.md#health-checks).
+
+This is Quartz's judgement rather than an industry convention, and it is worth knowing which way the rest
+of the ecosystem leans: Microsoft's own readiness sample reports *unhealthy* while start-up work is still
+running, and MassTransit reports unhealthy for a bus that has not connected. The reasoning for the other
+choice is the HTTP mapping — *degraded* answers 200 by default and *unhealthy* answers 503 — so a probe
+that cannot tell "deliberately waiting" from "broken" removes the node either way. The verdict itself is
+not configurable: `QuartzHealthCheckOptions.FailureStatus` sets what the *registration* reports when the
+check fails, and does not turn a deliberate *degraded* into *unhealthy*. An application that wants the
+stricter reading maps it at the probe, with `HealthCheckOptions.ResultStatusCodes`.
+
+Where the moment is decided by an election outside the process rather than by your own readiness, see
+[Running under an External Leader Election](external-leader.md).
+
+## Cross-cutting concerns are middleware
+
+Every embedder needs to surround a firing with something: a log scope, a tenant context, a unit of work, a
+consume context, a translation of what the library throws into a `JobExecutionException`. On 3.x the only
+place to put it was a job that constructed and called the real job — the adapter ABP, Elsa and Brighter
+each ship — because `IJobListener` is notification-only: it is told a job is about to run and told what it
+did, with the execution happening between the two notifications rather than inside them.
+
+An adapter job costs more than it looks, and every cost is structural rather than stylistic:
+
+* **The store records the wrapper.** `JOB_CLASS_NAME` holds the type Quartz was given, so a listing, the
+  dashboard and every diagnostic say the adapter's name rather than the job's. A generic adapter writes the
+  inner type in as a type argument, which is how ABP's `QuartzPeriodicBackgroundWorkerAdapter<T>` overflowed
+  the column's 250 characters and broke start-up
+  ([abp#4609](https://github.com/abpframework/abp/issues/4609)).
+* **`[DisallowConcurrentExecution]` and `[PersistJobDataAfterExecution]` are read from the wrapper.**
+  Quartz asks the type it was handed, its base types and its interfaces — not the object the wrapper holds.
+  An inner job that declares either attribute silently loses it.
+* **It takes over construction**, so the application's job factory and DI scope stop applying to the real
+  job, and interruption stops working unless the wrapper forwards the cancellation token by hand.
+* **It does not compose.** Two libraries each shipping an adapter cannot both wrap one firing.
+
+4.0 has the seam:
+
+<!-- snippet: sample_embedding_middleware -->
+```csharp
+public sealed class OutboxScopeMiddleware(IOutboxContext outbox) : IJobExecutionMiddleware
+{
+    public async ValueTask Invoke(
+        IJobExecutionContext context,
+        JobExecutionDelegate next,
+        CancellationToken cancellationToken = default)
+    {
+        // Ambient state the library's own services read, established around the job rather than
+        // inside a wrapper job that has to know how to construct the real one.
+        using (outbox.Begin(context.FireInstanceId))
+        {
+            await next(context, cancellationToken);
+        }
+    }
+}
+```
+<!-- endSnippet -->
+
+<!-- snippet: sample_embedding_middleware_registration -->
+```csharp
+services.ConfigureAllQuartzSchedulers(q => q.AddJobMiddleware<OutboxScopeMiddleware>());
+```
+<!-- endSnippet -->
+
+Middleware is keyed per scheduler, runs in registration order outermost first, and is composed once when the
+scheduler is built — so one instance serves every firing, and per-firing state belongs in an `AsyncLocal<T>`
+or in the job's scope rather than in a field. Not calling `next` short-circuits the firing. It runs inside
+the execution span and the duration measurement, and outside the run shell's exception handling, so a
+`JobExecutionException` a middleware throws is honoured exactly as one the job raised.
+
+[Job Execution Middleware](../tutorial/job-execution-middleware.md) has the whole of it, including which
+concerns belong in a listener instead.
+
+## Retry
+
+There is no retry policy attached to a trigger on 4.0. `Quartz.RetryPolicy` exists as a value — `Fixed`,
+`Exponential`, `Explicit`, with the storage columns reserved — but nothing on a trigger carries one and
+nothing acts on one yet. It is [#3520](https://github.com/quartznet/quartznet/issues/3520).
+
+Until then, be clear about what the one existing mechanism is:
+
+```csharp
+throw new JobExecutionException(ex) { RefireImmediately = true };
+```
+
+**`RefireImmediately` is not a retry.** It re-executes the job on the same thread, with no delay, no
+ceiling and no backoff, until it stops throwing — which against a database that is down is a tight loop
+that holds a worker thread and hammers the dependency. It is the right answer to "this failed for a reason
+that has already gone away", and the wrong answer to everything else.
+
+A library that needs real retry today has two honest options: put a resilience pipeline
+([Polly](https://www.pollydocs.org/) or `Microsoft.Extensions.Http.Resilience`) inside the job, where the
+retries are yours and bounded; or make the retry a schedule, by having the failing job schedule its own
+next attempt with a computed delay and an attempt count in the payload. The first is right for a fault that
+will clear in seconds, the second for one that will not — and only the second survives a process restart.
+
+## Trace context across the scheduled gap
+
+A scheduled job runs long after the call that asked for it, so the trace that wanted the work and the trace
+that did it are not the same trace, and cannot be. Quartz records the W3C trace context of whatever
+activity was current when the trigger was stored — under `SchedulerConstants.TraceParent` and
+`SchedulerConstants.TraceState` — and the firing's `Quartz.Job.Execute` span carries an `ActivityLink` back
+to it.
+
+Nothing needs configuring for this, and a library gets it for free: schedule from inside a request or a
+message handler and the link is written. It is a link rather than a parent deliberately, which is the shape
+OpenTelemetry gives a producer and a consumer separated by a store-and-forward gap — the firing stays its
+own trace root, and the link is how a backend walks back.
+
+The cost is two string entries on each trigger's data map, visible wherever trigger data is. A library
+whose own rows are read by something that does not expect them can turn it off:
+
+<!-- snippet: sample_embedding_trace_context_off -->
+```csharp
+services.ConfigureAllQuartzSchedulers(q =>
+    q.ConfigureScheduler(options => options.PropagateTraceContext = false));
+```
+<!-- endSnippet -->
+
+Do not invent a second key for the same job. If you were carrying your own correlation headers in job data
+across the gap, these two keys are the standard spelling of the trace half of that; see
+[Linking a firing to what scheduled it](../packages/opentelemetry-integration.md#linking-a-firing-to-what-scheduled-it).
+
+## Running inside somebody else's transaction
+
+A library that writes its own rows and then schedules a job to act on them has two transactions where it
+wants one: the rows can commit while the scheduling fails, or the reverse. The persistent store can use a
+connection the application already owns, so the two commit together:
+
+<!-- snippet: sample_embedding_accept_enlisted -->
+```csharp
+services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseSqlServer(connectionString);
+    store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
+}));
+```
+<!-- endSnippet -->
+
+<!-- snippet: sample_embedding_enlist -->
+```csharp
+public sealed class Outbox(IScheduler scheduler)
+{
+    /// <summary>
+    /// Schedules inside a transaction the caller owns, so the scheduling and whatever else that
+    /// transaction did commit together or not at all.
+    /// </summary>
+    public async ValueTask Enqueue(
+        DbTransaction transaction,
+        SendReminder reminder,
+        DateTimeOffset at,
+        CancellationToken cancellationToken)
+    {
+        // The enlistment flows with the asynchronous context, so it has to be established in the
+        // same scope as the calls it covers - which is why this takes the transaction rather than
+        // establishing one and handing it back.
+        using (scheduler.EnlistTransaction(transaction))
+        {
+            await scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+                reminder,
+                at,
+                new OneOffJobOptions { Name = reminder.MessageId, Group = reminder.ConversationId, Replace = true },
+                cancellationToken);
+        }
+    }
+}
+```
+<!-- endSnippet -->
+
+Take the transaction as a parameter, as the sample does, rather than opening one inside the library. The
+enlistment flows with the asynchronous context, so it has to be established in the same scope as the calls
+it covers — establishing it inside an `async` helper does not carry it back out to the caller, which is the
+same rule that makes `TransactionScope` need `TransactionScopeAsyncFlowOption.Enabled`.
+
+Four caveats, and they matter more for a library than for an application, because a library does not
+control any of the surrounding conditions:
+
+* **It has to be the same database.** The enlisted connection's provider must match the one the store was
+  configured with, and Quartz refuses the enlistment rather than failing deep inside the first statement.
+  If your rows and the scheduler's tables live in different databases, this is not available and a
+  transactional outbox in your own tables is the answer.
+* **The application must have opted in.** `AcceptEnlistedTransactions` is off by default, and enlisting
+  against a store that has not enabled it throws. A library cannot enable it on the application's behalf
+  without also changing how the store locks, so document it as a prerequisite and fail with a message that
+  says so.
+* **The store holds its locks in your transaction.** They are released when you commit, so a long
+  transaction blocks trigger acquisition, the misfire handler and cluster check-in for every node.
+* **It only works on a persistent ADO.NET store.** Against `RAMJobStore` the call throws rather than
+  silently ignoring the enlistment.
+
+[Joining an existing transaction](../tutorial/job-stores.md#joining-an-existing-transaction) has the
+`TransactionScope` variant and the full list.
+
+## Shipping a package that multi-targets
+
+Quartz 4 targets `net10.0` and nothing else. An application can be told to upgrade; an integration package
+serving `net8.0` and `net9.0` consumers cannot. The mechanical part is a conditional `PackageReference`:
+
+<!-- Not a compiled sample: it is csproj rather than C#, and the point of it is the condition, which no
+     sample project in this repository can carry twice. -->
+
+```xml
+<PropertyGroup>
+  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+</PropertyGroup>
+
+<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+  <PackageReference Include="Quartz" Version="4.0.0" />
+</ItemGroup>
+
+<ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
+  <PackageReference Include="Quartz" Version="3.20.0" />
+  <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.20.0" />
+  <PackageReference Include="Quartz.Extensions.Hosting" Version="3.20.0" />
+</ItemGroup>
+```
+
+**Read the limit before you write the `#if`s.** This works when the difference is *inside* your library. It
+stops working the moment your own public surface would differ per target framework — and it will, if you
+expose an `IJobFactory` of your own, a clock, a scheduler you construct, or anything returning `Task` that
+Quartz now wants as `ValueTask`. A type that exists on one target and not another is not a shim, it is two
+libraries in one package, and consumers discover which one they got at compile time. When you reach that
+point the answers are a separate `net10.0`-only package, or dropping the old targets — not a deeper `#if`.
+
+### What actually differs
+
+These are the renames a real port hit, verified against the public API baselines both branches keep. The
+[migration guide's appendix](../migration-guide.md#appendix-what-happened-to-a-name) is the exhaustive
+version, indexed by the name you would have typed; this is the subset an integration package meets.
+
+| 3.x | 4.x |
+|---|---|
+| `Task` / `Task<T>` on every asynchronous member | `ValueTask` / `ValueTask<T>`. The only public members still returning `Task` are `QuartzHostedService`'s, because `IHostedService` says so |
+| `ValueTask Execute(IJobExecutionContext context)` | `ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)` — the token is a parameter as well as a context member |
+| `IScheduler.CheckExists(JobKey \| TriggerKey)` | `IScheduler.Exists(JobKey \| TriggerKey)` |
+| `MisfireInstruction.SimpleTrigger.FireNow` and the other nested `const int`s | five enums — `SimpleTriggerMisfireInstruction`, `CronTriggerMisfireInstruction`, `CalendarIntervalTriggerMisfireInstruction`, `DailyTimeIntervalTriggerMisfireInstruction`, `RecurrenceTriggerMisfireInstruction`. Values are unchanged; several names are not: `IgnoreMisfirePolicy` is `IgnoreMisfires`, and cron's, calendar's and daily's `FireOnceNow` is `FireAndProceed` |
+| `ITrigger.MisfireInstruction` (`int`) | `ITrigger.MisfireInstructionCode` (`int`), plus a typed `MisfireInstruction` on each family interface |
+| `trigger.GetNextFireTimeUtc()`, `GetPreviousFireTimeUtc()`, `GetMayFireAgain()` | the properties `NextFireTimeUtc`, `PreviousFireTimeUtc`, `MayFireAgain`. `FinalFireTimeUtc` was already a property and `GetFireTimeAfter(…)` is still a method |
+| `new JobExecutionException(ex, refireImmediately: true)` | `new JobExecutionException(ex) { RefireImmediately = true }` — the flags are `init`, the `bool` constructor overloads are gone, and the type is sealed |
+| `Quartz.Util.TimeZoneUtil.FindTimeZoneById(id)` | `Quartz.TimeZones.FindById(id)` |
+| `TimeZoneUtil.CustomResolver = resolver` | `TimeZones.AddResolver(resolver)`, which returns an `IDisposable` that removes that one resolver |
+| your own `TryGetValue<T>` extension on `JobDataMap` | **unchanged — keep it.** `JobDataMap` still implements `IDictionary<string, object?>`, so the extension still binds. Do *not* substitute 4.x's `TryGet<T>`: that is a pure `is T` type test with no conversion, so it returns `false` for a value stored as a string. `TryGetInt` and its siblings are the converting readers |
+| `Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting` (packages) | merged into `Quartz`. The namespace was `Quartz` on both sides, so only the `PackageReference` changes |
+| `IServiceCollectionQuartzConfigurator` | `IQuartzBuilder` |
+| `scheduler.JobFactory = factory` (setter-only, on `IScheduler`) | `q.UseJobFactory(factory)` / `UseJobFactory<T>()` on the builder, or `ConfigureJobScope(…)` when all you wanted was to seed the DI scope |
+| `IJobFactory.NewJob(bundle, scheduler)` returning `IJob`; `ReturnJob(IJob)` | `CreateJob(bundle, scheduler, ct)` returning `ValueTask<JobScope>`; `ReturnJob(JobScope, ct)` |
+| `SystemTime.UtcNow = () => …` (a public mutable field) | `q.UseTimeProvider(provider)`, read back as `IScheduler.TimeProvider`. Per scheduler, not process-wide |
+| `StdSchedulerFactory` / `SchedulerBuilder` | `QuartzSchedulerBuilder.Create()`, whose `Build()` gives a `StandaloneSchedulerFactory` |
+| `TriggerBuilder.ModifiedByCalendar(name)` | `WithCalendarName(name)` |
+| `SchedulerMetaData` / `GetMetaData()` | `SchedulerMetadata` / `GetMetadata()` — note the lower-case `d` in both |
+| `GetCurrentlyExecutingJobs()` | `QueryFireInstances(new FireInstanceQuery())`, returning `PagedResult<FireInstance>` |
+| `IsStarted`, `InStandbyMode`, `IsShutdown` | one `SchedulerStatus Status` |
+| `Interrupt(fireInstanceId)` | `InterruptFireInstance(fireInstanceId)` |
+| `Quartz.Spi`, `Quartz.Simpl`, `Quartz.Impl.Matchers`, `Quartz.Util`, `Quartz.Listener` | `Quartz.Extensibility`, `Quartz.Impl`, `Quartz` (matchers and `Key<T>` are top-level now), dissolved, `Quartz.Listeners` |
+| `Quartz.Logging` — `ILogProvider`, `LogContext`, `LogLevel` | gone with LibLog, and there is **no** replacement for the abstraction. `LogProvider` moved to `Quartz.Diagnostics` and takes an `ILoggerFactory` |
+
+Two of those are traps rather than renames, and both bite a library harder than an application:
+
+* **A listener that still has 3.x signatures compiles.** Every listener member on 4.0 has a default
+  implementation, so a `Task`-returning `JobToBeExecuted` is not an error — it is simply a method that
+  overrides nothing, and your listener silently does nothing. Quartz rejects such a listener at
+  registration and names the member, so the failure is loud, but the compiler will not point at it.
+* **The `Quartz` namespace gained about ninety types**, several with names a host library plausibly
+  declares itself. `QuartzSchedulerOptions` is the known case — it shadowed MassTransit's own type of that
+  name under `using Quartz;`, producing compile errors that named the right members on the wrong type.
+  `RetryPolicy`, `TimeRange`, `PagedResult<T>`, `Key<T>`, `Matchers`, `ThreadPoolOptions`,
+  `DataSourceOptions`, `JobType`, `SchedulerStatus`, `TimeZones` and `JsonSerializationException` (which
+  Newtonsoft.Json also declares) are the others worth checking for. The fix is a using-alias in the
+  affected file, which wins over the namespace import:
+  `using QuartzSchedulerOptions = Acme.Bus.QuartzSchedulerOptions;`. The full list is in the migration
+  guide's [types 4.0 added to the `Quartz` namespace](../migration-guide.md#types-4-0-added-to-the-quartz-namespace).
+
+## See also
+
+* [Multiple Schedulers](../packages/multiple-schedulers.md) — named schedulers in full
+* [Execution Groups](../tutorial/execution-groups.md) — limiting what a share of a scheduler costs
+* [Job Execution Middleware](../tutorial/job-execution-middleware.md) — the seam, and middleware against
+  listeners
+* [Quartz.NET with Wolverine](wolverine.md) — this page's advice as one worked integration: correlation
+  keys, the latency triple, a bus-owned start and a shared outbox transaction, all against a real library
+* [One-Off Job](one-off-job.md) — the typed one-call scheduling this page derives keys for
+* [Running under an External Leader Election](external-leader.md) — when the moment to start is somebody
+  else's decision
+* [Migration Guide](../migration-guide.md) — the exhaustive 3.x to 4.x delta
+
+## Sources
+
+Prior art surveyed in August 2026. Quartz.NET's own behaviour is stated from the source in this
+repository rather than from any of these.
+
+* OpenIddict,
+  [`OpenIddictQuartzConfiguration`](https://github.com/openiddict/openiddict-core/blob/dev/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs)
+  — the `IConfigureOptions<QuartzOptions>` contributor this page's recipe replaces
+* ABP, [abp#4609](https://github.com/abpframework/abp/issues/4609) — a generic adapter job overflowing
+  `JOB_CLASS_NAME`
+* OpenTelemetry,
+  [Semantic conventions for messaging spans](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/)
+  — span links as the default correlation between a producer and a later consumer
+* MassTransit, [Scheduling](https://masstransit.io/documentation/configuration/scheduling) — scheduled-message
+  tokens, and the recurring scheduler whose `ScheduleId`/`ScheduleGroup` are Quartz's own key
+* Particular Software, [Saga timeouts](https://docs.particular.net/nservicebus/sagas/timeouts) — a
+  requested timeout that cannot be revoked, and deciding at the firing instead
+* Hangfire, [Best Practices](https://docs.hangfire.io/en/latest/best-practices.html) and
+  [Passing arguments](https://docs.hangfire.io/en/latest/background-methods/passing-arguments.html) —
+  pass identifiers rather than objects, and keep the payload small
+* Temporal, [Workflow ID](https://docs.temporal.io/workflow-execution/workflowid-runid) and
+  [Data conversion](https://docs.temporal.io/dataconversion) — a business identifier as the workflow id,
+  and payload limits as the reason to pass a reference rather than the thing
+* Microsoft, [Health checks in ASP.NET Core](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks)
+  — `HealthStatus`, readiness probes, and `ResultStatusCodes`
+* NuGet, [Target frameworks](https://learn.microsoft.com/nuget/create-packages/multiple-target-frameworks-project-file)
+  — conditional `PackageReference` per target framework

--- a/docs/documentation/quartz-4.x/how-tos/external-leader.md
+++ b/docs/documentation/quartz-4.x/how-tos/external-leader.md
@@ -1,0 +1,371 @@
+---
+
+title: 'Running under an External Leader Election'
+---
+
+# Running under an External Leader Election
+
+Some applications already know which of their processes is in charge. A Kubernetes `Lease`, Wolverine's
+leader-pinned agents, a Consul or etcd session, a database advisory lock, a message bus that only starts
+one consumer — the election exists, it gates other singletons, and the operations team already watches it.
+Running Quartz's own clustering underneath it means two elections deciding overlapping questions.
+
+This page describes the alternative: **a persistent job store with clustering off, exactly one process
+scheduling at a time, started and stopped by somebody else's election**. It is a real topology with real
+edges, and the edges are the reason it needs writing down.
+
+::: warning This is not the default answer
+[Clustering](../tutorial/advanced-enterprise-features.md) is how Quartz runs on more than one node, and it
+is what to use unless you can name why you are not. It gives failover recovery of a dead node's firings,
+which nothing on this page does, and it lets every node do work rather than leaving all but one idle.
+Choose an external election when the election already exists and must gate several components together,
+or when it is the only thing your platform can offer.
+:::
+
+## Not clustering, and staying that way
+
+Clustering is spelled by calling `UseClustering()`. **Not clustering is spelled by not calling it** —
+not by calling it and turning it off:
+
+```csharp
+// Refused at startup
+q.UsePersistentStore(store => store.UseClustering(c => c.Enabled = false));
+```
+
+`UseClustering` does two things: it sets `ClusteringOptions.Enabled`, and it sets
+`AdoJobStoreOptions.UseDbLocks`, because clustering has never worked without database locking. Turning
+`Enabled` back off inside the callback — or in a later `Configure<ClusteringOptions>` — leaves the store
+with database locking on, no cluster manager and no check-in row: a configuration nobody means to write.
+`ClusteringStaysEnabledValidator` refuses it, and because `ClusteringOptions` is registered with
+`ValidateOnStart`, it fails as the host starts rather than at the first firing.
+
+It is scoped to the scheduler that asked, so a sibling scheduler in the same container legitimately runs
+un-clustered.
+
+What a non-clustered persistent store does not do, and this page assumes you know:
+
+* it writes no `QRTZ_SCHEDULER_STATE` row and runs no check-in, so `QueryClusterNodes()` returns nothing;
+* it never runs the failover sweep, so no peer takes over a dead node's firings;
+* it takes its `TRIGGER_ACCESS` lock **in process**, through `InProcessLockHandler`, which excludes the
+  threads of one scheduler and nothing else.
+
+That last one is what makes the election load-bearing rather than an optimisation. See
+[Two leaders at once](#two-leaders-at-once).
+
+## Building it
+
+<!-- snippet: sample_external_leader_registration -->
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.UsePersistentStore(store => store.UseSqlServer(connectionString));
+
+    // No UseClustering(). Exactly one process is meant to be scheduling, and the election
+    // outside Quartz is what says which one.
+});
+
+builder.Services.AddQuartzHostedService(options =>
+{
+    // Built, initialized and bound with the host - and then left alone. The leader starts it.
+    options.AutoStart = false;
+
+    // A leader that is stepping down because the host is stopping should finish what it began.
+    options.WaitForJobsToComplete = true;
+});
+
+builder.Services.AddHealthChecks().AddQuartz();
+```
+<!-- endSnippet -->
+
+`AutoStart = false` has the hosted service build, initialize and bind the scheduler with the host and then
+leave it in `Created` for the application to start. It is not the same as omitting the hosted service:
+shutdown still runs, so the scheduler is stopped cleanly whether or not it was ever started. The
+[hosted service page](../packages/hosted-services-integration.md#a-scheduler-the-application-starts-itself)
+has the rest of that setting.
+
+## Starting and standing down
+
+<!-- snippet: sample_external_leader_callbacks -->
+```csharp
+/// <summary>
+/// The two callbacks every leader election has, whatever it calls them.
+/// </summary>
+public sealed class SchedulerLeadership(IScheduler scheduler)
+{
+    public ValueTask OnStartedLeading(CancellationToken cancellationToken)
+    {
+        // The first acquisition starts the scheduler and every later one resumes it from standby.
+        // Start does both, and does nothing when the scheduler is already running.
+        return scheduler.Start(cancellationToken);
+    }
+
+    public ValueTask OnStoppedLeading(CancellationToken cancellationToken)
+    {
+        // Standby, not Shutdown: a shut-down scheduler cannot be started again, and this process
+        // may well be elected once more in a minute. Losing the lease while the host is already
+        // stopping is ordinary, and Standby throws once the scheduler has shut down.
+        return scheduler.Status == SchedulerStatus.Running
+            ? scheduler.Standby(cancellationToken)
+            : default;
+    }
+}
+```
+<!-- endSnippet -->
+
+Wire those two to whatever your election calls them: `OnStartedLeading`/`OnStoppedLeading` on the
+Kubernetes client's `LeaderElector`, the start and stop of a Wolverine agent, `PostCreate`/`PreStop` on a
+MassTransit bus observer, the acquire and release callbacks of a distributed lock.
+
+Three things decide the shape:
+
+* **`Start` is idempotent and resumes from standby.** The first call starts the scheduler; every later
+  one resumes it. Only the first runs the store's start-up recovery and starts the plugins, so a
+  re-election is cheap.
+* **`Standby` is not `Shutdown`.** Shutdown is terminal — a shut-down scheduler cannot be started again,
+  and `Start` after it throws *"The Scheduler cannot be restarted after Shutdown() has been called."*
+  Standby is reversible, which is what a leadership that can come back needs.
+* **`Standby` after shutdown throws**, with `SchedulerException("The Scheduler has been Shutdown.")`.
+  Losing a lease while the host is already stopping is ordinary, so read `Status` before standing down
+  rather than catching the exception.
+
+`SchedulerStatus` replaces 3.x's `IsStarted` / `InStandbyMode` / `IsShutdown` triple: `Created`,
+`Running`, `Standby`, `ShuttingDown`, `Shutdown`. A scheduler that has never been started stands down to
+`Created`, not `Standby`, because "never started" is the more precise answer.
+
+### What standby does, and what it does not
+
+Standby pauses the scheduling loop and tells the job store the scheduler is paused. It does **not**:
+
+* **stop a firing that is already in flight.** Running jobs are untouched, by design — a job that must end
+  on request watches `IJobExecutionContext.CancellationToken`.
+* **release triggers this node has already acquired.** The loop asks for triggers due within the next
+  `IdleWaitTime` and then waits out the first one's fire time; standing down in the middle of that wait
+  does not abandon it. So a node that has just stood down can still fire up to `MaxBatchSize` triggers,
+  as late as `IdleWaitTime` after it stopped leading. Only shutdown releases an acquired batch.
+* **stop the misfire handler.** It is started on the scheduler's first start and stopped only by shutdown,
+  and it reads no pause flag. A stood-down leader keeps scanning for misfires on
+  `MisfireHandlerFrequency` — defaulting to `MisfireThreshold`, one minute for the ADO store — and keeps
+  writing trigger state while it does.
+
+The last of those is the one that surprises people: **standby means "not acquiring", not "not touching the
+database"**. A process that has never been elected at all is genuinely inert, because the misfire handler
+does not exist until the first `Start()`. A process that led once and stood down is not.
+
+The health check follows the same distinction. It reports *degraded* — not *unhealthy* — both while a
+scheduler sits in `Created` with `AutoStart = false` and while it is in `Standby`, because in both cases it
+is doing exactly what it was configured to do. A non-leader replica therefore stays in rotation for
+traffic it can still serve; see [Health checks](../packages/hosted-services-integration.md#health-checks).
+
+## What the loop costs while it waits
+
+Three settings decide how quickly a due trigger is noticed and how much database traffic the waiting
+costs. Their defaults are tuned for a cluster of ordinary size, and an integration that also polls
+something else will want to move them:
+
+| Setting | Default | What it decides |
+|---|---|---|
+| `QuartzSchedulerOptions.IdleWaitTime` | 30 seconds | How long the loop waits before asking the store again when it found nothing. Must be at least one second. |
+| `QuartzSchedulerOptions.MaxBatchSize` | 1 | The upper bound on triggers acquired per round. Must not exceed `ThreadPoolOptions.MaxConcurrency`. |
+| `QuartzSchedulerOptions.BatchTriggerAcquisitionFireAheadTimeWindow` | `TimeSpan.Zero` | How far past the current time a trigger may fire in order to join the batch that is already forming. |
+
+**`IdleWaitTime` is not the firing latency for anything scheduled in this process.** Every scheduling call
+made through this scheduler signals the loop, which cuts the wait short immediately: schedule a trigger for
+five seconds' time and it fires in five seconds, whatever `IdleWaitTime` says. What the wait bounds is the
+pickup of a trigger written by **another process** — an API node inserting into the same tables, a
+migration, a hand-written row. There is no cross-process wakeup: nothing signals this loop from outside it.
+
+Two details worth knowing before choosing a number. The idle wait is randomized into
+`[0.8 × IdleWaitTime, IdleWaitTime)`, so several nodes coming up together do not synchronize their polls.
+And a round acquires triggers due within the next `IdleWaitTime`, so a longer wait is not simply a longer
+blind spot — it is a wider look-ahead as well, and a trigger that came due during the sleep is picked up
+late rather than lost.
+
+`MaxBatchSize` and the fire-ahead window are one setting in two halves. Raising the batch size alone leaves
+the effective batch at one trigger for any schedule whose fire times are spread out, because a batch stops
+at the first trigger not due within the window of the one that opened it. Raising the window alone gives a
+batch nothing to grow into. Move them together, or neither:
+
+<!-- snippet: sample_external_leader_tuning -->
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.ConfigureScheduler(options =>
+    {
+        // How long a trigger written by another process may sit before this one looks again.
+        options.IdleWaitTime = TimeSpan.FromSeconds(5);
+
+        // Both halves or neither: a batch stops at the first trigger that is not due within
+        // the window of the one that opened it.
+        options.MaxBatchSize = 10;
+        options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromSeconds(2);
+    });
+
+    // MaxBatchSize may not exceed this: triggers acquired beyond the number of threads there
+    // are to run them on are held by this node, unfireable by any other, until the pool drains.
+    q.UseDefaultThreadPool(maxConcurrency: 10);
+});
+```
+<!-- endSnippet -->
+
+Each half has a cost. A batch size above one makes every acquisition round take the `TRIGGER_ACCESS` lock,
+including the rounds that acquire nothing — which is why the default is the one value that needs no lock at
+all. A wide fire-ahead window fires triggers early by up to that much, and widens the window in which a
+batch this node has acquired but not yet fired is unavailable to anyone else. In this topology that second
+cost is larger than it looks: nothing recovers an acquired batch from a process that died holding it until
+that scheduler starts again, because there is no peer running the failover sweep.
+
+## When the leader moves
+
+A new leader starting a non-clustered ADO.NET store runs the start-up recovery pass under the trigger-access
+lock, and it is worth knowing exactly what that pass does, because it is all that happens:
+
+1. **Every trigger of this scheduler in `ACQUIRED` or `BLOCKED` goes back to `WAITING`**, and every
+   `PAUSED_BLOCKED` back to `PAUSED`. This is scoped by scheduler name, not by instance, so it frees what
+   the previous leader left behind whoever that was. This is what un-sticks the schedule.
+2. **Every misfire is resolved, with no batch limit.** The `MaxMisfiresToHandleAtATime` cap — 20 by
+   default — bounds the background handler, not this pass, so a store that was leaderless for hours does
+   not have to catch up twenty triggers at a time.
+3. **Jobs marked for recovery are re-scheduled**, from the fired-trigger rows carrying
+   `REQUESTS_RECOVERY`. Each becomes a `recover_<instanceId>_<n>` trigger in the
+   `SchedulerConstants.DefaultRecoveryGroup` group, starting at the firing's scheduled time with
+   `IgnoreMisfires`, carrying the original trigger's job data plus the four `QRTZ_FAILED_JOB_ORIG_*`
+   entries. The job sees `IJobExecutionContext.Recovering`.
+4. **Lingering `COMPLETE` triggers are deleted, and then every fired-trigger row of this scheduler is
+   deleted** — all of them, with no instance filter.
+
+Step 3 is the one with a condition on it, and step 4 is the one that makes the condition unforgiving.
+
+### The instance id decides whether recovery survives a leader move
+
+Step 3 selects fired-trigger rows whose `INSTANCE_NAME` is *this store's own instance id*. Step 4 then deletes
+every row regardless of instance. So a new leader that presents a **different** instance id from the one
+that died finds nothing to recover, and then deletes the evidence: jobs with `RequestsRecovery` are
+silently not re-run. Scheduling still resumes correctly, because steps 1 and 2 are scoped by scheduler
+name — only the recovery is lost.
+
+For a non-clustered store you cannot get this wrong by accident, and you can get it wrong on purpose:
+
+* `InstanceId` defaults to `"NON_CLUSTERED"`, which is the same string in every process. Recovery works
+  across a leader move, because both leaders present it.
+* Asking for a generated id — `GenerateInstanceId`, or the flat `quartz.scheduler.instanceId = AUTO`, or
+  any `UseInstanceIdGenerator(...)` — is **ignored** for a non-clustered store, which returns
+  `"NON_CLUSTERED"` regardless. A generated id buys nothing for a store that shares its database with
+  nobody.
+* Setting a **literal** `InstanceId` — the pod name, a host name, anything per-process — is honoured, and
+  it is what breaks recovery across a leader move. In this topology, do not.
+
+That is the opposite of the advice for a cluster, where every node must have an id of its own; see
+[Naming a node in a container](../operations.md#naming-a-node-in-a-container). Here the id is not
+identifying a node, it is identifying *the leader*, and there is only ever meant to be one.
+
+The jobs that want any of this have to ask:
+
+<!-- snippet: sample_external_leader_request_recovery -->
+```csharp
+builder.Services.AddQuartz(q =>
+{
+    q.AddJob<ReportingJob>(j => j
+        .WithIdentity("nightly-close", "reporting")
+        .RequestRecovery()
+        .StoreDurably());
+});
+```
+<!-- endSnippet -->
+
+::: tip Recovery is a re-run, not a resume
+A recovered firing starts the job again from the beginning. Whether that is safe is the job's problem, not
+the scheduler's — which is the same requirement idempotency imposes below, arrived at from the other side.
+:::
+
+## Two leaders at once
+
+Leader election gives mutual exclusion when it is working, and every election has a window in which it is
+not: a lease that expired while its holder was paused by a long garbage collection or a frozen container, a
+clock that drifted, a partition that healed. This is the fencing problem, it is not specific to Quartz, and
+the systems that implement election say so themselves. Kubernetes' `client-go` leader election states in
+its own package documentation that "this implementation does not guarantee that only one client is acting
+as a leader (a.k.a. fencing)". Apache Curator's tech note walks the case in detail — a three-second session
+timeout against a ten-second GC pause — and concludes, in its capitals, that "**BOTH CLIENT A AND CLIENT B
+WILL BELIEVE THEY ARE THE LOCK HOLDER**".
+
+The published remedy is a fencing token: the resource itself rejects work carrying a stale one. Some
+backends can supply one — etcd's revision number, Consul's `LockIndex` sequencer — and it does not help
+here, because **a token only fences if the resource validates it**. etcd's own documentation makes the
+point for us: the resources to be protected "must provide the version number validation mechanism", and
+its lock "cannot be used for protecting external resources". The `QRTZ_*` schema has no epoch column and no
+statement that compares one, so there is nothing for a token to be checked against. And a non-clustered
+store takes its `TRIGGER_ACCESS` lock in process, so two schedulers against one set of tables exclude each
+other not at all.
+
+What that costs, precisely, if a second process starts while the first still believes it leads:
+
+* The newcomer's start-up recovery resets the incumbent's `ACQUIRED` triggers to `WAITING`, so both nodes
+  can acquire and fire them.
+* Both nodes carry the same `"NON_CLUSTERED"` instance id, so the newcomer's step 3 reads the incumbent's
+  *in-flight* firings as its own to recover, and schedules recovery triggers for jobs that are still
+  running.
+* Its step 4 deletes the incumbent's fired-trigger rows, so the incumbent's own completions have nothing
+  left to clean up, and its firings are no longer visible to `QueryFireInstances`.
+* `[DisallowConcurrentExecution]` is honoured within a scheduler and not between two of them.
+
+None of it corrupts a job or a trigger definition; all of it double-fires and mis-reports. So:
+
+* **Write the jobs to tolerate running twice.** This is the mitigation. It is not a fallback for a
+  badly-configured election, it is the requirement the topology carries.
+* **Give the departing leader time to finish.** Standby leaves in-flight jobs running and does not release
+  an acquired batch, so the drain window matters: `WaitForJobsToComplete`, `HostOptions.ShutdownTimeout`,
+  and a `terminationGracePeriodSeconds` longer than the longest job. See
+  [Shutdown has a budget](../packages/hosted-services-integration.md#shutdown-has-a-budget). Consul is the
+  one election here that builds the same idea into itself: its `LockDelay`, fifteen seconds by default,
+  refuses re-acquisition for that long "to allow the potentially still live leader to detect the
+  invalidation and stop processing" — and its documentation is candid that this is "not a bulletproof
+  method".
+* **Prefer an election that lives in the same database as the tables.** A lock taken with
+  `pg_advisory_lock` or `sp_getapplock` on the connection that also writes `QRTZ_*` is one thing failing
+  or holding, rather than two systems that can disagree. Note the asymmetry if you reach for advisory
+  locks specifically: PostgreSQL documents that they "relate only to the server on which they are
+  acquired", and a hot standby grants them too — so after a failover an old and a new primary can both
+  hold the same lock with nothing raising an error.
+* **If you find yourself adding safeguards, you are rebuilding clustering.** Turning on `UseDbLocks`
+  without a cluster manager serializes the two processes' store operations, which stops them mis-reading
+  each other's state — but it does not stop either of them scheduling, so both still fire. One connection,
+  one database, one lock the store itself takes, is what `UseClustering()` already is; at that point it is
+  the smaller change and the supported one.
+
+## See also
+
+* [Advanced Enterprise Features](../tutorial/advanced-enterprise-features.md) — clustering, which this page
+  is the alternative to
+* [Operating a Cluster](../operations.md) — check-in, failover and what the tables are telling you, for
+  when you change your mind
+* [Hosted Services Integration](../packages/hosted-services-integration.md) — `AutoStart`, the health
+  check and the shutdown budget
+* [Embedding Quartz in a Library](embedding-quartz-in-a-library.md) — the other half of this, for a package
+  that must fit into an application it does not own
+* [Quartz.NET with Wolverine](wolverine.md#letting-wolverine-start-the-scheduler) — one concrete election: a bus's
+  leader-pinned agent pressing start on the scheduler
+* [Configuration Reference](../configuration/reference.md#persistent-job-store) — every setting named here,
+  with its default
+
+## Sources
+
+Prior art surveyed in August 2026. Quartz.NET's own behaviour is stated from the source in this
+repository rather than from any of these.
+
+* Kubernetes, [`client-go/tools/leaderelection`](https://pkg.go.dev/k8s.io/client-go/tools/leaderelection)
+  — the fencing caveat, in the package's own words; the C# client's
+  [`LeaderElector`](https://github.com/kubernetes-client/csharp) exposes the same
+  `OnStartedLeading`/`OnStoppedLeading` shape
+* Apache Curator, [Tech Note 10](https://curator.apache.org/docs/tech-note-10) — the GC-pause scenario in
+  which two clients both hold the lock
+* etcd, [Why etcd](https://etcd.io/docs/v3.6/learning/why/) — that a lease is not mutual exclusion, and
+  that a revision number only fences a resource which validates it
+* HashiCorp, [Consul sessions](https://developer.hashicorp.com/consul/docs/automate/session) — `LockDelay`
+  and the sequencer
+* PostgreSQL, [Hot Standby](https://www.postgresql.org/docs/current/hot-standby.html) — advisory locks
+  relate only to the server that granted them
+* madelson, [DistributedLock — Other topics](https://github.com/madelson/DistributedLock/blob/master/docs/Other%20topics.md)
+  — the renewal-timeout risk, and why a lock sharing the protected database's connection is the shape that
+  holds
+* Hangfire, [Running multiple server instances](https://docs.hangfire.io/en/latest/background-processing/running-multiple-server-instances.html)
+  — the competing-consumers alternative to electing anybody

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -87,6 +87,18 @@ style `.config` files.
 If you are running on an older .NET version, you will need to upgrade your application to .NET 10
 before upgrading to Quartz 4.x.
 
+### If you are a library rather than an application
+
+An application can be told to upgrade. An integration package that serves `net8.0` and `net9.0`
+consumers cannot, and has to reference Quartz 3.x for those targets and Quartz 4 for `net10.0`. That is
+a conditional `PackageReference` plus `#if NET10_0_OR_GREATER` at the call sites that differ, and it
+works only while the difference stays *inside* the library — the moment your own public surface would
+differ per target framework, a separate `net10.0`-only package or dropping the old targets is the
+answer, not a deeper `#if`.
+
+[Embedding Quartz in a Library](how-tos/embedding-quartz-in-a-library.md#shipping-a-package-that-multi-targets)
+has the csproj fragment, the honest limit, and the table of renames a real port hit.
+
 ## Package Changes
 
 `Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`, and `Quartz.Serialization.SystemTextJson` have been merged into the main `Quartz` package. You can remove these package references from your project:
@@ -105,13 +117,20 @@ resolve is retried against `Quartz`, with a warning naming both spellings.
 
 `Quartz.OpenTracing` is **dropped** and has no 4.x release. It consumed the `DiagnosticSource` events that
 4.x replaced with `System.Diagnostics.Activity`, and the OpenTracing project itself is archived. Remove the
-package reference and the `AddQuartzOpenTracing` call, and instrument with
-[OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
-instead — see [OpenTelemetry Integration](packages/opentelemetry-integration.md#coming-from-quartz-opentracing).
+package reference and the `AddQuartzOpenTracing` call, and subscribe to Quartz's activity source and meter
+directly — see [OpenTelemetry Integration](packages/opentelemetry-integration.md#coming-from-quartz-opentracing).
 
 ```diff
 - <PackageReference Include="Quartz.OpenTracing" Version="3.*" />
-+ <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
+```
+
+**`OpenTelemetry.Instrumentation.Quartz` is not the replacement.** It reads the same `DiagnosticSource`
+events, so on 4.x it produces no spans at all — silently. Remove that reference too, and add
+`AddSource(QuartzInstrumentation.ActivitySourceName)`; see
+[OpenTelemetry.Instrumentation.Quartz](packages/opentelemetry-integration.md#opentelemetry-instrumentation-quartz).
+
+```diff
+- <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
 ```
 
 ### `Quartz.Aspire` is new
@@ -282,6 +301,110 @@ can drive a scan from. PostgreSQL gets the largest change: several of its indexe
 a single-scheduler lookup at all.
 
 Full table creation scripts for fresh installations are available in [database/tables/](https://github.com/quartznet/quartznet/tree/main/database/tables).
+
+## Defaults that changed
+
+Almost none of them did. Every option that carried a default on 3.x carries the same one on 4.x — the
+thread pool's size, the ADO store's misfire threshold and misfire batch, the retry intervals, the table
+prefix, the cluster check-in interval, the hosted service's two switches. If a value matters to you and
+you set it, nothing here applies.
+
+Three effective defaults did change, and they change for one group of users only: those who never
+configured Quartz at all. `StdSchedulerFactory.Initialize()` seeded them from an embedded `quartz.config`
+that 4.x does not read, so a scheduler built by `new StdSchedulerFactory()` or
+`GetDefaultScheduler()` — and nothing else — was running on them.
+
+| Setting | 3.x, unconfigured | 4.x |
+|---|---|---|
+| `quartz.scheduler.instanceName` | `DefaultQuartzScheduler` | `QuartzScheduler` (`QuartzSchedulerOptions.InstanceName`). **Persistent stores key every row on this**, so an upgraded application that never named its scheduler stops seeing its own jobs and triggers until it sets the old name back |
+| `quartz.jobStore.misfireThreshold` | 60 seconds | 5 seconds (`InMemoryJobStoreOptions.MisfireThreshold`). This was always the in-memory store's *code* default on both branches; the embedded file was what raised it |
+| `quartz.threadPool.threadCount` | 10 | 10 (`ThreadPoolOptions.MaxConcurrency`) — unchanged, listed so the table is the whole of it |
+
+Handing the 3.x factory properties always bypassed the file, so `new StdSchedulerFactory(properties)`
+and `AddQuartz` already fell back to the typed defaults. See
+[The `quartz.config` file is no longer read](#the-quartz-config-file-is-no-longer-read).
+
+One default is new rather than changed: `QuartzSchedulerOptions.PropagateTraceContext` is on, so a
+trigger scheduled inside an `Activity` carries two extra entries in its data map. See
+[Silent behaviour changes](#silent-behaviour-changes).
+
+## Silent behaviour changes
+
+Most of this guide is about code that stops compiling, which is the easy half: the compiler says where to
+look. This section is the other half — **calls that still compile and now do something different**. Read
+it before the first run of the upgraded application rather than after it.
+
+### Reading job data
+
+Five of these are in one place, because 3.x had two overlapping accessor sets and 4.x kept the shorter
+names with the longer set's semantics. If you called `GetIntValue`, `GetBooleanValue` and friends, nothing
+here moved for you; if you called `GetInt` and `GetBoolean`, all of it did.
+
+* **The indexer throws on a missing key.** `map["absent"]` returned `null` on 3.x. On 4.x it goes straight
+  to the backing dictionary and throws `KeyNotFoundException`, on both `JobDataMap` and `SchedulerContext`.
+  The "read an optional entry" idiom has to become `TryGetValue` or a `TryGet…` accessor.
+* **`GetString` no longer throws.** 3.x threw `KeyNotFoundException` for an absent key and
+  `InvalidCastException` for a value that was not a string. 4.x returns `null` for both, so a mistyped key
+  and a wrongly-typed value are indistinguishable from "no value".
+* **The typed accessors throw a different exception for an absent key.** `GetInt`, `GetDouble`,
+  `GetBoolean` and the rest threw `KeyNotFoundException` on 3.x and throw `InvalidCastException` on 4.x.
+  A `catch (KeyNotFoundException)` around one stops catching.
+* **`GetBoolean` reads anything that is not `"true"` as `false`.** 3.x used `Convert.ToBoolean`, so a
+  stored `"1"` or `"yes"` threw `InvalidCastException`. 4.x compares against `"true"` case-insensitively
+  and *succeeds*, so a flag stored as `"1"` used to fail loudly and now quietly reads as off.
+  `TryGetBoolean` reports success for it too.
+* **Strings are parsed with the invariant culture.** `GetInt`, `GetDouble`, `GetFloat` and `GetDecimal`
+  used the current culture when the stored value was a string. On a comma-decimal culture `"3.14"` used to
+  read as `314` and now reads as `3.14`; `"3,14"` used to read as `3.14` and now throws. The new reading is
+  the correct one, and it is still a different number from the one the job saw yesterday.
+* **`TryGetDateTime` parses with `DateTimeStyles.RoundtripKind`**, so a stored string ending in `Z` comes
+  back as `Kind=Utc` rather than shifted to local time — see
+  [`PutAsString` writes round-trip formats now](#putasstring-writes-round-trip-formats-now).
+* **The scheduler context is no longer merged into job properties** — see
+  [Scheduler context entries are no longer injected into job properties](#scheduler-context-entries-are-no-longer-injected-into-job-properties).
+
+### Serialization and the store
+
+* **`quartz.serializer.type = json` means System.Text.Json now.** On 3.x the `json` alias expanded to the
+  Newtonsoft serializer, with a logged warning that the name was ambiguous. On 4.x `json` and `stj` both
+  resolve to `SystemTextJsonObjectSerializer`, and nothing warns. A configuration file carried over
+  verbatim therefore changes which serializer writes and reads the store's blobs, which is a different
+  payload shape and a different set of registered trigger and calendar serializers. Spell it `newtonsoft`
+  if Newtonsoft is what you meant.
+* **System.Text.Json refuses a job data value it cannot read back**, at write time rather than at the next
+  read — see [System.Text.Json refuses a job data value it cannot read back](#system-text-json-refuses-a-job-data-value-it-cannot-read-back).
+* **Five calendar types serialize to a new shape.** 4.x reads both forms and 3.x reads only its own, so
+  this is invisible on a clean cut-over and fatal in a mixed window — see
+  [A mixed 3.x and 4.0 window](operations.md#a-mixed-3-x-and-4-0-window).
+* **The formerly optional columns are required**, and an unmigrated schema fails at the first trigger load
+  or store with a provider-level missing-column error rather than at startup — see
+  [The optional columns are required, so the probes are gone](#the-optional-columns-are-required-so-the-probes-are-gone).
+* **The two stores now answer the same way** where they used to disagree, which changes what the ADO store
+  does in six places — see [The two job stores answer the same way](#the-two-job-stores-answer-the-same-way).
+
+### Lifecycle and telemetry
+
+* **`Standby()` after `Shutdown()` throws** instead of silently pausing something already stopped — see
+  [The transitions are honest about themselves](#the-transitions-are-honest-about-themselves).
+* **A trigger scheduled inside an `Activity` carries two extra job-data entries.**
+  `QuartzSchedulerOptions.PropagateTraceContext` is on by default, and the two reserved keys are visible
+  wherever trigger data is: `MergedJobDataMap`, the dashboard, `GET /triggers`. Turn it off with
+  `q.ConfigureScheduler(options => options.PropagateTraceContext = false)`.
+
+### Ordering
+
+* **`JobKey` and `TriggerKey` compare ordinally**, where 3.x compared with the current culture, so any
+  sorted listing of keys comes out in a different order — see
+  [`Key<T>` moved to `Quartz` and is immutable](#key-t-moved-to-quartz-and-is-immutable).
+
+### What is on nobody's list because it did not change
+
+Worth stating, because the reasonable fear is that everything moved. These were checked against both
+branches and are identical: every misfire instruction's numeric value, so a `MISFIRE_INSTR` column carried
+over still means what it meant; `TriggerState`'s existing values, with `Executing` appended; the misfire
+computation of every trigger family; the merge order and content of `MergedJobDataMap`; the rule that
+`[PersistJobDataAfterExecution]` writes back only a map that was modified; the lock handler a store picks
+for itself; `StringOperator`'s matching; and the effective default of `Shutdown(waitForJobsToComplete)`.
 
 ## Configuration
 
@@ -2691,6 +2814,74 @@ Under a host, the same call goes on the `AddQuartz` builder:
 services.AddQuartz(q => q.UseTimeProvider(new FakeTimeProvider()));
 ```
 
+### The clock is a construction parameter, which is an API-shape change
+
+`SystemTime.UtcNow` was a public mutable field: anything could assign it, from anywhere, at any time,
+and every scheduler in the process saw the result. `TimeProvider` is handed to a scheduler when it is
+built. That is the point — but it means anything of yours that *wraps* scheduler construction has to
+grow a way to be told which clock to use, because there is no longer a hook to reach in afterwards.
+Builders are the same story: a trigger built by `TriggerBuilder.Create()` with no argument reads
+`TimeProvider.System`, so a component that builds triggers outside the container needs the clock passed
+to it. See [The trap: triggers built outside the container](tutorial/time-and-timeprovider.md#the-trap-triggers-built-outside-the-container).
+
+### Replacing a `SystemTime` *offset*, not a freeze
+
+`FakeTimeProvider` — from `Microsoft.Extensions.TimeProvider.Testing` — is the right answer when a test
+owns the whole clock: it starts stopped and only moves when you advance it. It is the wrong answer when
+something else in the process still computes from the real clock, because the two then disagree by
+however long the test has been running, and it cannot be moved backwards at all.
+
+3.x code that assigned an *offset* — `SystemTime.UtcNow = () => DateTimeOffset.UtcNow + skew` — wants a
+clock that still runs, and that is about thirty lines:
+
+<!-- snippet: sample_migration_offset_time_provider -->
+```csharp
+/// <summary>
+/// A clock that runs at the system's speed, shifted by an offset that can be moved at will —
+/// forwards or backwards — without stopping.
+/// </summary>
+public sealed class OffsetTimeProvider(TimeProvider inner) : TimeProvider
+{
+    private long offsetTicks;
+
+    public TimeSpan Offset
+    {
+        get => TimeSpan.FromTicks(Interlocked.Read(ref offsetTicks));
+        set => Interlocked.Exchange(ref offsetTicks, value.Ticks);
+    }
+
+    public override DateTimeOffset GetUtcNow() => inner.GetUtcNow() + Offset;
+
+    public override TimeZoneInfo LocalTimeZone => inner.LocalTimeZone;
+
+    public override long GetTimestamp() => inner.GetTimestamp();
+
+    public override long TimestampFrequency => inner.TimestampFrequency;
+
+    // Left to the real clock deliberately: a timer that only fires when something advances the
+    // offset would deadlock every wait inside the scheduler.
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        => inner.CreateTimer(callback, state, dueTime, period);
+}
+```
+<!-- endSnippet -->
+
+<!-- snippet: sample_migration_offset_time_provider_use -->
+```csharp
+OffsetTimeProvider clock = new(TimeProvider.System);
+services.AddQuartz(q => q.UseTimeProvider(clock));
+
+// ... and later, from the test or the diagnostic endpoint that owns it:
+clock.Offset = TimeSpan.FromHours(26);
+```
+<!-- endSnippet -->
+
+`CreateTimer` deliberately delegates to the real clock. A timer that only fires when something advances
+the offset would stall every wait inside the scheduler — which is exactly what `FakeTimeProvider` does,
+and why advancing it is not enough on its own. When you *do* want a frozen clock, advance it and then
+wait for the scheduler to react rather than sleeping; see
+[Controlling time](tutorial/testing.md#controlling-time).
+
 ### A clock belongs to one scheduler
 
 `UseTimeProvider` used to replace the container's `TimeProvider` registration, so calling it on one named
@@ -3743,6 +3934,7 @@ and `SchedulerContext`), so the call sites read the same:
 | every `TryGet…Value` / `TryGet…ValueFromString` | the matching `TryGet…` |
 | `GetNullableGuidValue` | `TryGetGuid`, or read the entry and test it yourself |
 | (none) | `GetString`, `TryGetString`, `GetDecimal`, `TryGetDecimal` |
+| your own `TryGetValue<T>` extension | **keep it.** 3.x's `JobDataMap` had no `TryGetValue<T>` either, so such a call was always the caller's own extension on `IDictionary<string, object>` — and `JobDataMap` still implements that interface, so it still binds. Do not substitute `TryGet<T>`, which is a different thing: see below |
 
 The `…FromString` half collapses because the retained accessors already convert: a value written as a
 string — which is what `StoreJobDataAsStrings` forces, and what `PutAsString` writes — is parsed on the way
@@ -3763,6 +3955,15 @@ the same test said as a question with one answer — it throws a `KeyNotFoundExc
 when there is no entry, and an `InvalidCastException` naming the key, the stored type and the
 requested one when there is one of the wrong type — and `GetValueOrDefault<T>(key, defaultValue)` is
 the same test with a fallback.
+
+::: warning `TryGet<T>` is not a converting reader
+The name invites it, so say it plainly: `TryGet<T>` is `stored is T` and nothing else. It does not parse,
+it does not convert, and it returns `false` rather than throwing when the type is wrong. A value written
+through `PutAsString`, or by any store running with `StoreJobDataAsStrings = true`, is a `string` — so
+`TryGet<int>` on it returns `false` where `TryGetInt` parses it and succeeds. If you are replacing a
+`TryGetValue<T>` extension of your own that used `Convert.ChangeType`, the named accessor is the
+equivalent; `TryGet<T>` is not.
+:::
 
 ### `PutAsString` writes round-trip formats now
 
@@ -4440,7 +4641,7 @@ re-fired.
 | `RetryPolicy.Exponential(maxAttempts, initialDelay, factor = 2, maxDelay = null)` | A wait multiplied by `factor` each time, optionally clamped |
 | `RetryPolicy.Explicit(params delays)` | A table of waits; `MaxAttempts` is its length and the last entry repeats |
 | `RetryPolicy.DelayFor(attempt)` | The wait before the given retry, counting from one |
-| `RetryPolicy.ToStoredString()` / `Parse` / `TryParse` | The form the `RETRY_POLICY` column, the JSON payload and a serialized trigger all carry |
+| `RetryPolicy.ToStoredString()` / `Parse` / `TryParse` | The single-string form the `RETRY_POLICY` column, the JSON payload and a serialized trigger are to carry |
 
 There is no public constructor, so a policy that could not be honoured — no attempts, a negative wait,
 a backoff that shrinks — cannot be built. A policy carries which of the three factories made it, so
@@ -4453,6 +4654,16 @@ round-tripping it through the `"R"` format guarantees.
 
 `MaxAttempts` counts retries *after* the first failure, not fires: `Fixed(2, …)` runs a persistently
 failing job three times in total.
+
+::: warning Nothing acts on a policy yet
+This is the value and its storage format, landed ahead of the engine so that no later release has to add
+a column to `QRTZ_TRIGGERS`. On this release nothing attaches a `RetryPolicy` to a trigger, no statement
+reads or writes `RETRY_POLICY` or `RETRY_ATTEMPT`, and no failed job is re-fired on one. Follow
+[#3520](https://github.com/quartznet/quartznet/issues/3520). Until it lands, `RefireImmediately` — an
+in-process loop with no delay and no ceiling — is still the only built-in re-execution, and it is not a
+retry; see
+[Retry](how-tos/embedding-quartz-in-a-library.md#retry).
+:::
 
 ## Trimming annotations
 
@@ -6328,6 +6539,75 @@ var scheduler = await builder.BuildScheduler();
 There is no by-hand path left: `QuartzScheduler` is internal, so the job factory is always configured through
 the builder or the container.
 
+#### When the factory's dependency does not exist yet
+
+Setting `IScheduler.JobFactory` late was how 3.x code handled a factory that needed something the
+application only has after startup — a connected bus, a tenant catalogue, an elected leader. Configuring
+the factory at build time does not mean *resolving* its dependency at build time. Two shapes cover it:
+
+**Resolve per firing.** `UseJobFactory<T>()` constructs the factory from the scheduler's own service
+provider, so a factory that takes `IServiceProvider` can resolve whatever it needs inside `CreateJob`,
+which runs once per firing rather than once per scheduler:
+
+<!-- snippet: sample_migration_late_bound_job_factory_use -->
+```csharp
+services.AddSingleton<LateBound<IMessageBus>>();
+services.AddQuartz(q => q.UseJobFactory<BusAwareJobFactory>());
+```
+<!-- endSnippet -->
+
+**Hand it a holder.** When the dependency is not in the container at all — because whatever produces it
+also runs at startup — register a holder the factory can read through, and fill it when the value exists.
+That is the late-bound-holder pattern, and it is what the standalone `QuartzSchedulerBuilder` needs too,
+since it builds its own container and there is nothing to add to afterwards:
+
+<!-- snippet: sample_migration_late_bound_job_factory -->
+```csharp
+/// <summary>
+/// Holds something the container cannot supply yet, so that a component built at startup can be
+/// given the handle now and read the value later.
+/// </summary>
+public sealed class LateBound<T> where T : class
+{
+    private T? value;
+
+    public T Value => value ?? throw new InvalidOperationException($"{typeof(T).Name} is not available yet.");
+
+    public void Set(T instance) => value = instance;
+}
+
+public sealed class BusAwareJobFactory(IServiceProvider provider, LateBound<IMessageBus> bus) : IJobFactory
+{
+    public ValueTask<JobScope> CreateJob(
+        TriggerFiredBundle bundle,
+        IScheduler scheduler,
+        CancellationToken cancellationToken = default)
+    {
+        IServiceScope scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+        // Read per firing rather than captured per scheduler, which is what makes a dependency that
+        // only exists once the bus has connected reachable from a factory built long before it.
+        IJob job = (IJob) ActivatorUtilities.CreateInstance(
+            scope.ServiceProvider,
+            bundle.JobDetail.JobType.Type,
+            bus.Value);
+
+        return new ValueTask<JobScope>(new JobScope(job, scope));
+    }
+
+    public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default)
+    {
+        (scope.State as IServiceScope)?.Dispose();
+        return default;
+    }
+}
+```
+<!-- endSnippet -->
+
+Keep `CreateJob` synchronous. An `async` method restores the caller's `ExecutionContext` when it
+resumes, which discards any `AsyncLocal<T>` the factory set while building the job — the job then runs
+without the ambient state the factory established.
+
 ## Trigger fire times are properties
 
 ```diff
@@ -7341,7 +7621,11 @@ Keys can also be sorted now. `JobKey` and `TriggerKey` implement `IComparable<Jo
 `Comparer<JobKey>.Default` finds a real comparison. On 3.x only `IComparable<Key<T>>` was there, which
 the default comparer does not recognise, and `keys.Sort()`, `keys.OrderBy(k => k)`,
 `SortedSet<JobKey>` and `SortedDictionary<JobKey, _>` all compiled and then threw at runtime. The
-ordering itself is unchanged: the default group first, then group and name ordinally.
+rule that puts the default group first is unchanged; the comparison under it is not. 3.x compared group
+and name with `CultureInfo.CurrentCulture.CompareInfo`, and 4.x compares them with
+`StringComparer.Ordinal` — so a sorted listing reorders, most visibly by putting every upper-case letter
+before every lower-case one. The order no longer depends on the machine's culture, which is the point,
+but it is a different order from the one 3.x produced.
 
 ## Listing queries can filter by name
 
@@ -9152,7 +9436,7 @@ across the two branches; package boundaries moved, so match the files up with th
 | `PublicApiTest_Quartz.Serialization.Json` | `PublicApiTest_Quartz.Serialization.Newtonsoft` |
 | `Quartz.Jobs`, `Quartz.Plugins`, `Quartz.Plugins.TimeZoneConverter`, `Quartz.Extensions.Redis`, `Quartz.AspNetCore`, `Quartz.Dashboard` | same name on both sides |
 | `PublicApiTest_Quartz.OpenTracing` | dropped; there is no 4.x package |
-| (no 3.x baseline — its ancient `OpenTelemetry` dependency fails restore there) | dropped; use [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz) |
+| (no 3.x baseline — its ancient `OpenTelemetry` dependency fails restore there) | dropped; subscribe to the `Quartz` activity source directly |
 | — | `PublicApiTest_Quartz.HttpClient` — new in 4.x |
 
 3.x snapshots `net10.0` only, so its `net472` and `REMOTING` surface never appears in that diff.
@@ -9240,7 +9524,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.Util.PropertiesParser` | Internal | No replacement; `QuartzPropertyBridge` is the only reader of flat `quartz.*` keys now — see [Flat keys still work](#flat-keys-still-work) |
 | `Quartz.PropertiesSetter` | Removed | Typed options — see [Removed](#removed) |
 | `Quartz.QuartzConfiguratorExecutionLimitsExtensions` | Removed | `IQuartzBuilder.UseExecutionLimits(Action<ExecutionLimitsBuilder>)` — see [Execution limits are built once, then frozen](#execution-limits-are-built-once-then-frozen) |
-| `Quartz.OpenTracing.QuartzDiagnosticOptions` | Removed with its package | [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz); job execution is on `Activity` through `QuartzActivitySource` |
+| `Quartz.OpenTracing.QuartzDiagnosticOptions` | Removed with its package | `AddSource(QuartzInstrumentation.ActivitySourceName)`; job execution is on `Activity` through `QuartzActivitySource` — see [Observability](packages/opentelemetry-integration.md) |
 | `Quartz.Util.QuartzEnvironment` | Internal | `System.Environment`, or `IConfiguration` for settings |
 | `Quartz.Core.QuartzRandom` | Internal | `System.Random` |
 | `Quartz.Core.QuartzScheduler` | Internal | Resolve `IScheduler` or `ISchedulerFactory` — see [Sealed and Internalized Types](#sealed-and-internalized-types) |
@@ -9314,6 +9598,7 @@ removals on types that are still public and still open, which no section above n
 | `IScheduler.InStandbyMode` | Removed | `Status is SchedulerStatus.Created or SchedulerStatus.Standby or SchedulerStatus.ShuttingDown` — see [A scheduler's lifecycle is one value](#a-scheduler-s-lifecycle-is-one-value) |
 | `IScheduler.IsShutdown` | Removed | `Status is SchedulerStatus.Shutdown` — see [A scheduler's lifecycle is one value](#a-scheduler-s-lifecycle-is-one-value) |
 | `IScheduler.IsStarted` | Removed | `Status is not SchedulerStatus.Created` faithfully; `Status is SchedulerStatus.Running` if what you meant was "is running now", which it did not say — see [A scheduler's lifecycle is one value](#a-scheduler-s-lifecycle-is-one-value) |
+| `IScheduler.JobFactory` (setter-only) | Removed, from `IScheduler`, `StdScheduler`, `DelegatingScheduler` and `HttpScheduler` | `IQuartzBuilder.UseJobFactory(IJobFactory)` or `UseJobFactory<T>()` where the scheduler is built; `ConfigureJobScope(...)` when all it did was seed the DI scope. A factory whose dependency does not exist yet resolves it in `CreateJob` — see [The factory is set where the scheduler is built](#the-factory-is-set-where-the-scheduler-is-built) |
 | `JobBuilder.CreateForAsync<T>()` | Removed | `JobBuilder.Create<T>()`; every job has been asynchronous since 3.0 |
 | `JobStoreSupport.calendarCache`, `.delegateType`, `.firstCheckIn` | Removed (`protected` fields) | No replacement; they are the base class's own bookkeeping |
 | `JobStoreSupport.GetTriggerNames(conn, matcher, ct)` | Removed (`protected`) | The listing members became queries — see [Job store listings became queries](#job-store-listings-became-queries) |
@@ -9329,3 +9614,78 @@ removals on types that are still public and still open, which no section above n
 | `StringKeyDirtyFlagMap.Put()` (eight overloads), `.PutAll()` | Removed; all were `[Obsolete]` in 3.x | `map[key] = value` |
 | `TaskSchedulingThreadPool.ThreadPriority` | Removed | No replacement; work runs on a `TaskScheduler`, which has no thread to prioritise — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
 | `ZeroSizeThreadPool.AvailableThreadCount` | Removed | `PoolSize`, which is `0` — the pool never had a thread to report |
+
+### Types 4.0 added to the `Quartz` namespace
+
+The two tables above answer "where did my type go". This one answers the opposite question, which a
+build only asks once and then asks loudly: **CS0104, "ambiguous reference"**, because a name Quartz now
+declares collides with one of yours under `using Quartz;`. Three packages folded into `Quartz` and the
+namespace absorbed the matchers, `Key<T>` and the options types, so the namespace is much larger than it
+was — and the errors it produces name the right members on the wrong type, which reads like your own code
+having gone wrong.
+
+Derived the same mechanical way as the tables above: types in the 4.x `Quartz` namespace that are in the
+3.x `Quartz` namespace of none of `Quartz`, `Quartz.Extensions.DependencyInjection` or
+`Quartz.Extensions.Hosting`. **Ninety-two names.** A project that also referenced
+`Quartz.Serialization.SystemTextJson` on 3.x already had `JsonSerializationException`.
+
+```text
+AddCalendarOptions                  AddJobOptions                              AdoJobStoreOptions
+AndMatcher<T>                       CalendarIntervalTriggerMisfireInstruction  CalendarNameMatcher
+CalendarQuery                       ClusteringOptions                          ClusterNode
+ClusterNodeState                    CronTriggerMisfireInstruction              DailyTimeIntervalTriggerMisfireInstruction
+DataMapExtensions                   DataSourceOptions                          EverythingMatcher<T>
+ExecutionGroupInFlight              ExecutionGroupLimit                        ExecutionGroupScope
+ExecutionLimitsBuilder              ExecutionLimitScope                        ExecutionSlots
+FireInstance                        FireInstanceQuery                          FireInstanceState
+GroupMatcher<T>                     IJob<T>                                    IJobConfigurator<T>
+IJobExecutionContextAccessor        IJobExecutionMiddleware                    InMemoryJobStoreOptions
+IPersistentStoreBuilder             IQuartzBuilder                             ISchedulerRegistry
+ITriggerConfigurator<T>             JobBuilder<T>                              JobDetailExtensions
+JobExecutionContextInputExtensions  JobExecutionDelegate                       JobExecutionProcessException
+JobGroup                            JobGroupQuery                              JobHeader
+JobInputBuilderExtensions           JobInstantiationException                  JobQuery
+JobType                             JsonSerializationException                 Key<T>
+KeyMatcher<T>                       Matchers                                   MonthDay
+NameMatcher<T>                      NotMatcher<T>                              OneOffJobOptions
+OrMatcher<T>                        PagedQuery                                 PagedResult<T>
+PersistentStoreBuilderExtensions    PreferredNode                              QuartzBuilderExtensions
+QuartzHealthCheckExtensions         QuartzHealthCheckOptions                   QuartzHostApplicationBuilderExtensions
+QuartzSchedulerBuilder              QuartzSchedulerOptions                     RecurrenceTriggerMisfireInstruction
+RetryPolicy                         ScheduleJobOptions                         SchedulerErrorContext
+SchedulerJobExtensions              SchedulerMetadata                          SchedulerOrigin
+SchedulerQueryExtensions            SchedulerRegistration                      SchedulerStatus
+SchedulingDataValidationException   SchemaProvisioning                         ShutdownJobInterruption
+SimpleTriggerMisfireInstruction     StandaloneSchedulerFactory                 StringMatcher<T>
+StringOperator                      SystemTextJsonConfigurationExtensions      ThreadPoolOptions
+TimeRange                           TimeZones                                  TriggerBuilder<T>
+TriggerConfiguratorExtensions       TriggerGroup                               TriggerGroupQuery
+TriggerHeader                       TriggerQuery
+```
+
+Most of those are unmistakably Quartz's. These are the ones a host application or an integration library
+plausibly declares itself, which makes them the ones to check first:
+
+| Name | Who else has one |
+|---|---|
+| `QuartzSchedulerOptions` | the known case — it shadowed MassTransit's own `QuartzSchedulerOptions`, producing six compile errors that named the right members on the wrong type. 3.x's equivalent was `Quartz.Core.QuartzSchedulerResources`, safely out of the way |
+| `JsonSerializationException` | **Newtonsoft.Json declares this exact name**, so a file with both `using Quartz;` and `using Newtonsoft.Json;` is ambiguous |
+| `RetryPolicy` | Polly, MassTransit, the Azure SDKs, and most in-house resilience code |
+| `TimeRange`, `MonthDay` | ordinary domain vocabulary; NodaTime has `MonthDay` |
+| `PagedResult<T>`, `PagedQuery` | near-universal in an API or repository layer |
+| `Key<T>` | was `Quartz.Util.Key<T>`; now a one-word name at the top level |
+| `Matchers`, `TimeZones` | one-word static helpers, previously `Quartz.Impl.Matchers` and `Quartz.Util.TimeZoneUtil` |
+| `ThreadPoolOptions`, `DataSourceOptions` | common options-class names |
+| `JobType`, `SchedulerStatus`, `ClusterNode`, `ClusterNodeState` | anything with a job or scheduler model of its own |
+| `StringOperator`, `ExecutionSlots`, `ExecutionGroupScope`, `ExecutionLimitScope` | generic concurrency and matching vocabulary |
+
+The fix is a using-alias in the affected file, which beats a namespace import and needs no change to
+either library:
+
+```csharp
+using QuartzSchedulerOptions = Acme.Bus.QuartzSchedulerOptions;
+```
+
+One collision went away: 3.x's `Quartz.ServiceCollectionExtensions` — the most common helper-class name in
+.NET — is not in the `Quartz` namespace on 4.x. Its members live on `QuartzServiceCollectionExtensions`
+and `QuartzBuilderExtensions`, and since both are extension methods, only a static-form call has to change.

--- a/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
+++ b/docs/documentation/quartz-4.x/packages/opentelemetry-integration.md
@@ -153,21 +153,51 @@ hosts in one test process, keep their measurements apart.
 ## OpenTelemetry.Instrumentation.Quartz
 
 [OpenTelemetry.Instrumentation.Quartz](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.Quartz)
-is the OpenTelemetry community's Quartz instrumentation library. It subscribes to the same activity source
-and adds filtering — which operations to record — over doing it yourself:
+is the OpenTelemetry community's Quartz instrumentation library, and it was written for 3.x.
 
-```shell
-dotnet add package OpenTelemetry.Instrumentation.Quartz
+::: danger It produces nothing against 4.0, and does not say so
+`AddQuartzInstrumentation()` yields **zero spans** on Quartz 4.x. Nothing throws, nothing warns, and the
+call still compiles — an upgraded application simply stops seeing its job spans.
+:::
+
+The reason is that the two versions publish through different `System.Diagnostics` mechanisms. 3.x wrote
+to a `DiagnosticListener` named `Quartz`, creating each `Activity` with `new Activity(...)` and no
+`ActivitySource` behind it. The package subscribes to exactly that: a `DiagnosticSourceSubscriber` filtered
+to the listener named `Quartz`, plus `AddLegacySource("Quartz.Job.Execute")` and
+`AddLegacySource("Quartz.Job.Veto")` — and "legacy source" in the OpenTelemetry SDK means precisely an
+activity that has *no* `ActivitySource`.
+
+4.x emits from an `ActivitySource` named `Quartz`. Its activities are therefore not legacy activities, and
+nothing writes to a `DiagnosticListener` at all, so both halves of the subscription match nothing.
+
+The 4.0 way is the two lines at the top of this page — `AddSource(QuartzInstrumentation.ActivitySourceName)`
+and `AddMeter(QuartzInstrumentation.MeterName)`. There is no package to install:
+
+<!-- Not a compiled sample: the first block references a package this repository does not take, and
+     taking a NuGet dependency purely to compile a documentation sample is not worth it. -->
+
+```diff
+- builder.Services.AddOpenTelemetry()
+-     .WithTracing(tracing => tracing.AddQuartzInstrumentation());
++ builder.Services.AddOpenTelemetry()
++     .WithTracing(tracing => tracing.AddSource(QuartzInstrumentation.ActivitySourceName))
++     .WithMetrics(metrics => metrics.AddMeter(QuartzInstrumentation.MeterName));
 ```
 
-```csharp
-builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing => tracing.AddQuartzInstrumentation());
+```diff
+- <PackageReference Include="OpenTelemetry.Instrumentation.Quartz" Version="1.*" />
 ```
+
+What is lost with the package is its `QuartzInstrumentationOptions.TracedOperations` filter. Subscribing
+directly records both `Quartz.Job.Execute` and `Quartz.Job.Veto`; drop one with an OpenTelemetry
+[processor or a sampler](https://opentelemetry.io/docs/languages/dotnet/) if a vetoed fire is not worth a
+span to you. What is gained is everything 4.0 added — the store spans and all eight metrics — none of
+which the package knows about.
 
 ## Older packages
 
-`Quartz.OpenTelemetry.Instrumentation` is obsolete and is not part of 4.x. Use the community package above.
+`Quartz.OpenTelemetry.Instrumentation` is obsolete and is not part of 4.x. Subscribe to the activity source
+directly, as at the top of this page.
 
 ### Coming from Quartz.OpenTracing
 

--- a/src/Quartz.Documentation.Samples/HowTos/EmbeddingSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/EmbeddingSamples.cs
@@ -1,0 +1,291 @@
+using System.Data.Common;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library.md.
+/// </summary>
+public static class EmbeddingSamples
+{
+    public static void OwnScheduler(IServiceCollection services, string connectionString)
+    {
+        #region sample_embedding_named_scheduler
+
+        // Everything this library registers lands under the scheduler's own service key: its thread
+        // pool, its job store, its listeners. Nothing it does can starve the application's scheduler,
+        // and nothing the application configures reaches this one.
+        services.AddQuartz("acme.outbox", q =>
+        {
+            q.UsePersistentStore(store => store.UseSqlServer(connectionString));
+            q.UseDefaultThreadPool(maxConcurrency: 4);
+        });
+
+        #endregion
+    }
+
+    public static void OwnSchedulerConsumer(IServiceProvider provider)
+    {
+        #region sample_embedding_named_scheduler_resolve
+
+        IScheduler scheduler = provider.GetRequiredKeyedService<IScheduler>("acme.outbox");
+
+        #endregion
+    }
+
+    public static void SharedSchedulerExecutionGroup(IServiceCollection services)
+    {
+        #region sample_embedding_execution_group
+
+        services.ConfigureAllQuartzSchedulers(q => q.UseExecutionLimits(limits => limits
+            .ForGroup("acme.outbox", maxConcurrent: 4)
+            .ForOtherGroups(int.MaxValue)));
+
+        #endregion
+    }
+
+    #region sample_embedding_contributor
+
+    public static IServiceCollection AddAcmeOutbox(this IServiceCollection services)
+    {
+        // Contributing twice is contributing twice: Quartz will not apply one delegate instance to one
+        // scheduler more than once, but a second call here creates a second delegate. Guard the
+        // extension method, not the delegate.
+        if (services.Any(descriptor => descriptor.ServiceType == typeof(AcmeOutboxMarker)))
+        {
+            return services;
+        }
+
+        services.AddSingleton<AcmeOutboxMarker>();
+
+        // Applied to every scheduler in the container - those registered before this call, and those
+        // registered after it. The application decides how many schedulers there are and what they are
+        // called; this does not have to know.
+        services.ConfigureAllQuartzSchedulers(q =>
+        {
+            q.AddJob<DrainOutboxJob>(j => j
+                .WithIdentity(DrainOutboxJob.Key)
+                .StoreDurably());
+
+            q.AddTrigger(t => t
+                .WithIdentity("drain", DrainOutboxJob.Key.Group)
+                .ForJob(DrainOutboxJob.Key)
+                .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(30)).RepeatForever()));
+        });
+
+        return services;
+    }
+
+    private sealed class AcmeOutboxMarker;
+
+    #endregion
+
+    #region sample_embedding_contributor_scheduler_name
+
+    public static IServiceCollection AddAcmeOutboxToOneScheduler(this IServiceCollection services, string schedulerName)
+    {
+        services.ConfigureAllQuartzSchedulers(q =>
+        {
+            // "" is the default scheduler; anything else is the name it was registered under.
+            if (!string.Equals(q.SchedulerName, schedulerName, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            q.AddJob<DrainOutboxJob>(j => j.WithIdentity(DrainOutboxJob.Key).StoreDurably());
+        });
+
+        return services;
+    }
+
+    #endregion
+
+    public static void DeferredStart(IHostApplicationBuilder builder)
+    {
+        #region sample_embedding_deferred_start
+
+        builder.Services.AddQuartz("acme.outbox", q => q.UseInMemoryStore());
+
+        // Built, initialized and bound with the host, and then left in Created. The library starts it
+        // when whatever it depends on - a bus connection, a leader lease, a migration - is ready.
+        builder.Services.AddQuartzHostedService("acme.outbox", options => options.AutoStart = false);
+
+        #endregion
+    }
+
+    public static void Middleware(IServiceCollection services)
+    {
+        #region sample_embedding_middleware_registration
+
+        services.ConfigureAllQuartzSchedulers(q => q.AddJobMiddleware<OutboxScopeMiddleware>());
+
+        #endregion
+    }
+
+    #region sample_embedding_middleware
+
+    public sealed class OutboxScopeMiddleware(IOutboxContext outbox) : IJobExecutionMiddleware
+    {
+        public async ValueTask Invoke(
+            IJobExecutionContext context,
+            JobExecutionDelegate next,
+            CancellationToken cancellationToken = default)
+        {
+            // Ambient state the library's own services read, established around the job rather than
+            // inside a wrapper job that has to know how to construct the real one.
+            using (outbox.Begin(context.FireInstanceId))
+            {
+                await next(context, cancellationToken);
+            }
+        }
+    }
+
+    #endregion
+
+    #region sample_embedding_typed_job
+
+    public sealed record SendReminder(string ConversationId, string MessageId, string Text);
+
+    public sealed class SendReminderJob(IReminderSink sink) : IJob<SendReminder>
+    {
+        public ValueTask Execute(
+            IJobExecutionContext context,
+            SendReminder input,
+            CancellationToken cancellationToken = default)
+        {
+            return sink.Send(input.ConversationId, input.Text, cancellationToken);
+        }
+    }
+
+    #endregion
+
+    #region sample_embedding_schedule_correlated
+
+    public sealed class Conversations(IScheduler scheduler)
+    {
+        public ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+                reminder,
+                delay,
+                new OneOffJobOptions
+                {
+                    // The name is this one firing; the group is what the firing is about. Both are the
+                    // library's own identifiers, so nothing has to be looked up to cancel later.
+                    Name = reminder.MessageId,
+                    Group = reminder.ConversationId,
+                    Replace = true
+                },
+                cancellationToken);
+        }
+
+        public ValueTask<bool> Cancel(TriggerKey firing, CancellationToken cancellationToken)
+        {
+            return scheduler.UnscheduleJob(firing, cancellationToken);
+        }
+
+        public ValueTask<List<TriggerKey>> CancelConversation(string conversationId, CancellationToken cancellationToken)
+        {
+            // Everything still scheduled for that conversation, in one store operation, answering with
+            // the keys it removed.
+            return scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(conversationId), cancellationToken);
+        }
+    }
+
+    #endregion
+
+    public static async ValueTask Upsert(
+        IScheduler scheduler,
+        SendReminder reminder,
+        DateTimeOffset at,
+        CancellationToken cancellationToken)
+    {
+        #region sample_embedding_upsert
+
+        ITrigger trigger = TriggerBuilder.Create<SendReminderJob>(scheduler.TimeProvider)
+            .WithIdentity(reminder.MessageId, reminder.ConversationId)
+            .ForJob(new JobKey(nameof(SendReminderJob), SchedulerConstants.ScheduledJobGroup))
+            .StartAt(at)
+            .UsingInput(reminder)
+            .Build();
+
+        await scheduler.ScheduleJob(trigger, ScheduleJobOptions.Replacing, cancellationToken);
+
+        #endregion
+    }
+
+    public static void AcceptEnlistedTransactions(IServiceCollection services, string connectionString)
+    {
+        #region sample_embedding_accept_enlisted
+
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(connectionString);
+            store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
+        }));
+
+        #endregion
+    }
+
+    #region sample_embedding_enlist
+
+    public sealed class Outbox(IScheduler scheduler)
+    {
+        /// <summary>
+        /// Schedules inside a transaction the caller owns, so the scheduling and whatever else that
+        /// transaction did commit together or not at all.
+        /// </summary>
+        public async ValueTask Enqueue(
+            DbTransaction transaction,
+            SendReminder reminder,
+            DateTimeOffset at,
+            CancellationToken cancellationToken)
+        {
+            // The enlistment flows with the asynchronous context, so it has to be established in the
+            // same scope as the calls it covers - which is why this takes the transaction rather than
+            // establishing one and handing it back.
+            using (scheduler.EnlistTransaction(transaction))
+            {
+                await scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+                    reminder,
+                    at,
+                    new OneOffJobOptions { Name = reminder.MessageId, Group = reminder.ConversationId, Replace = true },
+                    cancellationToken);
+            }
+        }
+    }
+
+    #endregion
+
+    public static void TraceContextOff(IServiceCollection services)
+    {
+        #region sample_embedding_trace_context_off
+
+        services.ConfigureAllQuartzSchedulers(q =>
+            q.ConfigureScheduler(options => options.PropagateTraceContext = false));
+
+        #endregion
+    }
+}
+
+/// <summary>
+/// The library-side services the embedding samples name in passing.
+/// </summary>
+public interface IOutboxContext
+{
+    IDisposable Begin(string fireInstanceId);
+}
+
+public interface IReminderSink
+{
+    ValueTask Send(string conversationId, string text, CancellationToken cancellationToken = default);
+}
+
+public sealed class DrainOutboxJob : IJob
+{
+    public static JobKey Key { get; } = new("drain-outbox", "acme.outbox");
+
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+}

--- a/src/Quartz.Documentation.Samples/HowTos/ExternalLeaderSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/ExternalLeaderSamples.cs
@@ -1,0 +1,103 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Quartz.Documentation.Samples.HowTos;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/how-tos/external-leader.md.
+/// </summary>
+public static class ExternalLeaderSamples
+{
+    public static void Registration(IHostApplicationBuilder builder, string connectionString)
+    {
+        #region sample_external_leader_registration
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.UsePersistentStore(store => store.UseSqlServer(connectionString));
+
+            // No UseClustering(). Exactly one process is meant to be scheduling, and the election
+            // outside Quartz is what says which one.
+        });
+
+        builder.Services.AddQuartzHostedService(options =>
+        {
+            // Built, initialized and bound with the host - and then left alone. The leader starts it.
+            options.AutoStart = false;
+
+            // A leader that is stepping down because the host is stopping should finish what it began.
+            options.WaitForJobsToComplete = true;
+        });
+
+        builder.Services.AddHealthChecks().AddQuartz();
+
+        #endregion
+    }
+
+    #region sample_external_leader_callbacks
+
+    /// <summary>
+    /// The two callbacks every leader election has, whatever it calls them.
+    /// </summary>
+    public sealed class SchedulerLeadership(IScheduler scheduler)
+    {
+        public ValueTask OnStartedLeading(CancellationToken cancellationToken)
+        {
+            // The first acquisition starts the scheduler and every later one resumes it from standby.
+            // Start does both, and does nothing when the scheduler is already running.
+            return scheduler.Start(cancellationToken);
+        }
+
+        public ValueTask OnStoppedLeading(CancellationToken cancellationToken)
+        {
+            // Standby, not Shutdown: a shut-down scheduler cannot be started again, and this process
+            // may well be elected once more in a minute. Losing the lease while the host is already
+            // stopping is ordinary, and Standby throws once the scheduler has shut down.
+            return scheduler.Status == SchedulerStatus.Running
+                ? scheduler.Standby(cancellationToken)
+                : default;
+        }
+    }
+
+    #endregion
+
+    public static void Tuning(IHostApplicationBuilder builder)
+    {
+        #region sample_external_leader_tuning
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                // How long a trigger written by another process may sit before this one looks again.
+                options.IdleWaitTime = TimeSpan.FromSeconds(5);
+
+                // Both halves or neither: a batch stops at the first trigger that is not due within
+                // the window of the one that opened it.
+                options.MaxBatchSize = 10;
+                options.BatchTriggerAcquisitionFireAheadTimeWindow = TimeSpan.FromSeconds(2);
+            });
+
+            // MaxBatchSize may not exceed this: triggers acquired beyond the number of threads there
+            // are to run them on are held by this node, unfireable by any other, until the pool drains.
+            q.UseDefaultThreadPool(maxConcurrency: 10);
+        });
+
+        #endregion
+    }
+
+    public static void RequestingRecovery(IHostApplicationBuilder builder)
+    {
+        #region sample_external_leader_request_recovery
+
+        builder.Services.AddQuartz(q =>
+        {
+            q.AddJob<ReportingJob>(j => j
+                .WithIdentity("nightly-close", "reporting")
+                .RequestRecovery()
+                .StoreDurably());
+        });
+
+        #endregion
+    }
+}

--- a/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
+++ b/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Documentation.Samples;
+
+/// <summary>
+/// Samples for docs/documentation/quartz-4.x/migration-guide.md.
+/// </summary>
+/// <remarks>
+/// The guide is otherwise written in plain fences, because most of what it shows is 3.x code or a diff
+/// between the two — neither of which can compile here. The blocks in this file are the 4.x half of an
+/// answer, so they can, and therefore should.
+/// </remarks>
+public static class MigrationGuideSamples
+{
+    #region sample_migration_offset_time_provider
+
+    /// <summary>
+    /// A clock that runs at the system's speed, shifted by an offset that can be moved at will —
+    /// forwards or backwards — without stopping.
+    /// </summary>
+    public sealed class OffsetTimeProvider(TimeProvider inner) : TimeProvider
+    {
+        private long offsetTicks;
+
+        public TimeSpan Offset
+        {
+            get => TimeSpan.FromTicks(Interlocked.Read(ref offsetTicks));
+            set => Interlocked.Exchange(ref offsetTicks, value.Ticks);
+        }
+
+        public override DateTimeOffset GetUtcNow() => inner.GetUtcNow() + Offset;
+
+        public override TimeZoneInfo LocalTimeZone => inner.LocalTimeZone;
+
+        public override long GetTimestamp() => inner.GetTimestamp();
+
+        public override long TimestampFrequency => inner.TimestampFrequency;
+
+        // Left to the real clock deliberately: a timer that only fires when something advances the
+        // offset would deadlock every wait inside the scheduler.
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+            => inner.CreateTimer(callback, state, dueTime, period);
+    }
+
+    #endregion
+
+    public static void UsingTheOffsetClock(IServiceCollection services)
+    {
+        #region sample_migration_offset_time_provider_use
+
+        OffsetTimeProvider clock = new(TimeProvider.System);
+        services.AddQuartz(q => q.UseTimeProvider(clock));
+
+        // ... and later, from the test or the diagnostic endpoint that owns it:
+        clock.Offset = TimeSpan.FromHours(26);
+
+        #endregion
+    }
+
+    #region sample_migration_late_bound_job_factory
+
+    /// <summary>
+    /// Holds something the container cannot supply yet, so that a component built at startup can be
+    /// given the handle now and read the value later.
+    /// </summary>
+    public sealed class LateBound<T> where T : class
+    {
+        private T? value;
+
+        public T Value => value ?? throw new InvalidOperationException($"{typeof(T).Name} is not available yet.");
+
+        public void Set(T instance) => value = instance;
+    }
+
+    public sealed class BusAwareJobFactory(IServiceProvider provider, LateBound<IMessageBus> bus) : IJobFactory
+    {
+        public ValueTask<JobScope> CreateJob(
+            TriggerFiredBundle bundle,
+            IScheduler scheduler,
+            CancellationToken cancellationToken = default)
+        {
+            IServiceScope scope = provider.GetRequiredService<IServiceScopeFactory>().CreateScope();
+
+            // Read per firing rather than captured per scheduler, which is what makes a dependency that
+            // only exists once the bus has connected reachable from a factory built long before it.
+            IJob job = (IJob) ActivatorUtilities.CreateInstance(
+                scope.ServiceProvider,
+                bundle.JobDetail.JobType.Type,
+                bus.Value);
+
+            return new ValueTask<JobScope>(new JobScope(job, scope));
+        }
+
+        public ValueTask ReturnJob(JobScope scope, CancellationToken cancellationToken = default)
+        {
+            (scope.State as IServiceScope)?.Dispose();
+            return default;
+        }
+    }
+
+    #endregion
+
+    public static void UsingTheLateBoundFactory(IServiceCollection services)
+    {
+        #region sample_migration_late_bound_job_factory_use
+
+        services.AddSingleton<LateBound<IMessageBus>>();
+        services.AddQuartz(q => q.UseJobFactory<BusAwareJobFactory>());
+
+        #endregion
+    }
+}
+
+/// <summary>
+/// Stands in for whatever a host's own scheduler-adjacent dependency is.
+/// </summary>
+public interface IMessageBus
+{
+    ValueTask Publish(object message, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
Closes #3537.

Two new how-to pages, plus the migration-guide and OpenTelemetry work the issue's comment asked for. Every C# block on the new pages, and the four new blocks in the migration guide, are generated from `#region sample_*` blocks in `src/Quartz.Documentation.Samples`.

## `how-tos/embedding-quartz-in-a-library.md`

For the author of a package rather than an application. Ownership of the scheduler (a named scheduler, the `ConfigureAllQuartzSchedulers` contributor, or an execution group) and the axis that decides between them; the contributor recipe, which is order-independent and reaches named schedulers, and which replaces the `IConfigureOptions<QuartzOptions>` shape [OpenIddict still uses](https://github.com/openiddict/openiddict-core/blob/dev/src/OpenIddict.Quartz/OpenIddictQuartzConfiguration.cs) on 3.x — with the warning that Quartz de-duplicates a *delegate instance*, so your own `Add…` still needs a marker guard; key derivation with the trigger group as the correlation axis and `UnscheduleJobs(GroupMatcher<TriggerKey>)` to cancel by it; typed input instead of a payload bag; the atomic upsert instead of `Exists` → `Unschedule` → `Schedule`; `AutoStart = false`; middleware instead of an adapter job, with the four costs of an adapter named and sourced; retry, stated honestly; trace context across the gap; `EnlistTransaction` with the four caveats a library cannot control; and the per-TFM shipping recipe with a verified shim table and the limit past which a shim is two libraries in one package.

## `how-tos/external-leader.md`

The topology the issue found spelled out in code and nowhere else. Why `ClusteringStaysEnabledValidator` refuses a disabled `UseClustering`; what standby does *not* do — including that the misfire handler keeps running and an acquired batch is not released, so a stood-down leader can still fire up to `MaxBatchSize` triggers as late as `IdleWaitTime` afterwards; the latency triple with the honest statement that in-process scheduling signals the loop, so the wait only bounds *another* process's writes; exactly what the start-up recovery pass does; that a literal per-pod `InstanceId` silently breaks `RequestsRecovery` across a leader move where the `NON_CLUSTERED` default does not; and the fencing problem, argued from the sources that say a lease is not mutual exclusion.

## `packages/opentelemetry-integration.md`

The page claimed the contrib package "subscribes to the same activity source". It does not: `AddQuartzInstrumentation()` subscribes to the `DiagnosticListener` named `Quartz` that 3.x wrote, plus `AddLegacySource("Quartz.Job.Execute"/"Quartz.Job.Veto")` — and a *legacy* source means an activity with no `ActivitySource`. 4.0 emits from an `ActivitySource` named `Quartz` and writes to no `DiagnosticListener`, so both halves match nothing and the package yields zero spans with no warning. The page now says so and gives the two-line replacement; the two other places that recommended the package were corrected to match.

## `migration-guide.md`

- **Silent behaviour changes** — a new checklist of calls that still compile and now behave differently, each verified against both branches.
- **Defaults that changed** — its own heading, and mostly a list of what did *not* change.
- **Types 4.0 added to the `Quartz` namespace** — mechanically derived from the baselines (92 names), with the subset that shadows common host types and the using-alias fix.
- The **offset `TimeProvider`** that replaces a `SystemTime` offset rather than freezing the clock, the **late-bound job factory**, an `IScheduler.JobFactory` appendix row, a `TryGetValue<T>` accessor row, and a note that the clock is now a construction parameter.

Two corrections fell out of verification: `Key<T>` compared with the current culture on 3.x and compares ordinally now, which the guide said was unchanged; and nothing yet reads or writes the retry columns, which the guide implied it did.

## Verification

`dotnet build Quartz.slnx`, `dotnet fallout DocsSnippets` + `VerifyDocsSnippets`, `npm ci && npm run docs:check-links` (219 pages, 1024 internal links, 619 fragments, no dead links or anchors), `markdownlint-cli2` on every touched page (no new errors; the migration guide's 19 MD004 + 1 MD040 are unchanged from `main`), and `dotnet test src/Quartz.Tests.Unit --filter "FullyQualifiedName~Docs|FullyQualifiedName~AgentInstructions|FullyQualifiedName~SourceEncoding"` — 13 passed.

Rebased on `cc88140f4`, which added `how-tos/wolverine.md`; the two pages cross-link it as the worked instance of the same material.
