### PR TITLE
The one-off job surface answers what its first integration asked of it

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library.md
+++ b/docs/documentation/quartz-4.x/how-tos/embedding-quartz-in-a-library.md
@@ -189,7 +189,10 @@ of it:
 
 * **The job key says what runs.** One durable job per job type is enough, because a job detail is a
   definition rather than an occurrence. That is what the typed `ScheduleJob` overloads store, at
-  `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)` — one row per job type, whatever the traffic.
+  `SchedulerJobExtensions.ScheduledJobKey<TJob>()` — which is
+  `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`, one row per job type whatever the traffic.
+  Ask for the key rather than re-deriving it: the group is reserved, and a library that also builds a
+  trigger of its own points it at that same job.
 * **The trigger key says which occurrence.** Its **name** is this one firing and its **group is the
   correlation id**: the saga, the conversation, the tenant. Everything scheduled for one of those shares a
   group and can be listed, paused or cancelled together.
@@ -215,9 +218,9 @@ public sealed class SendReminderJob(IReminderSink sink) : IJob<SendReminder>
 ```csharp
 public sealed class Conversations(IScheduler scheduler)
 {
-    public ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
+    public async ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
     {
-        return scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<SendReminderJob, SendReminder>(
             reminder,
             delay,
             new OneOffJobOptions
@@ -229,6 +232,9 @@ public sealed class Conversations(IScheduler scheduler)
                 Replace = true
             },
             cancellationToken);
+
+        // The call answers with the key it stored and the time the store will first fire it at.
+        return scheduled.TriggerKey;
     }
 
     public ValueTask<bool> Cancel(TriggerKey firing, CancellationToken cancellationToken)
@@ -318,7 +324,7 @@ check and the write in which another node does the same thing. Both `ScheduleJob
 ```csharp
 ITrigger trigger = TriggerBuilder.Create<SendReminderJob>(scheduler.TimeProvider)
     .WithIdentity(reminder.MessageId, reminder.ConversationId)
-    .ForJob(new JobKey(nameof(SendReminderJob), SchedulerConstants.ScheduledJobGroup))
+    .ForJob(SchedulerJobExtensions.ScheduledJobKey<SendReminderJob>())
     .StartAt(at)
     .UsingInput(reminder)
     .Build();

--- a/docs/documentation/quartz-4.x/how-tos/one-off-job.md
+++ b/docs/documentation/quartz-4.x/how-tos/one-off-job.md
@@ -140,9 +140,9 @@ public sealed class SendInvoiceJob : IJob<SendInvoice>
 
 public sealed class Invoicing
 {
-    public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+    public async ValueTask Remind(IScheduler scheduler, ILogger logger, SendInvoice invoice, CancellationToken cancellationToken)
     {
-        TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+        ScheduledOneOffJob firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
             invoice,
             TimeSpan.FromDays(7),
             new OneOffJobOptions
@@ -155,29 +155,134 @@ public sealed class Invoicing
             },
             cancellationToken);
 
+        // What was arranged: the trigger's key, and when the store says it will first fire.
+        logger.LogInformation("Reminder {Trigger} scheduled for {At}", firing.TriggerKey, firing.FirstFireTimeUtc);
+
         // ... and to call it off:
-        await scheduler.UnscheduleJob(firing, cancellationToken);
+        await scheduler.UnscheduleJob(firing.TriggerKey, cancellationToken);
     }
 }
 ```
 <!-- endSnippet -->
 
-There are two overloads, one taking a `DateTimeOffset` and one a `TimeSpan` from now, and both return the
-`TriggerKey` of the firing they stored — the handle to cancel it with, or to replace it by scheduling the same
-name again.
+There are two overloads, one taking a `DateTimeOffset` and one a `TimeSpan` from now, and both answer with a
+`ScheduledOneOffJob`: the `TriggerKey` of the firing they stored — the handle to cancel it with, or to replace
+it by scheduling the same name again — and `FirstFireTimeUtc`, the time the store says it will fire. Two
+members and no more; everything else about the firing is a property of the trigger the key names, and
+`GetTrigger` is how to ask for it.
 
 What is stored is **one durable job per job type**, under
-`(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`, plus one trigger per call. That is the shape a
-message bus's Quartz integration converges on: a scheduled message is a trigger, so there is no job churn to
-pay for however many firings are in flight. The job is stored idempotently the first time a call is made on a
-scheduler and remembered afterwards, so it is safe for several nodes to do at once and costs one round trip
-rather than two from the second call on. It is left behind when the last firing is cancelled — one row per job
-type, whatever the traffic.
+`SchedulerJobExtensions.ScheduledJobKey<TJob>()` — `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`
+— plus one trigger per call. That is the shape a message bus's Quartz integration converges on: a scheduled
+message is a trigger, so there is no job churn to pay for however many firings are in flight. The job is stored
+idempotently the first time a call is made on a scheduler and remembered afterwards, so it is safe for several
+nodes to do at once and costs one round trip rather than two from the second call on. It is left behind when
+the last firing is cancelled — one row per job type, whatever the traffic.
 
 `OneOffJobOptions` carries what would otherwise be `TriggerBuilder` calls: `Name` and `Group` (defaulting
 to a generated identifier in a group named after the job type), `Description`, `Priority`, `ExecutionGroup`,
 `MisfireInstruction`, and `Replace`. **The group is the correlation axis** — everything scheduled for one saga,
 one tenant or one conversation shares a group and can be listed, paused or unscheduled together.
+
+::: warning A group default that a cancellation contract has to know about
+`Group` defaults to the job type's name, not to `TriggerKey.DefaultGroup`. Code that cancels with
+`new TriggerKey(id)` is naming the *default* group, so a firing scheduled through these overloads without
+`Group = TriggerKey.DefaultGroup` is somewhere that cancellation silently stops matching — the unschedule
+finds nothing and reports it did nothing. An integration adopting the one-liner over an existing trigger-key
+contract sets the group its callers already expect.
+:::
+
+`RequestRecovery` is the one member that describes the durable job rather than the trigger. Set it and the
+ensured job is marked `RequestsRecovery`, so a firing interrupted by a hard shutdown is re-executed when the
+scheduler comes back:
+
+<!-- snippet: sample_one_off_job_request_recovery -->
+```csharp
+public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+{
+    await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+        invoice,
+        TimeSpan.FromDays(7),
+        new OneOffJobOptions { RequestRecovery = true },
+        cancellationToken);
+}
+```
+<!-- endSnippet -->
+
+The job is ensured once per scheduler instance, so **the first call's value wins for the lifetime of the
+process**: a later call asking for something else finds the job already stored and does not store it again.
+That is how everything else about the job works too — its description, its durability, the type it names — and
+it is why this is a boolean rather than a configuration delegate that would look as though it varied per call.
+
+## A schedule of your own on the same job
+
+The durable job is addressable, which is what a second scheduling path needs: an integration that also builds a
+recurring trigger for the same job points it at `ScheduledJobKey<TJob>()` rather than adding a job of its own to
+the reserved group.
+
+<!-- snippet: sample_one_off_job_scheduled_job_key -->
+```csharp
+public async ValueTask Nightly(IScheduler scheduler, CancellationToken cancellationToken)
+{
+    // A schedule of its own, pointed at the job the one-liner keeps rather than at a second job
+    // built here: same job, same payload shape, one more trigger.
+    ITrigger nightly = TriggerBuilder.Create<SendInvoiceJob>(scheduler.TimeProvider)
+        .WithIdentity("nightly", "invoicing")
+        .ForJob(SchedulerJobExtensions.ScheduledJobKey<SendInvoiceJob>())
+        .WithCronSchedule("0 0 2 * * ?")
+        .UsingInput(new SendInvoice("all", 0m))
+        .Build();
+
+    await scheduler.ScheduleJob(nightly, cancellationToken);
+}
+```
+<!-- endSnippet -->
+
+`SchedulerConstants.ScheduledJobGroup` is reserved for the jobs the one-liner maintains — do not put jobs of
+your own in it — but the job that *is* in it is meant to be pointed at, and `ScheduledJobKey<TJob>()` spells the
+whole key so nothing has to re-derive it.
+
+The key is derived from the type, so it answers before anything has been scheduled; the job itself appears the
+first time one of the one-call overloads is used on that scheduler. A store refuses a trigger whose job is
+missing, so a second path that can run *first* stores the durable job itself — `AddJob` under the same key,
+with `AddJobOptions.Replacing`, which is what the one-liner does and is idempotent between them.
+
+## Reading input written by an older schema
+
+`IJob<TInput>` fails a firing whose input is missing, by name, rather than running it with a default payload.
+That is right for a fresh 4.x application and wrong halfway through an upgrade: a 3.x application converting a
+job to `IJob<TInput>` finds its store already holding triggers whose payload is spread over flat `JobDataMap`
+keys, with nothing under `QRTZ_JOB_INPUT`, and every one of those firings would throw.
+
+A job that has to serve both shapes for a while stays an `IJob` and asks:
+
+<!-- snippet: sample_one_off_job_try_get_input -->
+```csharp
+public sealed class SendInvoiceCompatJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // A firing scheduled by 4.x carries the whole payload under one key. One scheduled before the
+        // upgrade carries the flat keys the 3.x job wrote, and there is nothing to read there — which
+        // is an answer here, where an IJob<SendInvoice> would have failed the firing instead.
+        if (!context.TryGetInput(out SendInvoice? invoice) || invoice is null)
+        {
+            invoice = new SendInvoice(
+                context.MergedJobDataMap.GetString("CustomerId")!,
+                context.MergedJobDataMap.GetDecimal("Amount"));
+        }
+
+        return Send(invoice, cancellationToken);
+    }
+
+    private static ValueTask Send(SendInvoice invoice, CancellationToken cancellationToken) => default;
+}
+```
+<!-- endSnippet -->
+
+`TryGetInput` answers `false` only when the key is absent. A value that is present but cannot be read — neither
+a `TInput` nor a payload the serializer understands — still throws, because corruption is not compatibility.
+Once the pre-upgrade triggers have drained, the job becomes an `IJob<TInput>` and the fallback goes.
 
 ## Calling off a whole correlation
 

