### PR TITLE
Schema validation checks QRTZ_SIMPROP_TRIGGERS too

### DIFF
--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SchemaValidationTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SchemaValidationTest.cs
@@ -1,0 +1,220 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// What a store does when the database is missing one of the tables it validates.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The database is a real one, but SQLite is a file, so a schema installed from
+/// <c>database/tables/tables_sqlite.sql</c> — the script a reader is told to run — costs a temporary
+/// path and no container. Installing it and then dropping one table is the shape of the real failure
+/// this guards against: a database that is almost right.
+/// </para>
+/// <para>
+/// The other half of the subject is <c>Quartz.Tests.Unit.Impl.AdoJobStore.SchemaValidationTest</c>,
+/// which holds <c>AdoConstants.AllTableNames</c> against every dialect's script without needing a
+/// database at all. Neither test alone would have caught #3564: the list agreed with itself, and the
+/// table it left out is one nothing here would have thought to drop.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+[Category("db-sqlite")]
+public class SchemaValidationTest
+{
+    /// <summary>The tables the cases below drop one at a time.</summary>
+    private static readonly string[] EveryValidatedTable = AdoConstants.AllTableNames;
+
+    private string databaseFile;
+    private string connectionString;
+    private IScheduler scheduler;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-validation-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public async Task DeleteDatabase()
+    {
+        if (scheduler != null)
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+            scheduler = null;
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        try
+        {
+            if (File.Exists(databaseFile))
+            {
+                File.Delete(databaseFile);
+            }
+        }
+        catch (IOException)
+        {
+            // The file is in the temporary directory and the run is over; failing the case that just
+            // passed because the operating system still holds a handle would say nothing about Quartz.
+        }
+    }
+
+    /// <summary>
+    /// The control: an untouched schema starts.
+    /// </summary>
+    /// <remarks>
+    /// Without it, a harness that installed nothing — a script that failed to run, a path that moved —
+    /// would make every case below pass for the wrong reason, since a database with no tables at all
+    /// also refuses to start.
+    /// </remarks>
+    [Test]
+    public async Task AStoreStartsAgainstTheSchemaTheFreshInstallScriptCreates()
+    {
+        InstallSchemaFromFreshInstallScript();
+
+        Func<Task> act = async () => scheduler = await GetScheduler(
+            nameof(AStoreStartsAgainstTheSchemaTheFreshInstallScriptCreates));
+
+        await act.Should().NotThrowAsync(
+            "the eleven tables database/tables/tables_sqlite.sql creates are the eleven the store "
+            + "validates, so a schema installed straight from it needs nothing else");
+    }
+
+    /// <summary>
+    /// Every table on the list is one a database can be missing and be refused for.
+    /// </summary>
+    /// <remarks>
+    /// Running the case for all of them is what makes the list mean something: a name added to
+    /// <c>AllTableNames</c> that no statement can query — a view, a misspelling, a table only some
+    /// dialects have — would pass the unit-level cases and fail here.
+    /// </remarks>
+    [TestCaseSource(nameof(EveryValidatedTable))]
+    public async Task AStoreRefusesToStartWhenATableIsMissing(string table)
+    {
+        InstallSchemaFromFreshInstallScript();
+        Execute($"DROP TABLE QRTZ_{table}");
+
+        Func<Task> act = () => GetScheduler($"{nameof(AStoreRefusesToStartWhenATableIsMissing)}_{table}");
+
+        SchedulerException failure = (await act.Should().ThrowAsync<SchedulerException>(
+                "a database missing a table Quartz writes to has to be a startup failure, not a "
+                + "scheduler that runs until something schedules the trigger type that needs it"))
+            .WithMessage("*schema validation failed*")
+            .Which;
+
+        MessagesOf(failure).Should().ContainMatch($"*QRTZ_{table}*",
+            "the message names the table that is missing, since the reader's next move is to run the "
+            + "migration or the fresh-install script that creates it");
+    }
+
+    /// <summary>
+    /// Runs <c>database/tables/tables_sqlite.sql</c>, the script the documentation tells a reader to
+    /// run, against the empty file.
+    /// </summary>
+    /// <remarks>
+    /// The whole text goes to one command: SQLite's own parser splits it, which is the only splitter
+    /// that gets every statement in the file right.
+    /// </remarks>
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        Execute(File.ReadAllText(ResolveRepositoryFile("database", "tables", "tables_sqlite.sql")));
+    }
+
+    private void Execute(string sql)
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText = sql;
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A store over the temporary database, with schema validation left at its default of on.
+    /// </summary>
+    private Task<IScheduler> GetScheduler(string schedulerName)
+    {
+        SchedulerBuilder config = SchedulerBuilder.Create($"{schedulerName}_instance", schedulerName);
+
+        config.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        return config.BuildScheduler();
+    }
+
+    /// <summary>Every message in an exception chain, outermost first.</summary>
+    private static List<string> MessagesOf(Exception exception)
+    {
+        List<string> messages = new List<string>();
+
+        for (Exception current = exception; current != null; current = current.InnerException)
+        {
+            messages.Add(current.Message);
+        }
+
+        return messages;
+    }
+
+    /// <summary>
+    /// A file in the working tree the test assembly was built in, found by walking up from the output
+    /// directory rather than counting directories, which is one more thing to fix when the layout moves.
+    /// </summary>
+    private static string ResolveRepositoryFile(params string[] pathSegments)
+    {
+        string relativePath = Path.Combine(pathSegments);
+        DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"{relativePath} was not found above {AppContext.BaseDirectory}", relativePath);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
@@ -1,0 +1,186 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The list of tables the store checks is there before it starts, held against the scripts that create
+/// them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AdoConstants.AllTableNames</c> is the whole of what <c>StdAdoDelegate.ValidateSchema</c> probes
+/// with a <c>SELECT 1</c>, and <c>JobStoreSupport.PerformSchemaValidation</c> is on by default. A table
+/// the scripts create and that list does not name is therefore one a database can be missing while
+/// startup reports the schema good — which is what #3564 was, about <c>QRTZ_SIMPROP_TRIGGERS</c>.
+/// </para>
+/// <para>
+/// The other half of the subject — installing a schema, dropping one table, and watching the store
+/// refuse to start — is <c>Quartz.Tests.Integration.Impl.AdoJobStore.SchemaValidationTest</c>. It needs
+/// a database, even if only a SQLite file, so it cannot live here. These cases need none.
+/// </para>
+/// </remarks>
+public class SchemaValidationTest
+{
+    /// <summary>
+    /// The fresh-install scripts, named rather than enumerated so a reader can see which ones took part.
+    /// <see cref="TheFreshInstallScriptsAreTheOnesThisTestKnowsAbout" /> keeps the list honest.
+    /// </summary>
+    private static readonly string[] FreshInstallScripts =
+    {
+        "tables_firebird.sql",
+        "tables_mysql_innodb.sql",
+        "tables_oracle.sql",
+        "tables_postgres.sql",
+        "tables_sqlServer.sql",
+        "tables_sqlServerMOT.sql",
+        "tables_sqlServer_Below2016.sql",
+        "tables_sqlite.sql"
+    };
+
+    private static readonly Regex CreateTableStatement = new Regex(
+        @"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?<name>[^\s(]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The eleven tables, spelled out rather than counted.
+    /// </summary>
+    /// <remarks>
+    /// A count would have passed all along: <c>QRTZ_SIMPROP_TRIGGERS</c> was missing from the list
+    /// because its name lived on the delegate that writes it rather than on <c>AdoConstants</c>, and ten
+    /// was what everything downstream agreed the answer was (#3564). Naming them is what makes a twelfth
+    /// table, or an eleventh that goes missing again, a failing test here rather than an insert against a
+    /// table nobody checked for.
+    /// </remarks>
+    [Test]
+    public void TheStoreValidatesEveryTableOfTheSchema()
+    {
+        AdoConstants.AllTableNames.Should().Equal(
+            new[]
+            {
+                "JOB_DETAILS",
+                "TRIGGERS",
+                "SIMPLE_TRIGGERS",
+                "SIMPROP_TRIGGERS",
+                "CRON_TRIGGERS",
+                "BLOB_TRIGGERS",
+                "FIRED_TRIGGERS",
+                "CALENDARS",
+                "PAUSED_TRIGGER_GRPS",
+                "LOCKS",
+                "SCHEDULER_STATE"
+            },
+            "these are the tables the schema has, and the list is the whole of what schema validation "
+            + "probes at startup");
+    }
+
+    /// <summary>
+    /// Every table a fresh install creates is one the store asks about.
+    /// </summary>
+    /// <remarks>
+    /// This is the guard that catches the class of bug #3564 was. A hand-written list of eleven would
+    /// not have: whoever wrote it would have written ten, for the same reason the original list did.
+    /// Reading the answer out of each dialect's script instead means the two can only agree by being
+    /// right.
+    /// </remarks>
+    [TestCaseSource(nameof(FreshInstallScripts))]
+    public void EveryTableTheFreshInstallScriptCreatesIsOneTheStoreValidates(string script)
+    {
+        List<string> created = TablesCreatedBy(script);
+
+        created.Should().BeEquivalentTo(AdoConstants.AllTableNames,
+            $"database/tables/{script} and AdoConstants.AllTableNames describe the same schema — one "
+            + "creates it, the other is the whole of what startup checks is there");
+    }
+
+    /// <summary>
+    /// The list above names every script in <c>database/tables/</c>, so a dialect added later is not
+    /// quietly left unchecked.
+    /// </summary>
+    [Test]
+    public void TheFreshInstallScriptsAreTheOnesThisTestKnowsAbout()
+    {
+        IEnumerable<string> onDisk = Directory
+            .GetFiles(Path.Combine(RepositoryRoot(), "database", "tables"), "tables_*.sql")
+            .Select(path => Path.GetFileName(path));
+
+        onDisk.Should().BeEquivalentTo(FreshInstallScripts,
+            "a fresh-install script this fixture does not name is a schema nothing holds "
+            + "AdoConstants.AllTableNames to");
+    }
+
+    /// <summary>The tables a script creates, without the configurable <c>QRTZ_</c> prefix.</summary>
+    private static List<string> TablesCreatedBy(string script)
+    {
+        string sql = File.ReadAllText(Path.Combine(RepositoryRoot(), "database", "tables", script));
+
+        return CreateTableStatement.Matches(sql)
+            .Cast<Match>()
+            .Select(match => UnprefixedTableName(match.Groups["name"].Value))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The bare name the store would append its table prefix to: no schema qualifier, no quoting, no
+    /// case, and no <c>QRTZ_</c>, which is configuration rather than part of the name.
+    /// </summary>
+    private static string UnprefixedTableName(string identifier)
+    {
+        string name = identifier
+            .Split('.')
+            .Last()
+            .Trim('[', ']', '"', '`', ';')
+            .ToUpperInvariant();
+
+        return name.StartsWith("QRTZ_", StringComparison.Ordinal) ? name.Substring("QRTZ_".Length) : name;
+    }
+
+    /// <summary>
+    /// The working tree the test assembly was built in, found by walking up to the
+    /// <c>database/tables</c> the scripts live in.
+    /// </summary>
+    /// <remarks>
+    /// Counting directories up from the output path would be one more thing to fix when a target
+    /// framework is added or the output layout moves.
+    /// </remarks>
+    private static string RepositoryRoot()
+    {
+        DirectoryInfo directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null && !Directory.Exists(Path.Combine(directory.FullName, "database", "tables")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull(
+            $"the fresh-install scripts are read from the working tree, and none was found above {AppContext.BaseDirectory}");
+
+        return directory.FullName;
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1378,6 +1378,7 @@ namespace Quartz.Impl.AdoJobStore
         public const string TableLocks = "LOCKS";
         public const string TablePausedTriggers = "PAUSED_TRIGGER_GRPS";
         public const string TableSchedulerState = "SCHEDULER_STATE";
+        public const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
         public const string TableSimpleTriggers = "SIMPLE_TRIGGERS";
         public const string TableTriggers = "TRIGGERS";
         public const string TriggerTypeBlob = "BLOB";

--- a/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
@@ -28,11 +28,21 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma(.NET)</author>
 public class AdoConstants
 {
+    /// <summary>
+    /// Every table the store reads or writes, in the order the schema scripts create them.
+    /// </summary>
+    /// <remarks>
+    /// This is what <see cref="StdAdoDelegate.ValidateSchema" /> probes at startup, so a table missing
+    /// from here is a table a database can be missing and still start — the failure moves to the first
+    /// statement that names it, which is what validation exists to prevent. Every table name therefore
+    /// belongs on this class, whichever delegate writes to it.
+    /// </remarks>
     internal static readonly string[] AllTableNames = new[]
     {
         TableJobDetails,
         TableTriggers,
         TableSimpleTriggers,
+        TableSimplePropertiesTriggers,
         TableCronTriggers,
         TableBlobTriggers,
         TableFiredTriggers,
@@ -46,6 +56,7 @@ public class AdoConstants
     public const string TableJobDetails = "JOB_DETAILS";
     public const string TableTriggers = "TRIGGERS";
     public const string TableSimpleTriggers = "SIMPLE_TRIGGERS";
+    public const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
     public const string TableCronTriggers = "CRON_TRIGGERS";
     public const string TableBlobTriggers = "BLOB_TRIGGERS";
     public const string TableFiredTriggers = "FIRED_TRIGGERS";

--- a/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimplePropertiesTriggerPersistenceDelegateSupport.cs
@@ -41,7 +41,16 @@ namespace Quartz.Impl.AdoJobStore;
 /// <author>Marko Lahma (.NET)</author>
 public abstract class SimplePropertiesTriggerPersistenceDelegateSupport : ITriggerPersistenceDelegate
 {
-    protected const string TableSimplePropertiesTriggers = "SIMPROP_TRIGGERS";
+    /// <summary>
+    /// The table this delegate persists into, kept here as the spelling a derived delegate writes.
+    /// </summary>
+    /// <remarks>
+    /// The value belongs to <see cref="AdoConstants" />, where every table the store reads or writes is
+    /// named, because that list is what startup schema validation probes. Declared only here, it was a
+    /// table validation did not know about: a database missing this one alone started, and failed on the
+    /// first calendar-interval, daily-time-interval or recurrence trigger written to it (#3564).
+    /// </remarks>
+    protected const string TableSimplePropertiesTriggers = AdoConstants.TableSimplePropertiesTriggers;
 
     protected const string ColumnStrProp1 = "STR_PROP_1";
     protected const string ColumnStrProp2 = "STR_PROP_2";

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -113,7 +113,7 @@ public class StdAdoConstants : AdoConstants
         Invariant($"DELETE FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnTriggerName} = @triggerName AND {ColumnTriggerGroup} = @triggerGroup");
 
     public static readonly string SqlDeleteAllSimpleTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{TableSimpleTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
-    public static readonly string SqlDeleteAllSimpropTriggers = Invariant($"DELETE FROM {TablePrefixSubst}SIMPROP_TRIGGERS WHERE {ColumnSchedulerName} = @schedulerName");
+    public static readonly string SqlDeleteAllSimpropTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{TableSimplePropertiesTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
     public static readonly string SqlDeleteAllCronTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{TableCronTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
     public static readonly string SqlDeleteAllBlobTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{TableBlobTriggers} WHERE {ColumnSchedulerName} = @schedulerName");
     public static readonly string SqlDeleteAllTriggers = Invariant($"DELETE FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName");


### PR DESCRIPTION
Companion of #3568 on `3.x`; see #3564.

`AdoConstants.AllTableNames` listed **ten** of this branch's **eleven** tables. `QRTZ_SIMPROP_TRIGGERS` was missing because its name lived on `SimplePropertiesTriggerPersistenceDelegateSupport` as a `protected const` rather than on `AdoConstants` — and `AllTableNames` is exactly what `StdAdoDelegate.ValidateSchema` probes with `SELECT 1`, which `JobStoreSupport.PerformSchemaValidation` runs at startup and which defaults to `true`. A database missing only that one table passed validation, the scheduler started, and the failure surfaced later as the first `INSERT` from a calendar-interval, daily-time-interval or recurrence trigger.

## What changed

- The name is `AdoConstants.TableSimplePropertiesTriggers` now, beside the other ten, and joins `AllTableNames` after `SIMPLE_TRIGGERS` — the position it holds on `main`.
- `SimplePropertiesTriggerPersistenceDelegateSupport.TableSimplePropertiesTriggers` stays `protected`, aliasing the new constant. On a released branch that is not a preference: the base class is a documented extension point, and removing the spelling would break source compatibility for any delegate deriving from it.
- `StdAdoConstants.SqlDeleteAllSimpropTriggers` stops spelling the table literally. (`main`'s equivalent line was `SqlSelectSimpropTriggersByKeysPrefix`; this branch has no such statement.)
- No change to the `SELECT 1` statement was needed: `QRTZ_SIMPROP_TRIGGERS` is an ordinary table carrying the configured prefix in all eight `database/tables/*.sql`, so it validates like the rest.

## Tests

`main` put all three of its cases in the unit project, which it can because `Microsoft.Data.Sqlite` is already referenced there. Here it is not, and adding it would pull `SQLitePCLRaw` and its unfixed advisory (GHSA-2m69-gcr7-jv3q) into a project that builds with warnings as errors — the integration project suppresses that advisory for exactly this reason. So the split is different, and the database half lives where SQLite already does:

- **Unit** — `src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs`. `EveryTableTheFreshInstallScriptCreatesIsOneTheStoreValidates` parses `CREATE TABLE` out of each of the eight `database/tables/tables_*.sql` and compares the result with `AllTableNames`. **This is the guard that catches this class of bug** — a hand-written list of eleven would not have, since whoever wrote it would have written ten. `TheStoreValidatesEveryTableOfTheSchema` names the eleven in order as the tripwire the issue asked for, and `TheFreshInstallScriptsAreTheOnesThisTestKnowsAbout` holds the fixture's list of scripts to what the directory contains, so a dialect added later is not quietly left unchecked. `main` has a `SchemaScriptTest` with a SQL parser to hang the first case off; this branch has none, so the file carries its own — that is the one place the port is a rewrite rather than a transcription.
- **Integration** — `src/Quartz.Tests.Integration/Impl/AdoJobStore/SchemaValidationTest.cs`, `[Category("db-sqlite")]`, so it runs in the existing `pr-integration-sqlite` leg. It installs `database/tables/tables_sqlite.sql` into a temporary file and drops each table in turn, checking the store refuses to start and names the missing table. SQLite is a file, so this needs no Docker — `QUARTZ_TEST_DATABASE=sqlite` starts no containers at all. A control case asserts the untouched schema starts, so a harness that installed nothing could not make the eleven pass for the wrong reason.

With the `AllTableNames` entry removed, nine of the ten unit cases fail (eight scripts plus the explicit list). The drop-one cases would not have: their case source *is* `AllTableNames`, so the missing table was one nothing thought to drop. That is why the unit-level cross-check is the one that matters.

## For a reviewer to decide

**The constant is public twice, in a sense.** `AdoConstants.TableSimplePropertiesTriggers` is `public const`; the `protected const` on the delegate base remains, now aliasing it. That is one added line in `PublicApiTest_Quartz.verified.txt` and nothing removed — additive, no break. Deleting the protected spelling would be tidier, and is what a fresh design would do, but this is the maintenance branch and it would break a delegate written against the documented extension point. `main` kept the alias for the same reason.

The baseline was accepted through Verify (received moved over verified, BOM intact); the diff is the single line above.

## Docs

Nothing to change. This branch carries no documentation site — only the per-package NuGet readmes — and none of them mentions the validated table set. `database/README.md` has one sentence about startup validation, in "Upgrading 3.x → 4.x is mandatory", and it is about 4.x having tables 3.x never had; it is still accurate. `main`'s companion updated `tutorial/job-stores.md`, which lives there.

## Verification

Ran locally on Windows:

- `dotnet build Quartz.slnx` — build succeeded, 0 warnings, 0 errors
- `dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj` — 1876 passed / 4 skipped (net10.0), 1865 passed / 5 skipped (net472)
- `dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj` — 122 passed (net8.0)
- `QUARTZ_TEST_DATABASE=sqlite dotnet test src/Quartz.Tests.Integration --filter TestCategory=db-sqlite` — 27 passed (net10.0), and the new fixture alone 12 passed on net472. No Docker daemon was involved; every other database category needs one and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUiR5GoHeqzbi6mJnCoU53
