### PR TITLE
A wait no timer will take is refused where it was configured

### DIFF
--- a/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
@@ -3,6 +3,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
+using Quartz.Util;
+
 namespace Quartz.Tests.Unit.Configuration;
 
 /// <summary>
@@ -247,6 +249,207 @@ public class OptionsValidationTest
         var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
 
         act.Should().NotThrow("checkConfiguration is the existing way to say the keys are yours");
+    }
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Durations that end up in a timer
+    //
+    // Each of these is handed to a wait whose own ceiling is lower than a TimeSpan's, so a value past
+    // it is refused by the BCL — in an ArgumentOutOfRangeException naming a parameter of whichever
+    // method happened to be running, from wherever that method happened to be called. #3577's arrived
+    // out of Shutdown. Startup is where a misconfigured duration can still be reported as one.
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    /// <summary>
+    /// #3577: the store used to start happily on a 90-day frequency, and the failure arrived later,
+    /// out of <c>Shutdown</c>, saying only that something called 'delay' was out of range.
+    /// </summary>
+    [Test]
+    public void AMisfireHandlerFrequencyPastTheTimerCeilingFailsAtStartup()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.MisfireHandlerFrequency = TimeSpan.FromDays(90);
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*MisfireHandlerFrequency*4294967294ms (49.7 days)*",
+                "the report has to name the option and the ceiling, and the one out of Task.Delay named neither");
+    }
+
+    [Test]
+    public void AMisfireHandlerFrequencyAtTheTimerCeilingIsFine()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.MisfireHandlerFrequency = TimerLimits.MaxDelay;
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow("the ceiling is the longest delay a timer accepts, not the first it refuses");
+    }
+
+    /// <summary>
+    /// Unset, the frequency <em>is</em> the threshold, so the threshold is what the misfire handler
+    /// sleeps for — and it is the setting the application wrote, so it is the one named.
+    /// </summary>
+    [Test]
+    public void AMisfireThresholdPastTheTimerCeilingFailsWhenItIsAlsoTheHandlerFrequency()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.MisfireThreshold = TimeSpan.FromDays(90);
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>()
+            .WithMessage("*MisfireThreshold*MisfireHandlerFrequency is unset*");
+    }
+
+    /// <summary>
+    /// With a frequency of its own the threshold never reaches a timer: it is only ever subtracted
+    /// from a clock reading, so it is bounded by nothing but the calendar.
+    /// </summary>
+    [Test]
+    public void AMisfireThresholdPastTheTimerCeilingIsFineOnceTheHandlerHasItsOwnFrequency()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.MisfireThreshold = TimeSpan.FromDays(90);
+            options.MisfireHandlerFrequency = TimeSpan.FromMinutes(1);
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void ADbRetryIntervalPastTheTimerCeilingFailsAtStartup()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.DbRetryInterval = TimeSpan.FromDays(90);
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*DbRetryInterval*4294967294ms (49.7 days)*");
+    }
+
+    [Test]
+    public void ATransientRetryIntervalPastTheTimerCeilingFailsAtStartup()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.ConfigureStore(options =>
+        {
+            options.DataSource = "test";
+            options.TransientRetryInterval = TimeSpan.FromDays(90);
+        })));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*TransientRetryInterval*4294967294ms (49.7 days)*");
+    }
+
+    [Test]
+    public void ACheckinIntervalPastTheTimerCeilingFailsAtStartup()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.ConfigureStore(options => options.DataSource = "test");
+            store.UseClustering(clustering => clustering.CheckinInterval = TimeSpan.FromDays(90));
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*CheckinInterval*4294967294ms (49.7 days)*");
+    }
+
+    /// <summary>
+    /// The idle wait is the one duration in the sweep that gets no ceiling. It is spent on a semaphore
+    /// rather than a timer, so that a scheduling change can cut it short, and a semaphore takes a
+    /// timeout of any length — so a wait past the timer ceiling is strange to configure but not a thing
+    /// that breaks, and refusing it would be inventing a limit.
+    /// </summary>
+    [Test]
+    public void AnIdleWaitTimePastTheTimerCeilingIsAllowedBecauseNoTimerWaitsItOut()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.ConfigureScheduler(options => options.IdleWaitTime = TimerLimits.MaxDelay + TimeSpan.FromDays(1)));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().NotThrow("TimerLimitsTest holds the semaphore behaviour this rests on");
+    }
+
+    /// <summary>
+    /// The start delay has the worst symptom of the lot: <c>StartDelayed</c> waits on a task nobody
+    /// observes, so a delay the timer refuses faults that task, is collected without a word, and leaves
+    /// a scheduler that was created, bound and reported healthy and simply never starts.
+    /// </summary>
+    /// <remarks>
+    /// Read through the monitor rather than <see cref="IStartupValidator"/>, because these options are
+    /// per scheduler name and the names are not known where the validator is registered. This is the
+    /// read the hosted service makes for every scheduler while the host starts.
+    /// </remarks>
+    [Test]
+    public void AStartDelayPastTheTimerCeilingFailsWhenTheHostedServiceReadsIt()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+        services.AddQuartzHostedService(options => options.StartDelay = TimeSpan.FromDays(90));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptionsMonitor<QuartzHostedServiceOptions>>().Get(Options.DefaultName);
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*StartDelay*4294967294ms (49.7 days)*");
+    }
+
+    [Test]
+    public void AStartDelayShortEnoughToWaitOutIsFine()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz();
+        services.AddQuartzHostedService(options => options.StartDelay = TimeSpan.FromMinutes(5));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptionsMonitor<QuartzHostedServiceOptions>>().Get(Options.DefaultName);
+
+        act.Should().NotThrow();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/Core/QuartzSchedulerTest.cs
@@ -115,6 +115,31 @@ public class QuartzSchedulerTest
         scheduler.Status.Should().Be(SchedulerStatus.Running);
     }
 