--- a/docs/documentation/quartz-4.x/how-tos/wolverine.md
+++ b/docs/documentation/quartz-4.x/how-tos/wolverine.md
@@ -238,13 +238,15 @@ public static class OrderPlacedHandler
 {
     public static async Task Handle(OrderPlaced message, IScheduler scheduler, CancellationToken cancellationToken)
     {
-        TriggerKey trigger = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
             new PaymentReminder(message.OrderId, message.Amount),
             ExampleOptions.Current.ReminderDelay,
             new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
             cancellationToken);
 
-        Ledger.Record(Events.ReminderScheduled, trigger.ToString());
+        // The call answers with the trigger's key and the time the store says it will first fire, so
+        // "scheduled for" is what will happen rather than what was asked for.
+        Ledger.Record(Events.ReminderScheduled, $"{scheduled.TriggerKey} at {scheduled.FirstFireTimeUtc:u}");
     }
 }
 ```
@@ -258,7 +260,7 @@ Because the group is part of the trigger's identity, withdrawing everything arra
 a single store operation, with the matcher evaluated where the triggers are:
 
 <!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
-     Copied from src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs:58 — WolverineHowToTest fails when the two stop
+     Copied from src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs:60 — WolverineHowToTest fails when the two stop
      matching. -->
 
 ```csharp
@@ -315,18 +317,20 @@ public static async ValueTask<TriggerKey> ScheduleSend<TMessage>(
         typeof(TMessage).ToMessageTypeName(),
         runtime.Options.DefaultSerializer.WriteMessage(message));
 
-    return await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
+    ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
         envelope,
         delay,
         new OneOffJobOptions { Group = "deferred-envelopes" },
         cancellationToken);
+
+    return scheduled.TriggerKey;
 }
 ```
 
 At fire time the job hands the stored bytes back to Wolverine:
 
 <!-- Not a compiled sample: `Quartz.Documentation.Samples` may not reference `WolverineFx`.
-     Copied from src/Quartz.Examples.Wolverine/Part3RawMessageData.cs:92 — WolverineHowToTest fails when the two stop
+     Copied from src/Quartz.Examples.Wolverine/Part3RawMessageData.cs:94 — WolverineHowToTest fails when the two stop
      matching. -->
 
 ```csharp

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1878,7 +1878,8 @@ runtime type — which is what keeps this working in a trimmed or native-AOT pub
 
 **The API added.** In `Quartz`: `IJob<TInput>`;
 `SchedulerConstants.JobInput` (`"QRTZ_JOB_INPUT"`);
-`JobExecutionContextInputExtensions.GetInput<TInput>(this IJobExecutionContext)`;
+`JobExecutionContextInputExtensions.GetInput<TInput>(this IJobExecutionContext)` and
+`TryGetInput<TInput>(this IJobExecutionContext, out TInput?)`;
 and `JobInputBuilderExtensions.UsingInput<TJob, TInput>` on `JobBuilder<TJob>`, `TriggerBuilder<TJob>`,
 `IJobConfigurator<TJob>` and `ITriggerConfigurator<TJob>`. In `Quartz.Extensibility`:
 `IJobInputSerializer`. In `Quartz.Impl`: `SystemTextJsonJobInputSerializer`, and a fourth optional
@@ -1901,6 +1902,27 @@ argument explicitly — `UsingInput<SendEmailJob, SendEmail>(payload)` — when 
 base type. And a `[PersistJobDataAfterExecution]` job whose *detail* carries the input writes it back
 after every firing; that is harmless, since it is already the string it will be read as, but an input
 that differs per firing belongs on the trigger.
+
+**Converting a job over a store that predates the input.** An `IJob<TInput>` fails a firing that carries no
+input, by name, rather than running it with a default payload — right for a fresh application, and a trap
+for one whose store already holds triggers written by its 3.x self, whose payload is spread over flat
+`JobDataMap` keys with nothing under `QRTZ_JOB_INPUT`. A job that has to serve both shapes while those
+triggers drain stays an `IJob` and reads them apart with `TryGetInput`:
+
+```csharp
+public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+{
+    SendEmail input = context.TryGetInput(out SendEmail? typed) && typed is not null
+        ? typed
+        : new SendEmail(context.MergedJobDataMap.GetString("to")!, context.MergedJobDataMap.GetString("subject")!);
+
+    // ...
+}
+```
+
+`TryGetInput` answers `false` only when the key is absent; a value that is present and unreadable still
+throws, because corruption is not compatibility. `GetInput<TInput>()` cannot tell the two apart — a payload
+that read back as `null` and no payload at all are the same answer there.
 
 **Serialization.** `IJobInputSerializer` is registered per scheduler, keyed by name like every other
 component, and defaults to `SystemTextJsonJobInputSerializer` built from the same
