### PR TITLE
A trigger's end time is the last instant at which it may fire

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -392,6 +392,29 @@ here moved for you; if you called `GetInt` and `GetBoolean`, all of it did.
   wherever trigger data is: `MergedJobDataMap`, the dashboard, `GET /triggers`. Turn it off with
   `q.ConfigureScheduler(options => options.PropagateTraceContext = false)`.
 
+### The end time is the last instant at which a trigger may fire
+
+`EndTimeUtc` means one thing on 4.x, for every trigger type: it is the last instant at which the trigger
+may fire, so a fire time exactly equal to it is one the trigger fires and the first instant after it is
+where the schedule stops. That is what Java Quartz's `AbstractTrigger` has always documented — "the time
+after which the trigger will not fire" — and on 3.x the types disagreed about it. Three of them change:
+
+| Trigger | 3.x | 4.x |
+| --- | --- | --- |
+| `SimpleTriggerImpl` | A fire time equal to `EndTimeUtc` is dropped | It fires |
+| `CalendarIntervalTriggerImpl` | A fire time equal to `EndTimeUtc` is dropped | It fires |
+| `DailyTimeIntervalTriggerImpl` | Fires *past* `EndTimeUtc` until the daily window closes, when the end time falls between two fire times; `FinalFireTimeUtc` reports the close of the daily window even when that is past `EndTimeUtc` | Firing stops at the end time, and `FinalFireTimeUtc` is never past it |
+| `CronTriggerImpl` | A fire time equal to `EndTimeUtc` fires | Unchanged |
+| `RecurrenceTriggerImpl` | New in 4.x | A fire time equal to `EndTimeUtc` fires |
+
+A simple or calendar-interval trigger whose `EndAt` lands exactly on one of its fire times therefore fires
+one more time than it did on 3.x, and a daily-time-interval trigger whose `EndAt` lands between two of them
+fires fewer. Move the end time a second off the boundary to keep the old count.
+
+`TriggerFireTimes.ComputeBetween` inherits the rule, because it bounds the walk by handing the window's end
+to the trigger as its `EndTimeUtc`: its `to` is inclusive, for every trigger type, and a fire time landing
+exactly on it is listed.
+
 ### Ordering
 
 * **`JobKey` and `TriggerKey` compare ordinally**, where 3.x compared with the current culture, so any

--- a/docs/documentation/quartz-4.x/tutorial/more-about-triggers.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-triggers.md
@@ -25,6 +25,8 @@ This means you can store a trigger with a schedule such as "every 5th day of the
  it will be a few months before the first firing.
 * The `EndTimeUtc` property indicates when the trigger's schedule should no longer be in effect.
 In other words, a trigger with a schedule of "every 5th day of the month" and with an end time of July 1st will fire for it's last time on June 5th.
+The end time is the last instant at which a trigger may fire: a fire time exactly equal to it is one the trigger fires, and the first instant after it is where the schedule stops.
+This is the same rule for every trigger type.
 
 Other properties, which take a bit more explanation are discussed in the following sub-sections.
 

--- a/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
@@ -74,21 +74,18 @@ public sealed class SchedulerAcrossDstTransitionTest
     private const string TablePrefix = "QRTZ_";
 
     /// <summary>
-    /// Ten minutes short of four hours of elapsed time, starting one hour before the transition
-    /// instant.
+    /// Four hours of elapsed time, starting one hour before the transition instant.
     /// </summary>
     /// <remarks>
-    /// The ten minutes are missing so that no schedule here lands exactly on the far edge of the
-    /// window, where the two sides of the comparison would have to agree about whether the edge is
-    /// inside it - and they do not. <see cref="TriggerFireTimes.ComputeBetween" /> bounds the walk by
-    /// assigning <c>EndTimeUtc = to</c>, and an end time is inclusive for
-    /// <see cref="Quartz.Impl.Triggers.DailyTimeIntervalTriggerImpl" /> and exclusive for
-    /// <see cref="Quartz.Impl.Triggers.SimpleTriggerImpl" />, so a fire at exactly <c>to</c> is
-    /// counted for one and not the other. A scheduler has no end time and fires both. That
-    /// disagreement is about <c>EndAt</c> rather than about daylight saving, so this fixture steps
-    /// around it rather than arbitrating it.
+    /// A whole number of hours, so the half-hourly and quarter-hourly schedules here land exactly on
+    /// the far edge of the window and the two sides of the comparison have to agree about whether
+    /// that edge is inside it. They do: <see cref="TriggerFireTimes.ComputeBetween" /> bounds the
+    /// walk by assigning <c>EndTimeUtc = to</c>, and an end time is the last instant at which a
+    /// trigger may fire, so a fire at exactly <c>to</c> is one every trigger type produces - which is
+    /// what a running scheduler, having no end time at all, does with it too. This window was ten
+    /// minutes shorter until #3458 arbitrated that boundary.
     /// </remarks>