+    /// <summary>
+    /// The delay is waited out on a task nobody observes, so one the timer refuses used to fault that
+    /// task and be collected in silence — leaving a scheduler that was never going to start, with
+    /// nothing thrown, nothing logged and nothing naming the delay.
+    /// </summary>
+    [Test]
+    public async Task StartDelayedRefusesADelayNoTimerWillWaitOut()
+    {
+        NameValueCollection properties = new NameValueCollection();
+        properties["quartz.serializer.type"] = TestConstants.DefaultSerializerType;
+        properties["quartz.scheduler.instanceName"] = "StartDelayedCeiling";
+        ISchedulerFactory sf = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
+        IScheduler scheduler = await sf.GetScheduler();
+
+        var act = async () => await scheduler.StartDelayed(TimeSpan.FromDays(60));
+
+        (await act.Should().ThrowAsync<ArgumentOutOfRangeException>(
+            "the caller has to hear about it; the wait itself has nobody to tell"))
+            .Which.ParamName.Should().Be("delay");
+
+        scheduler.Status.Should().Be(SchedulerStatus.Created, "a refused delay must not leave the scheduler half started");
+
+        await scheduler.Shutdown();
+    }
+
     [Test]
     public async Task TestRescheduleJob_SchedulerListenersCalledOnReschedule()
     {

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerRetryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerRetryTest.cs
@@ -94,6 +94,27 @@ public class DbLockHandlerRetryTest
     }
 
     /// <summary>
+    /// A backoff no timer will sit out is refused where it is configured. A lock handler has no options
+    /// type and so no startup validator, and the flat <c>quartz.jobStore.lockHandler.retryPeriod</c> key
+    /// writes this property by reflection — which the property binder turns into a
+    /// <c>SchedulerConfigException</c> naming the key. Left to the wait itself, the report would arrive
+    /// from the first contended lock attempt, with the lock unacquired and nothing naming the setting.
+    /// </summary>
+    [TestCase(60)]
+    [TestCase(-1)]
+    public void ARetryPeriodNoTimerWillWaitOutIsRefusedWhereItIsConfigured(int days)
+    {
+        TimeSpan period = TimeSpan.FromDays(days);
+        var provider = new FailingDbProvider();
+
+        var updateRow = () => new UpdateRowLockHandler(provider) { RetryPeriod = period };
+        updateRow.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*RetryPeriod*49.7 days*");
+
+        var selectForUpdate = () => new SelectForUpdateLockHandler(provider) { RetryPeriod = period };
+        selectForUpdate.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*RetryPeriod*49.7 days*");
+    }
+
+    /// <summary>
     /// Neither retry loop treats the caller's cancellation as a lock it could not get. The exception
     /// that ends the loop is a <see cref="LockException" />, which is a
     /// <see cref="JobPersistenceException" />, so a caller who asked to stop would be told the database

--- a/src/Quartz.Tests.Unit/RetryEngineTest.cs
+++ b/src/Quartz.Tests.Unit/RetryEngineTest.cs
@@ -337,6 +337,80 @@ public class RetryEngineTest
         trigger.ExecutionComplete(context, result: null).Should().Be(SchedulerInstruction.DeleteTrigger);
     }
 