@@ -1986,10 +2008,10 @@ Also new, on top of [typed inputs](#a-job-can-take-a-typed-input): two extension
 that schedule one firing of a job with a payload and a time, and nothing else to build.
 
 ```csharp
-ValueTask<TriggerKey> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, DateTimeOffset at,
+ValueTask<ScheduledOneOffJob> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, DateTimeOffset at,
     OneOffJobOptions options = default, CancellationToken cancellationToken = default) where TJob : IJob<TInput>;
 
-ValueTask<TriggerKey> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, TimeSpan delay,
+ValueTask<ScheduledOneOffJob> ScheduleJob<TJob, TInput>(this IScheduler scheduler, TInput input, TimeSpan delay,
     OneOffJobOptions options = default, CancellationToken cancellationToken = default) where TJob : IJob<TInput>;
 ```
 
@@ -1997,32 +2019,51 @@ They are the imperative twin of `IQuartzBuilder.ScheduleJob<TJob>`, which only e
 an application declares at start-up. 3.x had nothing of the kind.
 
 ```csharp
-TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+ScheduledOneOffJob firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
     invoice, TimeSpan.FromDays(7), new OneOffJobOptions { Name = $"invoice-{invoice.CustomerId}", Group = invoice.CustomerId, Replace = true });
 
-await scheduler.UnscheduleJob(firing);
+logger.LogInformation("Reminder {Trigger} scheduled for {At}", firing.TriggerKey, firing.FirstFireTimeUtc);
+
+await scheduler.UnscheduleJob(firing.TriggerKey);
 ```
 
+**What the call answers with** is `ScheduledOneOffJob`, a two-member `readonly record struct`: the
+`TriggerKey` of the firing — the handle to cancel it with, or to replace it by scheduling the same name
+again — and the `FirstFireTimeUtc` the store computed, which is what the
+`ScheduleJob(trigger, options)` overload it wraps returns and what a caller logging "scheduled for X"
+would otherwise have to infer from the time it asked for. It stays two members: everything else about the
+firing is a property of the trigger the key names.
+
 **One durable job per job type, many triggers.** The job is stored once under
+`SchedulerJobExtensions.ScheduledJobKey<TJob>()`, which is
 `(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)` — a new reserved constant spelled
 `"QRTZ_SCHEDULED"` — and every call adds a trigger to it. That is the shape a message bus's Quartz
 integration converges on: a scheduled message is a trigger, so there is no job churn to pay for. The job is
 ensured with `AddJob` and `Replace`, which is idempotent and cluster-safe, and remembered per scheduler
 instance; a store that reports the job missing gets it put back and the firing retried once, so a cluster
-restore or an operator's delete does not turn into a permanent failure.
+restore or an operator's delete does not turn into a permanent failure. The key is public because an
+integration with a second scheduling path — a recurring trigger it builds itself for the same job — has to
+point that trigger at the same job rather than add one of its own to a group it is told to stay out of.
 
 **`OneOffJobOptions` is named for what the call creates**, not for the call: one off, one firing, one
 trigger. It carries what would otherwise be `TriggerBuilder` calls — `Name`, `Group`, `Description`,
-`Priority`, `ExecutionGroup`, `MisfireInstruction` — plus `Replace`, which it passes on to the store.
-Every member is optional, and `default` is "a one-shot trigger with a generated name, in this job type's
-own group". An overload that schedules a *recurring* job would have something else to say — a schedule,
-an end time, a calendar — and will get an options type of its own rather than nullable members here that
-mean nothing to a single firing. It is a different thing from `ScheduleJobOptions`, which describes a
+`Priority`, `ExecutionGroup`, `MisfireInstruction` — plus `Replace`, which it passes on to the store, and
+`RequestRecovery`, the one member that describes the ensured *job*: set it and that job is marked
+`RequestsRecovery`, so a firing interrupted by a hard shutdown is re-executed when the scheduler comes back.
+Because the job is ensured once per scheduler instance, the first call's value wins for the lifetime of the
+process — which is why it is a named boolean rather than a configuration delegate that would look as though
+it varied per call. Every member is optional, and `default` is "a one-shot trigger with a generated name, in
+this job type's own group". An overload that schedules a *recurring* job would have something else to say — a
+schedule, an end time, a calendar — and will get an options type of its own rather than nullable members here
+that mean nothing to a single firing. It is a different thing from `ScheduleJobOptions`, which describes a
 *store* operation and says only whether it may over-write.
 
 The trigger group is the correlation axis: everything scheduled for one saga, one tenant or one
 conversation can share a group and be listed, paused or unscheduled together. Cancelling is
-`UnscheduleJob(key)`; the durable job stays behind, one row per job type whatever the traffic.
+`UnscheduleJob(key)`; the durable job stays behind, one row per job type whatever the traffic. Mind the
+default when adopting these overloads inside something that already has a trigger-key contract: `Group`
+defaults to the job type's name, so an integration whose callers cancel with `new TriggerKey(id)` — the
+*default* group — must say `Group = TriggerKey.DefaultGroup` or its cancellation silently stops matching.
 
 See [One-Off Job](how-tos/one-off-job.md#a-payload-and-a-time-in-one-call).
 

--- a/src/Quartz.Documentation.Samples/HowTos/EmbeddingSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/EmbeddingSamples.cs
@@ -165,9 +165,9 @@ public static class EmbeddingSamples
 
     public sealed class Conversations(IScheduler scheduler)
     {
-        public ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
+        public async ValueTask<TriggerKey> Remind(SendReminder reminder, TimeSpan delay, CancellationToken cancellationToken)
         {
-            return scheduler.ScheduleJob<SendReminderJob, SendReminder>(
+            ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<SendReminderJob, SendReminder>(
                 reminder,
                 delay,
                 new OneOffJobOptions
@@ -179,6 +179,9 @@ public static class EmbeddingSamples
                     Replace = true
                 },
                 cancellationToken);
+
+            // The call answers with the key it stored and the time the store will first fire it at.
+            return scheduled.TriggerKey;
         }
 
         public ValueTask<bool> Cancel(TriggerKey firing, CancellationToken cancellationToken)
@@ -206,7 +209,7 @@ public static class EmbeddingSamples
 
         ITrigger trigger = TriggerBuilder.Create<SendReminderJob>(scheduler.TimeProvider)
             .WithIdentity(reminder.MessageId, reminder.ConversationId)
-            .ForJob(new JobKey(nameof(SendReminderJob), SchedulerConstants.ScheduledJobGroup))
+            .ForJob(SchedulerJobExtensions.ScheduledJobKey<SendReminderJob>())
             .StartAt(at)
             .UsingInput(reminder)
             .Build();

--- a/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/OneOffJobSamples.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Quartz.Documentation.Samples.HowTos;
 
@@ -109,9 +110,9 @@ public sealed class SendInvoiceJob : IJob<SendInvoice>
 
 public sealed class Invoicing
 {
-    public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+    public async ValueTask Remind(IScheduler scheduler, ILogger logger, SendInvoice invoice, CancellationToken cancellationToken)
     {
-        TriggerKey firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+        ScheduledOneOffJob firing = await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
             invoice,
             TimeSpan.FromDays(7),
             new OneOffJobOptions
@@ -124,9 +125,73 @@ public sealed class Invoicing
             },
             cancellationToken);
 
+        // What was arranged: the trigger's key, and when the store says it will first fire.
+        logger.LogInformation("Reminder {Trigger} scheduled for {At}", firing.TriggerKey, firing.FirstFireTimeUtc);
+
         // ... and to call it off:
-        await scheduler.UnscheduleJob(firing, cancellationToken);
+        await scheduler.UnscheduleJob(firing.TriggerKey, cancellationToken);
     }
+}
+
+#endregion
+
+public sealed class RecoverableInvoicing
+{
+    #region sample_one_off_job_request_recovery
+
+    public async ValueTask Remind(IScheduler scheduler, SendInvoice invoice, CancellationToken cancellationToken)
+    {
+        await scheduler.ScheduleJob<SendInvoiceJob, SendInvoice>(
+            invoice,
+            TimeSpan.FromDays(7),
+            new OneOffJobOptions { RequestRecovery = true },
+            cancellationToken);
+    }
+
+    #endregion
+}
+
+public sealed class InvoicingOnASchedule
+{
+    #region sample_one_off_job_scheduled_job_key
+
+    public async ValueTask Nightly(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        // A schedule of its own, pointed at the job the one-liner keeps rather than at a second job
+        // built here: same job, same payload shape, one more trigger.
+        ITrigger nightly = TriggerBuilder.Create<SendInvoiceJob>(scheduler.TimeProvider)
+            .WithIdentity("nightly", "invoicing")
+            .ForJob(SchedulerJobExtensions.ScheduledJobKey<SendInvoiceJob>())
+            .WithCronSchedule("0 0 2 * * ?")
+            .UsingInput(new SendInvoice("all", 0m))
+            .Build();
+
+        await scheduler.ScheduleJob(nightly, cancellationToken);
+    }
+
+    #endregion
+}
+
+#region sample_one_off_job_try_get_input
+
+public sealed class SendInvoiceCompatJob : IJob
+{
+    public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    {
+        // A firing scheduled by 4.x carries the whole payload under one key. One scheduled before the
+        // upgrade carries the flat keys the 3.x job wrote, and there is nothing to read there — which
+        // is an answer here, where an IJob<SendInvoice> would have failed the firing instead.
+        if (!context.TryGetInput(out SendInvoice? invoice) || invoice is null)
+        {
+            invoice = new SendInvoice(
+                context.MergedJobDataMap.GetString("CustomerId")!,
+                context.MergedJobDataMap.GetDecimal("Amount"));
+        }
+
+        return Send(invoice, cancellationToken);
+    }
+
+    private static ValueTask Send(SendInvoice invoice, CancellationToken cancellationToken) => default;
 }
 
 #endregion

--- a/src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs
+++ b/src/Quartz.Examples.Wolverine/Part2OneOffFromHandler.cs
@@ -42,13 +42,15 @@ public static class OrderPlacedHandler
 {
     public static async Task Handle(OrderPlaced message, IScheduler scheduler, CancellationToken cancellationToken)
     {
-        TriggerKey trigger = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<PaymentReminderJob, PaymentReminder>(
             new PaymentReminder(message.OrderId, message.Amount),
             ExampleOptions.Current.ReminderDelay,
             new OneOffJobOptions { Group = OrderGroup.For(message.OrderId) },
             cancellationToken);
 
-        Ledger.Record(Events.ReminderScheduled, trigger.ToString());
+        // The call answers with the trigger's key and the time the store says it will first fire, so
+        // "scheduled for" is what will happen rather than what was asked for.
+        Ledger.Record(Events.ReminderScheduled, $"{scheduled.TriggerKey} at {scheduled.FirstFireTimeUtc:u}");
     }
 }
 

--- a/src/Quartz.Examples.Wolverine/Part3RawMessageData.cs
+++ b/src/Quartz.Examples.Wolverine/Part3RawMessageData.cs
@@ -69,11 +69,13 @@ public static class Part3RawMessageData
             typeof(TMessage).ToMessageTypeName(),
             runtime.Options.DefaultSerializer.WriteMessage(message));
 
-        return await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<DeferredEnvelopeJob, DeferredEnvelope>(
             envelope,
             delay,
             new OneOffJobOptions { Group = "deferred-envelopes" },
             cancellationToken);
+
+        return scheduled.TriggerKey;
     }
 }
 

--- a/src/Quartz.Tests.Integration/Scenarios/BusIntegrationScenarioTest.cs
+++ b/src/Quartz.Tests.Integration/Scenarios/BusIntegrationScenarioTest.cs
@@ -59,8 +59,9 @@ public enum BusStore
 /// Every primitive the 4.0 integrator work added is tested on its own somewhere else. This is the test
 /// for the place they meet: a scheduler the host builds but does not start, a typed payload put on a
 /// trigger under the bus's own message id, that id scheduled over atomically, a whole correlation
-/// called off in one call, a firing that links back to the request that asked for it, and middleware
-/// around all of it. A bus author should be able to read this top to bottom as "how to embed Quartz",
+/// called off in one call, a firing that links back to the request that asked for it, middleware around
+/// all of it, and a failure retried on the trigger's own policy. A bus author should be able to read
+/// this top to bottom as "how to embed Quartz",
 /// which is the other reason it is one method rather than eight.
 /// </para>
 /// <para>
@@ -100,6 +101,12 @@ public sealed class BusIntegrationScenarioTest
 
     /// <summary>Short enough that the loop re-reads the clock promptly after being signalled.</summary>
     private static readonly TimeSpan IdleWaitTime = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The wait the retry policy in step 7 asks for. On the fake clock, so its length costs nothing and
+    /// is chosen only to be unmistakably shorter than the trigger's next ordinary occurrence.
+    /// </summary>
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(30);
 
     /// <summary>Where the fake clock starts. An arbitrary instant, fixed so the test reads the same every run.</summary>
     private static readonly DateTimeOffset Origin = new DateTimeOffset(2026, 6, 1, 9, 0, 0, TimeSpan.Zero);
@@ -225,14 +232,7 @@ public sealed class BusIntegrationScenarioTest
         await AWholeCorrelationIsCalledOffInOneCall();
         await AFiringLinksBackToTheActivityThatScheduledIt();
         await MiddlewareWrapsEveryFiringAndSeesTheAmbientContext();
-
-        // TODO(#3520): a trigger's retry policy. RetryPolicy and the RETRY_POLICY / RETRY_ATTEMPT
-        // columns exist, but nothing on TriggerBuilder reaches them yet, so there is no call for this
-        // step to make. It belongs here, between the middleware step and shutdown:
-        //
-        //   a firing that throws is retried on the trigger's own policy rather than by holding a
-        //   thread-pool slot, and the attempt count is what the bus reads to give up.
-
+        await AFailedFiringIsRetriedOnTheTriggersOwnPolicy();
         await TheBusStopsTheSchedulerAndTheHostStopsCleanly();
     }
 
@@ -297,10 +297,12 @@ public sealed class BusIntegrationScenarioTest
         string correlationId = $"order-{run}";
         SendReceipt payload = new SendReceipt(correlationId, "customer@example.org", Attempt: 1);
 
