### PR TITLE
Both serializers refuse the same job data values on write

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -371,8 +371,9 @@ here moved for you; if you called `GetInt` and `GetBoolean`, all of it did.
   verbatim therefore changes which serializer writes and reads the store's blobs, which is a different
   payload shape and a different set of registered trigger and calendar serializers. Spell it `newtonsoft`
   if Newtonsoft is what you meant.
-* **System.Text.Json refuses a job data value it cannot read back**, at write time rather than at the next
-  read — see [System.Text.Json refuses a job data value it cannot read back](#system-text-json-refuses-a-job-data-value-it-cannot-read-back).
+* **Both serializers refuse a job data value they cannot read back**, at write time rather than at the next
+  read, and both refuse the same set — see
+  [Both serializers refuse a job data value they cannot read back](#both-serializers-refuse-a-job-data-value-they-cannot-read-back).
 * **Five calendar types serialize to a new shape.** 4.x reads both forms and 3.x reads only its own, so
   this is invisible on a clean cut-over and fatal in a mixed window — see
   [A mixed 3.x and 4.0 window](operations.md#a-mixed-3-x-and-4-0-window).
@@ -3340,7 +3341,7 @@ catch (Newtonsoft.Json.JsonSerializationException e)
 catch (Quartz.JsonSerializationException e)
 ```
 
-### System.Text.Json refuses a job data value it cannot read back
+### Both serializers refuse a job data value they cannot read back
 
 The System.Text.Json read side is closed on purpose — a stored job data value comes back as a string, a
 bool, an int, a long, a double, null or a `Dictionary<string, string>`, and there is no polymorphic
@@ -3352,12 +3353,12 @@ failure belonged to whoever next ran the job.
 Writing now refuses such a value, naming the entry and the type:
 
 ```
-Job data entry 'recipients' holds a System.Collections.Generic.List`1[[System.String, …]], which a
-persistent store cannot read back. A job data value has to be one of the types JobDataMap declares an
-accessor for (string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan,
-Guid, DateOnly, TimeOnly or an enum), a Dictionary<string, string>, or a type the application declares
-through SystemTextJsonSerializerRegistry.AddTypeInfoResolver. Anything with structure of its own has to
-be serialized by the job and stored as a string.
+Job data entry 'recipients' holds a System.Collections.Generic.List`1[[System.String, …]], which Quartz's
+JSON format cannot read back. A job data value has to be one of the types JobDataMap declares an accessor
+for (string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid,
+DateOnly, TimeOnly or an enum), a Dictionary<string, string>, or a type the application declares through
+SystemTextJsonSerializerRegistry.AddTypeInfoResolver. Anything with structure of its own has to be
+serialized by the job and stored as a string.
 ```
 
 The set is the one `DataMapExtensions` declares an accessor for, plus `Dictionary<string, string>`, plus
@@ -3365,17 +3366,39 @@ enums by rule. A type of your own is declared through `AddTypeInfoResolver` — 
 trimmed or native-AOT publish already needs — and is then written like any other, coming back as the
 string map the store format gives for any object.
 
-Nothing that used to round-trip stops working: what is refused is exactly what used to be written and
-then failed to load. If you were relying on a nested `JobDataMap` or a collection surviving, serialize it
-in the job and store the result as a string. Newtonsoft is unchanged, and `StoreJobDataAsStrings` was
-never affected.
-
 The check lives in the job data map converter, which the HTTP API shares with the store serializer, so
 it applies there too: a job whose map holds a `List<string>` — in a `RAMJobStore` as much as a
 persistent one — now fails to serialize into a `GET` response with the message above, where before the
 server sent a payload `Quartz.HttpClient` threw on reading. Both ends use the same closed reader, so a
 value the server cannot read back is one the client cannot either, and `AddTypeInfoResolver` is the
 answer on both.
+
+**Newtonsoft refuses the same set.** It had the same asymmetry, and one type of its own: a `TimeZoneInfo`
+in a job data map was written as `{"$type":"System.TimeZoneInfo, …","Id":"Tokyo Standard Time", …}` and
+then read back by nothing — the contract resolver keeps Json.NET off `ISerializable`, and every public
+member of a zone is read-only, so there was nothing to rebuild it from. It now refuses against the very
+same declaration System.Text.Json refuses against — not a copy of that list, that list — so the two
+cannot come to accept different things, and a value written by one serializer is a value the other's
+reader has an answer for. The message is the same but for the way out it names:
+
+```
+Job data entry 'zone' holds a System.TimeZoneInfo, which Quartz's JSON format cannot read back. … or a
+type the application declares through NewtonsoftJsonSerializerRegistry.AddJobDataValueType. …
+```
+
+`AddJobDataValueType<T>()` is this package's counterpart to `AddTypeInfoResolver`. Json.NET needs no
+metadata handed to it, so the call registers nothing but your word that the type reads back:
+
+```csharp
+store.UseNewtonsoftJsonSerializer(json => json.AddJobDataValueType<ReportOptions>());
+```
+
+Three things used to round-trip through Newtonsoft and now need that declaration, because the other
+serializer never accepted them and a value only one reader can load is a one-way door: a class of your
+own, a `JobKey` or `TriggerKey` held as a job data value, and a collection. A `TimeZoneInfo` and a nested
+`JobDataMap` are past declaring — Json.NET could not read either back — so store a zone's `Id`, and
+serialize a nested structure in the job and store the result as a string. `StoreJobDataAsStrings` was
+never affected by any of this.
 
 ### Custom trigger and calendar serializers are no longer static
 

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -87,6 +87,38 @@ await using StandaloneSchedulerFactory schedulerFactory = QuartzSchedulerBuilder
 driver either, describe it in the same call — see
 [the configuration reference](../configuration/reference.md#describing-a-driver-quartz-does-not-know).
 
+### What a job data map may hold
+
+A job data value has to be one of the types `JobDataMap` declares an accessor for — `string`, `bool`,
+`char`, the numeric types, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `DateOnly`, `TimeOnly`, an
+enum — or a `Dictionary<string, string>`; anything else is refused when the job or trigger is stored,
+with a `Quartz.JsonSerializationException` naming the entry and the type, rather than written as a blob
+that fails to load on the next fire. That is the same set the System.Text.Json serializer accepts, and
+literally the same declaration, so a value one of them writes is a value the other's reader has an answer
+for.
+
+To store a type of your own, declare it — which is your word that Json.NET can build it back, and a
+versioning commitment for as long as the value sits in the database:
+
+<!-- snippet: sample_newtonsoft_job_data_value_type -->
+```csharp
+builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+{
+    store.UseNewtonsoftJsonSerializer(json =>
+    {
+        // Without this, a ReportOptions in a JobDataMap is refused when the job is stored.
+        json.AddJobDataValueType<ReportOptions>();
+    });
+}));
+```
+<!-- endSnippet -->
+
+A `JobKey` or `TriggerKey` held as a job data value takes the same declaration. A `TimeZoneInfo` and a
+nested `JobDataMap` are past declaring, because Json.NET cannot read either back out of what it writes —
+store a zone's `Id`, and serialize a nested structure in the job and keep the result as a string. A
+string is also the answer when the value has to survive a change of serializer, since a declared type is
+read back by the serializer that wrote it and by no other.
+
 ### Migrating from binary serialization
 
 Quartz 4 no longer ships the `BinaryObjectSerializer`: the underlying `BinaryFormatter`
@@ -123,6 +155,11 @@ serializer below can read the old binary payloads and write everything back as J
 could never be part of a blob lost those attributes in 4.0; see
 [the migration guide](../migration-guide.md#serializable-survives-only-where-a-database-blob-needs-it)
 for the full list.
+
+A blob whose job data holds a key, or a class of the application's own, needs that type declared with
+`AddJobDataValueType<T>()` on the registry the migrator's inner serializer is built from — otherwise the
+value reads out of the binary payload and is refused on the way back in, which is
+[the gate described above](#what-a-job-data-map-may-hold) doing its job at the one moment it is unwelcome.
 
 One column is the exception: `BLOB_TRIGGERS.BLOB_DATA` holds whole trigger objects, and
 `BinaryFormatter` records private base-class fields under the base class's *name* - which 4.0

--- a/docs/documentation/quartz-4.x/packages/system-text-json.md
+++ b/docs/documentation/quartz-4.x/packages/system-text-json.md
@@ -260,5 +260,8 @@ Resolvers are asked in the order they were added, behind Quartz's own contract a
 reflection, so `AddTypeInfoResolver` can be called more than once and is safe to configure whether or
 not the application is published trimmed.
 
-The `Quartz.Serialization.Newtonsoft` serializer has no equivalent: it is reflection by nature, so an
-application that publishes trimmed uses this one.
+The `Quartz.Serialization.Newtonsoft` serializer has no equivalent for the metadata: it is reflection by
+nature, so an application that publishes trimmed uses this one. It does have a counterpart for the other
+thing `AddTypeInfoResolver` does — declaring a job-data value type the serializer will write at all,
+since both serializers refuse the same set — and that is
+[`AddJobDataValueType<T>()`](json-serialization.md#what-a-job-data-map-may-hold).

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -196,12 +196,16 @@ stay readable by the new version — a renamed property on a stored options clas
 its next fire, months after the deploy that renamed it. Standard framework types are safe; your own
 types are a versioning commitment.
 
-With System.Text.Json — the default — a persistent store accepts exactly the types the accessors above
-cover (`string`, `bool`, `char`, the numeric types, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`,
-`DateOnly`, `TimeOnly` and enums) plus `Dictionary<string, string>`, and refuses anything else when the
-job is stored rather than writing a blob that fails to load later. To store a type of your own, declare
-it with `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` — the same registration a trimmed or
-native-AOT publish needs — or serialize it yourself and store the result as a string.
+A persistent store accepts exactly the types the accessors above cover (`string`, `bool`, `char`, the
+numeric types, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `DateOnly`, `TimeOnly` and enums) plus
+`Dictionary<string, string>`, and refuses anything else when the job is stored rather than writing a blob
+that fails to load later. Both serializers refuse the same set, so a value you can store is one either of
+them can be switched to. To store a type of your own, declare it — with
+`SystemTextJsonSerializerRegistry.AddTypeInfoResolver` on the default serializer, which is the same
+registration a trimmed or native-AOT publish needs, or with
+`NewtonsoftJsonSerializerRegistry.AddJobDataValueType<T>()` on the Newtonsoft one — or serialize it
+yourself and store the result as a string. A declared type is read back by the serializer that wrote it
+and by no other, so the string is the portable answer.
 
 **String mode.** `AdoJobStoreOptions.StoreJobDataAsStrings` (the flat key is still
 `quartz.jobStore.useProperties`) makes the store persist the map as name/value string pairs instead of