+    /// <summary>A one-shot trigger, fired at 10:00, so there is no occurrence for a retry to lose to.</summary>
+    private IOperableTrigger OneShotTriggerFiredAtTen(RetryPolicy policy)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(clock)
+            .WithIdentity("one-shot", "retries")
+            .ForJob("job", "jobs")
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).WithRepeatCount(0))
+            .StartAt(now)
+            .WithRetryPolicy(policy)
+            .Build();
+
+        trigger.ComputeFirstFireTimeUtc(null);
+        trigger.Triggered(null);
+
+        trigger.NextFireTimeUtc.Should().BeNull("the fixture is a one-shot trigger that has had its single fire");
+        return trigger;
+    }
+
+    /// <summary>
+    /// The last instant a retry may land on, and the first one it may not. A fire time is a
+    /// <see cref="DateTimeOffset"/>, and adding to one of those throws rather than saturating, so the
+    /// end of the calendar is a boundary the retry arithmetic has to keep on the right side of.
+    /// </summary>
+    /// <remarks>
+    /// The supersede margin comes off the room available, because the instant is compared against the
+    /// next occurrence with that margin added — an instant with no room for the margin would overflow
+    /// in the comparison instead.
+    /// </remarks>
+    [Test]
+    public void TheEndOfTheCalendarIsTheLastInstantARetryMayLandOn()
+    {
+        TimeSpan room = DateTimeOffset.MaxValue - TriggerBase.RetrySupersedeMargin - now;
+
+        IOperableTrigger justFits = OneShotTriggerFiredAtTen(RetryPolicy.Fixed(1, room));
+        justFits.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.RetryTrigger);
+        justFits.NextFireTimeUtc.Should().Be(DateTimeOffset.MaxValue - TriggerBase.RetrySupersedeMargin);
+        justFits.RetryAttempt.Should().Be(1);
+
+        IOperableTrigger oneTickTooFar = OneShotTriggerFiredAtTen(RetryPolicy.Fixed(1, room + TimeSpan.FromTicks(1)));
+        oneTickTooFar.ExecutionComplete(context, Failure()).Should().Be(SchedulerInstruction.DeleteTrigger,
+            "a retry with nowhere to land is a retry that never comes, so the occurrence settles");
+        oneTickTooFar.RetryAttempt.Should().Be(0);
+    }
+
+    /// <summary>
+    /// An exponential policy runs out of calendar long before it runs out of attempts, and it does so
+    /// on numbers anybody might type: ten times a second, thirteen retries in. The waits themselves
+    /// saturate at <see cref="TimeSpan.MaxValue"/> by design, and it is turning a saturated wait into a
+    /// fire time that used to throw — out of <c>ExecutionComplete</c>, on the job's failure path, where
+    /// the trigger had done nothing wrong.
+    /// </summary>
+    [Test]
+    public void AnExponentialPolicyThatOutlivesTheCalendarSettlesInsteadOfThrowing()
+    {
+        RetryPolicy policy = RetryPolicy.Exponential(maxAttempts: 20, initialDelay: TimeSpan.FromSeconds(1), factor: 10);
+        policy.DelayFor(13).Should().Be(TimeSpan.MaxValue, "a factor of ten spends a whole TimeSpan in thirteen retries");
+
+        IOperableTrigger trigger = OneShotTriggerFiredAtTen(policy);
+
+        int scheduled = 0;
+        SchedulerInstruction instruction = trigger.ExecutionComplete(context, Failure());
+        while (instruction == SchedulerInstruction.RetryTrigger)
+        {
+            scheduled++;
+            ((TriggerBase) trigger).RetryFired(null);
+            instruction = trigger.ExecutionComplete(context, Failure());
+        }
+
+        scheduled.Should().Be(12, "the twelfth wait is the last one that lands on a date a fire time can hold");
+        instruction.Should().Be(SchedulerInstruction.DeleteTrigger,
+            "the trigger runs out of retries it can express, not out of the attempts its policy allows");
+        trigger.RetryAttempt.Should().Be(0);
+    }
+
     //////////////////////////////////////////////////////////////////////////////////////////////
     // RetryFired
     //////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Quartz.Tests.Unit/Util/TimerLimitsTest.cs
+++ b/src/Quartz.Tests.Unit/Util/TimerLimitsTest.cs
@@ -1,0 +1,95 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Util;
+
+/// <summary>
+/// Holds the ceiling the options validators check durations against, and the absence of one where a
+/// duration is waited out on something other than a timer, to what the primitives actually do.
+/// </summary>
+/// <remarks>
+/// Neither fact is anything the BCL exposes, so without these the ceiling is a number copied out of a
+/// runtime source file and the absence is an assumption. A framework that moved either would be found
+/// by a scheduler that had been running for a month rather than by a build.
+/// </remarks>
+public class TimerLimitsTest
+{
+    /// <summary>
+    /// A cancelled token, so that the calls below are validated without leaving a month-long timer
+    /// behind in the test process.
+    /// </summary>
+    private static CancellationToken Cancelled()
+    {
+        CancellationTokenSource source = new CancellationTokenSource();
+        source.Cancel();
+        return source.Token;
+    }
+
+    [Test]
+    public void MaxDelayIsTheLongestWaitATimerAccepts()
+    {
+        CancellationToken cancelled = Cancelled();
+
+        Action atTheLimit = () => _ = Task.Delay(TimerLimits.MaxDelay, TimeProvider.System, cancelled);
+        atTheLimit.Should().NotThrow("the limit is the longest accepted delay, not the first refused one");
+
+        Action pastIt = () => _ = Task.Delay(TimerLimits.MaxDelay + TimeSpan.FromMilliseconds(1), TimeProvider.System, cancelled);
+        pastIt.Should().Throw<ArgumentOutOfRangeException>(
+                "this is the failure #3577 reported, and the validators exist so nobody meets it")
+            .Which.ParamName.Should().Be("delay");
+    }
+
+    /// <summary>
+    /// Why <c>IdleWaitTime</c> is bounded below and not above. It is spent on a semaphore rather than a
+    /// timer, so that a scheduling change can cut it short, and a semaphore takes a timeout of any
+    /// length — including ones no timer would.
+    /// </summary>
+    [Test]
+    public void ASemaphoreTakesATimeoutNoTimerWould()
+    {
+        CancellationToken cancelled = Cancelled();
+        using SemaphoreSlim semaphore = new SemaphoreSlim(initialCount: 1);
+
+        Action wellPastTheTimerCeiling = () => _ = semaphore.WaitAsync(TimerLimits.MaxDelay * 1000, cancelled);
+
+        wellPastTheTimerCeiling.Should().NotThrow(
+            "the scheduling loop's idle wait would need a ceiling of its own if this ever stopped being true");
+    }
+
+    [Test]
+    public void MaxDelayIsTheNumberTheFailureMessagesQuote()
+    {
+        TimerLimits.MaxDelay.TotalMilliseconds.Should().Be(uint.MaxValue - 1);
+        TimerLimits.MaxDelay.TotalDays.Should().BeApproximately(49.7, 0.05, "the messages say 49.7 days");
+    }
+
+    [Test]
+    public void AFailureNamesTheOptionTheCeilingAndTheValue()
+    {
+        string message = TimerLimits.TooLong("MisfireHandlerFrequency", TimeSpan.FromDays(90), TimerLimits.MaxDelay, "Because.");
+
+        message.Should().Be(
+            "MisfireHandlerFrequency must be at most 4294967294ms (49.7 days), was 7776000000ms (90 days). Because.",
+            "the millisecond counts are what a reader compares with a configuration file, and the days are what say why it is a mistake");
+    }
+}