-        TriggerKey key = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             payload,
             TimeSpan.FromMinutes(5),
             new OneOffJobOptions { Name = messageId, Group = correlationId });
+
+        TriggerKey key = scheduled.TriggerKey;
 
         key.Should().Be(new TriggerKey(messageId, correlationId),
             "the bus named the firing after its own message id and correlation, and the key it gets back "
@@ -320,12 +322,19 @@ public sealed class BusIntegrationScenarioTest
             .Which.Should().Contain("customer@example.org",
                 "the string is the serialized payload rather than a placeholder");
 
+        scheduled.FirstFireTimeUtc.Should().Be(stored.StartTimeUtc,
+            "the call answers with the time the store computed as well as the key it stored, so a bus "
+            + "logging \"scheduled for\" says when the firing will happen rather than the delay it asked for");
+
         (await scheduler.Exists(DurableJobKey)).Should().BeTrue(
             "one durable job per job type and a trigger per message: a bus schedules thousands of firings "
             + "and must not write a job row for each of them");
 
         Task<Firing> firing = recorder.Expect(key);
-        await AdvanceTo(stored.StartTimeUtc);
+
+        // Driven by the time the call answered with rather than by a second read of the store: an answer
+        // is only worth having if the firing arranged for it happens then.
+        await AdvanceTo(scheduled.FirstFireTimeUtc);
         Firing fired = await Fires(key, firing);
 
         fired.Input.Should().Be(payload,
@@ -346,10 +355,10 @@ public sealed class BusIntegrationScenarioTest
         DateTimeOffset first = Now + TimeSpan.FromMinutes(10);
         SendReceipt draft = new SendReceipt(correlationId, "draft@example.org", Attempt: 1);
 
-        TriggerKey key = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        TriggerKey key = (await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             draft,
             first,
-            new OneOffJobOptions { Name = messageId, Group = correlationId });
+            new OneOffJobOptions { Name = messageId, Group = correlationId })).TriggerKey;
 
         Func<Task> withoutReplace = async () => await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             draft,
@@ -363,12 +372,16 @@ public sealed class BusIntegrationScenarioTest
         DateTimeOffset later = Now + TimeSpan.FromMinutes(20);
         SendReceipt corrected = new SendReceipt(correlationId, "billing@example.org", Attempt: 2);
 
-        TriggerKey replaced = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        ScheduledOneOffJob replaced = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             corrected,
             later,
             new OneOffJobOptions { Name = messageId, Group = correlationId, Replace = true });
 
-        replaced.Should().Be(key, "replacing is the same key by definition, or it is not a replacement");
+        replaced.TriggerKey.Should().Be(key, "replacing is the same key by definition, or it is not a replacement");
+
+        replaced.FirstFireTimeUtc.Should().Be(later,
+            "a replacement answers with its own fire time, so a bus moving a timeout out learns the new "
+            + "time from the call that moved it rather than from a read it would have to make afterwards");
 
         IReadOnlyList<TriggerHeader> underTheKey = await TriggersNamed(correlationId, messageId);
 
@@ -388,7 +401,7 @@ public sealed class BusIntegrationScenarioTest
                 + "payload would deliver a message the bus has already corrected");
 
         Task<Firing> firing = recorder.Expect(key);
-        await AdvanceTo(later);
+        await AdvanceTo(replaced.FirstFireTimeUtc);
         Firing fired = await Fires(key, firing);
 
         fired.Input.Should().Be(corrected,
@@ -412,16 +425,16 @@ public sealed class BusIntegrationScenarioTest
         List<TriggerKey> correlated = [];
         for (int step = 1; step <= 3; step++)
         {
-            correlated.Add(await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+            correlated.Add((await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
                 new SendReceipt(cancelled, "customer@example.org", step),
                 far,
-                new OneOffJobOptions { Name = $"step-{step}", Group = cancelled }));
+                new OneOffJobOptions { Name = $"step-{step}", Group = cancelled })).TriggerKey);
         }
 
-        TriggerKey other = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        TriggerKey other = (await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             new SendReceipt(survivor, "someone-else@example.org", Attempt: 1),
             far,
-            new OneOffJobOptions { Name = "step-1", Group = survivor });
+            new OneOffJobOptions { Name = "step-1", Group = survivor })).TriggerKey;
 
         List<TriggerKey> removed = await scheduler.UnscheduleJobs(GroupMatcher<TriggerKey>.GroupEquals(cancelled));
 
@@ -467,10 +480,10 @@ public sealed class BusIntegrationScenarioTest
 
             try
             {
-                traced = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+                traced = (await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
                     new SendReceipt(correlationId, "traced@example.org", Attempt: 1),
                     at,
-                    new OneOffJobOptions { Name = "traced", Group = correlationId });
+                    new OneOffJobOptions { Name = "traced", Group = correlationId })).TriggerKey;
             }
             finally
             {
@@ -481,10 +494,10 @@ public sealed class BusIntegrationScenarioTest
         Activity.Current.Should().BeNull(
             "the second trigger is the control, so it has to be scheduled from outside any activity");
 
-        TriggerKey untraced = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        TriggerKey untraced = (await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             new SendReceipt(correlationId, "untraced@example.org", Attempt: 1),
             at,
-            new OneOffJobOptions { Name = "untraced", Group = correlationId });
+            new OneOffJobOptions { Name = "untraced", Group = correlationId })).TriggerKey;
 
         Task<Firing> tracedFiring = recorder.Expect(traced);
         Task<Firing> untracedFiring = recorder.Expect(untraced);
@@ -522,10 +535,10 @@ public sealed class BusIntegrationScenarioTest
         string correlationId = $"wrapped-{run}";
         DateTimeOffset at = Now + TimeSpan.FromMinutes(5);
 
-        TriggerKey key = await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
+        TriggerKey key = (await scheduler.ScheduleJob<ReceiptJob, SendReceipt>(
             new SendReceipt(correlationId, "wrapped@example.org", Attempt: 1),
             at,
-            new OneOffJobOptions { Name = "wrapped", Group = correlationId });
+            new OneOffJobOptions { Name = "wrapped", Group = correlationId })).TriggerKey;
 
         Task<Firing> firing = recorder.Expect(key);
         await AdvanceTo(at);
@@ -551,6 +564,77 @@ public sealed class BusIntegrationScenarioTest
             "middleware wraps every firing the scheduler performs, including the ones scheduled before it "
             + "was ever asked about - a pipeline that only covered what a caller routed through it would "
             + "be a wrapper job by another name");
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // 7. A failure. A transient error is what a bus expects most of the time, and retrying it belongs
+    //    to the trigger rather than to a job that sleeps and holds its execution slot while it waits.
+    // -------------------------------------------------------------------------------------------
+
+    private async Task AFailedFiringIsRetriedOnTheTriggersOwnPolicy()
+    {
+        string correlationId = $"retried-{run}";
+        TriggerKey key = new TriggerKey("retried", correlationId);
+        DateTimeOffset at = Now + TimeSpan.FromMinutes(5);
+        SendReceipt payload = new SendReceipt(correlationId, "retried@example.org", Attempt: 1);
+
+        // A trigger the bus builds itself, pointed at the durable job the one-call overloads keep:
+        // OneOffJobOptions carries no policy, and pointing a second scheduling path at the same job is
+        // what ScheduledJobKey<TJob>() is for. Repeating, so there is still a trigger to read after the
+        // retry has succeeded - a one-shot one would be gone, and "the attempt was cleared" would have
+        // nowhere to be true.
+        ITrigger retried = TriggerBuilder.Create<ReceiptJob>(scheduler.TimeProvider)
+            .WithIdentity(key)
+            .ForJob(DurableJobKey)
+            .StartAt(at)
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(24)).RepeatForever())
+            .WithRetryPolicy(RetryPolicy.Fixed(maxAttempts: 2, RetryDelay))
+            .UsingInput(payload)
+            .Build();
+
+        // The first firing throws and the retry does not, which is the shape of the transient failure
+        // the policy exists for. Throwing is the whole of asking for a retry.
+        recorder.FailNextFirings(key, 1);
+
+        await scheduler.ScheduleJob(retried);
+        await AdvanceTo(at);
+
+        ITrigger waiting = await TriggerWhere(key, trigger => trigger.RetryAttempt > 0,
+            "a firing whose job threw is retried on the policy the trigger carries");
+
+        waiting.RetryAttempt.Should().Be(1,
+            "the store records how far through the policy the occurrence is, so the attempt survives a "
+            + "restart and every node in a cluster reads the same one - a counter the bus kept in memory "
+            + "would not");
+
+        waiting.NextFireTimeUtc.Should().Be(Now + RetryDelay,
+            "the retry is scheduled the policy's delay after the failure, measured on the scheduler's own "
+            + "clock - a job that slept for it instead would hold its execution slot for the whole wait");
+
+        (await scheduler.GetTriggerState(key)).Should().Be(TriggerState.Normal,
+            "a failed occurrence with attempts left is a trigger waiting to try again, not a broken one an "
+            + "operator has to reset");
+
+        await AdvanceTo(waiting.NextFireTimeUtc!.Value);
+
+        ITrigger recovered = await TriggerWhere(key, trigger => trigger.RetryAttempt == 0,
+            "a retry that succeeded ends the occurrence and clears its attempt");
+
+        recorder.JobRan.Count(ran => ran.Equals(key)).Should().Be(2,
+            "the occurrence ran twice - the firing that failed and the retry that did not - so a policy "
+            + "with attempts to spare stops as soon as the job stops throwing");
+
+        recorder.AttemptsOf(key).Should().Equal([0, 1],
+            "RetryAttempt is 0 on the scheduled occurrence and n on the n-th retry, which is how a job "
+            + "tells a first go from a last chance without the bus threading a counter through its payload");
+
+        recovered.RetryAttempt.Should().Be(0,
+            "the occurrence is over, so the next failure starts from the policy's first wait again rather "
+            + "than from where this one left off");
+
+        recovered.NextFireTimeUtc.Should().Be(at + TimeSpan.FromHours(24),
+            "the occurrence the schedule called for is exactly where it would have been if nothing had "
+            + "failed - a retry is another go at one occurrence and burns no repeat of the schedule");
     }
 
     // -------------------------------------------------------------------------------------------
