### PR TITLE
A cron schedule is parsed once, and the tie-break's cost is measured rather than guessed

### DIFF
--- a/src/Quartz.Benchmark/JobAndTriggerBuilderBenchmark.cs
+++ b/src/Quartz.Benchmark/JobAndTriggerBuilderBenchmark.cs
@@ -28,6 +28,17 @@ public class JobAndTriggerBuilderBenchmark
 
     private const string Group = "bench";
 
+    private ITrigger cronTrigger = null!;
+
+    [GlobalSetup(Target = nameof(ReadCronScheduleBackOffTrigger))]
+    public void BuildTheTriggerToReadBack()
+    {
+        cronTrigger = TriggerBuilder.Create()
+            .WithIdentity("trigger-read-back", Group)
+            .WithCronSchedule(CronSchedule)
+            .Build();
+    }
+
     [Benchmark]
     public IJobDetail BuildJobDetail()
     {
@@ -54,6 +65,16 @@ public class JobAndTriggerBuilderBenchmark
             .WithIdentity("trigger-build", Group)
             .WithCronSchedule(CronSchedule)
             .Build();
+    }
+
+    /// <summary>
+    /// Taking a cron trigger's schedule back off it, which is the first thing every reschedule does -
+    /// <c>ITrigger.GetTriggerBuilder</c> is this call plus the trigger's identity.
+    /// </summary>
+    [Benchmark]
+    public IScheduleBuilder ReadCronScheduleBackOffTrigger()
+    {
+        return cronTrigger.GetScheduleBuilder();
     }
 
     private sealed class NoOpJob : IJob

--- a/src/Quartz.Benchmark/README.md
+++ b/src/Quartz.Benchmark/README.md
@@ -187,6 +187,7 @@ Recorded rather than acted on — #3538 asks for the measurement, not for an opt
   `CronScheduleNoParseException`, which constructs a second one. Two parses at 307 ns and 576 B each
   account for most of `BuildCronTrigger`'s 1,024 ns and 1,824 B, against `BuildSimpleTrigger`'s 98 ns
   and 616 B. `CronTriggerImpl.GetScheduleBuilder()` goes down the same path.
+  **Fixed in #3542** — see the next section.
 - **Most of the cron/simple gap in `ScheduleJob` is not cron.** The two cases differ by 5.9 µs, of
   which the build accounts for 0.9 µs. The rest is a property of the fixtures rather than of cron
   parsing: every one of the 50,000 cron triggers in an invocation is `0 0/5 * * * ?`, so they all
@@ -196,3 +197,45 @@ Recorded rather than acted on — #3538 asks for the measurement, not for an opt
   `trig1.Key.CompareTo(trig2.Key)`, which ends in `StringComparer.Ordinal.Compare` on the trigger
   name — a string comparison per level of the store's `SortedSet` on every insert. The published
   comparison uses the same single cron expression, so its 31 µs carries the same effect.