--- a/src/Quartz/Configuration/QuartzOptionsValidators.cs
+++ b/src/Quartz/Configuration/QuartzOptionsValidators.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Quartz.Impl;
+using Quartz.Util;
 
 namespace Quartz.Configuration;
 
@@ -39,6 +40,10 @@ internal sealed class QuartzSchedulerOptionsValidator : IValidateOptions<QuartzS
                 $"{nameof(QuartzSchedulerOptions.GenerateInstanceId)} is enabled.");
         }
 
+        // Bounded below and not above. The idle wait is spent on a SemaphoreSlim, so that a scheduling
+        // change can cut it short, and a semaphore takes a timeout of any length — unlike the timer the
+        // durations in TimerLimits are checked against. A wait of years is a strange thing to configure,
+        // but it is not a thing that breaks.
         if (options.IdleWaitTime < minimumIdleWaitTime)
         {
             (failures ??= []).Add(
@@ -431,14 +436,63 @@ internal sealed class AdoJobStoreOptionsValidator : IValidateOptions<AdoJobStore
             (failures ??= []).Add($"{nameof(AdoJobStoreOptions.MisfireThreshold)} must be at least 1ms.");
         }
 
-        if (options.MisfireHandlerFrequency is { } frequency && frequency < TimeSpan.FromMilliseconds(1))
+        // How long the misfire handler sleeps between passes has two spellings, and both of them reach
+        // the same Task.Delay: the frequency when it is set, and the threshold when it is not. The
+        // ceiling is checked against whichever one the application actually wrote, so the failure names
+        // a setting that is in its configuration.
+        if (options.MisfireHandlerFrequency is { } frequency)
         {
-            (failures ??= []).Add($"{nameof(AdoJobStoreOptions.MisfireHandlerFrequency)} must be at least 1ms when set.");
+            if (frequency < TimeSpan.FromMilliseconds(1))
+            {
+                (failures ??= []).Add($"{nameof(AdoJobStoreOptions.MisfireHandlerFrequency)} must be at least 1ms when set.");
+            }
+            else if (frequency > TimerLimits.MaxDelay)
+            {
+                (failures ??= []).Add(TimerLimits.TooLong(
+                    nameof(AdoJobStoreOptions.MisfireHandlerFrequency),
+                    frequency,
+                    TimerLimits.MaxDelay,
+                    "The misfire handler sleeps for it between passes, and a delay longer than this is "
+                    + "refused by the timer rather than by the store — which is why an unbounded value "
+                    + "used to be reported out of Shutdown."));
+            }
+        }
+        else if (options.MisfireThreshold > TimerLimits.MaxDelay)
+        {
+            (failures ??= []).Add(TimerLimits.TooLong(
+                nameof(AdoJobStoreOptions.MisfireThreshold),
+                options.MisfireThreshold,
+                TimerLimits.MaxDelay,
+                $"{nameof(AdoJobStoreOptions.MisfireHandlerFrequency)} is unset, so this is also how long "
+                + $"the misfire handler sleeps between passes. Set {nameof(AdoJobStoreOptions.MisfireHandlerFrequency)} "
+                + "to keep a threshold this long."));
         }
 
         if (options.DbRetryInterval < TimeSpan.Zero)
         {
             (failures ??= []).Add($"{nameof(AdoJobStoreOptions.DbRetryInterval)} must not be negative.");
+        }
+        else if (options.DbRetryInterval > TimerLimits.MaxDelay)
+        {
+            (failures ??= []).Add(TimerLimits.TooLong(
+                nameof(AdoJobStoreOptions.DbRetryInterval),
+                options.DbRetryInterval,
+                TimerLimits.MaxDelay,
+                "The store waits it out after a database failure, and the misfire handler and the cluster "
+                + "manager both sleep for it while their last pass is failing."));
+        }
+
+        if (options.TransientRetryInterval < TimeSpan.Zero)
+        {
+            (failures ??= []).Add($"{nameof(AdoJobStoreOptions.TransientRetryInterval)} must not be negative.");
+        }
+        else if (options.TransientRetryInterval > TimerLimits.MaxDelay)
+        {
+            (failures ??= []).Add(TimerLimits.TooLong(
+                nameof(AdoJobStoreOptions.TransientRetryInterval),
+                options.TransientRetryInterval,
+                TimerLimits.MaxDelay,
+                "It is waited out between the retries of a transiently failed statement."));
         }
 
         // Zero is not "no timeout" here even though ADO.NET reads it that way, because nothing in the
@@ -470,6 +524,14 @@ internal sealed class ClusteringOptionsValidator : IValidateOptions<ClusteringOp
         if (options.CheckinInterval <= TimeSpan.Zero)
         {
             (failures ??= []).Add($"{nameof(ClusteringOptions.CheckinInterval)} must be positive.");
+        }
+        else if (options.CheckinInterval > TimerLimits.MaxDelay)
+        {
+            (failures ??= []).Add(TimerLimits.TooLong(
+                nameof(ClusteringOptions.CheckinInterval),
+                options.CheckinInterval,
+                TimerLimits.MaxDelay,
+                "The cluster manager sleeps for it between check-ins."));
         }
 
         if (options.CheckinMisfireThreshold < TimeSpan.Zero)
@@ -518,6 +580,46 @@ internal sealed class ClusteringStaysEnabledValidator : IValidateOptions<Cluster
             $"{nameof(ClusteringOptions.Enabled)} is false, but UseClustering() was called for this "
             + "scheduler. Remove the UseClustering() call to run un-clustered; setting Enabled to false "
             + "inside it leaves database locking on with no cluster manager and no check-in.");