@@ -662,8 +746,11 @@ public sealed class BusIntegrationScenarioTest
 
     private DateTimeOffset Now => clock.GetUtcNow();
 
-    /// <summary>The single durable job every firing of <see cref="ReceiptJob" /> hangs off.</summary>
-    private static JobKey DurableJobKey => new JobKey(nameof(ReceiptJob), SchedulerConstants.ScheduledJobGroup);
+    /// <summary>
+    /// The single durable job every firing of <see cref="ReceiptJob" /> hangs off, named the way an
+    /// integration names it rather than by re-deriving the key the extension already spells.
+    /// </summary>
+    private static JobKey DurableJobKey => SchedulerJobExtensions.ScheduledJobKey<ReceiptJob>();
 
     /// <summary>
     /// Moves the scheduler's clock to just past <paramref name="instant" /> and wakes the loop.
@@ -730,6 +817,35 @@ public sealed class BusIntegrationScenarioTest
         return null;
     }
 
+    /// <summary>
+    /// Waits for the stored trigger to satisfy <paramref name="condition" />, and answers with it.
+    /// </summary>
+    /// <remarks>
+    /// Polled rather than awaited, for the reason <see cref="ExecuteActivityFor" /> is: the store is
+    /// written after the job returns, so a firing the recorder already knows about can still be one
+    /// whose outcome has not reached the store. The deadline is real time, and failing it is a failure
+    /// rather than a hang.
+    /// </remarks>
+    private async Task<ITrigger> TriggerWhere(TriggerKey key, Func<ITrigger, bool> condition, string expectation)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + FireDeadline;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ITrigger stored = await scheduler.GetTrigger(key);
+
+            if (stored is not null && condition(stored))
+            {
+                return stored;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"Trigger {key} never reached the state this step waited for within {FireDeadline}: {expectation}.");
+        return null;
+    }
+
     private async Task<IReadOnlyList<TriggerHeader>> TriggersIn(string group)
     {
         PagedResult<TriggerHeader> page = await scheduler.QueryTriggers(new TriggerQuery
@@ -791,6 +907,12 @@ public sealed class BusRecorder
 {
     private readonly ConcurrentDictionary<TriggerKey, TaskCompletionSource<Firing>> firings = new();
 
+    /// <summary>What each firing of a trigger reported as its retry attempt, in the order they ran.</summary>
+    private readonly ConcurrentDictionary<TriggerKey, ConcurrentQueue<int>> attempts = new();
+
+    /// <summary>How many more firings of a trigger must throw.</summary>
+    private readonly ConcurrentDictionary<TriggerKey, int> failures = new();
+
     /// <summary>Every entered / ran / left event, in the order they happened.</summary>
     public ConcurrentQueue<string> Timeline { get; } = new();
 
@@ -812,11 +934,41 @@ public sealed class BusRecorder
     /// </summary>
     public Task<Firing> Expect(TriggerKey key) => Slot(key).Task;
 
-    public void Ran(TriggerKey key, SendReceipt input, bool ambientContextWasThisFiring)
+    public void Ran(TriggerKey key, SendReceipt input, bool ambientContextWasThisFiring, int retryAttempt)
     {
         JobRan.Add(key);
+        attempts.GetOrAdd(key, static _ => new ConcurrentQueue<int>()).Enqueue(retryAttempt);
         Timeline.Enqueue($"job ran {key.Name}");
         Slot(key).TrySetResult(new Firing(key, input, ambientContextWasThisFiring));
+    }
+
+    /// <summary>
+    /// Tells the job to throw on the next <paramref name="count" /> firings of this trigger.
+    /// </summary>
+    /// <remarks>
+    /// A count rather than a flag, so a step says how many attempts fail and the retry after them is a
+    /// real success rather than a second failure nothing asked for.
+    /// </remarks>
+    public void FailNextFirings(TriggerKey key, int count) => failures[key] = count;
+
+    /// <summary>Whether this firing is one a step asked to fail, spending it if so.</summary>
+    public bool FailThisFiring(TriggerKey key)
+    {
+        while (failures.TryGetValue(key, out int left) && left > 0)
+        {
+            if (failures.TryUpdate(key, left - 1, left))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>What the firings of one trigger reported as their retry attempt, in the order they ran.</summary>
+    public List<int> AttemptsOf(TriggerKey key)
+    {
+        return attempts.TryGetValue(key, out ConcurrentQueue<int> recorded) ? [.. recorded] : [];
     }
 
     public void MiddlewareEntered(TriggerKey key, bool ambientContextWasThisFiring)
@@ -849,7 +1001,19 @@ public sealed class ReceiptJob(BusRecorder recorder, IJobExecutionContextAccesso
 {
     public ValueTask Execute(IJobExecutionContext context, SendReceipt input, CancellationToken cancellationToken = default)
     {
-        recorder.Ran(context.Trigger.Key, input, accessor.Current?.FireInstanceId == context.FireInstanceId);
+        recorder.Ran(
+            context.Trigger.Key,
+            input,
+            accessor.Current?.FireInstanceId == context.FireInstanceId,
+            context.RetryAttempt);
+
+        if (recorder.FailThisFiring(context.Trigger.Key))
+        {
+            // Letting an exception out is the whole of asking for a retry: no interface to implement,
+            // no attribute, and nothing for the job to know about the policy the trigger carries.
+            throw new InvalidOperationException($"the receipt for {input.CorrelationId} could not be sent");
+        }
+
         return default;
     }
 }
@@ -864,8 +1028,16 @@ public sealed class BusMiddleware(BusRecorder recorder, IJobExecutionContextAcce
     {
         recorder.MiddlewareEntered(context.Trigger.Key, accessor.Current?.FireInstanceId == context.FireInstanceId);
 
-        await next(context, cancellationToken);
-
-        recorder.MiddlewareLeft(context.Trigger.Key);
+        try
+        {
+            await next(context, cancellationToken);
+        }
+        finally
+        {
+            // In a finally, because a firing whose job throws has to unwind the middleware too: a log
+            // scope or a transport context closed only on the success path would leak on exactly the
+            // firings worth reading about.
+            recorder.MiddlewareLeft(context.Trigger.Key);
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -541,12 +541,12 @@ public class SchedulerTest
     {
         await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerStoresOneDurableJobAndOneTriggerPerCall));
 
-        TriggerKey first = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
-        TriggerKey second = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
+        ScheduledOneOffJob first = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+        ScheduledOneOffJob second = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
 
-        second.Should().NotBe(first, "a call with no name of its own gets a generated one, so two calls never collide");
+        second.TriggerKey.Should().NotBe(first.TriggerKey, "a call with no name of its own gets a generated one, so two calls never collide");
 
-        first.Group.Should().Be(nameof(ReminderJob),
+        first.TriggerKey.Group.Should().Be(nameof(ReminderJob),
             "the trigger group defaults to the job type, and is the axis a caller correlates firings on");
 
         IJobDetail job = await scheduler.GetJobDetail(new JobKey(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup));
@@ -556,7 +556,7 @@ public class SchedulerTest
         List<ITrigger> triggers = await scheduler.GetTriggersOfJob(job.Key);
         triggers.Should().HaveCount(2, "each call adds a trigger; there is no job churn to pay for");
 
-        ITrigger stored = await scheduler.GetTrigger(second);
+        ITrigger stored = await scheduler.GetTrigger(second.TriggerKey);
         stored.StartTimeUtc.Should().Be(FarFuture);
         stored.JobDataMap[SchedulerConstants.JobInput].Should().Be("""{"Note":"second"}""",
             "the payload rides on the trigger, so one job serves every firing");
@@ -570,15 +570,15 @@ public class SchedulerTest
         OneOffJobOptions options = new() { Name = "order-42", Group = "orders", Replace = true };
 
         await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture, options);
-        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture.AddDays(1), options);
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture.AddDays(1), options);
 
-        key.Should().Be(new TriggerKey("order-42", "orders"));
+        scheduled.TriggerKey.Should().Be(new TriggerKey("order-42", "orders"));
 
         IJobDetail job = await scheduler.GetJobDetail(new JobKey(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup));
         (await scheduler.GetTriggersOfJob(job.Key)).Should().ContainSingle(
             "naming the firing and asking to replace is how a caller upserts it, in one call rather than three");
 
-        ITrigger stored = await scheduler.GetTrigger(key);
+        ITrigger stored = await scheduler.GetTrigger(scheduled.TriggerKey);
         stored.StartTimeUtc.Should().Be(FarFuture.AddDays(1));
         stored.JobDataMap[SchedulerConstants.JobInput].Should().Be("""{"Note":"second"}""");
     }
@@ -602,10 +602,10 @@ public class SchedulerTest
         await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerCanBeToldADelayInsteadOfATime));
 
         DateTimeOffset before = DateTimeOffset.UtcNow;
-        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("later"), TimeSpan.FromHours(2));
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("later"), TimeSpan.FromHours(2));
         DateTimeOffset after = DateTimeOffset.UtcNow;
 
-        ITrigger stored = await scheduler.GetTrigger(key);
+        ITrigger stored = await scheduler.GetTrigger(scheduled.TriggerKey);
         stored.StartTimeUtc.Should().BeOnOrAfter(before.AddHours(2)).And.BeOnOrBefore(after.AddHours(2),
             "a delay is measured from the moment the call was made");
     }