--- a/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/NewtonsoftJsonSamples.cs
@@ -100,6 +100,22 @@ public static class NewtonsoftJsonSamples
         }));
     }
 
+    public static void DeclareAJobDataValueType(IHostApplicationBuilder builder)
+    {
+        #region sample_newtonsoft_job_data_value_type
+
+        builder.Services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseNewtonsoftJsonSerializer(json =>
+            {
+                // Without this, a ReportOptions in a JobDataMap is refused when the job is stored.
+                json.AddJobDataValueType<ReportOptions>();
+            });
+        }));
+
+        #endregion
+    }
+
     public static void RegisterCalendarSerializer(IHostApplicationBuilder builder)
     {
         #region sample_newtonsoft_register_calendar_serializer
@@ -127,6 +143,15 @@ public static class NewtonsoftJsonSamples
 
         #endregion
     }
+}
+
+/// <summary>
+/// A job-data value type of the application's own, which no contract of Quartz's can name, and which the
+/// serializer therefore writes only once the application has declared it.
+/// </summary>
+public sealed class ReportOptions
+{
+    public string Format { get; set; } = "pdf";
 }
 
 #region sample_newtonsoft_custom_calendar

--- a/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
@@ -2,10 +2,18 @@ using Newtonsoft.Json;
 
 namespace Quartz.Serialization.Newtonsoft;
 