-    private static readonly TimeSpan WindowLength = TimeSpan.FromMinutes(230);
+    private static readonly TimeSpan WindowLength = TimeSpan.FromHours(4);
 
     /// <summary>How far the fake clock moves per step. Eight steps span the window.</summary>
     private static readonly TimeSpan Step = TimeSpan.FromMinutes(30);

--- a/src/Quartz.Tests.Unit/Impl/Triggers/SimpleTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/SimpleTriggerImplTest.cs
@@ -113,7 +113,8 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.That(actual, Is.Null);
+        actual.Should().Be(endTimeUtc,
+            "the next repeat lands on the end time, which is the last instant at which a trigger may fire");
     }
 
     [Test]
@@ -370,6 +371,7 @@ public class SimpleTriggerImplTest
 
         var actual = trigger.GetFireTimeAfter(afterTimeUtc);
 
-        Assert.That(actual, Is.Null);
+        actual.Should().Be(startTimeUtc.AddDays(2),
+            "a fire time that lands exactly on the end time is one the trigger fires");
     }
 }

--- a/src/Quartz.Tests.Unit/RetryEngineTest.cs
+++ b/src/Quartz.Tests.Unit/RetryEngineTest.cs
@@ -190,6 +190,73 @@ public class RetryEngineTest
         trigger.RetryAttempt.Should().Be(0);
     }
 