@@ -622,11 +622,78 @@ public class SchedulerTest
         JobKey jobKey = new(nameof(ReminderJob), SchedulerConstants.ScheduledJobGroup);
         (await scheduler.DeleteJob(jobKey)).Should().BeTrue();
 
-        TriggerKey key = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture);
 
         (await scheduler.GetJobDetail(jobKey)).Should().NotBeNull(
             "the memo is only an optimization: a store that says the job is missing gets it back and the firing is stored");
-        (await scheduler.GetTrigger(key)).Should().NotBeNull();
+        (await scheduler.GetTrigger(scheduled.TriggerKey)).Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task TheOneLinerAnswersWithTheKeyItStoredAndTheTimeItWillFire()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheOneLinerAnswersWithTheKeyItStoredAndTheTimeItWillFire));
+
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+
+        ITrigger stored = await scheduler.GetTrigger(scheduled.TriggerKey);
+        stored.Should().NotBeNull("the key it answers with is the key it stored, so the handle needs no lookup to be trusted");
+
+        scheduled.FirstFireTimeUtc.Should().Be(stored.NextFireTimeUtc,
+            "the fire time is the store's own answer, which is what makes 'scheduled for' something a caller can log rather than infer from the time it asked for");
+    }
+
+    [Test]
+    public async Task TheEnsuredJobIsTheOneScheduledJobKeyNames()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheEnsuredJobIsTheOneScheduledJobKeyNames));
+
+        ScheduledOneOffJob scheduled = await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+
+        JobKey key = SchedulerJobExtensions.ScheduledJobKey<ReminderJob>();
+        key.Group.Should().Be(SchedulerConstants.ScheduledJobGroup, "the group is reserved, which is why the key is named rather than re-derived");
+
+        (await scheduler.GetJobDetail(key)).Should().NotBeNull(
+            "the key the extension answers with is the key the durable job was actually stored under");
+
+        (await scheduler.GetTrigger(scheduled.TriggerKey)).JobKey.Should().Be(key,
+            "an integration pointing a schedule of its own at that job needs the same key the firings hang off");
+    }
+
+    [Test]
+    public async Task TheEnsuredJobRequestsRecoveryOnlyWhenAsked()
+    {
+        await using IScheduler quiet = await NewScheduler(nameof(TheEnsuredJobRequestsRecoveryOnlyWhenAsked) + "_quiet");
+        await quiet.ScheduleJob<ReminderJob, Reminder>(new Reminder("first"), FarFuture);
+
+        (await quiet.GetJobDetail(SchedulerJobExtensions.ScheduledJobKey<ReminderJob>())).RequestsRecovery
+            .Should().BeFalse("the default is the builder's own, so nothing changes for a caller who says nothing");
+
+        await using IScheduler recovering = await NewScheduler(nameof(TheEnsuredJobRequestsRecoveryOnlyWhenAsked) + "_recovering");
+        await recovering.ScheduleJob<ReminderJob, Reminder>(
+            new Reminder("first"),
+            FarFuture,
+            new OneOffJobOptions { RequestRecovery = true });
+
+        (await recovering.GetJobDetail(SchedulerJobExtensions.ScheduledJobKey<ReminderJob>())).RequestsRecovery
+            .Should().BeTrue("the job every firing hangs off is the one thing the caller cannot otherwise reach, and recovery is a property of it");
+    }
+
+    [Test]
+    public async Task TheFirstCallDecidesWhetherTheEnsuredJobRequestsRecovery()
+    {
+        await using IScheduler scheduler = await NewScheduler(nameof(TheFirstCallDecidesWhetherTheEnsuredJobRequestsRecovery));
+
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(
+            new Reminder("first"),
+            FarFuture,
+            new OneOffJobOptions { RequestRecovery = true });
+
+        await scheduler.ScheduleJob<ReminderJob, Reminder>(new Reminder("second"), FarFuture.AddDays(1));
+
+        (await scheduler.GetJobDetail(SchedulerJobExtensions.ScheduledJobKey<ReminderJob>())).RequestsRecovery
+            .Should().BeTrue(
+                "the job is ensured once per scheduler instance, so the second call does not store it again and cannot quietly undo what the first asked for");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/TypedJobInputTest.cs
+++ b/src/Quartz.Tests.Unit/TypedJobInputTest.cs
@@ -262,6 +262,58 @@ public sealed class TypedJobInputTest
     }
 
     [Test]
+    public void TryGetInputAnswersFalseWhenNothingWasScheduled()
+    {
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            TestUtil.NewMinimalTriggerFiredBundle(),
+            job: null,
+            new SystemTextJsonJobInputSerializer());
+
+        context.TryGetInput(out SendEmail input).Should().BeFalse(
+            "a firing stored before the job took a typed input carries nothing under the key, and an application upgrading from 3.x has to be able to ask rather than be thrown at");
+
+        input.Should().BeNull("nothing was read, so nothing is handed back");
+    }
+
+    [Test]
+    public void TryGetInputReadsTheStoredPayload()
+    {
+        TriggerFiredBundle bundle = TestUtil.NewMinimalTriggerFiredBundle();
+        bundle.Trigger.JobDataMap[SchedulerConstants.JobInput] = """{"To":"someone@example.org","Subject":"hello"}""";
+
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            bundle,
+            job: null,
+            new SystemTextJsonJobInputSerializer());
+
+        context.TryGetInput(out SendEmail input).Should().BeTrue("the firing carries an input, which is the whole of what the answer means");
+
+        input.Should().Be(new SendEmail("someone@example.org", "hello"),
+            "asking whether there is one and reading it are the same operation, so a caller does not deserialize twice");
+    }
+
+    [Test]
+    public void TryGetInputStillThrowsOnAValueItCannotRead()
+    {
+        TriggerFiredBundle bundle = TestUtil.NewMinimalTriggerFiredBundle();
+        bundle.Trigger.JobDataMap[SchedulerConstants.JobInput] = "not json at all";
+
+        IJobExecutionContext context = new JobExecutionContextImpl(
+            scheduler: null,
+            bundle,
+            job: null,
+            new SystemTextJsonJobInputSerializer());
+
+        Action act = () => context.TryGetInput(out SendEmail _);
+
+        act.Should().Throw<SchedulerException>()
+            .WithMessage("*not json at all*",
+                "corruption is not compatibility: only an absent input is an answer, and a present one that will not read is still a failure");
+    }
+
+    [Test]
     public async Task AContextBuiltWithoutASerializerSaysSo()
     {
         SendEmailJob job = new(new Recorder());

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -940,6 +940,7 @@ namespace Quartz
     public static class JobExecutionContextInputExtensions
     {
         public static TInput? GetInput<TInput>(this Quartz.IJobExecutionContext context) { }
+        public static bool TryGetInput<TInput>(this Quartz.IJobExecutionContext context, out TInput? input) { }
     }
     public delegate System.Threading.Tasks.ValueTask JobExecutionDelegate(Quartz.IJobExecutionContext context, System.Threading.CancellationToken cancellationToken);
     public sealed class JobExecutionException : Quartz.SchedulerException
@@ -1157,6 +1158,7 @@ namespace Quartz
         public string? Name { get; init; }
         public int? Priority { get; init; }
         public bool Replace { get; init; }
+        public bool RequestRecovery { get; init; }
     }
     public sealed class OrMatcher<TKey> : Quartz.IMatcher<TKey>
         where TKey : Quartz.Key<TKey>
@@ -1525,6 +1527,12 @@ namespace Quartz
         public bool Replace { get; init; }
         public static Quartz.ScheduleJobOptions Replacing { get; }
     }