-internal sealed class StringKeyDirtyFlagMapConverter : JsonConverter
+internal sealed class StringKeyDirtyFlagMapConverter(NewtonsoftJsonSerializerRegistry registry) : JsonConverter
 {
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
+        // A JobDataMap is what a persistent store puts in a column, so an entry the reader could never
+        // turn back into a value is refused here — before a byte of it is written, and while there is
+        // still someone to tell. A SchedulerContext is not stored, so it is written as it always was.
+        if (value is JobDataMap jobDataMap)
+        {
+            JobDataValues.Refuse(jobDataMap, registry);
+        }
+
         var map = new Dictionary<string, object?>((IDictionary<string, object?>) value!);
         serializer.Serialize(writer, map);
     }

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -14,6 +14,10 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
         {
             var trigger = (ITrigger) value!;
 
+            // Before anything is written, so a trigger carrying one unreadable job data value puts
+            // nothing at all in the column.
+            JobDataValues.Refuse(trigger.JobDataMap, registry);
+
             writer.WriteStartObject();
             var type = value!.GetType().AssemblyQualifiedNameWithoutVersion();
             var triggerSerializer = registry.GetTriggerSerializer(type);
@@ -70,6 +74,12 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
 
             triggerSerializer.SerializeFields(writer, trigger);
             writer.WriteEndObject();
+        }
+        // A refused job data value already says which entry it is about and what to do; wrapping it in
+        // a second exception of the same type would only bury that.
+        catch (Quartz.JsonSerializationException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
@@ -89,7 +89,7 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
             Converters = new List<JsonConverter>
             {
                 new NameValueCollectionConverter(),
-                new StringKeyDirtyFlagMapConverter(),
+                new StringKeyDirtyFlagMapConverter(Registry),
                 new CronExpressionConverter(),
                 new CalendarConverter(Registry)
             },

--- a/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
+++ b/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
@@ -1,0 +1,81 @@
+namespace Quartz.Serialization.Newtonsoft;
+
+/// <summary>
+/// What a job data value may be when this serializer writes one, which is what it may be when the
+/// built-in one does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The write side used to accept whatever Json.NET could reflect over, and reflection being able to
+/// write a value is not the same as anything being able to read it back. A <see cref="TimeZoneInfo" />
+/// in a job data map was the case that showed it: written as
+/// <c>{"$type":"System.TimeZoneInfo, …","Id":"Tokyo Standard Time", …}</c> and then unreadable, because
+/// <see cref="QuartzContractResolver" /> sets <c>IgnoreSerializableInterface</c> and every public member
+/// of a zone is read-only, so there was nothing to rebuild it from. The blob was in the column by then,
+/// and the failure belonged to whoever next ran the job.
+/// </para>
+/// <para>
+/// The accepted set is not a copy of the System.Text.Json one, it <em>is</em> that one — the same
+/// <c>JobDataValues.Accepted</c> the built-in serializer refuses against, read out of the core package
+/// this one already depends on. Two lists meaning to say the same thing is how the write and read sides
+/// came to disagree in the first place, and the same trap is open across the two serializers: both are
+/// documented store formats and an application is free to switch between them, so a value only one of
+/// them accepts is a one-way door nobody is warned about. <c>JobDataMapPortabilityTest</c> is what holds
+/// the pair to it.
+/// </para>
+/// <para>
+/// Past that set, a value is the application's own choice, and
+/// <see cref="NewtonsoftJsonSerializerRegistry.AddJobDataValueType{T}" /> is how it declares one. That is
+/// this package's counterpart to
+/// <c>SystemTextJsonSerializerRegistry.AddTypeInfoResolver</c>: Json.NET needs no metadata handed to it,
+/// so the declaration carries nothing but the application's word that the type reads back.
+/// </para>
+/// </remarks>
+internal static class JobDataValues
+{
+    /// <summary>
+    /// Throws unless <paramref name="value" /> is one a reader will accept back.
+    /// </summary>
+    /// <remarks>
+    /// The check is by runtime type rather than by trying the write and inspecting what came out,
+    /// because refusing has to happen before a single byte reaches the column.
+    /// </remarks>
+    /// <exception cref="Quartz.JsonSerializationException">
+    /// The value is of a type no reader can turn back into it, and the application has not declared one.
+    /// </exception>
+    public static void Refuse(string key, object? value, NewtonsoftJsonSerializerRegistry registry)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        Type type = value.GetType();
+
+        // Enums are accepted by rule rather than by name, because they are written as their number and
+        // read back as one, and no list can enumerate an application's own.
+        if (SystemTextJson.JobDataValues.Accepted.Contains(type) || type.IsEnum || registry.DeclaresJobDataValueType(type))
+        {
+            return;
+        }
+
+        throw new Quartz.JsonSerializationException(
+            $"Job data entry '{key}' holds a {type.FullName}, which Quartz's JSON format cannot read back. " +
+            "A job data value has to be one of the types JobDataMap declares an accessor for " +
+            "(string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid, DateOnly, TimeOnly or an enum), " +
+            "a Dictionary<string, string>, or a type the application declares through NewtonsoftJsonSerializerRegistry.AddJobDataValueType. " +
+            "Anything with structure of its own has to be serialized by the job and stored as a string.");
+    }
+
+    /// <summary>
+    /// Refuses on the first unreadable entry of a map, before any of them is written, so a map with one
+    /// such value in it puts nothing at all in the column.
+    /// </summary>
+    public static void Refuse(JobDataMap jobDataMap, NewtonsoftJsonSerializerRegistry registry)
+    {
+        foreach (KeyValuePair<string, object?> pair in jobDataMap)
+        {
+            Refuse(pair.Key, pair.Value, registry);
+        }
+    }
+}

--- a/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
+++ b/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonSerializerRegistry.cs
@@ -28,11 +28,18 @@ namespace Quartz.Serialization.Newtonsoft;
 /// stays registered — and, when the serializer provides one, under its
 /// <see cref="ICalendarSerializer.CalendarTypeName"/> discriminator.
 /// </para>