+    /// <summary>
+    /// The other side of that boundary: a retry landing exactly <em>on</em> the end time is a fire at
+    /// the end time, and the end time is the last instant at which a trigger may fire.
+    /// </summary>
+    [Test]
+    public void ARetryLandingExactlyOnTheEndTimeIsScheduled()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("ending-on-the-instant", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .StartAt(now)
+            .EndAt(now.AddMinutes(5))
+            .WithRetryPolicy(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull("the next hourly occurrence is an hour past the end time");
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger,
+            "the retry lands on the end time rather than past it, and a fire on the end time fires");
+        trigger.RetryAttempt.Should().Be(1);
+        trigger.NextFireTimeUtc.Should().Be(now.AddMinutes(5));
+
+        ((TriggerBase) trigger).RetryFired(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull("nothing fires after the end time, retry or occurrence");
+    }
+
+    /// <summary>
+    /// A failure on the occurrence before the last one, where the last one lands exactly on the end
+    /// time: the retry runs and the boundary occurrence is still there afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Both halves of this are the end time being inclusive (#3458). While it was exclusive for a
+    /// simple trigger, <see cref="ITrigger.NextFireTimeUtc" /> was already <see langword="null" />
+    /// here, so the trigger was deleted at the end of the failed occurrence and the fire on the end
+    /// time - which <see cref="ITrigger.FinalFireTimeUtc" /> named all along - never happened.
+    /// </remarks>
+    [Test]
+    public void ARetryKeepsTheOccurrenceThatLandsOnTheEndTime()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("ending-on-an-occurrence", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .StartAt(now)
+            .EndAt(now.AddHours(1))
+            .WithRetryPolicy(RetryPolicy.Fixed(3, TimeSpan.FromMinutes(5)))
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1),
+            "the last occurrence lands on the end time, which is the last instant at which it may fire");
+
+        trigger.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        trigger.NextFireTimeUtc.Should().Be(now.AddMinutes(5), "the retry comes before that occurrence");
+
+        ((TriggerBase) trigger).RetryFired(null);
+
+        trigger.NextFireTimeUtc.Should().Be(now.AddHours(1),
+            "a retry is another attempt at the occurrence that failed, so the one on the end time is still to come");
+        trigger.MayFireAgain.Should().BeTrue();
+    }
+
     [Test]
     public void ATriggerWithNoPolicyIsUnchanged()
     {

--- a/src/Quartz.Tests.Unit/TriggerEndTimeBoundaryTest.cs
+++ b/src/Quartz.Tests.Unit/TriggerEndTimeBoundaryTest.cs
@@ -1,0 +1,219 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Microsoft.Extensions.Time.Testing;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// <see cref="ITrigger.EndTimeUtc" /> means one thing for every shipped trigger type: it is the last
+/// instant at which a trigger may fire, so a fire time exactly equal to it is produced, and nothing
+/// past it is.
+/// </summary>
+/// <remarks>
+/// One table over all five types, because the types disagreed — see #3458.
+/// </remarks>
+public class TriggerEndTimeBoundaryTest
+{
+    /// <summary>
+    /// Every schedule in the table fires hourly from here, so the third repeat lands exactly on
+    /// <see cref="End" /> and the boundary is a fire time the schedule genuinely produces.
+    /// </summary>
+    private static readonly DateTimeOffset Start = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static readonly DateTimeOffset End = Start.AddHours(3);
+
+    /// <summary>
+    /// An end time that falls between two fire times, where "the trigger fires at the end time"
+    /// cannot be what stops the schedule.
+    /// </summary>
+    private static readonly DateTimeOffset MisalignedEnd = Start.AddHours(2).AddMinutes(30);
+
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// The five shipped trigger types, each building the same hourly schedule, with an end time the
+    /// caller chooses so the same schedule can be walked with and without one.
+    /// </summary>
+    public static IEnumerable<TestCaseData> TriggerTypes()
+    {
+        yield return Case("Simple", (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+            .WithSchedule(SimpleScheduleBuilder.Create().WithInterval(Interval).RepeatForever()));
+
+        yield return Case("Cron", (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+            .WithSchedule(CronScheduleBuilder.Create("0 0 * * * ?").InTimeZone(TimeZoneInfo.Utc)));
+
+        yield return Case("CalendarInterval", (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+            .WithSchedule(CalendarIntervalScheduleBuilder.Create().WithInterval(1, IntervalUnit.Hour).InTimeZone(TimeZoneInfo.Utc)));
+
+        yield return Case("DailyTimeInterval", (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+            .WithSchedule(DailyTimeIntervalScheduleBuilder.Create()
+                .WithInterval(1, IntervalUnit.Hour)
+                .OnEveryDay()
+                .InTimeZone(TimeZoneInfo.Utc)));
+
+        yield return Case("Recurrence", (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+            .WithSchedule(RecurrenceScheduleBuilder.Create("FREQ=HOURLY").InTimeZone(TimeZoneInfo.Utc)));
+    }
+
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void GetFireTimeAfter_ProducesTheFireTimeThatLandsOnTheEndTime(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, End);
+
+        trigger.GetFireTimeAfter(End - Interval).Should().Be(End,
+            "the end time is the last instant at which a trigger may fire, so a fire time equal to it still fires");
+    }
+
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void GetFireTimeAfter_ProducesNothingPastTheEndTime(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, End);
+
+        trigger.GetFireTimeAfter(End).Should().BeNull(
+            "the end time is the last instant at which a trigger may fire, so nothing after it fires");
+    }
+
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void TheWalkEndsOnTheEndTime(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, End);
+
+        List<DateTimeOffset> fireTimes = TriggerFireTimes.Compute(trigger, calendar: null, numberOfTimes: 10);
+
+        fireTimes.Should().Equal(
+            [Start, Start.AddHours(1), Start.AddHours(2), End],
+            "the schedule runs out at the end time, having fired on it");
+    }
+
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void FinalFireTimeIsTheFireTimeOnTheEndTime(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, End);
+
+        trigger.FinalFireTimeUtc.Should().Be(End,
+            "the fire time that lands on the end time is the last one, so it is the final one");
+    }
+
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void NothingFiresPastAnEndTimeThatIsNoFireTime(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, MisalignedEnd);
+
+        trigger.GetFireTimeAfter(Start.AddHours(2)).Should().BeNull(
+            "the next repeat falls past the end time, and an end time between two fire times ends the schedule at the earlier one");
+
+        TriggerFireTimes.Compute(trigger, calendar: null, numberOfTimes: 10).Should().Equal(
+            [Start, Start.AddHours(1), Start.AddHours(2)],
+            "an end time is a bound on firing, not merely on how far the schedule is walked");
+
+        trigger.FinalFireTimeUtc.Should().BeOnOrBefore(MisalignedEnd,
+            "a trigger's last fire cannot be past the last instant at which it may fire");
+    }
+
+    /// <summary>
+    /// The daily-time-interval trigger reports the last instant at which it may fire rather than a
+    /// fire time its schedule produces, which the other four types do. What it may not report is a
+    /// time past the end time.
+    /// </summary>
+    [Test]
+    public void DailyTimeIntervalFinalFireTimeStopsAtTheEndTimeRatherThanTheDailyWindow()
+    {
+        IOperableTrigger trigger = Build(
+            (clock, endTimeUtc) => Builder(clock, endTimeUtc)
+                .WithSchedule(DailyTimeIntervalScheduleBuilder.Create()
+                    .WithInterval(1, IntervalUnit.Hour)
+                    .OnEveryDay()
+                    .InTimeZone(TimeZoneInfo.Utc)),
+            MisalignedEnd);
+
+        trigger.FinalFireTimeUtc.Should().Be(MisalignedEnd,
+            "the daily window closing at 23:59:59 is no reason to report a final fire past the end time");
+    }
+
+    /// <summary>
+    /// The other reading of the same rule: where the daily window closes before the end time, the
+    /// window is the last instant at which the trigger may fire.
+    /// </summary>
+    [Test]
+    public void DailyTimeIntervalFinalFireTimeStopsAtTheDailyWindowWhenThatComesFirst()
+    {
+        DateTimeOffset endTimeUtc = Start.AddHours(20);
+
+        IOperableTrigger trigger = Build(
+            (clock, endAt) => Builder(clock, endAt)
+                .WithSchedule(DailyTimeIntervalScheduleBuilder.Create()
+                    .WithInterval(1, IntervalUnit.Hour)
+                    .OnEveryDay()
+                    .StartingDailyAt(new TimeOnly(8, 0))
+                    .EndingDailyAt(new TimeOnly(17, 0))
+                    .InTimeZone(TimeZoneInfo.Utc)),
+            endTimeUtc);
+
+        trigger.FinalFireTimeUtc.Should().Be(Start.AddHours(17),
+            "the trigger cannot fire between the window closing at 17:00 and the end time three hours later");
+    }
+
+    /// <summary>
+    /// <see cref="TriggerFireTimes.ComputeBetween" /> bounds the walk by assigning the window's end
+    /// to the trigger, so its <c>to</c> is inclusive for the same reason every trigger's end time is.
+    /// </summary>
+    [TestCaseSource(nameof(TriggerTypes))]
+    public void ComputeBetween_IncludesAFireTimeOnTheWindowEnd(TriggerFactory factory)
+    {
+        IOperableTrigger trigger = Build(factory, endTimeUtc: null);
+
+        List<DateTimeOffset> fireTimes = TriggerFireTimes.ComputeBetween(trigger, calendar: null, from: Start, to: End);
+
+        fireTimes.Should().Equal(
+            [Start, Start.AddHours(1), Start.AddHours(2), End],
+            "the window's end is a boundary of the same kind as a trigger's own end time");
+    }
+
+    /// <summary>
+    /// Builds one of the tabulated triggers against a clock reading a minute before <see cref="Start" />,
+    /// so that no trigger sees its own schedule as past due.
+    /// </summary>
+    private static IOperableTrigger Build(TriggerFactory factory, DateTimeOffset? endTimeUtc)
+    {
+        FakeTimeProvider clock = new FakeTimeProvider(Start.AddMinutes(-1));
+        return (IOperableTrigger) factory(clock, endTimeUtc).Build();
+    }
+
+    private static TriggerBuilder<IJob> Builder(TimeProvider clock, DateTimeOffset? endTimeUtc)
+    {
+        return TriggerBuilder.Create(clock)
+            .WithIdentity("trigger", "group")
+            .ForJob("job", "group")
+            .StartAt(Start)
+            .EndAt(endTimeUtc);
+    }
+
+    private static TestCaseData Case(string name, TriggerFactory factory)
+    {
+        return new TestCaseData(factory).SetArgDisplayNames(name);
+    }
+
+    /// <summary>
+    /// Builds one trigger type's hourly schedule, with the given end time.
+    /// </summary>
+    public delegate TriggerBuilder<IJob> TriggerFactory(TimeProvider clock, DateTimeOffset? endTimeUtc);
+}

--- a/src/Quartz/Configuration/ITriggerConfigurator.cs
+++ b/src/Quartz/Configuration/ITriggerConfigurator.cs
@@ -181,6 +181,8 @@ public interface ITriggerConfigurator<[DynamicallyAccessedMembers(JobTypeMembers
     /// schedule has remaining repeats.
     /// </summary>
     /// <remarks>
+    /// The end time is inclusive: it is the last instant at which the trigger may fire, so a fire
+    /// time that lands exactly on it is one the trigger fires.
     /// </remarks>
     /// <param name="endTimeUtc">the end time for the Trigger.  If null, the end time is indefinite.</param>
     /// <returns>the updated TriggerBuilder</returns>

--- a/src/Quartz/Extensibility/IMutableTrigger.cs
+++ b/src/Quartz/Extensibility/IMutableTrigger.cs
@@ -103,6 +103,7 @@ public interface IMutableTrigger : ITrigger
     /// </para>
     /// </summary>
     /// <remarks>
+    /// The end time is inclusive: it is the last instant at which the trigger may fire.
     /// </remarks>
     new DateTimeOffset? EndTimeUtc { get; set; }
 

--- a/src/Quartz/Extensibility/TriggerFireTimes.cs
+++ b/src/Quartz/Extensibility/TriggerFireTimes.cs
@@ -142,8 +142,12 @@ public static class TriggerFireTimes
     /// </summary>
     /// <param name="trigger">The trigger upon which to do the work</param>
     /// <param name="calendar">The calendar to apply to the trigger's schedule</param>
-    /// <param name="from">The starting date at which to find fire times</param>
-    /// <param name="to">The ending date at which to stop finding fire times</param>
+    /// <param name="from">The starting date at which to find fire times, inclusive</param>
+    /// <param name="to">
+    /// The ending date at which to stop finding fire times, inclusive: a fire time that lands
+    /// exactly on it is listed. The window is handed to the trigger as its
+    /// <see cref="ITrigger.EndTimeUtc" />, which is inclusive for the same reason.
+    /// </param>
     public static List<DateTimeOffset> ComputeBetween(IOperableTrigger trigger, ICalendar? calendar, DateTimeOffset from, DateTimeOffset to)
     {
         List<DateTimeOffset> lst = new List<DateTimeOffset>();

--- a/src/Quartz/ITrigger.cs
+++ b/src/Quartz/ITrigger.cs
@@ -193,9 +193,14 @@ public interface ITrigger
     /// <summary>
     /// Gets and sets the date/time on which the trigger must stop firing. This
     /// defines the final boundary for trigger firings &#x8212; the trigger will
-    /// not fire after to this date and time. If this value is null, no end time
+    /// not fire after this date and time. If this value is null, no end time
     /// boundary is assumed, and the trigger can continue indefinitely.
     /// </summary>
+    /// <remarks>
+    /// The end time is inclusive, for every trigger type: it is the last instant at which the
+    /// trigger may fire, so a fire time exactly equal to it is one the trigger fires, and the first
+    /// instant after it is where the schedule stops.
+    /// </remarks>
     DateTimeOffset? EndTimeUtc { get; }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CalendarIntervalTriggerImpl.cs
@@ -465,6 +465,10 @@ public class CalendarIntervalTriggerImpl : TriggerBase, ICalendarIntervalTrigger
     /// after the given time. If the trigger will not fire after the given time,
     /// <see langword="null" /> will be returned.
     /// </summary>
+    /// <remarks>
+    /// A fire time that lands exactly on <see cref="EndTimeUtc" /> is one the trigger fires: the
+    /// end time is the last instant at which a trigger may fire.
+    /// </remarks>
     public override DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime)
     {
         return GetFireTimeAfter(afterTime, false);
@@ -487,7 +491,10 @@ public class CalendarIntervalTriggerImpl : TriggerBase, ICalendarIntervalTrigger
         DateTimeOffset afterMillis = afterTime.Value;
         DateTimeOffset endMillis = EndTimeUtc ?? DateTimeOffset.MaxValue;
 
-        if (!ignoreEndTime && endMillis <= afterMillis)
+        // afterMillis is already a second past the time asked about, so a fire time landing on the
+        // end time is still reachable from the second before it; only a question asked past the end
+        // time has nothing left to answer with.
+        if (!ignoreEndTime && endMillis < afterMillis)
         {
             return null;
         }
@@ -643,7 +650,7 @@ public class CalendarIntervalTriggerImpl : TriggerBase, ICalendarIntervalTrigger
                 time = sTime;
             }
         } // case of interval of a day or greater
-        if (!ignoreEndTime && endMillis <= time)
+        if (!ignoreEndTime && endMillis < time)
         {
             return null;
         }

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -527,9 +527,33 @@ public class DailyTimeIntervalTriggerImpl : TriggerBase, IDailyTimeIntervalTrigg
     /// fire, after the given time. If the trigger will not fire after the given
     /// time, <see langword="null" /> will be returned.
     /// </summary>
+    /// <remarks>
+    /// A fire time that lands exactly on <see cref="EndTimeUtc" /> is one the trigger fires: the
+    /// end time is the last instant at which a trigger may fire.
+    /// </remarks>
     /// <param name="afterTime"></param>
     /// <returns></returns>
     public override DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime)
+    {
+        DateTimeOffset? fireTime = ComputeFireTimeAfter(afterTime);
+        DateTimeOffset? endTime = EndTimeUtc;
+
+        // The walk below consults the end time only where it has to advance to another day, so a
+        // fire time reached by stepping the interval within one day is bounded here instead.
+        // Without this the trigger goes on firing past its end time until the daily window closes.
+        if (fireTime is not null && endTime is not null && fireTime.Value > endTime.Value)
+        {
+            return null;
+        }
+
+        return fireTime;
+    }
+
+    /// <summary>
+    /// The schedule walk behind <see cref="GetFireTimeAfter" />, which bounds what this returns by
+    /// <see cref="EndTimeUtc" />.
+    /// </summary>
+    private DateTimeOffset? ComputeFireTimeAfter(DateTimeOffset? afterTime)
     {
         // Check if trigger has completed or not.
         if (complete)
@@ -782,25 +806,34 @@ public class DailyTimeIntervalTriggerImpl : TriggerBase, IDailyTimeIntervalTrigg
     /// Returns the final time at which the <see cref="IDailyTimeIntervalTrigger" /> will
     /// fire, if there is no end time set, null will be returned.
     /// </summary>
-    /// <remarks>Note that the return time may be in the past.</remarks>
+    /// <remarks>
+    /// <para>Note that the return time may be in the past.</para>
+    /// <para>
+    /// Unlike the other shipped trigger types this is the last instant at which the trigger may
+    /// fire rather than a fire time its schedule produces: neither <see cref="EndTimeUtc" /> nor
+    /// <see cref="EndTimeOfDay" /> has to land on a repeat of the interval. It is never past
+    /// <see cref="EndTimeUtc" />, which is where every trigger's firing stops.
+    /// </para>
+    /// </remarks>
     /// <returns></returns>
     public override DateTimeOffset? FinalFireTimeUtc
     {
         get
         {
-            if (complete || EndTimeUtc is null)
+            DateTimeOffset? endTime = EndTimeUtc;
+
+            if (complete || endTime is null)
             {
                 return null;
             }
 
-            // We have an endTime, we still need to check to see if there is a endTimeOfDay if that's applicable.
-            DateTimeOffset? endTime = EndTimeUtc;
-            DateTimeOffset? endTimeOfDayDate = endTimeOfDay.OnDate(endTime);
-            if (endTime < endTimeOfDayDate)
-            {
-                endTime = endTimeOfDayDate;
-            }
-            return endTime;
+            // The daily window closes on the end time's own local day, which comes first whenever
+            // the end time falls after it. Resolved through the trigger's time zone rather than the
+            // end time's offset, which is the offset the window would be read in otherwise.
+            DateTimeOffset endTimeLocal = TimeZones.ConvertTime(endTime.Value, TimeZone);
+            DateTimeOffset endOfWindow = TimeZones.ResolveLocal(endTimeOfDay.OnDate(endTimeLocal).DateTime, TimeZone);
+
+            return endTime.Value < endOfWindow ? endTime.Value : endOfWindow;
         }
     }
 

--- a/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/SimpleTriggerImpl.cs
@@ -531,6 +531,10 @@ public class SimpleTriggerImpl : TriggerBase, ISimpleTrigger
     /// fire, after the given UTC time. If the trigger will not fire after the given
     /// time, <see langword="null" /> will be returned.
     /// </summary>
+    /// <remarks>
+    /// A fire time that lands exactly on <see cref="TriggerBase.EndTimeUtc" /> is one the trigger
+    /// fires: the end time is the last instant at which a trigger may fire.
+    /// </remarks>
     public override DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTimeUtc)
     {
         if (repeatCount != RepeatIndefinitely && timesTriggered > repeatCount)
@@ -553,6 +557,9 @@ public class SimpleTriggerImpl : TriggerBase, ISimpleTrigger
 
         DateTimeOffset? endTimeUtc = EndTimeUtc;
 
+        // Every fire time this method can produce is strictly after afterMillis, so once the end
+        // time has been reached there is nothing left to produce - the fire time that lands on the
+        // end time has already been handed out.
         if (endTimeUtc.HasValue && endTimeUtc.GetValueOrDefault() <= afterMillis)
         {
             return null;
@@ -573,7 +580,7 @@ public class SimpleTriggerImpl : TriggerBase, ISimpleTrigger
 
         DateTimeOffset time = startMillis.AddTicks(numberOfTimesExecuted * repeatInterval.Ticks);
 
-        if (endTimeUtc.HasValue && endTimeUtc.GetValueOrDefault() <= time)
+        if (endTimeUtc.HasValue && endTimeUtc.GetValueOrDefault() < time)
         {
             return null;
         }

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -450,9 +450,14 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     /// <summary>
     /// Gets and sets the date/time on which the trigger must stop firing. This
     /// defines the final boundary for trigger firings &#x8212; the trigger will
-    /// not fire after to this date and time. If this value is null, no end time
+    /// not fire after this date and time. If this value is null, no end time
     /// boundary is assumed, and the trigger can continue indefinitely.
     /// </summary>
+    /// <remarks>
+    /// The end time is inclusive, for every trigger type: it is the last instant at which the
+    /// trigger may fire, so a fire time exactly equal to it is one the trigger fires, and the first
+    /// instant after it is where the schedule stops.
+    /// </remarks>
     public virtual DateTimeOffset? EndTimeUtc
     {
         get => endTimeUtc;

--- a/src/Quartz/TriggerBuilder.cs
+++ b/src/Quartz/TriggerBuilder.cs
@@ -426,6 +426,8 @@ public sealed class TriggerBuilder<[DynamicallyAccessedMembers(JobTypeMembers.Re
     /// schedule has remaining repeats.
     /// </summary>
     /// <remarks>
+    /// The end time is inclusive: it is the last instant at which the trigger may fire, so a fire
+    /// time that lands exactly on it is one the trigger fires.
     /// </remarks>
     /// <param name="endTimeUtc">the end time for the Trigger.  If null, the end time is indefinite.</param>
     /// <returns>the updated TriggerBuilder</returns>


### PR DESCRIPTION
`EndTimeUtc` meant two things. A fire time exactly equal to it was produced by three of the five shipped
trigger types and dropped by the other two, so the same window yielded a different number of fires
depending on which type walked it — which is what made `TriggerFireTimes.ComputeBetween`, whose walk is
bounded by assigning `EndTimeUtc = to`, disagree with a running scheduler about its own far edge.

**The end time is inclusive**: it is the last instant at which a trigger may fire, so a fire time exactly
equal to it is one the trigger fires and the first instant after it is where the schedule stops. That is
what Java Quartz's `AbstractTrigger` has always documented — "the time after which the trigger will not
fire" — and it is now what all five types do.

## The table

`src/Quartz.Tests.Unit/TriggerEndTimeBoundaryTest.cs` is a `[TestCaseSource]` over all five types, each
building the same hourly schedule from `2026-06-01T00:00Z`. It was written against current behaviour
first; this is what it reported, run on `e770ed04a`:

| Trigger type | Fires at `EndTimeUtc`, when a fire time lands on it | Fires *past* `EndTimeUtc`, when the end falls between two fire times | `FinalFireTimeUtc` |
| --- | --- | --- | --- |
| `SimpleTriggerImpl` | **no** | no | the boundary fire it refused to produce |
| `CronTriggerImpl` | yes | no | the last fire |
| `CalendarIntervalTriggerImpl` | **no** | no | the boundary fire it refused to produce |
| `DailyTimeIntervalTriggerImpl` | yes | **yes** — on until the daily window closed | **`23:59:59` on the end date**, a day past the end |
| `RecurrenceTriggerImpl` | yes | no | the last fire |

After this change every cell reads "yes / no / the last fire (or, for the daily trigger, never past the end
time)", and the same table covers `TriggerFireTimes.Compute`, `TriggerFireTimes.ComputeBetween` and
`FinalFireTimeUtc` for each type.

Two things the tabulation turned up that the issue did not name:

* **`CalendarIntervalTriggerImpl` was exclusive too**, the same way `SimpleTriggerImpl` was — the issue
  left cron, calendar-interval and recurrence untabulated, and this is the third outlier. Cron and
  recurrence were already inclusive and are untouched.
* **`DailyTimeIntervalTriggerImpl` was not merely inclusive, it leaked.** Its walk consulted the end time
  only where it had to advance to another day, so an end time falling between two fire times let the
  trigger go on firing past it until the daily window closed: with `EndAt(02:30)` on an hourly schedule,
  `GetFireTimeAfter(02:00)` answered `03:00`. And `FinalFireTimeUtc` reported the close of the daily
  window — `23:59:59` — even when that was most of a day past the end time.

Both exclusive types were also self-inconsistent before this: each reported the boundary fire as its
`FinalFireTimeUtc` while refusing to produce it, and each already fired it when it happened to be the
trigger's *first* fire (`ComputeFirstFireTimeUtc` consults no end time).

## The change

* `SimpleTriggerImpl.GetFireTimeAfter` and `CalendarIntervalTriggerImpl.GetFireTimeAfter`: `<=` becomes
  `<` against the end time. The early-out on the *asked-about* time stays exclusive in both, because every
  fire time either can produce is strictly after it.
* `DailyTimeIntervalTriggerImpl.GetFireTimeAfter` becomes a wrapper that bounds the schedule walk — now
  `ComputeFireTimeAfter` — by the end time, which is the one seam every return path passes through.
* `DailyTimeIntervalTriggerImpl.FinalFireTimeUtc` returns the earlier of the end time and the close of the
  daily window on the end time's own local day, resolved through the trigger's time zone rather than
  through whatever offset the end time carries.
* Doc comments on `ITrigger.EndTimeUtc`, `TriggerBase.EndTimeUtc`, `IMutableTrigger.EndTimeUtc`,
  `TriggerBuilder.EndAt` and the three `GetFireTimeAfter` overrides state the rule.
* `TriggerFireTimes.ComputeBetween`: its `to` is documented as inclusive. The walk's own bound was already
  `d > to → break`, so `to` and the `EndTimeUtc` it assigns to the trigger now agree for every type; a
  fire time landing exactly on `to` is listed.
* The scheduler-across-DST fixture had its window shortened by ten minutes to step around this
  disagreement (#3455). It is back to four hours, so the far edge is a fire time both sides of that
  comparison assert — the half-hourly and quarter-hourly triggers land on it. Without the product change
  that fixture now fails, which makes it the end-to-end regression test for this.

## What a reviewer should know

* **`DailyTimeIntervalTriggerImpl.FinalFireTimeUtc` is still an upper bound, not a fire time.** The other
  four types compute the last fire time their schedule produces; this one answers with a boundary, and
  after this change with the tighter and never-past-the-end of the two boundaries it has. Computing the
  actual last fire needs a backwards day-of-week walk with its own DST corners, which is a bigger change
  than this issue asked for. Ratified as it stands; nothing filed.
* **Nobody's stored data changes**, and no public API does: the baselines do not move (only XML doc
  comments were added to public members).
* **Behaviour that changes for an application**: a simple or calendar-interval trigger whose `EndAt` lands
  exactly on one of its fire times fires one more time than before; a daily-time-interval trigger whose
  `EndAt` falls between two fire times fires fewer. Both are in the migration guide, with the advice to
  move the end time a second off the boundary to keep the old count.

## The retry engine reads the same boundary

Rebased onto `801482101`, so #3569 is underneath this rather than beside it, and the interplay is tested
rather than argued. The retry engine's own end-time tests pass unchanged, and the 25-case
`RetryMatrixTest` passes unchanged over both stores — no expectation moved, so nothing was re-pinned. Two
tests are added to `RetryEngineTest`, because the matrix carries no case with an `EndAt` and the engine's
existing pair covers only "past the end time":

* **`ARetryLandingExactlyOnTheEndTimeIsScheduled`** — `TryScheduleRetry`'s `retryAt > EndTimeUtc` guard is
  exactly right under inclusive semantics, and this pins it from the other side: a retry landing *on* the
  end time is scheduled and fires, and `RetryFired` then finds nothing after it.
* **`ARetryKeepsTheOccurrenceThatLandsOnTheEndTime`** — this one fails without the product change, and it
  is the sharpest statement of what the bug cost. A simple trigger ending exactly on one of its own fire
  times, whose job fails on the occurrence before it: `NextFireTimeUtc` was already `null` when
  `ExecutionComplete` ran, so the trigger was deleted at the end of the failed occurrence and the fire on
  the end time — which its own `FinalFireTimeUtc` named all along — never happened. Now the retry runs and
  the boundary occurrence is still there afterwards.

`DailyTimeIntervalTriggerImpl.RetryFired`, which sets that type's `complete` flag when the base walk comes
back empty, now sets it at the end time rather than at the close of the daily window — its own test,
`ADailyTimeIntervalTriggerThatRunsOutWhileRetryingIsFinished`, passes unchanged.

## Verification

All of this on the rebased tree, with the retry engine underneath it:

* `dotnet build Quartz.slnx` — 0 warnings, 0 errors.
* `dotnet test src/Quartz.Tests.Unit` — 4271 passed, 0 failed. Two tests in `SimpleTriggerImplTest` asserted
  the old exclusive answer at the boundary and now assert the fire (their names describe inputs, so they
  did not need renaming); nothing else in either suite encoded either behaviour.
* `dotnet test src/Quartz.Tests.Integration --filter RetryMatrixTest` — 25 passed, unchanged.
* `dotnet test src/Quartz.Tests.Integration` (container-free basic leg, every `db-*` category excluded) —
  408 passed, including all 12 `SchedulerAcrossDstTransitionTest` cases against the restored window.
* The DST suites on their own — `TriggerEndTimeBoundaryTest` plus every unit fixture matching `Dst` or
  `DaylightSaving` — 283 passed.
* `dotnet test src/Quartz.Tests.AspNetCore` — 548 passed.
* Container legs, since Docker was available here: `db-sqlite` 14 passed, `db-postgres` 169 passed,
  `db-sqlserver` 161 passed (run before the rebase, on the same product change).
* `dotnet fallout VerifyDocsSnippets` — up to date, 102 markdown files checked.
* `npm run docs:check-links` — 220 pages, 1039 internal links, 625 fragments, no dead links or anchors.

Closes #3458