+    public readonly struct ScheduledOneOffJob : System.IEquatable<Quartz.ScheduledOneOffJob>
+    {
+        public ScheduledOneOffJob(Quartz.TriggerKey TriggerKey, System.DateTimeOffset FirstFireTimeUtc) { }
+        public System.DateTimeOffset FirstFireTimeUtc { get; init; }
+        public Quartz.TriggerKey TriggerKey { get; init; }
+    }
     public sealed class SchedulerConfigException : Quartz.SchedulerException
     {
         public SchedulerConfigException(string message) { }
@@ -1602,10 +1610,12 @@ namespace Quartz
     {
         public static System.Threading.Tasks.ValueTask<System.DateTimeOffset> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob>(this Quartz.IScheduler scheduler, Quartz.ITrigger trigger, System.Action<Quartz.IJobConfigurator<TJob>>? configure = null, System.Threading.CancellationToken cancellationToken = default)
             where TJob : Quartz.IJob { }
-        public static System.Threading.Tasks.ValueTask<Quartz.TriggerKey> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.DateTimeOffset at, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
+        public static System.Threading.Tasks.ValueTask<Quartz.ScheduledOneOffJob> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.DateTimeOffset at, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
             where TJob : Quartz.IJob<TInput> { }
-        public static System.Threading.Tasks.ValueTask<Quartz.TriggerKey> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.TimeSpan delay, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
+        public static System.Threading.Tasks.ValueTask<Quartz.ScheduledOneOffJob> ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  TJob, TInput>(this Quartz.IScheduler scheduler, TInput input, System.TimeSpan delay, Quartz.OneOffJobOptions options = default, System.Threading.CancellationToken cancellationToken = default)
             where TJob : Quartz.IJob<TInput> { }
+        public static Quartz.JobKey ScheduledJobKey<TJob>()
+            where TJob : Quartz.IJob { }
     }
     public sealed class SchedulerMetadata : System.IEquatable<Quartz.SchedulerMetadata>
     {

--- a/src/Quartz/JobInput.cs
+++ b/src/Quartz/JobInput.cs
@@ -60,6 +60,57 @@ public static class JobExecutionContextInputExtensions
 
         return JobInput.TryRead(context, out TInput? input) ? input : default;
     }
+
+    /// <summary>
+    /// The input this firing carries, reporting whether it carried one at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// What <see cref="GetInput{TInput}" /> cannot say: a payload that deserialized to
+    /// <see langword="null" /> and no payload at all are the same answer there, and different here.
+    /// </para>
+    /// <para>
+    /// The reason it exists is an upgrade. A 3.x application converting a job to
+    /// <see cref="IJob{TInput}" /> over a store that already holds its triggers finds those triggers
+    /// carrying the old shape — the payload spread over flat <see cref="JobDataMap" /> keys — and
+    /// nothing under <see cref="SchedulerConstants.JobInput" />; an <see cref="IJob{TInput}" /> fails
+    /// such a firing by name rather than running it with a default payload. A job that has to serve both
+    /// shapes for a while stays an <see cref="IJob" /> and reads them apart:
+    /// </para>
+    /// <code>
+    /// public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+    /// {
+    ///     SendInvoice invoice = context.TryGetInput(out SendInvoice? typed) &amp;&amp; typed is not null
+    ///         ? typed
+    ///         : new SendInvoice(context.MergedJobDataMap.GetString("CustomerId")!, context.MergedJobDataMap.GetDecimal("Amount"));
+    ///
+    ///     return Send(invoice, cancellationToken);
+    /// }
+    /// </code>
+    /// <para>
+    /// It is still an error for a stored input to be unreadable: a value that is present but neither a
+    /// <typeparamref name="TInput" /> nor a payload the serializer can read throws, because corruption
+    /// is not compatibility. Only <em>absence</em> is answered with <see langword="false" />.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TInput">The type the input was scheduled as.</typeparam>
+    /// <param name="context">The firing to read the input of.</param>
+    /// <param name="input">The input this firing carries, or <see langword="default" /> when it carries none.</param>
+    /// <returns>
+    /// <see langword="true" /> when the firing carries an input, <see langword="false" /> when nothing is
+    /// stored under <see cref="SchedulerConstants.JobInput" />.
+    /// </returns>
+    /// <exception cref="SchedulerException">
+    /// The input is stored but cannot be read: the context was built without an
+    /// <see cref="IJobInputSerializer" />, or the stored value is neither a payload nor a
+    /// <typeparamref name="TInput" />.
+    /// </exception>
+    public static bool TryGetInput<TInput>(this IJobExecutionContext context, out TInput? input)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return JobInput.TryRead(context, out input);
+    }
 }
 
 /// <summary>

--- a/src/Quartz/OneOffJobOptions.cs
+++ b/src/Quartz/OneOffJobOptions.cs
@@ -59,8 +59,17 @@ public readonly record struct OneOffJobOptions
     /// The trigger's group. Defaults to the job type's name.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The group is the correlation axis: everything scheduled for one saga, one tenant or one
     /// conversation can share a group and be listed, paused or unscheduled together.
+    /// </para>
+    /// <para>
+    /// The default is a group of the job type's name rather than <see cref="Key{T}.DefaultGroup" />,
+    /// which matters to anything that already has a trigger-key contract of its own: a caller that
+    /// cancels with <c>new TriggerKey(id)</c> is naming the default group, so scheduling through these
+    /// overloads without saying <c>Group = TriggerKey.DefaultGroup</c> puts the trigger somewhere that
+    /// cancellation silently stops matching. Name the group the contract expects, and the two agree.
+    /// </para>
     /// </remarks>
     public string? Group { get; init; }
 
@@ -97,4 +106,31 @@ public readonly record struct OneOffJobOptions
     /// Only meaningful together with <see cref="Name" />: a generated name has nothing to replace.
     /// </remarks>
     public bool Replace { get; init; }
+
+    /// <summary>
+    /// Whether the durable job the firings hang off is marked
+    /// <see cref="IJobDetail.RequestsRecovery" />, so that a firing interrupted by a hard shutdown is
+    /// re-executed when the scheduler comes back. Defaults to <see langword="false" />, which is
+    /// <see cref="JobBuilder" />'s own default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The one member here that describes the <em>job</em> rather than the trigger, because the job is
+    /// the one thing the one-liner builds that a caller cannot otherwise reach — and recovery is a
+    /// property of it, not of a firing.
+    /// </para>
+    /// <para>
+    /// The job is ensured once per scheduler instance, so the first call's value wins for the process's
+    /// lifetime: a later call asking for something else finds the job already there and does not store
+    /// it again. That is how the memo already treats every other aspect of the job — its description,
+    /// its durability, the type it names — and it is why this is a named boolean rather than a
+    /// configuration delegate, which would look as though it varied per call.
+    /// </para>
+    /// <para>
+    /// A process that has to change it restarts, or deletes the job
+    /// <see cref="SchedulerJobExtensions.ScheduledJobKey{TJob}" /> names — the next call finds it gone
+    /// and stores it afresh with whatever that call asked for.
+    /// </para>
+    /// </remarks>
+    public bool RequestRecovery { get; init; }
 }

--- a/src/Quartz/ScheduledOneOffJob.cs
+++ b/src/Quartz/ScheduledOneOffJob.cs
@@ -1,0 +1,52 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// What one call to the <c>ScheduleJob&lt;TJob, TInput&gt;</c> one-liners arranged: the trigger that was
+/// stored, and when it will first fire.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two members, because the one-liner wraps
+/// <see cref="IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, System.Threading.CancellationToken)" />
+/// and should not answer less than what it wrapped: the key is the handle, and the fire time is what a
+/// caller logging "scheduled for X" would otherwise have to guess from the time it asked for — which is
+/// not the same answer once a calendar or a misfire policy has had its say.
+/// </para>
+/// <para>
+/// It is not a query object, and stays two members. Everything else about the firing is a property of the
+/// trigger the key names, and <see cref="IScheduler.GetTrigger" /> is how to ask for it.
+/// </para>
+/// </remarks>
+/// <param name="TriggerKey">
+/// The key of the trigger that was stored, which is the handle to cancel it with — see
+/// <see cref="IScheduler.UnscheduleJob" /> — or to replace it by scheduling the same name again.
+/// </param>
+/// <param name="FirstFireTimeUtc">
+/// The first time at which the trigger will fire, as the store computed it. The same value the
+/// <see cref="IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, System.Threading.CancellationToken)" />
+/// overload the one-liner wraps returns.
+/// </param>
+/// <seealso cref="SchedulerJobExtensions" />
+/// <seealso cref="OneOffJobOptions" />
+public readonly record struct ScheduledOneOffJob(TriggerKey TriggerKey, DateTimeOffset FirstFireTimeUtc);

--- a/src/Quartz/SchedulerConstants.cs
+++ b/src/Quartz/SchedulerConstants.cs
@@ -129,8 +129,16 @@ public static class SchedulerConstants
     /// overloads keep their durable jobs in — one per job type, named after the type.
     /// </summary>
     /// <remarks>
-    /// Clients should not use this value for a job group of their own. It is named here so that a
+    /// <para>
+    /// Clients should not build jobs of their own in this group: it is the scheduler's, and what is in
+    /// it is one job per job type that the one-call overloads maintain. It is named here so that a
     /// dashboard, a query or a clean-up can say which jobs it means without spelling the string.
+    /// </para>
+    /// <para>
+    /// Addressing the job that <em>is</em> in it — to point a trigger of one's own at it, or to look it
+    /// up — is <see cref="SchedulerJobExtensions.ScheduledJobKey{TJob}" />, which spells the whole key
+    /// so nothing has to re-derive it.
+    /// </para>
     /// </remarks>
     public const string ScheduledJobGroup = "QRTZ_SCHEDULED";
 

--- a/src/Quartz/SchedulerJobExtensions.cs
+++ b/src/Quartz/SchedulerJobExtensions.cs
@@ -89,16 +89,17 @@ public static class SchedulerJobExtensions
     // arranges while it runs rather than at start-up - a retry, a timeout, a reminder, the next step
     // of a saga.
     //
-    // One durable job per job type, many triggers. The job is stored once under
-    // (typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup) and every call adds a trigger to it,
-    // which is the shape a message bus's Quartz integration converges on: a scheduled message is a
-    // trigger, and there is no job churn to pay for. The job is ensured with AddJobOptions.Replacing,
-    // so it is idempotent and safe for several nodes to do at once, and the result is remembered per
-    // scheduler instance so the second call is one round trip rather than two.
+    // One durable job per job type, many triggers. The job is stored once under ScheduledJobKey<TJob>()
+    // and every call adds a trigger to it, which is the shape a message bus's Quartz integration
+    // converges on: a scheduled message is a trigger, and there is no job churn to pay for. The job is
+    // ensured with AddJobOptions.Replacing, so it is idempotent and safe for several nodes to do at
+    // once, and the result is remembered per scheduler instance so the second call is one round trip
+    // rather than two - which is also why the only thing OneOffJobOptions says about the job itself,
+    // RequestRecovery, is first-call-wins.
     //
-    // Cancelling is UnscheduleJob. Give the firing a name and the returned TriggerKey is the handle
-    // to cancel or to replace with; the durable job stays behind, one row per job type whatever the
-    // traffic.
+    // Cancelling is UnscheduleJob. Give the firing a name and the returned ScheduledOneOffJob carries
+    // the handle to cancel or to replace with, beside the time the store says it will first fire; the
+    // durable job stays behind, one row per job type whatever the traffic.
     // -------------------------------------------------------------------------------------------
 
     /// <summary>
@@ -121,8 +122,8 @@ public static class SchedulerJobExtensions
     /// <param name="at">When the job should run.</param>
     /// <param name="options">The trigger's identity and the rest of what can be said about one firing.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    /// <returns>The key of the trigger that was stored, which is the handle to cancel or replace it.</returns>