+/// <para>
+/// A registry is also where an application declares a job data value type of its own, through
+/// <see cref="AddJobDataValueType{T}" />. The serializer writes the value types a
+/// <see cref="JobDataMap" /> has an accessor for and refuses the rest, so that a value nothing can read
+/// back is refused while there is still someone to tell rather than stored and failed on later.
+/// </para>
 /// </remarks>
 public sealed class NewtonsoftJsonSerializerRegistry
 {
     private readonly SerializerMap<ITriggerSerializer> triggerSerializers = new(StringComparer.OrdinalIgnoreCase);
     private readonly SerializerMap<ICalendarSerializer> calendarSerializers = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<Type> jobDataValueTypes = [];
 
     /// <summary>
     /// Creates a registry holding the serializers for the built-in trigger and calendar types.
@@ -91,6 +98,48 @@ public sealed class NewtonsoftJsonSerializerRegistry
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Declares a job data value type of the application's own, which this serializer otherwise refuses
+    /// to write.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The exact runtime type of the values to accept. A declaration does not extend to a derived type,
+    /// because it is the runtime type of the stored value that is looked up — declare each type you
+    /// actually put in a map.
+    /// </typeparam>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="JobDataMap" /> accepts the types <see cref="DataMapExtensions" /> declares an
+    /// accessor for, plus a <c>Dictionary&lt;string, string&gt;</c>; anything else is refused when the
+    /// job or trigger is stored, rather than written as a blob that fails to load later. This is how an
+    /// application says a type of its own is one Json.NET can read back — a class with a constructor
+    /// Json.NET can call, and a versioning commitment for as long as the value sits in the database.
+    /// </para>
+    /// <para>
+    /// It is this package's counterpart to
+    /// <c>SystemTextJsonSerializerRegistry.AddTypeInfoResolver</c>, and the narrower of the two: Json.NET
+    /// needs no metadata handed to it, so nothing is registered here but the permission. A blob holding a
+    /// declared type is readable by this serializer only — the System.Text.Json reader hands any object
+    /// back as a <c>Dictionary&lt;string, string&gt;</c> — so a value that has to survive a change of
+    /// serializer belongs in a string the job writes itself.
+    /// </para>
+    /// </remarks>
+    public NewtonsoftJsonSerializerRegistry AddJobDataValueType<T>()
+    {
+        jobDataValueTypes.Add(typeof(T));
+        return this;
+    }
+
+    /// <summary>
+    /// Whether the application has declared <paramref name="type" /> through
+    /// <see cref="AddJobDataValueType{T}" />, which is what makes it a job data value this serializer
+    /// will write.
+    /// </summary>
+    internal bool DeclaresJobDataValueType(Type type)
+    {
+        return jobDataValueTypes.Contains(type);
     }
 
     internal ITriggerSerializer GetTriggerSerializer(string? typeName)

--- a/src/Quartz.Serialization.Newtonsoft/README.md
+++ b/src/Quartz.Serialization.Newtonsoft/README.md
@@ -34,6 +34,12 @@ The same `UseNewtonsoftJsonSerializer` call configures a store built without a h
 `StoreJobDataAsStrings` is worth setting whichever serializer you use: it keeps job data out of the
 serializer altogether, which is what avoids surprises when a persisted type later changes shape.
 
+A job data value has to be one of the types `JobDataMap` declares an accessor for, or a
+`Dictionary<string, string>` — the same set the System.Text.Json serializer accepts, so a blob written
+here is one the other reader has an answer for. Anything else is refused when the job is stored, naming
+the entry and the type; declare a type of your own with
+`NewtonsoftJsonSerializerRegistry.AddJobDataValueType<T>()`.
+
 ## Trimming
 
 This package is deliberately **not** trimmable, and does not declare `IsTrimmable`. Json.NET decides what

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -80,21 +80,18 @@ public class StdAdoDelegateTest
 
         Action serializeApplicationType = () => del.SerializeJobData(jdm);
 
-        if (serializer is SystemTextJsonObjectSerializer)
-        {
-            // The read side has no polymorphic object deserialization, so a class of the application's
-            // own could never come back as itself. Writing it would put a blob in JOB_DATA that the next
-            // load of this job fails on, which is why the refusal happens here instead.
-            serializeApplicationType.Should().Throw<JsonSerializationException>(
-                    "System.Text.Json refuses at write time a value it could not read back")
-                .Which.Message.Should().Contain("AddTypeInfoResolver",
-                    "the failure has to name the way an application declares a type of its own");
-        }
-        else
-        {
-            serializeApplicationType.Should().NotThrow(
-                "with binary serialization out of the picture, a private type is no obstacle to Newtonsoft");
-        }
+        // A class of the application's own is not part of either store format, so writing one would put
+        // a blob in JOB_DATA that the next load of this job fails on. Both serializers refuse it here
+        // instead, and each names the registration that says otherwise — which is the only part of the
+        // message that differs between them.
+        string declaration = serializer is SystemTextJsonObjectSerializer
+            ? "AddTypeInfoResolver"
+            : "AddJobDataValueType";
+
+        serializeApplicationType.Should().Throw<JsonSerializationException>(
+                "a value the reader could not accept is refused at write time, which is the last moment anyone can be told")
+            .Which.Message.Should().Contain(declaration,
+                "the failure has to name the way an application declares a type of its own");
     }
 
     private sealed class NonSerializableTestClass;

--- a/src/Quartz.Tests.Unit/KeySerializationTest.cs
+++ b/src/Quartz.Tests.Unit/KeySerializationTest.cs
@@ -23,6 +23,7 @@ using System.Text;
 
 using Quartz.Extensibility;
 using Quartz.Impl;
+using Quartz.Serialization.Newtonsoft;
 
 namespace Quartz.Tests.Unit;
 
@@ -83,17 +84,41 @@ public class KeySerializationTest
 /// The System.Text.Json serializer does not do polymorphic values in a job data map at all, for keys or for
 /// anything else, so there is nothing to assert for it here.
 /// </summary>