+    }
+}
+
+/// <summary>
+/// Validates <see cref="QuartzHostedServiceOptions"/>.
+/// </summary>
+/// <remarks>
+/// The start delay is the one setting here that can be wrong rather than merely unusual, and its
+/// symptom is the worst of the durations Quartz waits out: <c>StartDelayed</c> runs its wait on a task
+/// nobody observes, so a delay the timer refuses faults that task, is collected unnoticed, and leaves
+/// a scheduler that was created, bound and reported healthy and simply never starts.
+/// </remarks>
+internal sealed class QuartzHostedServiceOptionsValidator : IValidateOptions<QuartzHostedServiceOptions>
+{
+    public ValidateOptionsResult Validate(string? name, QuartzHostedServiceOptions options)
+    {
+        if (options.StartDelay is not { } delay)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        if (delay < TimeSpan.Zero)
+        {
+            return ValidateOptionsResult.Fail(
+                $"{nameof(QuartzHostedServiceOptions.StartDelay)} must not be negative. Leave it unset to "
+                + "start the scheduler as soon as the host does.");
+        }
+
+        if (delay > TimerLimits.MaxDelay)
+        {
+            return ValidateOptionsResult.Fail(TimerLimits.TooLong(
+                nameof(QuartzHostedServiceOptions.StartDelay),
+                delay,
+                TimerLimits.MaxDelay,
+                "The hosted service waits it out before starting the scheduler. Set "
+                + $"{nameof(QuartzHostedServiceOptions.AutoStart)} to false and start the scheduler yourself "
+                + "if it should wait longer than that."));
+        }
+
+        return ValidateOptionsResult.Success;
     }
 }
 

--- a/src/Quartz/Configuration/QuartzTypedOptions.cs
+++ b/src/Quartz/Configuration/QuartzTypedOptions.cs
@@ -54,6 +54,12 @@ internal static class QuartzTypedOptions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<ClusteringOptions>, ClusteringOptionsValidator>());
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DataSourceOptions>, DataSourceOptionsValidator>());
 
+        // Not declared with ValidateOnStart: these options are per scheduler name, and the names are not
+        // all known here — a named scheduler may be registered after this runs. Registering the validator
+        // is enough, because the hosted service reads every scheduler's copy through the monitor while
+        // the host starts, and validation runs on that read.
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<QuartzHostedServiceOptions>, QuartzHostedServiceOptionsValidator>());
+
         return services;
     }
 

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -28,6 +28,7 @@ using Microsoft.Extensions.Logging;
 using Quartz.Impl.Triggers;
 using Quartz.Impl;
 using Quartz.Extensibility;
+using Quartz.Util;
 
 namespace Quartz.Core;
 