+  **The mechanism is real; the size was a guess and it was wrong** — #3542 measured it at about a
+  tenth of a microsecond a schedule, not microseconds. See the next section.
+
+## What #3542 changed (2026-08-31, same machine)
+
+Same box and runtime as above. The `ScheduleJobBenchmark` rows are not repeated here: on the day
+these were taken its `ScheduleJob_SimpleTrigger` row — which no part of #3542 can touch — read
+between 3.8 and 6.8 µs across four alternating runs, so that suite's `Mean` column was measuring the
+machine rather than the change. The suites below are tight enough to read.
+
+### A cron schedule is parsed once
+
+`JobAndTriggerBuilderBenchmark`, default job, alternating before/after runs.
+
+| Method                         |               Before |                After |
+|------------------------------- |---------------------:|---------------------:|
+| BuildCronTrigger               | 607-628 ns / 1,824 B | 365-385 ns / 1,248 B |
+| ReadCronScheduleBackOffTrigger |     678 ns / 1,776 B |        6.4 ns / 48 B |
+| BuildSimpleTrigger (control)   |    90-97 ns /  616 B |    90-97 ns /  616 B |
+
+`BuildCronTrigger` loses exactly one parse — 576 B, the `Parse_Simple` row above.
+`ReadCronScheduleBackOffTrigger` is new, and it loses both: a trigger already holds its parsed,
+immutable expression, so `GetScheduleBuilder` hands that instance over instead of sending the string
+back through the parser twice.
+
+### Equal fire times still compare names, deliberately
+
+`TriggerTimeComparatorBenchmark`'s sorted-insert cases, default job. One operation is one insert into
+a `SortedSet` that ends up holding 50,000 triggers, which is the depth `RAMJobStore` reaches in
+`ScheduleJobBenchmark`.
+
+| Method                                | Mean      | Allocated |
+|-------------------------------------- |----------:|----------:|
+| SortedInsert_DistinctFireTimes        |  73.07 ns |      48 B |
+| SortedInsert_OneFireTime              | 173.97 ns |      48 B |
+| SortedInsert_OneFireTime_HashTieBreak | 237.86 ns |      48 B |
+
+Sharing a fire time costs about 100 ns an insert, and #3542's proposed cure — tie-breaking on the
+key's cached hash before the name — costs 64 ns more than the disease. Ordering by hash scatters keys
+that the ordinal order keeps adjacent, so the tree walk it lengthens costs more than the string
+comparison it skips; and a string's hash is seeded per process, so the order would stop being the
+same order twice. The tie-break stays the key.

--- a/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
+++ b/src/Quartz.Benchmark/TriggerTimeComparatorBenchmark.cs
@@ -6,10 +6,20 @@ namespace Quartz.Benchmark;
 [MemoryDiagnoser]
 public class TriggerTimeComparatorBenchmark
 {
+    /// <summary>
+    /// How many triggers the sorted-insert cases put in one set. The size <see cref="ScheduleJobBenchmark" />
+    /// fills <c>RAMJobStore</c> to, so the tree is as deep here as it is there and a comparison is paid at
+    /// as many levels.
+    /// </summary>
+    private const int SortedSetSize = 50_000;
+
     private readonly TriggerKey _triggerKeyA;
     private readonly TriggerKey _triggerKeyB;
     private readonly TriggerTimeComparator _comparerNew;
     private readonly TriggerTimeComparatorLegacy _comparerLegacy;
+    private readonly TriggerTimeComparatorHashTieBreak _comparerHashTieBreak = new();
+    private MutableTrigger[] _oneFireTime = [];
+    private MutableTrigger[] _distinctFireTimes = [];
     private readonly MutableTrigger _triggerAPrio1NextFireTimeMinValue;
     private readonly MutableTrigger _triggerAPrio1NextFireTimeMaxValue;
     private readonly MutableTrigger _triggerAPrio1NextFireTimeNull;
@@ -33,6 +43,65 @@ public class TriggerTimeComparatorBenchmark
         _triggerBPrio2NextFireTimeNull = new MutableTrigger(_triggerKeyB, new JobKey("B"), 2, null);
         _triggerBPrio1NextFireTimeMinValue = new MutableTrigger(_triggerKeyB, new JobKey("B"), 1, DateTimeOffset.MinValue);
         _triggerBPrio2NextFireTimeMinValue = new MutableTrigger(_triggerKeyB, new JobKey("B"), 2, DateTimeOffset.MinValue);
+    }
+
+    /// <summary>
+    /// The trigger sets the sorted-insert cases fill from. Only those cases pay for building them, which
+    /// is why this is a targeted setup rather than the constructor every case runs.
+    /// </summary>
+    [GlobalSetup(Targets = [nameof(SortedInsert_DistinctFireTimes), nameof(SortedInsert_OneFireTime), nameof(SortedInsert_OneFireTime_HashTieBreak)])]
+    public void SetupSortedInsert()
+    {
+        DateTimeOffset fireAt = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero);
+        JobKey jobKey = new JobKey("job", "bench");
+
+        _oneFireTime = new MutableTrigger[SortedSetSize];
+        _distinctFireTimes = new MutableTrigger[SortedSetSize];
+        for (int i = 0; i < SortedSetSize; i++)
+        {
+            _oneFireTime[i] = new MutableTrigger(new TriggerKey("cron-trigger-" + i, "bench"), jobKey, 5, fireAt);
+            _distinctFireTimes[i] = new MutableTrigger(new TriggerKey("simple-trigger-" + i, "bench"), jobKey, 5, fireAt.AddMilliseconds(i));
+        }
+    }
+
+    /// <summary>
+    /// The comparison a store pays when the triggers it holds fire at different times: it is decided on
+    /// the fire time and the tie-break never runs.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = SortedSetSize)]
+    public int SortedInsert_DistinctFireTimes()
+    {
+        return Fill(_distinctFireTimes, _comparerNew);
+    }
+
+    /// <summary>
+    /// The same insert when every trigger shares one fire time - one cron expression scheduled many
+    /// times, which is the ordinary shape - so every level of the tree is decided on the key.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = SortedSetSize)]
+    public int SortedInsert_OneFireTime()
+    {
+        return Fill(_oneFireTime, _comparerNew);
+    }
+
+    /// <summary>
+    /// The alternative #3542 proposed for that tie-break, kept as the measurement that refused it.
+    /// </summary>
+    [Benchmark(OperationsPerInvoke = SortedSetSize)]
+    public int SortedInsert_OneFireTime_HashTieBreak()
+    {
+        return Fill(_oneFireTime, _comparerHashTieBreak);
+    }
+
+    private static int Fill(MutableTrigger[] triggers, IComparer<ITrigger> comparer)
+    {
+        SortedSet<ITrigger> set = new SortedSet<ITrigger>(comparer);
+        foreach (MutableTrigger trigger in triggers)
+        {
+            set.Add(trigger);
+        }
+
+        return set.Count;
     }
 
     [Benchmark(OperationsPerInvoke = 300_000)]