+/// <remarks>
+/// A key is not one of the value types a job data map declares an accessor for, so it takes a declaration
+/// to write one — the same declaration any type of the application's own takes, and for the same reason:
+/// the other serializer hands that blob back as a string map rather than as a key, so the value belongs to
+/// whichever serializer wrote it. What is asserted here is that a declared key still travels intact, since
+/// the contract resolver's work is what makes it possible at all.
+/// </remarks>
 public class NewtonsoftKeySerializationTest
 {
     [Test]
-    public void KeyInAJobDataMapKeepsItsType()
+    public void KeyInAJobDataMapIsRefusedUntilItIsDeclared()
     {
         NewtonsoftJsonObjectSerializer serializer = new();
+        JobDataMap map = new() { ["job"] = new JobKey("myJob", "reports") };
+
+        Action write = () => serializer.Serialize(map);
+
+        write.Should().Throw<JsonSerializationException>(
+                "a key is not a job data value either store format promises to give back, so it is refused like any other type of the application's own")
+            .Which.Message.Should().Contain("job", "the failure has to say which entry it is about")
+            .And.Contain("Quartz.JobKey", "and what was in it");
+    }
+
+    [Test]
+    public void ADeclaredKeyInAJobDataMapKeepsItsType()
+    {
+        NewtonsoftJsonSerializerRegistry registry = new();
+        registry.AddJobDataValueType<JobKey>();
+        NewtonsoftJsonObjectSerializer serializer = new(registry);
         JobDataMap map = new() { ["job"] = new JobKey("myJob", "reports") };
 
         JobDataMap deserialized = serializer.Deserialize<JobDataMap>(serializer.Serialize(map));
 
         deserialized.Should().NotBeNull();
-        deserialized["job"].Should().Be(new JobKey("myJob", "reports"));
+        deserialized["job"].Should().Be(new JobKey("myJob", "reports"),
+            "the contract resolver names the key's constructor on the $type path, which is what a converter could not reach");
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -19,10 +19,12 @@
 
 #endregion
 
+using System.Text;
 using System.Text.Json.Serialization;
 
 using Quartz.Extensibility;
 using Quartz.Impl;
+using Quartz.Serialization.Newtonsoft;
 using Quartz.Serialization.SystemTextJson;
 
 namespace Quartz.Tests.Unit.Simpl;
@@ -37,8 +39,10 @@ namespace Quartz.Tests.Unit.Simpl;
 /// The set covered here is the set <see cref="DataMapExtensions" /> declares an accessor for: those
 /// are the types Quartz teaches an application to store, and so the ones the store format owes an
 /// answer for. Everything past them is the application's own choice — see <c>JobDataValues</c>, which
-/// declares what System.Text.Json will write and what it hands back, and refuses the rest at the one
-/// moment anyone can still be told.
+/// declares what the store format will write and what it hands back, and refuses the rest at the one
+/// moment anyone can still be told. Both serializers refuse against that same declaration, so the
+/// negative cases below are asserted of both: a value only one of them accepts is a blob only one of
+/// them can load.
 /// </remarks>
 public class JobDataMapPortabilityTest
 {
@@ -120,15 +124,21 @@ public class JobDataMapPortabilityTest
     }
 
     /// <summary>
-    /// The values System.Text.Json refuses to write, because it could never read them back. Each of
-    /// these used to serialize without complaint and throw on the way out, by which time the blob was
-    /// in the database and the failure belonged to whoever next ran the job.
+    /// The values neither serializer will write, because neither could read them back. Each of these
+    /// used to serialize without complaint and throw on the way out, by which time the blob was in the
+    /// database and the failure belonged to whoever next ran the job.
     /// </summary>
+    /// <remarks>
+    /// The time zone is the one Newtonsoft brought: Json.NET wrote it as its whole public surface, of
+    /// which every member is read-only, so the payload it produced could not be read by anything —
+    /// itself included.
+    /// </remarks>
     private static IEnumerable<TestCaseData> UnreadableValues()
     {
         yield return Refused("list", new List<string> { "a", "b" }, "System.Collections.Generic.List");
         yield return Refused("dictionaryOfObject", new Dictionary<string, object> { ["inner"] = 1 }, "System.Collections.Generic.Dictionary");
         yield return Refused("nested", new JobDataMap { { "inner", "value" } }, "Quartz.JobDataMap");
+        yield return Refused("zone", TimeZones.FindById("Tokyo Standard Time"), "System.TimeZoneInfo");
     }
 
     private static TestCaseData Refused(string key, object value, string expectedTypeName)
@@ -137,17 +147,20 @@ public class JobDataMapPortabilityTest
     }
 
     [TestCaseSource(nameof(UnreadableValues))]
-    public void AValueTheReaderCannotAcceptIsRefusedOnWrite(string key, object value, string expectedTypeName)
+    public void AValueTheReaderCannotAcceptIsRefusedOnWriteByEitherSerializer(string key, object value, string expectedTypeName)
     {
         JobDataMap original = new JobDataMap { { key, value } };
 
-        Action write = () => systemTextJsonSerializer.Serialize(original);
+        foreach ((string label, IObjectSerializer writer, string declaration) in Writers())
+        {
+            Action write = () => writer.Serialize(original);
 
-        write.Should().Throw<JsonSerializationException>(
-                "a value written now and unreadable later is a blob in the database nobody can load, and the write is the last moment anyone can be told")
-            .Which.Message.Should().Contain(key, "the failure has to say which entry it is about")
-            .And.Contain(expectedTypeName, "and what was in it")
-            .And.Contain("AddTypeInfoResolver", "and how an application declares a type of its own");
+            write.Should().Throw<JsonSerializationException>(
+                    "{0}: a value written now and unreadable later is a blob in the database nobody can load, and the write is the last moment anyone can be told", label)
+                .Which.Message.Should().Contain(key, "the failure has to say which entry it is about")
+                .And.Contain(expectedTypeName, "and what was in it")
+                .And.Contain(declaration, "and how an application declares a type of its own");
+        }
     }
 
     /// <summary>
@@ -176,18 +189,52 @@ public class JobDataMapPortabilityTest
     }
 
     /// <summary>
-    /// Nesting is where the two formats stop agreeing, so this is the guarantee an application gets:
-    /// none. Newtonsoft writes a nested map and hands back its own <c>JObject</c> or a string map,
-    /// never the <see cref="JobDataMap" /> that went in; System.Text.Json refuses to write one at all.
-    /// Job code that needs structure has to serialize the structure itself and store the result as a
-    /// string.
+    /// Refusing on write must not close the door this package tells an application to use. A type
+    /// declared through <see cref="NewtonsoftJsonSerializerRegistry.AddJobDataValueType{T}" /> is
+    /// written, and Json.NET — which carries a <c>$type</c> and constructs from it — hands the type
+    /// itself back.
     /// </summary>
+    /// <remarks>
+    /// That is where the two escape hatches differ, and deliberately: what a declared type comes back as
+    /// is each reader's own answer, so a value that has to survive a change of serializer belongs in a
+    /// string the job writes itself. The declaration is what the serializers agree on.
+    /// </remarks>
     [Test]
