### PR TITLE
A job type rename is declared as a map, not written as a type loader

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -585,6 +585,44 @@ services.AddQuartz(q => q.ConfigureJobScope((scope, bundle, scheduler) => { /* �
 ```
 <!-- endSnippet -->
 
+## Type loader
+
+`TypeLoaderOptions`, bound from `Quartz:TypeLoader`. This is the one options type that is the
+**container's** rather than a scheduler's, because the loader it configures is: one `ITypeLoader` serves
+every scheduler in the container.
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `Aliases` | `Dictionary<string, string>` | empty | What a type name that no longer names anything means today: the name as it was stored or configured, mapped to the name of the type that replaced it. |
+
+<!-- snippet: sample_reference_type_loader_aliases -->
+```csharp
+services.AddQuartz(q => q.UseTypeLoader(loader =>
+    loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob))));
+```
+<!-- endSnippet -->
+
+```json
+{
+  "Quartz": {
+    "TypeLoader": {
+      "Aliases": {
+        "Acme.Jobs.NightlyReport, Acme.Jobs": "Acme.Jobs.NightlyRollupJob, Acme.Jobs"
+      }
+    }
+  }
+}
+```
+
+An alias applies wherever Quartz turns a string into a type at run time — a stored `JOB_CLASS_NAME`, a
+job named in XML or JSON scheduling data, a `quartz.plugin.<name>.type` or
+`quartz.jobListener.<name>.type` key. The flat keys naming a scheduler's own components are read while
+the service collection is still being built, before any options exist, and are not aliased. An alias
+whose target names no type this application can load fails options validation at startup, and nothing is
+ever written back, so retiring one is still the SQL `UPDATE`; see [Job deserialization failures after
+refactoring](../../troubleshooting.md#job-deserialization-failures-after-refactoring) for the whole
+story.
+
 ## The other seams
 
 Each of these replaces one collaborator of the scheduler. All are `IQuartzBuilder` members, so they work
@@ -594,6 +632,7 @@ identically under `AddQuartz` and on a standalone `QuartzSchedulerBuilder`.
 |---|---|---|
 | `UseTimeProvider(timeProvider)` | the clock every trigger, store and misfire calculation reads | `TimeProvider.System`, or the container's registration when there is one |
 | `UseTypeLoader<T>()` | how a type named by a string — a stored `JOB_CLASS_NAME`, a `.type` key — is resolved | resolution through the container's assemblies, with the 3.x namespace fallbacks |
+| `UseTypeLoader(configure)` | *configures* that loader rather than replacing it: `loader.Map(oldName, typeof(NewType))` declares what a renamed type is called now, and `Quartz:TypeLoader:Aliases` is the same map from configuration. See [Job deserialization failures after refactoring](../../troubleshooting.md#job-deserialization-failures-after-refactoring) | no aliases |
 | `UseInstanceIdGenerator<T>()` | how `InstanceId` is derived when `GenerateInstanceId` is on | `SimpleInstanceIdGenerator`: host name plus a timestamp |
 | `UseJobStore<T>()`, `UseJobStore<T, TOptions>()` | the job store, for one that is neither of the two Quartz ships | the in-memory store |
 | `UseDriverDelegate<T>()`, `UseDriverDelegate(factory)` (on the persistent store builder) | the SQL dialect the ADO.NET store speaks | selected by the database method — `UseSqlServer` picks `SqlServerDelegate`, and so on |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1736,6 +1736,60 @@ names. A `UseGenericDatabase` callback that sets them from `typeof(...)` already
 was therefore serialized when it fired but not when it was acquired, so a batch could hold two of its
 triggers and the second was released again. Both now ask the same question.
 
+## A job type rename is declared as a map
+
+A persistent job store keeps the job's type as text, in `QRTZ_JOB_DETAILS.JOB_CLASS_NAME`. Renaming the
+class, moving its namespace or moving it to another assembly therefore breaks every row that names it,
+and on 3.x the supported answer was an `ITypeLoadHelper` of your own: a class to write, register and
+keep, for a one-line fact.
+
+4.0 lets the fact be stated as a fact. `TypeLoaderOptions.Aliases` maps the name as it was stored to the
+name the type has now, and `UseTypeLoader(configure)` is the typed way to add one:
+
+<!-- snippet: sample_reference_type_loader_aliases -->
+```csharp
+services.AddQuartz(q => q.UseTypeLoader(loader =>
+    loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob))));
+```
+<!-- endSnippet -->
+
+The same map binds from configuration, so the rename can ship in `appsettings.json` with the deployment
+that performs it:
+
+```json
+{
+  "Quartz": {
+    "TypeLoader": {
+      "Aliases": {
+        "Acme.Jobs.NightlyReport, Acme.Jobs": "Acme.Jobs.NightlyRollupJob, Acme.Jobs"
+      }
+    }
+  }
+}
+```
+
+The map is read by the loader Quartz ships, which is the one place a type name is resolved at run time —
+so it applies to `JOB_CLASS_NAME`, to jobs named in XML or JSON scheduling data, and to the
+`quartz.plugin.<name>.type` and `quartz.jobListener.<name>.type` keys. The flat keys naming a scheduler's
+own components are read while the service collection is still being built, before any options exist, and
+are not aliased. Keys are compared the way that loader already compares its own table of Quartz's
+3.x → 4.0 renames: ordinal, matching either the whole name or the part of it before the comma that
+starts the assembly.
+
+Two things are deliberate. An alias whose target names no loadable type **fails options validation at
+startup**, naming both halves of the entry, rather than surfacing later as a `TypeLoadException` that
+names the dead name and nothing about the mapping meant to save it. And nothing is ever written back: a
+job read under an aliased name still has the old spelling in its row, which is what makes an alias safe
+during a rolling deployment — the nodes still running the old build keep writing the old name while the
+new ones read it. Retiring an alias is still the SQL `UPDATE` in
+[Job deserialization failures after
+refactoring](../troubleshooting.md#job-deserialization-failures-after-refactoring), run once nothing is
+hitting it any more.
+
+`UseTypeLoader<T>()` is unchanged and still replaces the loader outright, for a scheme rather than a
+list — a name resolved out of a plugin's `AssemblyLoadContext`, say. Replacing the loader takes the map
+with it, since the map is the shipped loader's.
+
 ## The job scope is prepared without writing a job factory
 
 `ConfigureScope` — the hook that prepares the dependency injection scope a job is built in, and the place
@@ -4482,6 +4536,7 @@ already have them.
 * **Builder methods for three more plugins** — `UseJobHistoryLogging()`, `UseTriggerHistoryLogging()` and `UseShutdownHook()`. Only the structured-logging variants had one, so the classic history plugins and the shutdown hook could previously be reached only through `quartz.plugin.*` property keys
 * **A plugin implements only what it has to say** — `ISchedulerPlugin.Start` and `Shutdown` have default implementations, so a plugin that does its work in `Initialize` writes one member rather than three (see [A plugin implements only what it has to say](#a-plugin-implements-only-what-it-has-to-say))
 * **A calendar can have dependencies** — `AddCalendar(name, serviceProvider => …)` builds the calendar from the container, which the `where T : ICalendar, new()` generic overloads cannot (see [A calendar can be built from the container](#a-calendar-can-be-built-from-the-container))
+* **A renamed job type is declared, not coded around** — `q.UseTypeLoader(loader => loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob)))`, or the same map under `Quartz:TypeLoader:Aliases` in configuration, keeps every row still carrying the old `JOB_CLASS_NAME` firing. On 3.x the only answer was an `ITypeLoadHelper` of your own (see [A job type rename is declared as a map](#a-job-type-rename-is-declared-as-a-map))
 * **A `quartz.*` key that lost its prefix is refused** — `QuartzOptions.Properties` is read only through the `quartz.` prefix, so a key without one produced no symptom at all; it now fails options validation at startup (see [A property key without the `quartz.` prefix is refused](#a-property-key-without-the-quartz-prefix-is-refused))
 * **An `IJobDetail` of your own** — the interface no longer declares a member only Quartz can implement, so an application can supply its own job detail type and have `RAMJobStore` hand it back rather than quietly swapping it for Quartz's (see [An `IJobDetail` of your own](#an-ijobdetail-of-your-own))
 * **A one-word question needs no query object** — `QueryJobs()`, `QueryTriggers()`, `QueryFireInstances()`, `QueryFireInstancesOfJob(jobKey)` and `QueryTriggersInError()` are the query members with the query record filled in, `ResetTriggersFromErrorState(GroupMatcher<TriggerKey>)` resets the failed triggers of a group, `Exists(string calendarName)` answers whether a calendar is there without deserializing it, and `ISchedulerFactory.GetRequiredScheduler(name)` throws where `LookupScheduler` returns null (see [Asking a one-word question does not need a query object](#asking-a-one-word-question-does-not-need-a-query-object))
@@ -9626,7 +9681,7 @@ having gone wrong.
 
 Derived the same mechanical way as the tables above: types in the 4.x `Quartz` namespace that are in the
 3.x `Quartz` namespace of none of `Quartz`, `Quartz.Extensions.DependencyInjection` or
-`Quartz.Extensions.Hosting`. **Ninety-two names.** A project that also referenced
+`Quartz.Extensions.Hosting`. **Ninety-three names.** A project that also referenced
 `Quartz.Serialization.SystemTextJson` on 3.x already had `JsonSerializationException`.
 
 ```text
@@ -9660,7 +9715,7 @@ SimpleTriggerMisfireInstruction     StandaloneSchedulerFactory                 S
 StringOperator                      SystemTextJsonConfigurationExtensions      ThreadPoolOptions
 TimeRange                           TimeZones                                  TriggerBuilder<T>
 TriggerConfiguratorExtensions       TriggerGroup                               TriggerGroupQuery
-TriggerHeader                       TriggerQuery
+TriggerHeader                       TriggerQuery                               TypeLoaderOptions
 ```
 
 Most of those are unmistakably Quartz's. These are the ones a host application or an integration library

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -336,7 +336,7 @@ A handful of things are container-wide, shared by every scheduler in the process
 
 | | |
 |---|---|
-| `ITypeLoader` | type loading is a container-wide concern; `UseTypeLoader<T>()` **replaces** it for everyone |
+| `ITypeLoader` | type loading is a container-wide concern; `UseTypeLoader<T>()` **replaces** it for everyone, and the renames `UseTypeLoader(configure)` declares are in force for everyone |
 | `ISchedulerRepository` | one per container — that is what makes `GetAllSchedulers` and the dashboard see all of them |
 | `ISchedulerRegistry` | one per container — it answers for every registration in it, which is what makes it an inventory rather than a scheduler's own view |
 | `IJobExecutionContextAccessor` | one per container, and the firing it reports is a property of the asynchronous flow rather than of a scheduler — a flow is inside at most one firing, whichever scheduler started it |

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -293,12 +293,65 @@ WHERE JOB_CLASS_NAME = 'OldNamespace.OldClassName, OldAssembly';
 Run it during the deployment that renames the type, and clear the affected triggers with
 `IScheduler.ResetTriggerFromErrorState` afterwards if any reached `ERROR` first.
 
-**Resolution — teach the scheduler the old name (4.x):**
+**Resolution — declare the rename (4.x):**
 
-Every stored type name is resolved through `ITypeLoader`, which is a single method and a replaceable
-seam. An implementation that consults a rename table before falling back to `Type.GetType` makes the old
-name keep working without touching a row, which is what a rolling deployment needs: the nodes still
-running the old build write the old name while the new ones read it.
+Say what the old name means now, and every stored row carrying it keeps resolving. That is what a
+rolling deployment needs: the nodes still running the old build write the old name while the new ones
+read it, so nothing has to be rewritten while both are running.
+
+<!-- snippet: sample_troubleshooting_type_loader_map -->
+```csharp
+services.AddQuartz(q => q.UseTypeLoader(loader =>
+{
+    // Old assembly-qualified name as stored, and the type it means now. Keep the entry until
+    // every row that could carry the old name has been rewritten or has aged out.
+    loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob));
+}));
+```
+<!-- endSnippet -->
+
+The same map binds from configuration, so a rename can ship in `appsettings.json` with the deployment
+that performs it rather than in a rebuild:
+
+```json
+{
+  "Quartz": {
+    "TypeLoader": {
+      "Aliases": {
+        "Acme.Jobs.NightlyReport, Acme.Jobs": "Acme.Jobs.NightlyRollupJob, Acme.Jobs"
+      }
+    }
+  }
+}
+```
+
+A few things worth knowing about the map:
+
+* It applies wherever Quartz turns a **string** into a type at run time — a stored `JOB_CLASS_NAME`, a
+  job named in XML or JSON scheduling data, a `quartz.plugin.<name>.type`,
+  `quartz.jobListener.<name>.type` or `quartz.triggerListener.<name>.type` key. The flat keys naming a
+  scheduler's own components — the job store, thread pool, serializer, lock handler, job factory,
+  instance id generator, time provider and connection provider — are resolved while the service
+  collection is still being built, before any options exist, and are **not** aliased. Each of those
+  names a type in a file you can edit, which is why the feature is not for them.
+* A key matches the whole stored name, or the part of it before the comma that starts the assembly.
+  `Acme.Jobs.NightlyReport` therefore covers however the assembly was spelled after it, and
+  `Acme.Jobs.NightlyReport, Acme.Jobs` covers only that one.
+* An alias whose target names no type this application can load **fails at startup**, naming both halves
+  of the entry. An alias that resolves to nothing would otherwise surface as a `TypeLoadException`
+  naming the dead name and nothing about the mapping meant to save it.
+* Type loading is container-wide, so the map is the container's: a rename declared through any
+  scheduler's builder is in force for every scheduler in it.
+* **Nothing is written back.** A job read under an aliased name still has the old spelling in
+  `JOB_CLASS_NAME`, which is what makes the alias safe during a rollout — and what makes the `UPDATE`
+  above the way to eventually retire it. Enable `Debug` logging for `Quartz.Impl.SimpleTypeLoader` to
+  see whether anything is still hitting an alias before you remove it.
+
+**Resolution — a type loader of your own (4.x):**
+
+The map covers a rename. Where the answer is not a table — a name resolved out of a plugin's
+`AssemblyLoadContext`, or a scheme rather than a list — `ITypeLoader` is a single method and a
+replaceable seam, and `UseTypeLoader<T>()` replaces the loader altogether:
 
 <!-- snippet: sample_troubleshooting_type_loader_implementation -->
 ```csharp
@@ -340,21 +393,23 @@ services.AddQuartz(q => q.UseTypeLoader<RenameAwareTypeLoader>());
 ```
 <!-- endSnippet -->
 
-An implementation must **throw** rather than return `null` for a name it cannot resolve — Quartz only
-asks when it already knows a type is required, so a `null` surfaces later with nothing left to point at.
-`null` is reserved for a null or empty name.
+Replacing the loader replaces it for the whole container, and takes the declared map with it: the map is
+read by the loader Quartz ships. An implementation must **throw** rather than return `null` for a name it
+cannot resolve — Quartz only asks when it already knows a type is required, so a `null` surfaces later
+with nothing left to point at. `null` is reserved for a null or empty name.
 
-The loader Quartz ships already does this for **Quartz's own** 3.x → 4.0 renames: it retries
+The loader Quartz ships also carries **Quartz's own** 3.x → 4.0 renames: it retries
 `Quartz.Spi.*` as `Quartz.Extensibility.*`, `Quartz.Simpl.*` as `Quartz.Impl.*`, `Quartz.Job.*` as
 `Quartz.Jobs.*`, `Quartz.Plugin.*` as `Quartz.Plugins.*`, `Quartz.Listener.*` as `Quartz.Listeners.*`,
 the job stores' old names (`JobStoreTX`, `JobStoreCMT`) and the assemblies that were merged into the
-core package, logging a warning each time so the configuration can be corrected. It knows nothing about
-your types, which is what the sample above is for.
+core package, logging a warning each time so the configuration can be corrected. Those are the same
+mechanism the map is, applied to Quartz's own type names rather than to yours.
 
 **Prevention:**
 
 * Keep job class names and namespaces stable across releases.
-* If you must rename, apply the database update as part of your deployment process.
+* If you must rename, declare the alias in the deployment that renames the type (4.x), and apply the
+  database update in a later one — once nothing is hitting the alias any more.
 * Name the type in one place — a `public static readonly JobKey` on the job class, and registration
   through `AddJob<T>()` rather than a type-name string.
 
@@ -440,5 +495,5 @@ Jobs should check `IJobExecutionContext.CancellationToken` to respond to shutdow
 | `ObjectAlreadyExistsException` | Attempting to schedule a job or trigger with a key that already exists | Use `scheduler.RescheduleJob()` to replace an existing trigger, or check existence first with `scheduler.Exists()` (Quartz 4.x; on Quartz 3.x the method is `scheduler.CheckExists()`) |
 | `JobPersistenceException` | Database error during job store operation | Check database connectivity, connection pool size, and query timeouts |
 | `SchedulerException: Scheduler has been shutdown` | Calling scheduler methods after `Shutdown()` | Ensure your application lifecycle correctly manages the scheduler |
-| `TypeLoadException` on job execution | Job class not found — possibly renamed or moved | Update `JOB_CLASS_NAME` in `QRTZ_JOB_DETAILS` (see [Job Deserialization Failures](#job-deserialization-failures-after-refactoring)) |
+| `TypeLoadException` on job execution | Job class not found — possibly renamed or moved | Declare the rename on the type loader (4.x), or update `JOB_CLASS_NAME` in `QRTZ_JOB_DETAILS` (see [Job Deserialization Failures](#job-deserialization-failures-after-refactoring)) |
 | `JobExecutionException` | Unhandled exception inside `IJob.Execute()` | Add try-catch in your job's Execute method (see [Best Practices](best-practices.md#what-happens-when-a-job-throws)) |

--- a/src/Quartz.Documentation.Samples/Configuration/ReferenceSamples.cs
+++ b/src/Quartz.Documentation.Samples/Configuration/ReferenceSamples.cs
@@ -7,6 +7,8 @@ using Quartz.Impl.AdoJobStore.Common;
 
 namespace Quartz.Documentation.Samples.Configuration;
 
+// NightlyRollupJob lives in the parent namespace, which this one already sees.
+
 /// <summary>
 /// Samples for docs/documentation/quartz-4.x/configuration/reference.md.
 /// </summary>
@@ -229,6 +231,16 @@ public static class ReferenceSamples
 
         services.AddQuartz("reporting", q => q.UsePersistentStore(store => store.UseSqlServer(reportingDb)));
         services.AddQuartz("ingest", q => q.UseInMemoryStore());
+
+        #endregion
+    }
+
+    public static void TypeLoaderAliases(IServiceCollection services)
+    {
+        #region sample_reference_type_loader_aliases
+
+        services.AddQuartz(q => q.UseTypeLoader(loader =>
+            loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob))));
 
         #endregion
     }

--- a/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
+++ b/src/Quartz.Documentation.Samples/VersionNeutralPageSamples.cs
@@ -111,6 +111,20 @@ public static class VersionNeutralPageSamples
         });
     }
 
+    public static void RenamedJobTypesDeclared(IServiceCollection services)
+    {
+        #region sample_troubleshooting_type_loader_map
+
+        services.AddQuartz(q => q.UseTypeLoader(loader =>
+        {
+            // Old assembly-qualified name as stored, and the type it means now. Keep the entry until
+            // every row that could carry the old name has been rewritten or has aged out.
+            loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob));
+        }));
+
+        #endregion
+    }
+
     public static void RenamedJobTypes(IServiceCollection services)
     {
         #region sample_troubleshooting_type_loader

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
@@ -44,9 +44,9 @@ namespace Quartz.Tests.Unit.Configuration;
 public class ConfigurationBindingIsSourceGeneratedTest
 {
     /// <summary>
-    /// The six calls the generator has to intercept, which are all of the binder calls Quartz makes.
+    /// The seven calls the generator has to intercept, which are all of the binder calls Quartz makes.
     /// </summary>
-    private const int InterceptedBinderCalls = 6;
+    private const int InterceptedBinderCalls = 7;
 
     /// <summary>
     /// The file those calls are written in. The generator intercepts call sites in the project being
@@ -100,7 +100,8 @@ public class ConfigurationBindingIsSourceGeneratedTest
             typeof(InMemoryJobStoreOptions),
             typeof(AdoJobStoreOptions),
             typeof(ClusteringOptions),
-            typeof(DataSourceOptions)
+            typeof(DataSourceOptions),
+            typeof(TypeLoaderOptions)
         ];
 
         List<Type> generated = GeneratedBinder()
@@ -155,6 +156,12 @@ public class ConfigurationBindingIsSourceGeneratedTest
         AssertEveryMemberBinds<DataSourceOptions>($"{QuartzTypedOptions.DataSourceSection}:reporting", "reporting");
     }
 
+    /// <summary>
+    /// <see cref="TypeLoaderOptions"/> has no case of its own above, because the harness fills a string
+    /// dictionary with a canary value — and every value in this one has to name a loadable type, so the
+    /// canary would fail options validation rather than the binding.
+    /// <c>TypeLoaderAliasTest.AnAliasBindsFromConfiguration</c> binds it with a real type name instead.
+    /// </summary>
     [Test]
     public void EveryCodeOnlyMemberIsStillEarningItsPlace()
     {
@@ -250,6 +257,7 @@ public class ConfigurationBindingIsSourceGeneratedTest
         yield return typeof(AdoJobStoreOptions);
         yield return typeof(ClusteringOptions);
         yield return typeof(DataSourceOptions);
+        yield return typeof(TypeLoaderOptions);
     }
 
     private static IEnumerable<PropertyInfo> Settable(Type type) => type

--- a/src/Quartz.Tests.Unit/Configuration/QuartzSchedulerBuilderForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzSchedulerBuilderForwardingTest.cs
@@ -37,6 +37,18 @@ public class QuartzSchedulerBuilderForwardingTest
             services => Unkeyed(services).Any(descriptor =>
                 descriptor.ServiceType == typeof(ITypeLoader) && descriptor.ImplementationType?.Name == "SimpleTypeLoader")),
 
+        // UseTypeLoader<T>() is an interface member rather than an extension, but it shares its name with
+        // one — and the coverage check pairs cases with mirrors by name — so both overloads need a case.
+        new Case("UseTypeLoader", "UseTypeLoader<T>()",
+            builder => builder.UseTypeLoader<ForwardingTypeLoader>(),
+            services => Unkeyed(services).Any(descriptor =>
+                descriptor.ServiceType == typeof(ITypeLoader) && descriptor.ImplementationType == typeof(ForwardingTypeLoader))),
+
+        new Case("UseTypeLoader", "UseTypeLoader(configure)",
+            builder => builder.UseTypeLoader(loader => loader.Map("Acme.Jobs.Renamed, Acme.Jobs", typeof(ForwardingJob))),
+            services => Resolve(services, provider =>
+                provider.GetRequiredService<IOptions<TypeLoaderOptions>>().Value.Aliases.ContainsKey("Acme.Jobs.Renamed, Acme.Jobs"))),
+
         new Case("ConfigureJobScope", "ConfigureJobScope(configure)",
             builder => builder.ConfigureJobScope((_, _, _) => { }),
             services => Resolve(services, provider =>
@@ -205,5 +217,10 @@ public class QuartzSchedulerBuilderForwardingTest
 
     private sealed class DerivedForwardingJob : ForwardingJob
     {
+    }
+
+    private sealed class ForwardingTypeLoader : ITypeLoader
+    {
+        public Type LoadType(string name) => Type.GetType(name, throwOnError: true)!;
     }
 }

--- a/src/Quartz.Tests.Unit/Configuration/TypeLoaderAliasTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/TypeLoaderAliasTest.cs
@@ -1,0 +1,302 @@
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// A job type that was renamed says so as a map, rather than as a type loader the application has to
+/// write.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SimpleTypeLoaderTest"/> covers how one alias is matched and substituted. What is under
+/// test here is the seam: that the map reaches the loader the container hands its schedulers, from the
+/// builder and from configuration alike, that an alias naming nothing is a startup failure, and that a
+/// job whose stored <c>JOB_CLASS_NAME</c> is a dead name fires anyway — without the row being rewritten.
+/// </para>
+/// <para>
+/// The round trip runs against a real SQLite file, which is what makes the last of those a fact about
+/// the ADO.NET store rather than about the loader on its own: the name is read back out of a column, by
+/// the store, on the acquisition path.
+/// </para>
+/// </remarks>
+public sealed class TypeLoaderAliasTest
+{
+    /// <summary>
+    /// The name a deployment before this one stored, naming a type nothing is called any more.
+    /// </summary>
+    private const string StoredName = "Acme.Jobs.NightlyReport, Acme.Jobs";
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-alias-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public void AnAliasDeclaredOnTheBuilderReachesTheSchedulersTypeLoader()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(loader => loader.Map(StoredName, typeof(NightlyRollupJob))));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        container.GetRequiredService<ITypeLoader>().LoadType(StoredName).Should().Be<NightlyRollupJob>(
+            "the map is the declarative form of the rename-aware loader, so it has to reach the one place "
+            + "every stored and configured type name is resolved");
+    }
+
+    [Test]
+    public void AnAliasBindsFromConfiguration()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(Section(
+            ($"Quartz:TypeLoader:Aliases:{StoredName}", typeof(NightlyRollupJob).AssemblyQualifiedNameWithoutVersion())));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        container.GetRequiredService<ITypeLoader>().LoadType(StoredName).Should().Be<NightlyRollupJob>(
+            "a rename has to be able to ship in appsettings with the deployment that performs it, without "
+            + "a rebuild");
+    }
+
+    [Test]
+    public void AliasesDeclaredForSeveralSchedulersMakeOneTable()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz("reporting", Section(
+            ($"Quartz:TypeLoader:Aliases:{StoredName}", typeof(NightlyRollupJob).AssemblyQualifiedNameWithoutVersion())));
+        services.AddQuartz("billing", q => q.UseTypeLoader(
+            loader => loader.Map("Acme.Jobs.Invoicing, Acme.Jobs", typeof(NightlyRollupJob))));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+        ITypeLoader loader = container.GetRequiredService<ITypeLoader>();
+
+        loader.LoadType(StoredName).Should().Be<NightlyRollupJob>();
+        loader.LoadType("Acme.Jobs.Invoicing, Acme.Jobs").Should().Be<NightlyRollupJob>(
+            "there is one type loader per container, so its aliases are the container's — a rename "
+            + "declared through either scheduler is in force for both");
+    }
+
+    [Test]
+    public void AnAliasNamingATypeThatCannotBeLoadedFailsAtStartup()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(
+            loader => loader.Aliases[StoredName] = "Acme.Jobs.NightlyRollupJob, Acme.Jobs"));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        var act = () => container.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage($"*{StoredName}*")
+            .WithMessage("*Acme.Jobs.NightlyRollupJob, Acme.Jobs*",
+                "an alias is only consulted when a name is about to become a type, so one that resolves to "
+                + "nothing would otherwise surface as a TypeLoadException naming the dead name and nothing "
+                + "about the mapping meant to save it");
+    }
+
+    [Test]
+    public void AnAliasNamingATypeThatCannotBeLoadedAlsoFailsWhenTheLoaderIsBuilt()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(
+            loader => loader.Aliases[StoredName] = "Acme.Jobs.NightlyRollupJob, Acme.Jobs"));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        var act = () => container.GetRequiredService<ITypeLoader>();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage($"*{StoredName}*",
+            "the standalone builder's container runs no startup validation, so building the loader has to "
+            + "report the same mistake rather than starting with an alias that does nothing");
+    }
+
+    [Test]
+    public void ABlankAliasFailsAtStartup()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(loader => loader.Aliases[""] = "Quartz.Jobs.NoOpJob, Quartz.Jobs"));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        var act = () => container.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*blank name*",
+            "an alias is matched against the start of every name the loader resolves, so a blank one "
+            + "would claim all of them");
+    }
+
+    [Test]
+    public void AnAliasWithNoTargetFailsAtStartup()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(loader => loader.Aliases[StoredName] = " "));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        var act = () => container.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage($"*{StoredName}*")
+            .WithMessage("*blank type name*");
+    }
+
+    [Test]
+    public void AnAliasWhoseTargetIsSpelledWithAPre40NameIsAccepted()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q.UseTypeLoader(
+            loader => loader.Aliases["Acme.Threading.Pool, Acme"] = "Quartz.Simpl.DefaultThreadPool, Quartz"));
+
+        using ServiceProvider container = services.BuildServiceProvider();
+
+        container.GetRequiredService<IStartupValidator>().Validate();
+
+        container.GetRequiredService<ITypeLoader>().LoadType("Acme.Threading.Pool, Acme")
+            .Should().Be<Quartz.Impl.DefaultThreadPool>(
+                "the target is resolved the way the loader resolves anything, so Quartz's own 3.x "
+                + "fallbacks apply to it too");
+    }
+
+    [Test]
+    public async Task AJobStoredUnderItsOldNameFiresAsTheTypeTheAliasNames()
+    {
+        const string SchedulerName = "alias-round-trip";
+
+        // The deployment before the rename: the schema is created and the job is stored under the name
+        // this build knows the type by.
+        await using (ServiceProvider before = Container(SchedulerName))
+        {
+            IScheduler scheduler = await before.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+            await scheduler.ScheduleJob(
+                JobBuilder.Create<NightlyRollupJob>().WithIdentity("job", SchedulerName).Build(),
+                TriggerBuilder.Create()
+                    .WithIdentity("trigger", SchedulerName)
+                    .StartNow()
+                    // Repeating, so the trigger is still there to fire again on the second start.
+                    .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                    .Build());
+
+            await scheduler.Shutdown();
+
+            var act = () => before.GetRequiredService<ITypeLoader>().LoadType(StoredName);
+            act.Should().Throw<TypeLoadException>(
+                "without the alias the stored name resolves to nothing, which is what makes the run below "
+                + "a test of the alias rather than of the job");
+        }
+
+        // The rename itself, standing in for the JOB_CLASS_NAME an older build wrote.
+        (await Execute($"UPDATE QRTZ_JOB_DETAILS SET JOB_CLASS_NAME = '{StoredName}'")).Should().Be(1);
+
+        await using (ServiceProvider after = Container(
+            SchedulerName,
+            q => q.UseTypeLoader(loader => loader.Map(StoredName, typeof(NightlyRollupJob)))))
+        {
+            IScheduler scheduler = await after.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+            TaskCompletionSource fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            scheduler.Context[NightlyRollupJob.SignalKey] = fired;
+
+            await scheduler.Start();
+            await fired.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+
+        (await Scalar("SELECT JOB_CLASS_NAME FROM QRTZ_JOB_DETAILS")).Should().Be(StoredName,
+            "the loader translates the name it is given and never writes one back, so the SQL UPDATE in "
+            + "the troubleshooting page stays the way an alias is retired");
+    }
+
+    private ServiceProvider Container(string schedulerName, Action<IQuartzBuilder>? configure = null)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = schedulerName;
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+
+            configure?.Invoke(q);
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private static IConfiguration Section(params (string Key, string? Value)[] values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values.ToDictionary(entry => entry.Key, entry => entry.Value))
+            .Build()
+            .GetSection("Quartz");
+    }
+
+    private async Task<int> Execute(string sql)
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        return await command.ExecuteNonQueryAsync();
+    }
+
+    private async Task<string?> Scalar(string sql)
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        return (string?) await command.ExecuteScalarAsync();
+    }
+
+    /// <summary>
+    /// Public with a public constructor, because the store hands the job factory nothing but the type
+    /// the alias resolved <c>JOB_CLASS_NAME</c> to.
+    /// </summary>
+    public sealed class NightlyRollupJob : IJob
+    {
+        internal const string SignalKey = "fired";
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            ((TaskCompletionSource) context.Scheduler.Context[SignalKey]!).TrySetResult();
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/SimpleTypeLoaderTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/SimpleTypeLoaderTest.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Options;
+
 using Quartz.Extensibility;
 using Quartz.Extensions.Redis;
 using Quartz.Impl;
@@ -206,5 +208,100 @@ public class SimpleTypeLoaderTest
     public void ShouldReturnNullForAnEmptyName()
     {
         typeLoader.LoadType("").Should().BeNull();
+    }
+
+    // -------------------------------------------------------------------------------------------------
+    // Aliases the application declares, which ride the same table mechanism as the renames above.
+    // -------------------------------------------------------------------------------------------------
+
+    [Test]
+    public void ShouldResolveANameThroughADeclaredAlias()
+    {
+        ITypeLoader loader = WithAliases(options => options.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NoOpJob)));
+
+        loader.LoadType("Acme.Jobs.NightlyReport, Acme.Jobs").Should().Be<NoOpJob>(
+            "a declared rename is what keeps a stored JOB_CLASS_NAME firing after the type moved");
+    }
+
+    [Test]
+    public void ShouldResolveANameThroughAnAliasThatNamesNoAssembly()
+    {
+        ITypeLoader loader = WithAliases(options => options.Map("Acme.Jobs.NightlyReport", typeof(NoOpJob)));
+
+        loader.LoadType("Acme.Jobs.NightlyReport, Acme.Jobs").Should().Be<NoOpJob>(
+            "an alias matches the part of the name before the assembly, so one entry covers however the "
+            + "assembly was spelled beside it");
+    }
+
+    [Test]
+    public void ShouldKeepTheStoredAssemblyWhenTheAliasTargetNamesNone()
+    {
+        ITypeLoader loader = WithAliases(options => options.Aliases["Quartz.Jobs.NightlyReport"] = "Quartz.Jobs.NoOpJob");
+
+        loader.LoadType("Quartz.Jobs.NightlyReport, Quartz.Jobs").Should().Be<NoOpJob>(
+            "a target that names no assembly is a rename within the assembly the name already carried");
+    }
+
+    [Test]
+    public void ShouldNotClaimANameThatMerelyStartsWithADeclaredAlias()
+    {
+        ITypeLoader loader = WithAliases(options => options.Map("Acme.Jobs.Nightly", typeof(NoOpJob)));
+
+        var act = () => loader.LoadType("Acme.Jobs.NightlyReport, Acme.Jobs");
+
+        act.Should().Throw<TypeLoadException>().WithMessage("*Acme.Jobs.NightlyReport*",
+            "an alias applies to a whole type name, exactly as Quartz's own rename table does");
+    }
+
+    [Test]
+    public void ShouldPreferADeclaredAliasOverANameThatStillResolves()
+    {
+        ITypeLoader loader = WithAliases(options => options.Map("Quartz.Jobs.NoOpJob, Quartz.Jobs", typeof(DirectoryScanJob)));
+
+        loader.LoadType("Quartz.Jobs.NoOpJob, Quartz.Jobs").Should().Be<DirectoryScanJob>(
+            "an alias states what a stored name means now, so it holds through the window in which the "
+            + "old type is still deployed beside the new one");
+    }
+
+    [Test]
+    public void ShouldFallBackToTheNameAsGivenWhenAnAliasTargetCannotBeLoaded()
+    {
+        ITypeLoader loader = WithAliases(options => options.Aliases["Quartz.Impl.DefaultThreadPool"] = "Acme.Nope, Acme");
+
+        loader.LoadType("Quartz.Impl.DefaultThreadPool, Quartz").Should().Be<DefaultThreadPool>(
+            "an alias that resolves to nothing is refused at startup, so a loader built without validation "
+            + "carries on rather than losing a name that was never broken");
+    }
+
+    [Test]
+    public void ShouldIgnoreABlankAlias()
+    {
+        ITypeLoader loader = WithAliases(options =>
+        {
+            options.Aliases[" "] = "Quartz.Jobs.NoOpJob, Quartz.Jobs";
+            options.Aliases["Acme.Jobs.NightlyReport"] = "";
+        });
+
+        loader.LoadType("Quartz.Impl.DefaultThreadPool, Quartz").Should().Be<DefaultThreadPool>(
+            "a blank alias would prefix-match every name there is; it is refused at startup, and ignored "
+            + "by a loader that was built without validation");
+    }
+
+    [Test]
+    public void ShouldStillApplyTheBuiltInRenamesBesideADeclaredAlias()
+    {
+        ITypeLoader loader = WithAliases(options => options.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NoOpJob)));
+
+        loader.LoadType("Quartz.Simpl.DefaultThreadPool, Quartz").Should().Be<DefaultThreadPool>(
+            "declaring a rename of your own does not displace Quartz's own 3.x table");
+        loader.LoadType("Quartz.Impl.AdoJobStore.JobStoreTX, Quartz").Should().Be<LocalTransactionJobStore>(
+            "nor the type renames in it, which keep quartz.jobStore.type resolving");
+    }
+
+    private static ITypeLoader WithAliases(Action<TypeLoaderOptions> configure)
+    {
+        TypeLoaderOptions options = new();
+        configure(options);
+        return new SimpleTypeLoader(logger: null, Options.Create(options));
     }
 }

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -414,3 +414,5 @@
     "Unable to read environment variable '{Key}' due to security exception, probably running under medium trust"
 5110  Warning  UtilityLog.EnvironmentVariablesReadDenied
     "Unable to read environment variables due to security exception, probably running under medium trust"
+5111  Debug  UtilityLog.TypeFoundUnderDeclaredAlias
+    "Type '{OldName}' was resolved as '{NewName}' through a declared type loader alias."

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1284,6 +1284,7 @@ namespace Quartz
         public static Quartz.IQuartzBuilder ScheduleJob<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces)]  T>(this Quartz.IQuartzBuilder builder, System.Action<System.IServiceProvider, Quartz.ITriggerConfigurator<T>> trigger, System.Action<System.IServiceProvider, Quartz.IJobConfigurator<T>>? job = null)
             where T : Quartz.IJob { }
         public static Quartz.IQuartzBuilder UseSimpleTypeLoader(this Quartz.IQuartzBuilder builder) { }
+        public static Quartz.IQuartzBuilder UseTypeLoader(this Quartz.IQuartzBuilder builder, System.Action<Quartz.TypeLoaderOptions> configure) { }
     }
     public static class QuartzHealthCheckExtensions
     {
@@ -1443,6 +1444,7 @@ namespace Quartz
         public Quartz.QuartzSchedulerBuilder UseThreadPool<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
             where T :  class, Quartz.Extensibility.IThreadPool { }
         public Quartz.QuartzSchedulerBuilder UseTimeProvider(System.TimeProvider timeProvider) { }
+        public Quartz.QuartzSchedulerBuilder UseTypeLoader(System.Action<Quartz.TypeLoaderOptions> configure) { }
         public Quartz.QuartzSchedulerBuilder UseTypeLoader<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()
             where T :  class, Quartz.Extensibility.ITypeLoader { }
         public static Quartz.QuartzSchedulerBuilder Create() { }
@@ -1921,6 +1923,12 @@ namespace Quartz
         Blocked = 4,
         None = 5,
         Executing = 6,
+    }
+    public sealed class TypeLoaderOptions
+    {
+        public TypeLoaderOptions() { }
+        public System.Collections.Generic.Dictionary<string, string?> Aliases { get; }
+        public Quartz.TypeLoaderOptions Map(string name, System.Type type) { }
     }
 }
 namespace Quartz.Diagnostics

--- a/src/Quartz/Configuration/QuartzBuilderExtensions.cs
+++ b/src/Quartz/Configuration/QuartzBuilderExtensions.cs
@@ -37,6 +37,38 @@ public static class QuartzBuilderExtensions
     }
 
     /// <summary>
+    /// Configures the type loader, which is where a job type that was renamed says what it is called
+    /// now.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>UseTypeLoader&lt;T&gt;()</c> replaces the loader; this configures the one Quartz ships.
+    /// Declaring a rename here is the declarative form of the rename-aware loader the troubleshooting
+    /// page used to be the only answer — one line per renamed type instead of a class to write, register
+    /// and keep — and the same map can arrive from configuration under
+    /// <c>Quartz:TypeLoader:Aliases</c>, so a rename can ship with the deployment that performs it.
+    /// </para>
+    /// <para>
+    /// The options are the container's rather than one scheduler's, because the loader is: a rename
+    /// declared through any scheduler's builder is in force for every scheduler in the container. An
+    /// alias whose target names no loadable type fails validation at startup.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The builder.</param>
+    /// <param name="configure">Declares the renames.</param>
+    public static IQuartzBuilder UseTypeLoader(this IQuartzBuilder builder, Action<TypeLoaderOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Registered here as well as by AddQuartz, because this is reachable from a builder that has not
+        // registered a scheduler yet, and an alias with no validator is one that fails on first use.
+        builder.Services.AddQuartzOptionsValidation();
+        builder.Services.Configure<TypeLoaderOptions>(configure);
+        return builder;
+    }
+
+    /// <summary>
     /// Prepares the dependency injection scope each job is built in, so services that are scoped can be
     /// given the ambient context of the job about to run.
     /// </summary>

--- a/src/Quartz/Configuration/QuartzOptionsValidators.cs
+++ b/src/Quartz/Configuration/QuartzOptionsValidators.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
+using Quartz.Impl;
+
 namespace Quartz.Configuration;
 
 /// <summary>
@@ -333,6 +335,63 @@ internal sealed class ThreadPoolOptionsValidator : IValidateOptions<ThreadPoolOp
         }
 
         return ValidateOptionsResult.Success;
+    }
+}
+
+/// <summary>
+/// Refuses a type loader alias that maps a name onto nothing, because such an alias is a rename that
+/// has not happened.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An alias is only ever consulted for a name that is about to be turned into a type — a stored
+/// <c>JOB_CLASS_NAME</c>, most of the time — so an alias whose target does not resolve fails on the
+/// first job that needs it, in a <c>TypeLoadException</c> naming the <em>old</em> name and nothing
+/// about the mapping that was supposed to save it. Checked here instead, it is a startup failure that
+/// names both halves of the entry that is wrong.
+/// </para>
+/// <para>
+/// The target is resolved the way the loader resolves it, so a target may itself be spelled with a
+/// pre-4.0 name; only the key is left alone, since a key that no longer resolves is exactly the point.
+/// A blank key is refused as well: it would prefix-match every name the loader is ever asked for.
+/// </para>
+/// </remarks>
+internal sealed class TypeLoaderOptionsValidator : IValidateOptions<TypeLoaderOptions>
+{
+    public ValidateOptionsResult Validate(string? name, TypeLoaderOptions options)
+    {
+        List<string>? failures = null;
+
+        foreach ((string alias, string? target) in options.Aliases)
+        {
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                (failures ??= []).Add(
+                    $"{nameof(TypeLoaderOptions.Aliases)} contains a blank name, mapped to '{target}'. An alias is "
+                    + "matched against the start of every type name Quartz resolves, so a blank one would claim all "
+                    + "of them; give it the name as it is stored or configured.");
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                (failures ??= []).Add(
+                    $"Type loader alias '{alias}' maps to a blank type name. Give it the name of the type that "
+                    + "replaced it, or remove the entry.");
+                continue;
+            }
+
+            if (!SimpleTypeLoader.CanResolve(target))
+            {
+                (failures ??= []).Add(
+                    $"Type loader alias '{alias}' maps to '{target}', which names no type this application can "
+                    + "load. The target is the type as it is called now, assembly-qualified — "
+                    + "'Namespace.TypeName, AssemblyName' — and the assembly has to be one this application "
+                    + "references; the alias is the dead name, and is not checked.");
+            }
+        }
+
+        return QuartzSchedulerOptionsValidator.Result(failures);
     }
 }
 

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -60,6 +60,13 @@ internal static class QuartzServiceRegistration
 
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<ITypeLoader, SimpleTypeLoader>();
+
+        // The type loader is container-wide, and so are its options. An alias naming a type nothing can
+        // load is only ever consulted when a name is about to become a type, which on the usual path is
+        // the first job read out of the store — so it is validated at startup instead, where it can be
+        // reported as the configuration mistake it is.
+        services.ValidateOnStart<TypeLoaderOptions>(schedulerName: null);
+
         // The repository belongs to this container and nothing else. It has no process-wide instance any
         // more, so "which repository am I in" is answered by which container built the scheduler rather
         // than by how it was built.

--- a/src/Quartz/Configuration/QuartzTypedOptions.cs
+++ b/src/Quartz/Configuration/QuartzTypedOptions.cs
@@ -30,6 +30,7 @@ internal static class QuartzTypedOptions
     internal const string JobStoreSection = "JobStore";
     internal const string ClusteringSection = "Clustering";
     internal const string DataSourceSection = "DataSource";
+    internal const string TypeLoaderSection = "TypeLoader";
 
     /// <summary>
     /// Registers the validators for every Quartz options type. Safe to call repeatedly.
@@ -47,6 +48,7 @@ internal static class QuartzTypedOptions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<QuartzSchedulerOptions>, QuartzSchedulerOptionsValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<QuartzSchedulerOptions>, DefaultSchedulerNameValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<ThreadPoolOptions>, ThreadPoolOptionsValidator>());
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<TypeLoaderOptions>, TypeLoaderOptionsValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<InMemoryJobStoreOptions>, InMemoryJobStoreOptionsValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<AdoJobStoreOptions>, AdoJobStoreOptionsValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<ClusteringOptions>, ClusteringOptionsValidator>());
@@ -121,6 +123,12 @@ internal static class QuartzTypedOptions
         {
             services.Configure<DataSourceOptions>(dataSource.Key, dataSource);
         }
+
+        // Type loading is container-wide — one ITypeLoader serves every scheduler — so the aliases bind
+        // to the unnamed options whichever scheduler's section they were written in. Two schedulers each
+        // declaring a rename therefore contribute to one table rather than to two the loader could not
+        // tell apart.
+        services.Configure<TypeLoaderOptions>(quartzSection.GetSection(TypeLoaderSection));
 
         // A named scheduler's instance name is always the name it was registered under.
         if (!string.IsNullOrEmpty(schedulerName))

--- a/src/Quartz/Configuration/TypeLoaderOptions.cs
+++ b/src/Quartz/Configuration/TypeLoaderOptions.cs
@@ -1,0 +1,69 @@
+using Quartz.Util;
+
+namespace Quartz;
+
+/// <summary>
+/// Strongly typed configuration for the type loader, which turns a type <em>name</em> into a type — a
+/// stored <c>JOB_CLASS_NAME</c>, a <c>quartz.*</c> <c>.type</c> key, a job named in XML or JSON
+/// scheduling data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Binds from the <c>TypeLoader</c> section of the Quartz configuration, so a rename can ship in
+/// <c>appsettings.json</c> with the deployment that performs it:
+/// <c>Quartz:TypeLoader:Aliases:&lt;old name&gt;</c> is the new name.
+/// </para>
+/// <para>
+/// Type loading is container-wide rather than per-scheduler — one <c>ITypeLoader</c> serves every
+/// scheduler in the container, which is what <c>UseTypeLoader&lt;T&gt;()</c> replaces — so these are the
+/// container's options whichever scheduler's section they were written in.
+/// </para>
+/// </remarks>
+public sealed class TypeLoaderOptions
+{
+    /// <summary>
+    /// What a type name that no longer names anything means today: the name as it was stored or
+    /// configured, mapped to the name of the type that replaced it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Keys are compared the way the built-in loader compares its own table of Quartz's 3.x → 4.0
+    /// renames: ordinal, and matching either the whole name or the part of it before the comma that
+    /// starts the assembly. So <c>Acme.Jobs.NightlyReport</c> matches however the assembly is spelled
+    /// after it, and <c>Acme.Jobs.NightlyReport, Acme.Jobs</c> matches only that assembly.
+    /// </para>
+    /// <para>
+    /// A value that names its own assembly replaces the whole name; one that does not keeps whatever
+    /// followed the old name, which is what makes a mapping between two types in the same assembly a
+    /// single namespace-qualified name.
+    /// </para>
+    /// <para>
+    /// Nothing is written back. A job read out of the store under an aliased name still has the stored
+    /// spelling in <c>JOB_CLASS_NAME</c>, so an alias is what keeps a rolling deployment working rather
+    /// than a migration in disguise; the <c>UPDATE</c> in the troubleshooting page is still how an alias
+    /// is eventually retired.
+    /// </para>
+    /// </remarks>
+    public Dictionary<string, string?> Aliases { get; } = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Declares that <paramref name="name" /> — a type name already stored or already written in a
+    /// configuration file — now means <paramref name="type" />.
+    /// </summary>
+    /// <remarks>
+    /// The typed half of <see cref="Aliases" />, for a rename whose target the application can name in
+    /// code. The type is recorded by the same assembly-qualified, version-free spelling Quartz stores a
+    /// job type under, so a mapping written here and one written in configuration are the same entry.
+    /// </remarks>
+    /// <param name="name">The name as it was stored or configured.</param>
+    /// <param name="type">The type that name resolves to now.</param>
+    /// <returns>This instance, so several renames can be declared in one chain.</returns>
+    public TypeLoaderOptions Map(string name, Type type)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(type);
+
+        Aliases[name] = type.AssemblyQualifiedNameWithoutVersion();
+        return this;
+    }
+}

--- a/src/Quartz/Impl/SimpleTypeLoader.cs
+++ b/src/Quartz/Impl/SimpleTypeLoader.cs
@@ -18,6 +18,7 @@
 #endregion
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using Quartz.Diagnostics;
 using Quartz.Extensibility;
@@ -95,14 +96,28 @@ internal sealed class SimpleTypeLoader : ITypeLoader
 
     private readonly ILogger<SimpleTypeLoader> logger;
 
+    /// <summary>
+    /// The application's own renames, in the same shape as <see cref="renamedTypes" /> and matched by
+    /// the same rule, because they are the same kind of fact about the same kind of string.
+    /// </summary>
+    private readonly (string Old, string New)[] aliases;
+
     /// <param name="logger">
     /// Where a legacy type name that had to be rewritten is reported. The container fills this in; a
     /// loader constructed by hand — every plugin that builds its own — reads
     /// <see cref="LogProvider" />, as before.
     /// </param>
-    public SimpleTypeLoader(ILogger<SimpleTypeLoader>? logger = null)
+    /// <param name="options">
+    /// The application's declared renames. A loader constructed by hand has none, which is what every
+    /// caller outside the container wants: those resolve Quartz's own type names.
+    /// </param>
+    public SimpleTypeLoader(ILogger<SimpleTypeLoader>? logger = null, IOptions<TypeLoaderOptions>? options = null)
     {
         this.logger = logger ?? LogProvider.CreateLogger<SimpleTypeLoader>();
+
+        // Read here rather than per lookup, so a bad alias is a failure to build the loader — which is a
+        // failure to build the scheduler — rather than a TypeLoadException on the first job that needs it.
+        aliases = DeclaredAliases(options?.Value);
     }
 
     /// <inheritdoc />
@@ -112,16 +127,102 @@ internal sealed class SimpleTypeLoader : ITypeLoader
         {
             return null;
         }
-        var type = Type.GetType(name, false);
-        if (type is null)
-        {
-            type = LoadLegacyName(name);
-        }
+        Type? type = LoadDeclaredAlias(name) ?? Type.GetType(name, false) ?? LoadLegacyName(name);
         if (type is null)
         {
             Throw.TypeLoadException($"Could not load type '{name}'");
         }
         return type;
+    }
+
+    /// <summary>
+    /// Whether a name resolves to a type, without the <see cref="TypeLoadException" />
+    /// <see cref="LoadType" /> throws when it does not.
+    /// </summary>
+    /// <remarks>
+    /// What <c>TypeLoaderOptionsValidator</c> asks of an alias's target at startup. It lives here so
+    /// that resolving a type from a string stays in the one type whose contract that is — the trim
+    /// analyzer's <c>IL2057</c> is recorded against this type and nothing else — and so that a target
+    /// may itself be spelled with a pre-4.0 name.
+    /// </remarks>
+    internal static bool CanResolve(string name)
+    {
+        if (Type.GetType(name, false) is not null)
+        {
+            return true;
+        }
+
+        foreach (string candidate in LegacyNameCandidates(name))
+        {
+            if (Type.GetType(candidate, false) is not null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The renames the application declared, dropping the entries that say nothing.
+    /// </summary>
+    /// <remarks>
+    /// A blank alias or a blank target is refused by <c>TypeLoaderOptionsValidator</c>, which is where
+    /// it is reported; skipping it here as well is what keeps a loader built without validation — one
+    /// constructed by hand, with options handed to it directly — from matching a blank alias against
+    /// every name it is ever asked for.
+    /// </remarks>
+    private static (string Old, string New)[] DeclaredAliases(TypeLoaderOptions? options)
+    {
+        if (options is null || options.Aliases.Count == 0)
+        {
+            return [];
+        }
+
+        List<(string Old, string New)> declared = [];
+        foreach ((string alias, string? target) in options.Aliases)
+        {
+            if (!string.IsNullOrWhiteSpace(alias) && !string.IsNullOrWhiteSpace(target))
+            {
+                declared.Add((alias, target));
+            }
+        }
+
+        return declared.ToArray();
+    }
+
+    /// <summary>
+    /// Resolves a name the application declared an alias for, before the runtime is asked at all.
+    /// </summary>
+    /// <remarks>
+    /// An alias states what a stored name means <em>now</em>, so it holds even where the old name would
+    /// still resolve — a shim class left behind, or the old assembly still deployed beside the new one
+    /// mid-rollout. Nothing is written back: the row keeps the spelling it was stored with, and the SQL
+    /// <c>UPDATE</c> in the troubleshooting page stays the way to retire an alias.
+    /// </remarks>
+    private Type? LoadDeclaredAlias(string name)
+    {
+        if (aliases.Length == 0)
+        {
+            return null;
+        }
+
+        List<string> candidates = [];
+        AddRenames(candidates, name, aliases);
+
+        foreach (string candidate in candidates)
+        {
+            // The target is a type name like any other, so Quartz's own renames apply to it too: an
+            // alias may point at a type this application still spells the 3.x way.
+            Type? type = Type.GetType(candidate, false) ?? LoadLegacyName(candidate);
+            if (type is not null)
+            {
+                logger.TypeFoundUnderDeclaredAlias(name, candidate);
+                return type;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -181,23 +282,47 @@ internal sealed class SimpleTypeLoader : ITypeLoader
         }
 
         // Applied last, over every assembly and namespace spelling, because a renamed type can be
-        // named through any of them. The comma test keeps `JobStoreTXSomething` from matching.
+        // named through any of them.
         int namespaceCandidateCount = candidates.Count;
         for (int i = 0; i < namespaceCandidateCount; i++)
         {
-            foreach (var (oldType, newType) in renamedTypes)
-            {
-                string candidate = candidates[i];
-                if (candidate.StartsWith(oldType, StringComparison.Ordinal)
-                    && (candidate.Length == oldType.Length || candidate[oldType.Length] == ','))
-                {
-                    candidates.Add(string.Concat(newType, candidate.AsSpan(oldType.Length)));
-                }
-            }
+            AddRenames(candidates, candidates[i], renamedTypes);
         }
 
         // The first entry is the name exactly as configured, which the caller has already tried.
         candidates.RemoveAt(0);
         return candidates;
+    }
+
+    /// <summary>
+    /// Adds what a rename table makes of one candidate name.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A table entry matches the whole name or the part of it before the comma that starts the assembly,
+    /// which is what lets one entry cover every spelling of the assembly after it. The comma test is
+    /// also what keeps <c>JobStoreTXSomething</c> from matching <c>JobStoreTX</c>.
+    /// </para>
+    /// <para>
+    /// A replacement that names its own assembly stands on its own, so what followed the old name — its
+    /// assembly, and any version or public key after that — is dropped rather than carried over onto a
+    /// type that lives somewhere else now. Quartz's own tables never name one, since every rename in
+    /// them stays inside the assembly it was already in; an application's alias usually does.
+    /// </para>
+    /// </remarks>
+    private static void AddRenames(List<string> candidates, string candidate, (string Old, string New)[] table)
+    {
+        foreach (var (oldName, newName) in table)
+        {
+            if (!candidate.StartsWith(oldName, StringComparison.Ordinal)
+                || (candidate.Length != oldName.Length && candidate[oldName.Length] != ','))
+            {
+                continue;
+            }
+
+            candidates.Add(newName.Contains(',', StringComparison.Ordinal)
+                ? newName
+                : string.Concat(newName, candidate.AsSpan(oldName.Length)));
+        }
     }
 }

--- a/src/Quartz/QuartzSchedulerBuilder.cs
+++ b/src/Quartz/QuartzSchedulerBuilder.cs
@@ -598,6 +598,13 @@ public sealed class QuartzSchedulerBuilder : IQuartzBuilder
         return this;
     }
 
+    /// <inheritdoc cref="QuartzBuilderExtensions.UseTypeLoader(IQuartzBuilder, Action{TypeLoaderOptions})" />
+    public QuartzSchedulerBuilder UseTypeLoader(Action<TypeLoaderOptions> configure)
+    {
+        inner.UseTypeLoader(configure);
+        return this;
+    }
+
     /// <inheritdoc cref="QuartzBuilderExtensions.ConfigureJobScope" />
     public QuartzSchedulerBuilder ConfigureJobScope(Action<IServiceScope, TriggerFiredBundle, IScheduler> configure)
     {

--- a/src/Quartz/Util/UtilityLog.cs
+++ b/src/Quartz/Util/UtilityLog.cs
@@ -76,4 +76,16 @@ internal static partial class UtilityLog
 
     [LoggerMessage(EventId = 5110, Level = LogLevel.Warning, Message = "Unable to read environment variables due to security exception, probably running under medium trust")]
     public static partial void EnvironmentVariablesReadDenied(this ILogger logger);
+
+    /// <summary>
+    /// A type resolved through an alias the application declared, rather than through one of Quartz's
+    /// own 4.0 renames.
+    /// </summary>
+    /// <remarks>
+    /// Debug rather than the warning its 3.x counterpart carries: a declared alias is not a mistake to
+    /// correct, it is a rename that was announced. It is logged at all because an alias can only be
+    /// retired once nothing is hitting it, and nothing else says whether anything still is.
+    /// </remarks>
+    [LoggerMessage(EventId = 5111, Level = LogLevel.Debug, Message = "Type '{OldName}' was resolved as '{NewName}' through a declared type loader alias.")]
+    public static partial void TypeFoundUnderDeclaredAlias(this ILogger logger, string oldName, string newName);
 }


### PR DESCRIPTION
Renaming a job class breaks every persisted `JOB_CLASS_NAME` that names it. The supported answer was an
`ITypeLoader` that consults a rename table before `Type.GetType` — the `RenameAwareTypeLoader` the
troubleshooting page carries — and it works, but it turns a one-line fact into a class the application
has to write, register and keep. `SimpleTypeLoader` already carries exactly such a table for Quartz's own
3.x → 4.0 renames; this opens it to the application.

## What changed

**`TypeLoaderOptions`** (new, public, sealed, `Quartz` namespace):

```csharp
public sealed class TypeLoaderOptions
{
    public Dictionary<string, string?> Aliases { get; }
    public TypeLoaderOptions Map(string name, Type type);
}
```

Bound from `Quartz:TypeLoader:Aliases`, so a rename can ship in `appsettings.json` with the deployment
that performs it:

```json
{ "Quartz": { "TypeLoader": { "Aliases": {
  "Acme.Jobs.NightlyReport, Acme.Jobs": "Acme.Jobs.NightlyRollupJob, Acme.Jobs"
} } } }
```

**`UseTypeLoader(Action<TypeLoaderOptions>)`** is the typed half — an `IQuartzBuilder` extension, with
the usual `QuartzSchedulerBuilder` mirror:

```csharp
services.AddQuartz(q => q.UseTypeLoader(loader =>
    loader.Map("Acme.Jobs.NightlyReport, Acme.Jobs", typeof(NightlyRollupJob))));
```

`Map` records the target by the same assembly-qualified, version-free spelling Quartz stores a job type
under, so a mapping written in code and one written in configuration are the same entry.

**`SimpleTypeLoader`** takes `IOptions<TypeLoaderOptions>` and runs the declared map through the same
table mechanism its own `renamedTypes` uses — the substitution is now one shared `AddRenames` helper —
so keys compare the way that table already compares: ordinal, matching the whole name or the part before
the comma that starts the assembly. Because the loader is the one place a type name becomes a type at
run time, the map reaches `JOB_CLASS_NAME`, XML and JSON scheduling data, and the
`quartz.plugin.<name>.type` / `quartz.jobListener.<name>.type` keys without any of them knowing about it.

**`TypeLoaderOptionsValidator`** refuses an alias whose target names no loadable type, naming both halves
of the entry, plus a blank key (which would prefix-match every name there is) and a blank target. It is
`ValidateOnStart`-registered container-wide, and `SimpleTypeLoader`'s constructor reads `.Value`, so it
also fires in a container the standalone builder builds, where nothing runs startup validation.

## Decisions a reviewer should weigh

1. **An alias is consulted *before* `Type.GetType(name)`.** An alias states what a stored name means
   *now*; deferring it to the fallback would make it do nothing in exactly the window it exists for — a
   shim class left behind, or the old assembly still deployed beside the new one mid-rollout.
2. **A target that names its own assembly replaces the whole name**; one that does not keeps what
   followed the old name. Quartz's own tables never name an assembly (every rename in them stays inside
   its assembly), so that half is behaviour-preserving; the other half is what makes
   `Map(name, typeof(T))` correct across an assembly move rather than pasting the *old* assembly's
   version onto the new type.
3. **The options are the container's, not a scheduler's**, because `ITypeLoader` is. Two schedulers each
   declaring a rename contribute to one table. `AliasesDeclaredForSeveralSchedulersMakeOneTable` pins it.
4. **An alias's target is resolved the way any name is**, so a target may itself be spelled with a
   pre-4.0 name. `SimpleTypeLoader.CanResolve` is what the validator asks, which also keeps
   `Type.GetType(string)` — and its baselined `IL2057` — inside the one type whose contract that is.
5. **`JOB_CLASS_NAME` is never rewritten.** The `UPDATE` in the troubleshooting page stays the retirement
   path; a new `Debug` event (5111, `TypeFoundUnderDeclaredAlias`) is how you tell whether anything is
   still hitting an alias before you remove it. `Debug`, not the `Warning` its 3.x counterpart carries: a
   declared alias is not a mistake to correct.

## Deviations from the brief

* **The troubleshooting page is `docs/documentation/troubleshooting.md`, not
  `docs/documentation/quartz-4.x/troubleshooting.md`** — it is version-neutral. The 4.x-only material is
  marked as such, as the section already did. The map is now the first answer and the hand-written
  loader the escape hatch; the SQL `UPDATE` still leads, because a 3.x reader has nothing else.
* **The map does not reach the flat `quartz.*` keys that name a scheduler's own components** — job
  store, thread pool, serializer, lock handler, job factory, instance id generator, time provider,
  connection provider. `QuartzPropertyBridge` resolves those while the service collection is still open,
  before any options exist, with a `SimpleTypeLoader` of its own. Feeding it the map would mean reading
  options out of an unbuilt container. Each of those names a type in a file you can edit, which is the
  case the feature is not for, so this is scoped rather than worked around — and it is documented in all
  three places. The issue's bullet said "`quartz.*` keys" without that split.
* **No legacy `quartz.*` key was invented.** `LegacyPropertyKeys` has no 3.x spelling for a rename table,
  so configuration binding through the typed section is the only string form.

## Tests

* `TypeLoaderAliasTest` — the seam. Builder-declared and configuration-bound aliases reach the
  container's `ITypeLoader`; two schedulers make one table; a bad target fails both `IStartupValidator`
  and loader construction; blank key and blank target each fail; a target spelled with a pre-4.0 name is
  accepted. The round trip runs against a **real SQLite file** (`UseSqlite` + `ProvisionSchema()`): a job
  is stored, `JOB_CLASS_NAME` is overwritten with a dead name by SQL, and the next scheduler fires it
  through the alias — with a control asserting the name resolves to nothing without one, and an
  assertion afterwards that the row still says what it said.
* `SimpleTypeLoaderTest` — nine cases for the matching and substitution rules, including that the
  built-in 3.x table is unaffected beside a declared alias, that an alias does not claim a name merely
  starting with it, and that a blank alias is ignored by a loader built without validation.
* Baselines: `PublicApiTest_Quartz` and `LogEventCatalogTest_Quartz`, accepted through Verify. The API
  delta is the three additions above and nothing else. The same delta is in the migration guide, both as
  a **New Features** bullet and as its own section, and `TypeLoaderOptions` is in the appendix's
  `Quartz`-namespace name list (ninety-two → ninety-three).
* `ConfigurationBindingIsSourceGeneratedTest` gains the seventh intercepted binder call and the new
  bound type. It gets no `AssertEveryMemberBinds` case: that harness fills a string dictionary with a
  canary value, and every value in this one must name a loadable type, so the canary would fail
  validation rather than the binding — `TypeLoaderAliasTest.AnAliasBindsFromConfiguration` binds it with
  a real type name instead. The reason is written where the exception is.
* `QuartzSchedulerBuilderForwardingTest` gains two `UseTypeLoader` cases: the mirror check pairs cases
  with mirrors by name, and the interface's `UseTypeLoader<T>()` becomes a mirror the moment an extension
  shares its name.

## Verification

Everything below was run on this branch, on Windows:

* `dotnet build Quartz.slnx` — succeeded, 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — **4161 passed**, 0 failed
* `dotnet test src/Quartz.Tests.AspNetCore` — **548 passed**, 0 failed
* Container-free basic integration leg (`TestCategory!=db-*`) — **377 passed**, 0 failed.
  `dotnet fallout Compile IntegrationTest` skips the target off GitHub Actions Linux, so the same filter
  was run directly against `Quartz.Tests.Integration`
* SQLite integration leg (`TestCategory=db-sqlite`), for the ADO path this touches — **14 passed**
* `dotnet fallout DocsSnippets` / `VerifyDocsSnippets` — snippets up to date, 101 markdown files checked
* `npm run docs:check-links` — 219 pages, 1028 internal links, 623 fragments, no dead links or anchors

Docker is available here, but the other database legs were not run; they exercise nothing this change
touches beyond what the SQLite leg does.

Closes #3481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