@@ -212,6 +281,54 @@ public class TriggerTimeComparatorBenchmark
         for (var i = 0; i < 300_000; i++)
         {
             _comparerLegacy.Compare(_triggerAPrio1NextFireTimeNull, _triggerBPrio1NextFireTimeNull);
+        }
+    }
+
+    /// <summary>
+    /// The shipped comparison with a cached-hash tie-break in front of the key comparison, which is what
+    /// #3542 proposed to keep equal fire times off the trigger name at every level of the set.
+    /// </summary>
+    /// <remarks>
+    /// It is here as the measurement rather than as a candidate: the sorted-insert cases put it well
+    /// behind the shipped comparator. A hash order scatters keys the ordinal order keeps adjacent, so the
+    /// walk it lengthens costs more than the string comparison it skips - and a string's hash is seeded
+    /// per process, so the order would also stop being the same order from one run to the next.
+    /// </remarks>
+    public sealed class TriggerTimeComparatorHashTieBreak : IComparer<ITrigger>
+    {
+        public int Compare(ITrigger? trig1, ITrigger? trig2)
+        {
+            if (ReferenceEquals(trig1, trig2))
+            {
+                return 0;
+            }
+
+            DateTimeOffset? t1 = trig1!.NextFireTimeUtc;
+            DateTimeOffset? t2 = trig2!.NextFireTimeUtc;
+
+            int result = t1.GetValueOrDefault().CompareTo(t2.GetValueOrDefault());
+            if (result != 0)
+            {
+                return result;
+            }
+
+            int comp = trig2.Priority - trig1.Priority;
+            if (comp != 0)
+            {
+                return comp;
+            }
+
+            TriggerKey key1 = trig1.Key;
+            TriggerKey key2 = trig2.Key;
+
+            int hash1 = key1.GetHashCode();
+            int hash2 = key2.GetHashCode();
+            if (hash1 != hash2)
+            {
+                return hash1 < hash2 ? -1 : 1;
+            }
+
+            return key1.CompareTo(key2);
         }
     }
 

--- a/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronScheduleBuilderTest.cs
@@ -72,6 +72,23 @@ public class CronScheduleBuilderTest
     }
 
     [Test]