-    public void ANestedMapIsNotPartOfThePortableFormat()
+    public void ATypeTheApplicationDeclaredIsWrittenAndReadByNewtonsoftToo()
     {
-        JobDataMap original = new JobDataMap { { "nested", new JobDataMap { { "inner", "value" } } } };
+        JobDataMap original = new JobDataMap { { "report", new ApplicationJobDataValue { Name = "monthly" } } };
 
-        byte[] written = newtonsoftSerializer.Serialize(original);
+        Action withoutDeclaration = () => newtonsoftSerializer.Serialize(original);
+        withoutDeclaration.Should().Throw<JsonSerializationException>(
+            "an application type Quartz has not been told about is exactly the case the refusal exists for");
+
+        NewtonsoftJsonSerializerRegistry registry = new();
+        registry.AddJobDataValueType<ApplicationJobDataValue>();
+        IObjectSerializer declared = new NewtonsoftJsonObjectSerializer(registry);
+
+        JobDataMap restored = declared.Deserialize<JobDataMap>(declared.Serialize(original))!;
+
+        restored["report"].Should().BeOfType<ApplicationJobDataValue>(
+                "Json.NET writes the type name beside the value and builds the type back out of it")
+            .Which.Name.Should().Be("monthly");
+    }
+
+    /// <summary>
+    /// Nesting is where the two formats stopped agreeing, so this is the guarantee an application gets:
+    /// none. Neither reader hands a nested <see cref="JobDataMap" /> back — Newtonsoft gives its own
+    /// <c>JObject</c>, System.Text.Json a string map — which is why both now refuse to write one, and
+    /// why a blob that already holds one still has to be read for what it is. Job code that needs
+    /// structure has to serialize the structure itself and store the result as a string.
+    /// </summary>
+    /// <remarks>
+    /// The payload is what the Newtonsoft writer produced for a nested map before it was refused: the
+    /// map's converter owns its own output, so the nested map carried no <c>$type</c> and there was
+    /// never anything to rebuild it from.
+    /// </remarks>
+    [Test]
+    public void ABlobThatAlreadyHoldsANestedMapReadsBackAsSomethingElse()
+    {
+        byte[] written = Encoding.UTF8.GetBytes("""{"nested":{"inner":"value"}}""");
 
         foreach (IObjectSerializer reader in new[] { newtonsoftSerializer, systemTextJsonSerializer })
         {
@@ -204,6 +251,16 @@ public class JobDataMapPortabilityTest
         yield return ("newtonsoft -> system.text.json", newtonsoftSerializer, systemTextJsonSerializer);
         yield return ("system.text.json -> newtonsoft", systemTextJsonSerializer, newtonsoftSerializer);
         yield return ("system.text.json -> system.text.json", systemTextJsonSerializer, systemTextJsonSerializer);
+    }
+
+    /// <summary>
+    /// Each writer beside the registration its refusal points an application at, since that name is
+    /// half of what makes the message useful.
+    /// </summary>
+    private IEnumerable<(string Label, IObjectSerializer Writer, string Declaration)> Writers()
+    {
+        yield return ("newtonsoft", newtonsoftSerializer, "AddJobDataValueType");
+        yield return ("system.text.json", systemTextJsonSerializer, "AddTypeInfoResolver");
     }
 }
 

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerRoundTripTest.cs
@@ -288,20 +288,23 @@ public class NewtonsoftLegacyTimeZonePayloadTest
 }
 
 /// <summary>
-/// The converter is attached to typed <see cref="TimeZoneInfo" /> members by
-/// <c>QuartzContractResolver</c>, not registered on the serializer, and this is the difference that
-/// makes: a trigger's <c>TimeZone</c> property is written as its id, while a zone sitting in a job
-/// data map — where the slot is typed <see cref="object" /> — is written exactly as it always was.
+/// A <see cref="TimeZoneInfo" /> in a job data map is refused when it is written; the same zone on a
+/// trigger's <c>TimeZone</c> property travels as its id. The difference is that the converter for a
+/// zone is attached to typed members by <c>QuartzContractResolver</c> rather than registered on the
+/// serializer, so it never reaches an <see cref="object" />-typed slot — and what did reach one was a
+/// payload nothing could read back.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Scoping is what keeps that true: a converter on the serializer's list is consulted for a value's
-/// runtime type wherever it appears, so a global one would have written the zone as a bare string and
-/// dropped the <c>$type</c> that the object-typed path carries.
+/// Scoping is what keeps the trigger side true: a converter on the serializer's list is consulted for a
+/// value's runtime type wherever it appears, so a global one would have written a zone held as job data
+/// as a bare string and dropped the <c>$type</c> that the object-typed path carries. That left the job
+/// data side written and unreadable, which is the asymmetry #3500 closed — by refusing the value rather
+/// than by teaching the map to carry a zone, so that both serializers accept the same things.
 /// </para>
 /// <para>
-/// The written shape is asserted member by member rather than against a captured string, because most
-/// of what Json.NET writes for a zone is the running OS's own text: Windows says
+/// The trigger's written shape is asserted member by member rather than against a captured string,
+/// because most of what Json.NET writes for a zone is the running OS's own text: Windows says
 /// <c>"(UTC+09:00) Osaka, Sapporo, Tokyo"</c> where Linux says
 /// <c>"(UTC+09:00) Japan Standard Time (Tokyo)"</c>, and the standard and daylight names differ with
 /// them. Only <c>$type</c> and <c>Id</c> mean the same thing everywhere — and the id is compared
@@ -320,21 +323,19 @@ public class NewtonsoftJobDataTimeZoneTest
         """{"zone":{"$type":"System.TimeZoneInfo, System.Private.CoreLib","Id":"Tokyo Standard Time","HasIanaId":false,"DisplayName":"(UTC+09:00) Osaka, Sapporo, Tokyo","StandardName":"Tokyo Standard Time","DaylightName":"Tokyo Daylight Time","BaseUtcOffset":"09:00:00","SupportsDaylightSavingTime":false}}""";
 
     [Test]