@@ -380,6 +381,18 @@ internal sealed class QuartzScheduler
         {
             Throw.SchedulerException(
                 "The Scheduler cannot be restarted after Shutdown() has been called.");
+        }
+
+        // Checked here rather than left to the timer below. The wait runs on a task nobody observes, so
+        // a delay the timer refuses faults that task, is collected without a word, and leaves a
+        // scheduler that never starts — no exception, no log line, nothing pointing at the delay.
+        if (delay < TimeSpan.Zero || delay > TimerLimits.MaxDelay)
+        {
+            Throw.ArgumentOutOfRangeException(
+                nameof(delay),
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"A start delay is between zero and {TimerLimits.MaxDelay.TotalMilliseconds}ms ({TimerLimits.MaxDelay.TotalDays:0.#} days), which is as long as a timer will wait; {delay.TotalMilliseconds}ms is not."));
         }
 #pragma warning disable MA0134
         Task.Run(async () =>

--- a/src/Quartz/Impl/AdoJobStore/SelectForUpdateLockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/SelectForUpdateLockHandler.cs
@@ -25,6 +25,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Util;
 
 namespace Quartz.Impl.AdoJobStore;
 
@@ -116,7 +117,19 @@ public class SelectForUpdateLockHandler : DbLockHandler
     /// reflection is concerned.
     /// </remarks>
     [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
-    public TimeSpan RetryPeriod { get; init; } = TimeSpan.FromMilliseconds(1000);
+    public TimeSpan RetryPeriod
+    {
+        get;
+
+        init
+        {
+            // Checked here because a lock handler has no options type and so no startup validator. Left
+            // unchecked, a period longer than a timer will wait out is refused by the first contended
+            // lock attempt instead — with the lock unacquired and nothing naming the setting.
+            TimerLimits.EnsureWaitable(value, nameof(RetryPeriod));
+            field = value;
+        }
+    } = TimeSpan.FromMilliseconds(1000);
 
     /// <summary>
     /// Execute the SQL select for update that will lock the proper database row.

--- a/src/Quartz/Impl/AdoJobStore/UpdateRowLockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/UpdateRowLockHandler.cs
@@ -24,6 +24,7 @@ using System.Data.Common;
 using Microsoft.Extensions.Logging;
 
 using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Util;
 
 namespace Quartz.Impl.AdoJobStore;
 
@@ -70,7 +71,19 @@ public class UpdateRowLockHandler : DbLockHandler
     /// which an init accessor does not stop.
     /// </remarks>
     [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
-    public TimeSpan RetryPeriod { get; init; } = TimeSpan.FromMilliseconds(1000);
+    public TimeSpan RetryPeriod
+    {
+        get;
+
+        init
+        {
+            // Checked here because a lock handler has no options type and so no startup validator. Left
+            // unchecked, a period longer than a timer will wait out is refused by the first contended
+            // lock attempt instead — with the lock unacquired and nothing naming the setting.
+            TimerLimits.EnsureWaitable(value, nameof(RetryPeriod));
+            field = value;
+        }
+    } = TimeSpan.FromMilliseconds(1000);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UpdateRowLockHandler"/> class.

--- a/src/Quartz/Impl/Triggers/TriggerBase.cs
+++ b/src/Quartz/Impl/Triggers/TriggerBase.cs
@@ -673,7 +673,22 @@ public abstract class TriggerBase : IOperableTrigger, IEquatable<TriggerBase>
     {
         // The trigger's own clock, so a retry instant and the fire times it is compared with are two
         // readings of the same one.
-        DateTimeOffset retryAt = TimeProvider.GetUtcNow() + policy.DelayFor(RetryAttempt + 1);
+        DateTimeOffset now = TimeProvider.GetUtcNow();
+        TimeSpan delay = policy.DelayFor(RetryAttempt + 1);
+
+        // A retry that lands past the end of representable time is a retry nobody ever comes back for,
+        // which is the same answer as the two cases below: the occurrence settles and the trigger keeps
+        // its ordinary schedule. It has to be decided before the arithmetic rather than after, because
+        // adding to a DateTimeOffset throws where DelayFor saturates — and an exponential policy of one
+        // second times ten runs out of calendar on its twelfth retry, which is a policy somebody might
+        // actually write. The supersede margin comes off here too, so the comparison it is used in
+        // cannot overflow either.
+        if (delay > DateTimeOffset.MaxValue - RetrySupersedeMargin - now)
+        {
+            return false;
+        }
+
+        DateTimeOffset retryAt = now + delay;
 
         // What the schedule says comes next, which the fire that just completed advanced this to.
         DateTimeOffset? regularNext = NextFireTimeUtc;

--- a/src/Quartz/RetryPolicy.cs
+++ b/src/Quartz/RetryPolicy.cs
@@ -262,6 +262,14 @@ public sealed class RetryPolicy : IEquatable<RetryPolicy>
     /// decision to stop retrying belongs to the scheduler and not to the arithmetic.
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="attempt" /> is less than one.</exception>
+    /// <remarks>
+    /// A wait too long to be represented is not an error. The arithmetic saturates, and the scheduler
+    /// treats a retry it cannot express an instant for the way it treats one that would land on top of
+    /// the next occurrence: there is no room for it, so the occurrence settles and the trigger keeps its
+    /// ordinary schedule. Capping the waits when a policy is built or parsed instead would refuse a
+    /// stored form that <see cref="ToStoredString" /> had just written, and would refuse a policy over
+    /// attempts no trigger will reach.
+    /// </remarks>
     public TimeSpan DelayFor(int attempt)
     {
         if (attempt < 1)

--- a/src/Quartz/Util/TimerLimits.cs
+++ b/src/Quartz/Util/TimerLimits.cs
@@ -1,0 +1,105 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Globalization;
+
+namespace Quartz.Util;
+
+/// <summary>
+/// The longest wait a timer will take, which is shorter than the longest wait a <see cref="TimeSpan" />
+/// can express.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The limit is not Quartz's choice, and a wait past it is not something Quartz can honour: the BCL
+/// refuses it with an <see cref="ArgumentOutOfRangeException" /> naming a parameter of whichever method
+/// happened to be running, which is never the option the duration was configured on and is often not
+/// even the operation the application was performing — the misfire handler's arrived out of
+/// <c>Shutdown</c> (#3577). Every configurable duration that ends up in a timer is therefore checked
+/// against this while the options are validated, so that the report names the setting and the ceiling.
+/// </para>
+/// <para>
+/// A duration that ends up somewhere else is a separate question and gets a separate answer:
+/// <c>IdleWaitTime</c> is spent on a <see cref="SemaphoreSlim" />, which takes a timeout of any length,
+/// so it is bounded below and not above. <c>TimerLimitsTest</c> holds both of those facts to what the
+/// primitives actually do, because neither is a number the BCL exposes.
+/// </para>
+/// </remarks>
+internal static class TimerLimits
+{
+    /// <summary>
+    /// The longest delay <see cref="Task.Delay(TimeSpan, TimeProvider, CancellationToken)" /> accepts:
+    /// <c>uint.MaxValue - 1</c> milliseconds, a little under 50 days.
+    /// </summary>
+    /// <remarks>
+    /// This is <c>System.Threading.Timer.MaxSupportedTimeout</c>, which every timer in the BCL
+    /// validates against and none of them exposes.
+    /// </remarks>
+    internal static readonly TimeSpan MaxDelay = TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
+    /// <summary>
+    /// The failure reported for a configured duration longer than the primitive it ends up in accepts.
+    /// </summary>
+    /// <param name="option">The option as it is spelled, which is what a reader goes looking for.</param>
+    /// <param name="value">What it was configured to.</param>
+    /// <param name="limit">The ceiling, which is <see cref="MaxDelay" /> for everything so far.</param>
+    /// <param name="because">
+    /// One sentence saying which wait the duration becomes. The ceiling is arbitrary without it: the
+    /// number is the BCL's, and nothing about the option's own meaning suggests it.
+    /// </param>
+    /// <remarks>
+    /// Milliseconds and days both, in the shape the surrounding validators already use for their lower
+    /// bounds: the millisecond count is the number that has to be compared with a configuration file,
+    /// and the day count is the one that says why it is a mistake.
+    /// </remarks>
+    internal static string TooLong(string option, TimeSpan value, TimeSpan limit, string because)
+    {
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{option} must be at most {limit.TotalMilliseconds}ms ({limit.TotalDays:0.#} days), was {value.TotalMilliseconds}ms ({value.TotalDays:0.#} days). {because}");
+    }
+
+    /// <summary>
+    /// Refuses a duration no timer will wait out, where the value arrives somewhere an options validator
+    /// cannot see it.
+    /// </summary>
+    /// <param name="value">The duration, which is about to be waited out.</param>
+    /// <param name="option">
+    /// The name the duration is configured under, which is what the report has to carry — the parameter
+    /// the framework would have named is called <c>delay</c>.
+    /// </param>
+    /// <remarks>
+    /// For the lock handlers, whose retry period has no options type and so no startup validator: the
+    /// flat <c>quartz.jobStore.lockHandler.retryPeriod</c> key writes the property by reflection, and the
+    /// property binder turns whatever it throws into a <c>SchedulerConfigException</c> naming the key.
+    /// </remarks>
+    internal static void EnsureWaitable(TimeSpan value, string option)
+    {
+        if (value < TimeSpan.Zero || value > MaxDelay)
+        {
+            Throw.ArgumentOutOfRangeException(
+                option,
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"{option} is waited out by a timer, so it is between zero and {MaxDelay.TotalMilliseconds}ms ({MaxDelay.TotalDays:0.#} days); {value.TotalMilliseconds}ms is not."));
+        }
+    }
+}


### PR DESCRIPTION
`Task.Delay` tops out at `uint.MaxValue - 1` milliseconds — 49.7 days — and refuses anything longer with an `ArgumentOutOfRangeException` naming a parameter called `delay`. Every duration Quartz waits out that way is configurable, and none of them was checked against it. A too-large value started fine and was reported wherever the wait was eventually observed: #3577's 90-day `MisfireHandlerFrequency` surfaced out of `AdoJobStoreBase.Shutdown`, mentioning neither the setting nor the limit.

## The ceiling

`TimerLimits.MaxDelay` is `TimeSpan.FromMilliseconds(uint.MaxValue - 1)` — `System.Threading.Timer.MaxSupportedTimeout`, which every timer in the BCL validates against and none of them exposes. `TimerLimitsTest` holds it to what `Task.Delay` actually does, so a framework that moved it fails a build rather than a scheduler that has been running for a month.

Failures read `<Option> must be at most 4294967294ms (49.7 days), was 7776000000ms (90 days). <one sentence naming the wait it becomes>`, in the shape the surrounding validators already use for their lower bounds.

## Sweep

| Duration | Where it is waited | Verdict |
|---|---|---|
| `AdoJobStoreOptions.MisfireHandlerFrequency` | `MisfireHandler.Run` → `Task.Delay` | bounded — the reported bug |
| `AdoJobStoreOptions.MisfireThreshold` | the same `Task.Delay`, but only when `MisfireHandlerFrequency` is unset, because then it *is* the frequency | bounded, conditionally; with a frequency of its own it is only ever subtracted from a clock reading, and stays unbounded |
| `AdoJobStoreOptions.DbRetryInterval` | `Task.Delay` after a database failure, and both `ComputeTimeToSleep`s | bounded |
| `AdoJobStoreOptions.TransientRetryInterval` | `Task.Delay` between transient-failure retries | bounded — it had no validation at all, so it gets the non-negative check too |
| `ClusteringOptions.CheckinInterval` | `ClusterManager.Run` → `Task.Delay` | bounded |
| `QuartzHostedServiceOptions.StartDelay` | `StartDelayed` → `Task.Delay` | bounded, through an `IValidateOptions` rather than `ValidateOnStart` (see below) |
| `SelectForUpdateLockHandler.RetryPeriod`, `UpdateRowLockHandler.RetryPeriod` | `Task.Delay` between lock attempts | bounded in the accessor, because a lock handler has no options type (see below) |
| `QuartzSchedulerOptions.IdleWaitTime` | `SemaphoreSlim.WaitAsync(TimeSpan, …)` | **not bounded** — see below |
| `AdoJobStoreOptions.CommandTimeout` | `DbCommand.CommandTimeout`, whole seconds | not bounded; the int it is rounded into does not overflow under 68 years |
| `InMemoryJobStoreOptions.MisfireThreshold`, `ClusteringOptions.CheckinMisfireThreshold`, `QuartzSchedulerOptions.BatchTriggerAcquisitionFireAheadTimeWindow` | clock arithmetic only | not bounded; nothing waits them out |

### `IdleWaitTime` gets no ceiling, and that is the finding

The issue named it as a candidate, and it turns out not to be one. The idle wait is spent on a `SemaphoreSlim`, so that a scheduling change can cut it short, and on .NET 10 a semaphore takes a timeout of *any* length — I found this by probing the boundary rather than by reading, after a first draft bounded it at `int.MaxValue` milliseconds and the test refused to fail. An idle wait of years is a strange thing to configure but not a thing that breaks, so refusing it would be inventing a limit. `TimerLimitsTest` pins the semaphore behaviour the absence of the bound rests on, and the validator carries a comment saying why it is one-sided.

### Two durations that reach a timer without an options validator

- **`QuartzHostedServiceOptions.StartDelay`** is per scheduler name, and the names are not all known where validators are registered — a named scheduler may be added after `AddQuartzHostedService`. So it is an `IValidateOptions` that fires on the monitor read the hosted service makes for every scheduler while the host starts, rather than a `ValidateOnStart` declaration.
- **The lock handlers' `RetryPeriod`** has no options type at all; the flat `quartz.jobStore.lockHandler.retryPeriod` key writes the property by reflection. The check is therefore in the `init` accessor, and `PropertyBinder.SetObjectProperties` turns it into a `SchedulerConfigException` naming the key.

### `StartDelayed` checks its own argument

`QuartzScheduler.StartDelayed` runs its wait inside a `Task.Run` whose task is discarded, so a delay the timer refused faulted that task, was collected without a word, and left a scheduler that was created, bound, reported healthy — and never started. That is the worst symptom in the sweep, and it is reachable without any configuration at all, so the argument is now checked before the wait is started. A negative delay is refused with it: `-1ms` would have meant "wait forever" by the `Timeout.Infinite` convention, which `StartDelayed` never documented, and any other negative vanished the same way.

## Retry-policy delays: the clamp goes on the instant, not the parse

`RetryPolicy`'s waits never reach `Task.Delay`. They become a fire time — `TriggerBase.TryScheduleRetry` does `now + policy.DelayFor(…)` — so the limit that binds them is the calendar, not the timer, and `DateTimeOffset` addition throws where `DelayFor` deliberately saturates at `TimeSpan.MaxValue`.

It is reachable on numbers somebody might write. `RetryPolicy.Exponential(20, TimeSpan.FromSeconds(1), factor: 10)` spends a whole `TimeSpan` on its thirteenth retry, and before this the thirteenth failure answered with

```
System.ArgumentOutOfRangeException : The added or subtracted value results in an un-representable DateTime. (Parameter 't')
   at System.DateTimeOffset.op_Addition(DateTimeOffset dateTimeOffset, TimeSpan timeSpan)
```

out of `ExecutionComplete`, on the job's failure path, for a trigger that had done nothing wrong.

**Parse-time cap rejected.** It would refuse a stored form `ToStoredString` had just written, breaking the round-trip the type documents, and it would refuse a whole policy over attempts no trigger will ever reach — most retries are superseded by the next scheduled occurrence long before the waits get large. **Clamping inside `DelayFor` rejected** too: the saturation is the honest arithmetic answer and is documented public behaviour.

So the decision is made where the wait becomes an instant, as the third of the reasons `TryScheduleRetry` already has for declining one: there is no room, so the occurrence settles and the trigger keeps its ordinary schedule. The supersede margin comes off the room available, so the comparison that uses it cannot overflow either. `RetryPolicy.DelayFor`'s remarks now record the decision where a reader of the type will find it.

## Tests

Each bounded option gets a startup-validation test asserting the message names the option and the ceiling, plus a boundary case at `MaxDelay` that must pass. The retry decision gets the boundary pair — the last instant a retry may land on, and one tick past it — and the realistic exponential policy above. All of them were confirmed to fail without the corresponding product change; the retry pair fails with exactly the `Parameter 't'` exception quoted above.

## Reviewer's call

- Bounding `TransientRetryInterval` and the lock handlers' `RetryPeriod` goes slightly past what the issue asked for. Both are configurable durations that end up in a `Task.Delay`, which is the sweep the issue described, but say if you would rather they landed separately.
- No public API signature moved, so the baselines and the migration guide are untouched.

## Verification

```
dotnet build Quartz.slnx             0 Warning(s), 0 Error(s)
dotnet test Quartz.Tests.Unit        Passed! Failed: 0, Passed: 4300
dotnet test Quartz.Tests.AspNetCore  Passed! Failed: 0, Passed: 548
dotnet fallout BenchmarkSmoke        Succeeded (284 benchmarks)
```

`Quartz.Tests.Integration` was not run: no Docker daemon is available in this environment.

Closes #3577