-    public static ValueTask<TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+    /// <returns>The trigger that was stored and the time it will first fire.</returns>
+    public static ValueTask<ScheduledOneOffJob> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
         this IScheduler scheduler,
         TInput input,
         DateTimeOffset at,
@@ -144,7 +145,7 @@ public static class SchedulerJobExtensions
     /// "Now" is <see cref="IScheduler.TimeProvider" />, so a delay is measured against the same clock
     /// the scheduling loop will compare it to.
     /// </remarks>
-    public static ValueTask<TriggerKey> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+    public static ValueTask<ScheduledOneOffJob> ScheduleJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
         this IScheduler scheduler,
         TInput input,
         TimeSpan delay,
@@ -156,22 +157,48 @@ public static class SchedulerJobExtensions
         return Schedule<TJob, TInput>(scheduler, input, scheduler.TimeProvider.GetUtcNow() + delay, options, cancellationToken);
     }
 
-    private static async ValueTask<TriggerKey> Schedule<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
+    /// <summary>
+    /// The key of the single durable job every firing of <typeparamref name="TJob" /> scheduled by the
+    /// one-call overloads hangs off.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One durable job per job type, named after the type and kept in
+    /// <see cref="SchedulerConstants.ScheduledJobGroup" />. Named here because that group is reserved:
+    /// an integration with a second scheduling path of its own — a recurring trigger built by hand, say,
+    /// for the same job — needs to point that trigger at the job the one-liner ensures, and asking is
+    /// better than re-deriving the key against the advice not to build jobs in the group.
+    /// </para>
+    /// <para>
+    /// The key is derived from the type, not looked up, so it answers whether or not anything has been
+    /// scheduled yet. The job itself appears in the store the first time one of the one-call overloads
+    /// is used on a scheduler.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TJob">The job whose durable detail to name.</typeparam>
+    /// <returns>The key of the durable job the one-call overloads ensure.</returns>
+    public static JobKey ScheduledJobKey<TJob>() where TJob : IJob
+    {
+        return new JobKey(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup);
+    }
+
+    private static async ValueTask<ScheduledOneOffJob> Schedule<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob, TInput>(
         IScheduler scheduler,
         TInput input,
         DateTimeOffset at,
         OneOffJobOptions options,
         CancellationToken cancellationToken) where TJob : IJob<TInput>
     {
-        JobKey jobKey = JobKeyFor<TJob>();
-        await EnsureJob<TJob>(scheduler, cancellationToken).ConfigureAwait(false);
+        JobKey jobKey = ScheduledJobKey<TJob>();
+        await EnsureJob<TJob>(scheduler, options.RequestRecovery, cancellationToken).ConfigureAwait(false);
 
         ITrigger trigger = BuildTrigger<TJob, TInput>(scheduler, jobKey, input, at, options);
         ScheduleJobOptions storeOptions = new() { Replace = options.Replace };
 
+        DateTimeOffset firstFireTimeUtc;
         try
         {
-            await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
+            firstFireTimeUtc = await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
         }
         catch (JobPersistenceException)
         {
@@ -186,23 +213,16 @@ public static class SchedulerJobExtensions
                 throw;
             }
 
-            await EnsureJob<TJob>(scheduler, cancellationToken).ConfigureAwait(false);
-            await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
+            await EnsureJob<TJob>(scheduler, options.RequestRecovery, cancellationToken).ConfigureAwait(false);
+            firstFireTimeUtc = await scheduler.ScheduleJob(trigger, storeOptions, cancellationToken).ConfigureAwait(false);
         }
 
-        return trigger.Key;
-    }
-
-    /// <summary>
-    /// The single durable job every firing of <typeparamref name="TJob" /> hangs off.
-    /// </summary>
-    private static JobKey JobKeyFor<TJob>() where TJob : IJob
-    {
-        return new JobKey(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup);
+        return new ScheduledOneOffJob(trigger.Key, firstFireTimeUtc);
     }
 
     private static ValueTask EnsureJob<[DynamicallyAccessedMembers(JobTypeMembers.Required)] TJob>(
         IScheduler scheduler,
+        bool requestRecovery,
         CancellationToken cancellationToken) where TJob : IJob
     {
         ConcurrentDictionary<Type, bool> ensured = ensuredJobs.GetOrCreateValue(scheduler);
@@ -211,13 +231,14 @@ public static class SchedulerJobExtensions
             return default;
         }
 
-        return Store(scheduler, ensured, cancellationToken);
+        return Store(scheduler, ensured, requestRecovery, cancellationToken);
 
-        static async ValueTask Store(IScheduler scheduler, ConcurrentDictionary<Type, bool> ensured, CancellationToken cancellationToken)
+        static async ValueTask Store(IScheduler scheduler, ConcurrentDictionary<Type, bool> ensured, bool requestRecovery, CancellationToken cancellationToken)
         {
             IJobDetail job = JobBuilder.Create<TJob>()
-                .WithIdentity(JobKeyFor<TJob>())
+                .WithIdentity(ScheduledJobKey<TJob>())
                 .WithDescription($"Scheduled firings of {typeof(TJob).FullName}.")
+                .RequestRecovery(requestRecovery)
                 .StoreDurably()
                 .Build();
 


### PR DESCRIPTION
Porting a message bus's Quartz integration onto the alpha.4 one-call scheduling overloads found four
things the surface could not say. All four are small and additive, and they belong here while the
surface is new.

**The ensured durable job can be told to request recovery.** `OneOffJobOptions.RequestRecovery`
(default `false`) is applied when the job is ensured. It is a named boolean rather than an
`Action<JobBuilder<TJob>>` hook, deliberately: the job is ensured once per scheduler instance, so a
delegate that varied per call would be first-wins and a trap. The XML doc and the how-to both say that
the first call's value stands for the process's lifetime, and that this is how the ensure memo already
treats the job's description, its durability and the type it names.

**The ensured job's key is public.** `SchedulerJobExtensions.ScheduledJobKey<TJob>()` returns
`(typeof(TJob).Name, SchedulerConstants.ScheduledJobGroup)`, which is what an integration with a second
scheduling path needs — its own recurring trigger has to point at the same job rather than re-derive a
key inside a group whose own remarks say not to build jobs in it. `ScheduledJobGroup`'s remarks now say
both halves: do not put jobs of your own here, and this is how you address the one that is here. The
internal derivation is the same call, so there is one spelling of it. It needs no
`[DynamicallyAccessedMembers]` — the key is derived from the type's name, nothing is reflected over, and
the trim analyzers are clean.

**Both one-liner overloads answer with `ScheduledOneOffJob`** — a two-member `readonly record struct`
carrying the `TriggerKey` and the `FirstFireTimeUtc` the store computed — rather than the key alone,
which was less than the `ScheduleJob(trigger, options)` overload they wrap already returns. Every caller
in the repository is swept: the unit tests, the documentation samples, the Wolverine example (parts 2
and 3) and its hand-written page fences, and the embedding how-to's samples that landed in #3537 while
this was being written.

**`TryGetInput<TInput>(out TInput?)` answers whether a firing carries an input at all.** An application
converting a job to `IJob<TInput>` over a store that already holds its 3.x triggers finds those carrying
the payload as flat job data keys and nothing under `QRTZ_JOB_INPUT`, and `IJob<TInput>` fails every one
of them by name. A compat-minded `IJob` can now read both shapes. A value that is present and unreadable
still throws — corruption is not compatibility — and only absence is answered with `false`.

Documentation: `OneOffJobOptions.Group`'s XML doc and the how-to both carry the cancel-contract trap
(the default is the job type's name, so an integration whose callers cancel with `new TriggerKey(id)`
must set `Group = TriggerKey.DefaultGroup`); the one-off how-to gains the `RequestRecovery` and
`ScheduledJobKey` sections and a "reading input written by an older schema" section, all as
`#region sample_*` blocks in `Quartz.Documentation.Samples`; the migration guide's one-call section is
corrected for the new return type and gains the `RequestRecovery`, `ScheduledJobKey` and `Group`
paragraphs, and its typed-input section gains the `TryGetInput` compatibility note.

## For a reviewer to decide

* `RequestRecovery` is passed to the builder unconditionally (`.RequestRecovery(requestRecovery)`)
  rather than called only when `true`. The effect is identical — `false` is `JobBuilder`'s own default —
  and it is one line with no branch to leave untested.
* The embedding how-to's `Conversations.Remind` still returns a `TriggerKey`, projected from the record,
  because that page's point is the key it cancels by. The one-off how-to's sample shows both members.
* The Wolverine example's part 2 now records the fire time beside the key in its ledger, which is what
  made the new return value worth having; `--smoke` still passes.

## Verification

* `dotnet build Quartz.slnx` — succeeded, no warnings.
* `dotnet test src/Quartz.Tests.Unit` — 4142 passed, 0 failed.
* `dotnet test src/Quartz.Tests.AspNetCore` — 548 passed, 0 failed.
* `dotnet test src/Quartz.Tests.Integration` with the container-free `basic` filter — 375 passed, 0
  failed. The database legs need Docker and were not run here.
* `dotnet fallout DocsSnippets` + `VerifyDocsSnippets` — up to date, 101 markdown files checked.
* `npm run docs:check-links` — 219 pages, 1024 internal links, 619 fragments, no dead links or anchors.
* `dotnet run --project src/Quartz.Examples.Wolverine -- --smoke` — `smoke: ok`.

`PublicApiTest_Quartz.verified.txt` moves by exactly the four changes — `TryGetInput`,
`OneOffJobOptions.RequestRecovery`, the `ScheduledOneOffJob` type, `ScheduledJobKey<TJob>()` and the two
changed return types — accepted through Verify, never edited by hand.

Closes #3574