-    public void AZoneInAJobDataMapIsWrittenAsItAlwaysWas()
+    public void AZoneInAJobDataMapIsRefusedOnWrite()
     {
         IObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
         TimeZoneInfo tokyo = TimeZones.FindById("Tokyo Standard Time");
         JobDataMap map = new JobDataMap { { "zone", tokyo } };
 
-        using JsonDocument written = JsonDocument.Parse(serializer.Serialize(map));
-        JsonElement zone = written.RootElement.GetProperty("zone");
+        Action write = () => serializer.Serialize(map);
 
-        zone.ValueKind.Should().Be(JsonValueKind.Object,
-            "the converter is scoped to typed members, so an object-typed slot is left alone - a global one would have collapsed the zone to a bare string");
-        zone.GetProperty("$type").GetString().Should().Be("System.TimeZoneInfo, System.Private.CoreLib",
-            "the $type is what every payload already in a JOB_DATA column carries, and losing it would change the shape of a stored blob");
-        zone.GetProperty("Id").GetString().Should().Be(tokyo.Id,
-            "the id is the one member of a written zone that means the same thing on every platform");
+        write.Should().Throw<JsonSerializationException>(
+                "the payload this used to write cannot be read by anything, so the write is where the story has to end")
+            .Which.Message.Should().Contain("zone", "the failure has to say which entry it is about")
+            .And.Contain("System.TimeZoneInfo", "and what was in it")
+            .And.Contain("AddJobDataValueType", "and how an application declares a type of its own");
     }
 
     [Test]
@@ -360,11 +361,45 @@ public class NewtonsoftJobDataTimeZoneTest
     }
 
     /// <summary>
-    /// Reading that job data payload back has never worked: <c>IgnoreSerializableInterface</c> keeps
-    /// Json.NET off <see cref="TimeZoneInfo" />'s <c>ISerializable</c> implementation, and every public
-    /// member it writes instead is read-only, so there is nothing to construct the zone from. Recorded
-    /// here because it is a limitation this change deliberately neither introduces nor repairs — the
-    /// scoping is what proves it unchanged, and a job that needs a zone in its data should store the id.
+    /// With <see cref="NewtonsoftJsonObjectSerializer.RegisterTriggerConverters" /> on, a trigger's own
+    /// job data is written by the trigger converter rather than by the map's, and that is a second way
+    /// into the same column — so it is gated too, and gated before the object is opened, so a trigger
+    /// carrying one unreadable value writes nothing at all.
+    /// </summary>
+    /// <remarks>
+    /// The converter wraps what goes wrong inside it in "Failed to serialize ITrigger to json", which
+    /// would bury the one message that says which entry to fix; a refusal is rethrown instead, exactly
+    /// as the System.Text.Json job data map converter rethrows its own.
+    /// </remarks>
+    [Test]
+    public void ATriggersOwnJobDataIsRefusedWithTheTriggerConvertersOnToo()
+    {
+        NewtonsoftJsonObjectSerializer serializer = new() { RegisterTriggerConverters = true };
+        CalendarIntervalTriggerImpl trigger = new()
+        {
+            Key = new TriggerKey("calendarInterval", "group"),
+            RepeatIntervalUnit = IntervalUnit.Hour,
+            StartTimeUtc = new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero)
+        };
+        trigger.JobDataMap.Add("zone", TimeZones.FindById("Tokyo Standard Time"));
+
+        Action write = () => serializer.Serialize<ITrigger>(trigger);
+
+        write.Should().Throw<JsonSerializationException>(
+                "a trigger's job data lands in the same column as a job's, and neither reader can turn a written zone back into one")
+            .Which.Message.Should().Contain("zone", "the failure has to say which entry it is about")
+            .And.Contain("System.TimeZoneInfo", "and what was in it")
+            .And.NotContain("Failed to serialize ITrigger",
+                "the trigger converter's own wrapper would hide the only sentence that says what to change");
+    }
+
+    /// <summary>
+    /// Reading that job data payload back has never worked, and still does not:
+    /// <c>IgnoreSerializableInterface</c> keeps Json.NET off <see cref="TimeZoneInfo" />'s
+    /// <c>ISerializable</c> implementation, and every public member it writes instead is read-only, so
+    /// there is nothing to construct the zone from. That is the whole reason the write above is refused
+    /// — and a column that already holds one of these is why the read is left alone rather than taught
+    /// to guess, since the failure names the payload and a job that needs a zone should store the id.
     /// </summary>
     [Test]
     public void ReadingThatZoneBackHasNeverWorked()

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Serialization.Newtonsoft.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Serialization.Newtonsoft.verified.txt
@@ -47,6 +47,7 @@ namespace Quartz.Serialization.Newtonsoft
         public NewtonsoftJsonSerializerRegistry() { }
         public Quartz.Serialization.Newtonsoft.NewtonsoftJsonSerializerRegistry AddCalendarSerializer<TCalendar>(Quartz.Serialization.Newtonsoft.Calendars.CalendarSerializer<TCalendar> serializer)
             where TCalendar : Quartz.ICalendar { }
+        public Quartz.Serialization.Newtonsoft.NewtonsoftJsonSerializerRegistry AddJobDataValueType<T>() { }
         public Quartz.Serialization.Newtonsoft.NewtonsoftJsonSerializerRegistry AddTriggerSerializer<TTrigger>(Quartz.Serialization.Newtonsoft.Triggers.ITriggerSerializer serializer)
             where TTrigger : Quartz.ITrigger { }
     }

--- a/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
+++ b/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
@@ -69,6 +69,12 @@ internal static class JobDataValues
     /// <see cref="QuartzStoreJsonContext" /> too, so a trimmed publish can write them all;
     /// <c>StoreFormatSourceGenerationTest</c> is what fails when the two stop agreeing.
     /// </summary>