+    public void ParsesTheExpressionOnce()
+    {
+        const string Expression = "0 20 10 ? * *";
+
+        // Both measurements are of a warm path: the first call through either one pays for JIT and for
+        // whatever the parser caches, and neither is what this is counting.
+        CronScheduleBuilder.Create(Expression);
+        _ = new CronExpression(Expression);
+
+        long oneParse = Allocated(static () => _ = new CronExpression(Expression));
+        long create = Allocated(static () => CronScheduleBuilder.Create(Expression));
+
+        create.Should().BeLessThan(oneParse + oneParse / 2,
+            "Create validated the expression by constructing one it threw away and then constructed the one it keeps, so every WithCronSchedule(string) parsed its expression twice - and two parses cannot fit under one and a half");
+    }
+
+    [Test]
     public void CarriesTheTimeZoneOntoTheTrigger()
     {
         TimeZoneInfo timeZone = TestTimeZones.CentralEuropean;
@@ -153,5 +170,12 @@ public class CronScheduleBuilderTest
             .Build();
 
         trigger.MisfireInstructionCode.Should().Be(stored);
+    }
+
+    private static long Allocated(Action action)
+    {
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        action();
+        return GC.GetAllocatedBytesForCurrentThread() - before;
     }
 }

--- a/src/Quartz.Tests.Unit/CronTriggerTest.cs
+++ b/src/Quartz.Tests.Unit/CronTriggerTest.cs
@@ -207,6 +207,28 @@ public class CronTriggerTest
     }
 
     [Test]
+    public void ShouldGetScheduleBuilderWithoutParsingTheExpressionAgain()
+    {
+        CronTriggerImpl trigger = new CronTriggerImpl("name", "group", "0 0 12 * * ?");
+
+        CronTriggerImpl rebuilt = (CronTriggerImpl) trigger.GetScheduleBuilder().Build();
+
+        rebuilt.CronExpression.Should().BeSameAs(trigger.CronExpression,
+            "the trigger is already holding the parsed, immutable expression, so rebuilding its schedule hands that instance over rather than sending the string back through the parser");
+    }
+
+    [Test]
+    public void ShouldRefuseToGetAScheduleBuilderWithoutAnExpression()
+    {
+        CronTriggerImpl trigger = new CronTriggerImpl();
+
+        Action act = () => trigger.GetScheduleBuilder();
+
+        act.Should().Throw<ArgumentException>(
+            "a trigger that has never been given an expression has no schedule to hand back, which is what naming a null expression has always said");
+    }
+
+    [Test]
     public void TriggerWithBothStartAndEndDatesInPastShouldNotSchedule()
     {
         DateTimeOffset startDate = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -165,28 +165,37 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
 
         if (CronExpression.ContainsHashToken(cronExpression))
         {
-            string resolved = CronExpression.ResolveHash(cronExpression, 0);
-            CronExpression.ValidateExpression(resolved);
+            // The H tokens resolve against the trigger's key, which nobody knows yet, so the expression
+            // built here cannot be kept - it only proves the expression parses, so that a malformed one
+            // is refused by the call that named it rather than at Build. Which values H resolves to does
+            // not decide whether the result parses, so any seed does; the real one is built in SetHashKey.
+            CronExpression.ValidateExpression(CronExpression.ResolveHash(cronExpression, 0));
             return new CronScheduleBuilder(cronExpression);
         }
 
-        CronExpression.ValidateExpression(cronExpression);
-        return CronScheduleNoParseException(cronExpression);
+        // Constructing the expression is what validating it does - CronExpression.ValidateExpression's
+        // whole body is a construction it discards - and this instance is the one every trigger built
+        // from this schedule keeps, so the expression is parsed once instead of twice. An invalid one
+        // still leaves through the parser's own FormatException, which is what it threw before.
+        return Create(new CronExpression(cronExpression));
     }
 
     /// <summary>
-    /// Create a CronScheduleBuilder with the given cron-expression string - which
-    /// may not be a valid cron expression (and hence a ParseException will be thrown
-    /// f it is not).
+    /// Resolves a deferred <c>H</c> expression against the key that was finally supplied.
     /// </summary>