+    /// <remarks>
+    /// <c>Quartz.Serialization.Newtonsoft</c> refuses against this very field rather than a list of its
+    /// own, so the two serializers cannot come to accept different things: a blob written by one has to
+    /// be readable by the other, and a second list meaning to say the same thing is how the write and
+    /// read sides of *this* one came to disagree.
+    /// </remarks>
     internal static readonly FrozenSet<Type> Accepted = FrozenSet.ToFrozenSet(
     [
         // Read back as themselves.


### PR DESCRIPTION
`Quartz.Serialization.Newtonsoft` had the write/read asymmetry #3495 closed for System.Text.Json, and one
value of its own to show it with. A `JobDataMap` holding a `TimeZoneInfo` was written as
`{"$type":"System.TimeZoneInfo, …","Id":"Tokyo Standard Time", …}` and read back by nothing —
`QuartzContractResolver` sets `IgnoreSerializableInterface`, so Json.NET never takes the `ISerializable`
path that would rebuild the value, and every public member it writes instead is read-only. The blob was in
the column by then, and the failure belonged to whoever next ran the job.

## The contract

The writer refuses a job data value the reader will not accept, at `Serialize` time, throwing
`Quartz.JsonSerializationException` before a byte of the map reaches the column:

```
Job data entry 'zone' holds a System.TimeZoneInfo, which Quartz's JSON format cannot read back. A job data
value has to be one of the types JobDataMap declares an accessor for (string, bool, char, int, long, float,
double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid, DateOnly, TimeOnly or an enum), a
Dictionary<string, string>, or a type the application declares through
NewtonsoftJsonSerializerRegistry.AddJobDataValueType. Anything with structure of its own has to be
serialized by the job and stored as a string.
```

Word for word the System.Text.Json message but for the registration it names — and refused against the very
same declaration, `Quartz.Serialization.SystemTextJson.JobDataValues.Accepted`, rather than a copy of it.
Two lists meaning to say the same thing is how the write and read sides of *that* serializer came to
disagree, and the same trap is open across the two serializers: both are documented store formats and an
application is free to switch between them, so a value only one of them accepts is a one-way door nobody is
warned about.

Both write paths are gated: `StringKeyDirtyFlagMapConverter` (the default) and `TriggerConverter` (with
`RegisterTriggerConverters` on, where a trigger carries its own map). The trigger converter rethrows a
refusal rather than wrapping it in `Failed to serialize ITrigger to json`, exactly as the System.Text.Json
`JobDataMapConverter` rethrows its own — the wrapper would bury the one sentence that says what to change.
A `SchedulerContext` is left alone: nothing stores one.

## What a reviewer has to decide

**Symmetry costs three shapes Json.NET could round-trip on its own** — a class of the application's own, a
`JobKey`/`TriggerKey` held as a job data value, and a collection. The issue asked for "the same list …
symmetry with #3495 matters more than the one type", and that is what this does, but it is a behaviour
change beyond the broken value.

The way back is **new public API**, which the issue did not name:
`NewtonsoftJsonSerializerRegistry.AddJobDataValueType<T>()`. It is this package's counterpart to
`AddTypeInfoResolver` and the narrower of the two — Json.NET needs no metadata handed to it, so the call
registers nothing but the application's word that the type reads back. Without it the change would be a
capability removal with no answer; with it, three things that used to work are a one-line registration away,
and a declared type comes back as *itself* here (Json.NET resolves its `$type`), where System.Text.Json
hands any object back as a `Dictionary<string, string>`.

`TimeZoneInfo` and a nested `JobDataMap` are past declaring — verified, not assumed: with
`AddJobDataValueType<TimeZoneInfo>()` the read still throws, and a declared nested map still comes back as a
`JObject`, because the map's converter owns its own output and writes no `$type`. Store a zone's `Id`, and
serialize a nested structure in the job.

The public API baseline moved by exactly that one method, and the migration guide carries the same delta.

## Tests

- `JobDataMapPortabilityTest` — the refusal cases now run against **both** writers and assert each names the
  key, the type and its own registration; `TimeZoneInfo` joins them as the case this issue brought.
  `ATypeTheApplicationDeclaredIsWrittenAndReadByNewtonsoftToo` is the Newtonsoft half of the escape hatch.
  `ANestedMapIsNotPartOfThePortableFormat` became `ABlobThatAlreadyHoldsANestedMapReadsBackAsSomethingElse`:
  the guarantee is about reading what is already in a column, since writing one is now refused.
- `NewtonsoftJobDataTimeZoneTest` — the case that recorded the limitation is now the positive assertion.
  `ReadingThatZoneBackHasNeverWorked` stays, because a column that already holds one of those payloads is why
  the read is left alone rather than taught to guess.
  `ATriggersOwnJobDataIsRefusedWithTheTriggerConvertersOnToo` covers the second write path and asserts the
  message is not buried.
- `NewtonsoftKeySerializationTest` — a key is refused until declared, and a declared key still travels
  intact, which is what keeps the contract resolver's `$type`-path work under test.
- `StdAdoDelegateTest.TestSerializeJobData` — the `if System.Text.Json / else` collapsed into one assertion
  over both serializers.

Each of the new assertions was confirmed to fail with the gate removed.

## Docs

- `migration-guide.md` — the section is now *Both serializers refuse a job data value they cannot read back*
  (the old "Newtonsoft is unchanged" was the promise that stopped being true), with the Newtonsoft half, the
  three shapes that now need declaring, and a correction to the quoted message, which said "which a
  persistent store cannot read back" where the code says "which Quartz's JSON format cannot read back".
- `packages/json-serialization.md` — a *What a job data map may hold* section with a generated snippet, plus a
  note in the binary-migration section, since a hybrid migrator reading a key out of an old binary blob hits
  this gate.
- `tutorial/job-data-map.md`, `packages/system-text-json.md`, `src/Quartz.Serialization.Newtonsoft/README.md`
  — the same fact where each of them already said "System.Text.Json only".

`quartz-3.x/` is untouched.

## Verification

```
dotnet build Quartz.slnx                                → 0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit                       → 4139 passed, 0 failed
dotnet test src/Quartz.Tests.AspNetCore                 → 548 passed, 0 failed
dotnet fallout VerifyDocsSnippets                       → up to date (101 markdown files)
node docs/.vuepress/check-links.mjs                     → no dead links or anchors
```

`Quartz.Tests.Integration` **did not run**: `docker info` answers, but Docker Desktop's Linux backend is
unreachable from this machine (`Docker.DotNet` → `BadGateway: failed to connect to the backend: timed out
dialing Hyper-V socket`), so `TestAssemblySetup` fails before any test. Nothing in that project stores a job
data value outside the accepted set — the values are `string` and `int` — so none of it should be affected,
but that is inspection rather than a run.

## Found and left alone

A `Dictionary<string, string>` is accepted by both, but Newtonsoft writes it with a `$type` property and
System.Text.Json without one, so a Newtonsoft-written string map read by System.Text.Json comes back with an
extra `"$type"` entry in it. That is a pre-existing format difference, not part of this asymmetry, and
`JobDataMapPortabilityTest.PortableValues` does not cover it. It wants its own issue.

Closes #3500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