-    /// <param name="presumedValidCronExpression">the cron expression string to base the schedule on</param>
-    /// <returns>the new CronScheduleBuilder</returns>
+    /// <remarks>
+    /// <see cref="Create(string)" /> has already parsed this expression once, under a stand-in seed, to
+    /// prove it well-formed. A parse failure here is therefore not a caller who wrote a bad expression:
+    /// it is Quartz resolving <c>H</c> into something it cannot read back, which is a bug in Quartz.
+    /// </remarks>
+    /// <param name="presumedValidCronExpression">the cron expression string, H tokens unresolved</param>
+    /// <param name="hashKey">the key the H tokens are spread by</param>
     /// <seealso cref="CronExpression" />
-    private static CronScheduleBuilder CronScheduleNoParseException(string presumedValidCronExpression)
+    private static CronExpression CronScheduleNoParseException(string presumedValidCronExpression, string hashKey)
     {
         try
         {
-            return Create(new CronExpression(presumedValidCronExpression));
+            return new CronExpression(presumedValidCronExpression, hashKey);
         }
         catch (FormatException e)
         {
@@ -260,7 +269,7 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
             string hashKey = key.Group == TriggerKey.DefaultGroup
                 ? $":{key.Name}"
                 : $"{key.Group.Length}:{key.Group}{key.Name}";
-            cronExpression = new CronExpression(deferredHashExpression, hashKey);
+            cronExpression = CronScheduleNoParseException(deferredHashExpression, hashKey);
             if (deferredTimeZone is not null)
             {
                 cronExpression = cronExpression.WithTimeZone(deferredTimeZone);

--- a/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/CronTriggerImpl.cs
@@ -427,7 +427,13 @@ public class CronTriggerImpl : TriggerBase, ICronTrigger
 
     public override IScheduleBuilder GetScheduleBuilder()
     {
-        CronScheduleBuilder cb = CronScheduleBuilder.Create(CronExpressionString!).InTimeZone(TimeZone);
+        // The trigger is already holding the parsed, immutable expression, and its time zone is that
+        // expression's, so handing the instance over says everything passing the string back through the
+        // parser said - without parsing anything. A trigger with no expression keeps the ArgumentException
+        // that naming a null expression has always produced here.
+        CronScheduleBuilder cb = cronEx is not null
+            ? CronScheduleBuilder.Create(cronEx)
+            : CronScheduleBuilder.Create(CronExpressionString!);
 
         CronTriggerMisfireInstruction instruction = MisfireInstruction;
         if (Enum.IsDefined(instruction))

--- a/src/Quartz/TriggerTimeComparator.cs
+++ b/src/Quartz/TriggerTimeComparator.cs
@@ -7,6 +7,24 @@ namespace Quartz;
 /// value first), if the priorities are the same, then they are sorted
 /// by key.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The key is the tie-break and stays the key, even though a store holding many triggers on one fire
+/// time - one cron expression scheduled many times, which is the ordinary shape - then compares names
+/// at every level of its <see cref="SortedSet{T}" />. #3542 asked whether the cached key hash could
+/// stand in for the name there. It cannot: <c>TriggerTimeComparatorBenchmark</c>'s sorted-insert cases
+/// put an insert into a 50,000-trigger set at 174 ns when the fire times are equal against 73 ns when
+/// they differ, and a hash-first tie-break at 238 ns - slower than the comparison it was meant to
+/// save. Ordering by hash scatters keys that the ordinal order keeps adjacent, so the tree walk it
+/// lengthens costs more than the string comparison it skips.
+/// </para>
+/// <para>
+/// It would also stop the order being the same order twice. A string's hash is seeded per process, so
+/// the same triggers would sort one way in one run of a scheduler and another way in the next, while
+/// "same fire time, same priority, then by key" is a property the acquisition and misfire tests - and
+/// anyone reading a batch of triggers acquired at one instant - are written against.
+/// </para>
+/// </remarks>
 internal sealed class TriggerTimeComparator : IComparer<ITrigger>
 {
     public int Compare(ITrigger? trig1, ITrigger? trig2)


### PR DESCRIPTION
Part of milestone 4.0.0-alpha.4. Closes #3542.

Two costs #3541 found and left alone. One is real and is fixed here; the other was measured, and the
measurement says leave it alone — with numbers, which is what the issue asked for if that turned out
to be the answer.

## 1. A cron schedule is parsed once

`CronScheduleBuilder.Create(string)` called `CronExpression.ValidateExpression(cronExpression)` —
whose entire body is a `CronExpression` it constructs and drops — and then constructed the one it
keeps. Constructing it once *is* the validation, and an invalid expression still leaves through the
parser's own `FormatException`, which is what `RejectsAnExpressionItCannotParse` asserts.

`CronTriggerImpl.GetScheduleBuilder()` went down that same path with a string it never needed to hand
over: the trigger is already holding the parsed, immutable expression, and its `TimeZone` getter
*returns that expression's zone*, so `.InTimeZone(TimeZone)` was rebinding a zone to itself. It now
passes the instance and parses nothing — two parses gone per reschedule.

`CronExpression.ValidateExpression` is untouched: it is public and used elsewhere.

## 2. Equal fire times keep comparing names

The issue proposed tie-breaking on the key's cached hash before the ordinal name comparison. Three
new sorted-insert cases in `TriggerTimeComparatorBenchmark` measure it, and it is a pessimisation:

| Method (one insert into a set that ends at 50,000 triggers) | Mean | Allocated |
|-------------------------------------- |----------:|----------:|
| `SortedInsert_DistinctFireTimes`        |  73.07 ns |      48 B |
| `SortedInsert_OneFireTime`              | 173.97 ns |      48 B |
| `SortedInsert_OneFireTime_HashTieBreak` | 237.86 ns |      48 B |

Sharing a fire time costs ~100 ns an insert; the proposed cure costs 64 ns more than the disease. A
hash order scatters keys the ordinal order keeps adjacent, so the tree walk it lengthens costs more
than the string comparison it skips. `string.GetHashCode` is also seeded per process, so the order
would stop being the same order from one run of a scheduler to the next — and "same fire time, same
priority, then by key" is what the acquisition and misfire tests are written against.

Two order-preserving variants were tried in a scratch probe and are within noise of the shipped one,
so neither is here: calling `string.CompareOrdinal` directly instead of through `StringComparer.Ordinal`
(163.7 ns against 162.8 ns), and caching the key on `TriggerWrapper` so the comparison does not chase
wrapper → trigger → key (195.2 ns against 186.3 ns, both ± ~25 ns).

**So `TriggerTimeComparator` is unchanged.** It now carries a remark saying why, the refused
alternative stays in the benchmark as the measurement that refused it — beside `TriggerTimeComparatorLegacy`,
which is kept for the same reason — and `src/Quartz.Benchmark/README.md` gets the correction.

### The recorded finding in the README was wrong about the size

#3541 recorded that this tie-break was "most of the 5.9 µs" cron-versus-simple gap in `ScheduleJob`.
The mechanism is real; the size was a guess and it is off by an order of magnitude. A probe in the
scheduler's own shape — 50,000 simple triggers differing in nothing but whether they land on one fire
time or on 50,000 — put the whole effect at 0.67 µs a schedule (7.557 µs against 6.889 µs, with
errors of ±0.66 and ±0.47), and the isolated insert above puts it at ~0.1 µs. The README now says so.

## Numbers

BenchmarkDotNet v0.15.8; Windows 11 (10.0.26200.9168/25H2); AMD Ryzen 9 5950X, 32 logical / 16
physical cores; .NET SDK 10.0.400, host and job .NET 10.0.11, X64 RyuJIT x86-64-v3. Default job
throughout (not `--job short`) except where noted. Before and after were captured **alternating in
one session** — A, B, A, B — because this machine drifts.

### `JobAndTriggerBuilderBenchmark` — the gate

| Method                         |               Before |                After |
|------------------------------- |---------------------:|---------------------:|
| `BuildCronTrigger`               | 623.7 / 628.1 / 607.6 ns, 1,824 B | 385.3 / 382.2 / 365.0 ns, 1,248 B |
| `ReadCronScheduleBackOffTrigger` |     677.9 ns, 1,776 B |        6.4 ns, 48 B |
| `BuildSimpleTrigger` (control)   |     90.0-96.5 ns, 616 B |    90.6-97.2 ns, 616 B |
| `BuildJobDetail` (control)       |    94.5-103.4 ns, 672 B |   96.9-120.8 ns, 672 B |

`BuildCronTrigger` loses exactly one parse: −576 B, which is the `Parse_Simple` row in the README.
`ReadCronScheduleBackOffTrigger` is new in this PR and loses both.

### `ScheduleJobBenchmark` — the issue asked for it, and its `Mean` column is unreadable today

| Round | `ScheduleJob_SimpleTrigger` (control — nothing here can touch it) | `ScheduleJob_CronTrigger` |
|---|---:|---:|
| base, before  | 5.754 µs / 3.6 KB | 9.409 µs / 5.13 KB |
| after (B1)    | 6.797 µs / 3.6 KB | 7.737 µs / 4.29 KB |
| before (A1)   | 4.384 µs / 3.6 KB | 7.334 µs / 5.12 KB |
| after (B2)    | 3.771 µs / 3.6 KB | 10.525 µs / 4.60 KB |

The control row moves 3.8 → 6.8 µs across four runs of unchanged code, and the cron row is flagged
bimodal in three of them, so **the `Mean` column here is measuring the machine** (other work was on
the box throughout). The `Allocated` column is the readable signal: 5.12-5.13 KB → 4.29-4.60 KB for
the cron case while the simple case sits at 3.6 KB throughout. It is not exactly one parse because
`MemoryDiagnoser` counts the scheduler thread's allocations in this shape too.

`CronExpressionBenchmark` is untouched, as the issue asks.

## Tests

- `CronScheduleBuilderTest.ParsesTheExpressionOnce` counts allocated bytes and demands `Create` stay
  under one and a half parses. It read 1,056 B against a 756 B limit before the change and passes
  after — the technique `DbMetadataParameterNameTest` already uses here.
- `CronTriggerTest.ShouldGetScheduleBuilderWithoutParsingTheExpressionAgain` demands the rebuilt
  trigger carry the *same* `CronExpression` instance; it failed before the change.
- `CronTriggerTest.ShouldRefuseToGetAScheduleBuilderWithoutAnExpression` covers the branch a trigger
  with no expression takes.

## For a reviewer to decide

- **The issue said to keep `CronScheduleNoParseException`'s message; the method it lived in is now
  unreachable, so the message moved rather than staying put.** With one parse there is no state in
  which "an expression that already validated failed to parse" can arise in `Create(string)`. The one
  place that still validates and then builds again is `SetHashKey`, resolving a deferred `H`
  expression against the key that finally arrived — where a parse failure genuinely would be Quartz's
  bug and not the caller's — so the helper now guards that instead. Say the word and I will delete it
  outright, or restore it as dead code.
- **`GetScheduleBuilder` was not in the issue's "done means".** The issue's title says a cron schedule
  is parsed once, and #3541's finding named this method as taking the same path, so it is fixed here;
  it is also the larger of the two effects (678 ns → 6.4 ns). Easy to split out if you would rather.
- **Nothing in `TriggerTimeComparator` changed.** That is the issue's own escape hatch — "if the
  cheapest correct change is nothing, record that with the numbers" — and this is the record.

## Verification

- `dotnet build Quartz.slnx` — **Build succeeded, 0 Warning(s), 0 Error(s)** (`TreatWarningsAsErrors` on).
- `dotnet test src/Quartz.Tests.Unit` — **Failed: 0, Passed: 4138, Skipped: 0**.
- `dotnet test src/Quartz.Tests.AspNetCore` — **Failed: 0, Passed: 548**.
- `dotnet test src/Quartz.Tests.Integration` with the `basic` leg's filter (every `db-*` category
  excluded, Docker daemon 29.5.3 present but no container needed) — **Failed: 0, Passed: 377**, 2 m 36 s.
- `dotnet run -c Release --project src/Quartz.Benchmark -- --smoke` — exit 0, 284 benchmarks.
- `dotnet fallout VerifyDocsSnippets` — **Succeeded**, 101 markdown files checked.

No public API change, so no baseline moves and no migration-guide entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
