### PR TITLE
A cancelled lock acquire throws, and false means only re-entry

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/lock-handler.md
+++ b/docs/documentation/quartz-4.x/how-tos/lock-handler.md
@@ -61,6 +61,23 @@ lock the outer one is still relying on.
 
 `ReleaseLock` from a non-owner should warn, not throw — that is what the shipped handlers do.
 
+### And `false` means nothing else
+
+The other half of that rule: **an acquire that did not take the lock throws.** `LockException` when the
+lock was refused, `OperationCanceledException` when the token fired.
+
+::: danger
+Answering `false` on cancellation is not a gentler way of saying "I got nothing". The store reads
+`false` as *already held, do not release*, so it goes on to run the operation with no lock and releases
+nothing on the way out. Do not lean on the store's ordering to save you either: a handler with
+`RequiresConnection = false` is followed immediately by a connection open on the same token, which would
+throw first — statement ordering, not a guarantee.
+:::
+
+A handler that gives up also leaves nothing behind: a wait abandoned partway must not consume a
+handover meant for the next waiter, and anything taken before the failure — a local gate in front of a
+remote lock, say — is released before the exception escapes.
+
 ## Deriving from DbLockHandler
 
 When the lock *is* a database row, `DbLockHandler` does the plumbing — ownership tracking, re-entry,
@@ -229,10 +246,13 @@ node.
 
 ## Testing one
 
-The re-entry rule and the retry behaviour are the two things worth a test, and neither needs a
-scheduler:
+The re-entry rule, the cancellation rule and the retry behaviour are the three things worth a test, and
+none of them needs a scheduler:
 
 - Call `AcquireLock` twice with the same `requestorId` and assert the second returns `false`.
+- Acquire with a token that has already fired, and assert an `OperationCanceledException` rather than a
+  `false`. Then acquire again from another `requestorId` and assert it is served, which is how a lock
+  left held by the abandoned attempt shows up.
 - Give the handler a `FakeTimeProvider` through `LockHandlerContext` and advance it to drive the retry
   loop without the test waiting.
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6228,6 +6228,37 @@ with the same advice rather than reported as a typo. The store hands the handler
 `quartz.jobStore.tablePrefix` value, so the lock rows follow the store's table prefix without separate
 configuration.
 
+## A cancelled acquire throws, and `false` means only re-entry
+
+`ILockHandler.AcquireLock` returns a release obligation rather than a report of success: `true` says
+this call took the lock and its caller has to give it back, `false` says the calling context already
+held it and must not. That was the rule in 3.x too, and the store still reads the answer that way — what
+was never written down is that **re-entry is the only thing `false` may mean**, so an acquire that did
+not take the lock throws: `LockException` when it was refused, `OperationCanceledException` when the
+token fired.
+
+`SimpleSemaphore.ObtainLock` and `RedisSemaphore.ObtainLock` swallowed the cancellation and answered
+`false`, which the store reads as *already held, do not release* — it would then run the guarded
+operation with no lock and release nothing on the way out. Their 4.0 counterparts throw. Nothing ran
+unlocked in a shipped configuration, because both answer `false` to `RequiresConnection` and the
+connection open immediately after observes the same token, but that is statement ordering rather than a
+guarantee, and a handler of your own inherits the hole silently.
+
+A custom handler that caught `OperationCanceledException` around its wait rethrows instead, and gives
+back anything it had taken before the exception escapes:
+
+```diff
+  try
+  {
+      await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+  }
+  catch (OperationCanceledException)
+  {
+-     return false;
++     throw;
+  }
+```
+
 ## A job store of your own can join your transaction
 
 `AdoJobStoreBase` is public and abstract, but everything needed to honour an enlisted transaction was
@@ -9556,6 +9587,7 @@ Parameters and behavior are unchanged:
 | `ISemaphore` is `ILockHandler`, and every implementation says `LockHandler` | A semaphore is a counted permit; this is a mutual-exclusion lock with one holder. `DBSemaphore` is `DbLockHandler`, `SimpleSemaphore` is the internal `InProcessLockHandler`, `RedisSemaphore` is `RedisLockHandler` — see [The semaphores are lock handlers](#the-semaphores-are-lock-handlers) |
 | `ISemaphore.ObtainLock` is `ILockHandler.AcquireLock` | `ReleaseLock` and `RequiresConnection` are unchanged; the verb pairs with the one that gives the lock back |
 | `SemaphoreContext` is `LockHandlerContext` | The record `Initialize` takes. Its members are unchanged |
+| `ILockHandler.AcquireLock` throws on cancellation instead of answering `false` | `false` means a re-entrant acquire and nothing else, so a cancelled acquire that answered it told the store the lock was already held. `SimpleSemaphore` and `RedisSemaphore` did; their 4.0 counterparts throw — see [A cancelled acquire throws, and `false` means only re-entry](#a-cancelled-acquire-throws-and-false-means-only-re-entry) |
 | `ILockHandler.Initialize(LockHandlerContext)` replaces `ITablePrefixAware` | Identity arrives through one initialization call instead of a property pair; the default implementation does nothing — see [A lock handler is told which scheduler it locks for](#a-lock-handler-is-told-which-scheduler-it-locks-for) |
 | `LockHandlerContext` also carries `TimeProvider` and `CommandTimeout` | The environment a handler locks in, beside the identity it locks under. `DbLockHandler` exposes the clock as a `protected TimeProvider` and both shipped row-lock handlers back off on it, so a retry is observable without waiting out the real second |
 | `LockHandlerContext.LoggerFactory` and `DriverDelegateContext.LoggerFactory` added | Where the handler and the delegate create their loggers, defaulting to `NullLoggerFactory.Instance`. The job store passes the factory its container gave it, so lock contention and statement failures reach an application that never called `LogProvider.SetLogProvider` — see [The ambient logger factory stays ambient](#the-ambient-logger-factory-stays-ambient) |

--- a/src/Quartz.Extensions.Redis/RedisLockHandler.cs
+++ b/src/Quartz.Extensions.Redis/RedisLockHandler.cs
@@ -184,12 +184,17 @@ public sealed class RedisLockHandler : ILockHandler
         }
         catch (OperationCanceledException)
         {
+            // Reported as itself rather than answered with false. False is the store's word for "you
+            // already hold this, do not release it", so a cancelled wait dressed up as false would send
+            // the caller on to run its guarded operation with no lock at all - see the contract on
+            // ILockHandler.AcquireLock. Nothing to undo here: a cancelled WaitAsync leaves the local
+            // gate for the next waiter, and no Redis key was ever written.
             if (isDebugEnabled)
             {
                 logger.LockNotObtainedCancelled(lockName, requestorId);
             }
 
-            return false;
+            throw;
         }
 
         try
@@ -221,6 +226,10 @@ public sealed class RedisLockHandler : ILockHandler
         }
         catch (OperationCanceledException)
         {
+            // The local gate is this handler's to give back before the exception escapes: it was taken
+            // above and no Redis key was written, so leaving it held would keep every other requestor in
+            // this process out of a lock nobody owns. The cancellation itself is reported as itself -
+            // false would tell the store the caller already held the lock and could proceed unlocked.
             lockHandle.Release();
 
             if (isDebugEnabled)
@@ -228,7 +237,7 @@ public sealed class RedisLockHandler : ILockHandler
                 logger.LockNotObtainedCancelled(lockName, requestorId);
             }
 
-            return false;
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Quartz.Tests.Integration/Redis/RedisLockHandlerTest.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisLockHandlerTest.cs
@@ -125,16 +125,24 @@ public class RedisLockHandlerTest
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
 
-        var second = await lockHandler.AcquireLock(
+        // The lock is held, so this request never completes on its own; the token is what ends it, and
+        // that end is reported as cancellation rather than as the false that means re-entry (#3583).
+        Func<Task> second = async () => await lockHandler.AcquireLock(
             requestor2, null, SchedulerLock.TriggerAccess, cts.Token);
 
-        Assert.That(second, Is.False);
+        await second.Should().ThrowAsync<OperationCanceledException>(
+            "false would tell the store requestor2 already held the lock, and it would go on to write "
+            + "trigger rows while requestor1 was still inside");
 
         await lockHandler.ReleaseLock(requestor1, SchedulerLock.TriggerAccess);
     }
 
+    /// <summary>
+    /// A waiter that gives up leaves the lock where it was and takes nothing with it, so the requestor
+    /// that waits properly is still served.
+    /// </summary>
     [Test]
-    public async Task AcquireLock_Cancelled_ShouldReturnFalse()
+    public async Task AcquireLock_Cancelled_ShouldLeaveTheLockWithItsOwner()
     {
         var requestor1 = Guid.NewGuid();
         var requestor2 = Guid.NewGuid();
@@ -145,15 +153,21 @@ public class RedisLockHandlerTest
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
 
-            var result = await lockHandler.AcquireLock(
+            Func<Task> cancelled = async () => await lockHandler.AcquireLock(
                 requestor2, null, SchedulerLock.TriggerAccess, cts.Token);
 
-            Assert.That(result, Is.False);
+            await cancelled.Should().ThrowAsync<OperationCanceledException>();
         }
         finally
         {
             await lockHandler.ReleaseLock(requestor1, SchedulerLock.TriggerAccess);
         }
+
+        (await lockHandler.AcquireLock(requestor2, null, SchedulerLock.TriggerAccess)).Should().BeTrue(
+            "the abandoned waiter released nothing and kept nothing, so the lock is free once its owner "
+            + "gives it back");
+
+        await lockHandler.ReleaseLock(requestor2, SchedulerLock.TriggerAccess);
     }
 
     [Test]
@@ -268,9 +282,13 @@ public class RedisLockHandlerTest
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(500));
 
-        var second = await lockHandler2.AcquireLock(
+        // The second handler has a local gate of its own, so this request gets past it and is cancelled
+        // inside the SET NX poll loop - the one cancellation path that needs a live server to reach. It
+        // is reported as cancellation, and the gate it had taken is given back before the exception
+        // escapes, which is what the third acquire below proves (#3583).
+        Func<Task> second = async () => await lockHandler2.AcquireLock(
             requestor2, null, SchedulerLock.TriggerAccess, cts.Token);
-        Assert.That(second, Is.False);
+        await second.Should().ThrowAsync<OperationCanceledException>();
 
         await lockHandler.ReleaseLock(requestor1, SchedulerLock.TriggerAccess);
 

--- a/src/Quartz.Tests.Unit/Extensions/Redis/RedisLockHandlerCancellationTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/Redis/RedisLockHandlerCancellationTest.cs
@@ -1,0 +1,123 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Quartz.Extensions.Redis;
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Extensions.Redis;
+
+/// <summary>
+/// What <see cref="RedisLockHandler" /> answers when an acquire does not end in a lock, which is the
+/// half of its behaviour that needs no Redis server: the local gate it takes before the round-trip is a
+/// <see cref="SemaphoreSlim" /> in this process, and the round-trip itself can be made to fail by
+/// pointing the handler at nothing.
+/// </summary>
+/// <remarks>
+/// It answered <see langword="false" /> to a cancelled acquire, which is the store's word for a
+/// re-entrant one — "you already hold this, do not release it" — so the caller would have gone on to run
+/// the operation the lock exists to guard with nothing holding it, and would have released nothing on
+/// the way out. #3583. The paths that need a live server — cancellation while the <c>SET NX</c> loop is
+/// polling — are covered by <c>Quartz.Tests.Integration</c>.
+/// </remarks>
+public sealed class RedisLockHandlerCancellationTest
+{
+    /// <summary>
+    /// An endpoint nothing listens on, so the Redis round-trip fails rather than succeeding or hanging.
+    /// Port 1 is refused immediately; the timeout is a backstop for a host that drops instead.
+    /// </summary>
+    private const string UnreachableRedis = "127.0.0.1:1,connectTimeout=1000,connectRetry=1,abortConnect=true";
+
+    /// <summary>
+    /// How long an acquire may take before the test gives up. Not a timing assertion — it decides
+    /// whether a handler that never answers is reported as a failure or hangs the run.
+    /// </summary>
+    private static readonly TimeSpan GiveUpAfter = TimeSpan.FromSeconds(30);
+
+    private static RedisLockHandler Handler() => new()
+    {
+        RedisConfiguration = UnreachableRedis,
+        KeyPrefix = "quartz:unit:lock:",
+    };
+
+    [Test]
+    public async Task ACancelledAcquireReportsTheCancellationRatherThanAnsweringFalse()
+    {
+        RedisLockHandler lockHandler = Handler();
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Task<bool> cancelled = lockHandler.AcquireLock(Guid.NewGuid(), null, SchedulerLock.TriggerAccess, cancellation.Token).AsTask();
+
+        Func<Task> act = () => cancelled.WaitAsync(GiveUpAfter);
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "false says the calling context already holds the lock, so a caller told that would run its "
+            + "guarded operation unlocked");
+
+        cancelled.IsCanceled.Should().BeTrue(
+            "the caller asked to stop, so this is a cancelled task rather than a faulted one — a caller "
+            + "matching on cancellation has to be able to tell it from Redis being unreachable");
+    }
+
+    /// <summary>
+    /// The cancelled attempt never reached Redis, so it holds no part of the lock — including the local
+    /// gate that every requestor in this process queues on. That the next requestor gets as far as Redis
+    /// at all is the assertion: a leaked gate would leave it waiting forever instead.
+    /// </summary>
+    [Test]
+    public async Task ACancelledAcquireLeavesTheLocalGateForTheNextRequestor()
+    {
+        RedisLockHandler lockHandler = Handler();
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> cancelled = async () => await lockHandler.AcquireLock(Guid.NewGuid(), null, SchedulerLock.TriggerAccess, cancellation.Token);
+        await cancelled.Should().ThrowAsync<OperationCanceledException>();
+
+        Func<Task> next = () => lockHandler.AcquireLock(Guid.NewGuid(), null, SchedulerLock.TriggerAccess).AsTask().WaitAsync(GiveUpAfter);
+
+        await next.Should().ThrowAsync<LockException>(
+            "reaching Redis and failing there is the proof that the gate was free; had the cancelled "
+            + "acquire kept it, this request would still be queued behind a lock nobody owns");
+    }
+
+    /// <summary>
+    /// The same of an acquire that fails at Redis instead of being cancelled: the gate is given back
+    /// before the <see cref="LockException" /> escapes, so one unreachable moment does not shut every
+    /// requestor in the process out permanently.
+    /// </summary>
+    [Test]
+    public async Task AnAcquireThatFailsAtRedisGivesTheLocalGateBack()
+    {
+        RedisLockHandler lockHandler = Handler();
+
+        Func<Task> first = () => lockHandler.AcquireLock(Guid.NewGuid(), null, SchedulerLock.TriggerAccess).AsTask().WaitAsync(GiveUpAfter);
+        await first.Should().ThrowAsync<LockException>();
+
+        Func<Task> second = () => lockHandler.AcquireLock(Guid.NewGuid(), null, SchedulerLock.TriggerAccess).AsTask().WaitAsync(GiveUpAfter);
+        await second.Should().ThrowAsync<LockException>(
+            "the failed acquire released the gate it had taken, so the next one is answered rather than "
+            + "queued behind it");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerCancellationSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerCancellationSqliteTest.cs
@@ -1,0 +1,197 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The two shipped row-lock handlers under a cancelled acquire, against a real database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>DbLockHandlerRetryTest</c> pins the exception their retry loops end in, over a provider whose
+/// every statement fails. What it cannot show is the other half of the contract on
+/// <see cref="ILockHandler.AcquireLock" />: that the abandoned attempt recorded no ownership. That
+/// matters because <see cref="DbLockHandler" /> answers <see langword="false" /> to a requestor it
+/// already lists as an owner — the store's word for "you already hold this, do not release it" — so a
+/// failed attempt that left a mark behind would make the requestor's next acquire look re-entrant, and
+/// the operation it guards would run with no lock and never give one back. #3583.
+/// </para>
+/// <para>
+/// SQLite is a file, so both statements run for real here rather than only in the container legs. The
+/// row lock itself is the transaction's rather than the handler's, and these handlers are given a
+/// holder with no transaction; what is under test is the base class's bookkeeping, which is the same
+/// whichever database is underneath.
+/// </para>
+/// </remarks>
+public sealed class DbLockHandlerCancellationSqliteTest
+{
+    private const string SchedulerName = "row-locks";
+
+    /// <summary>
+    /// The stock <c>SELECT … FOR UPDATE</c> is not SQLite syntax, and the constructor that takes the
+    /// statement is the supported way to give a dialect its own. The lock it takes is weaker here, which
+    /// costs this test nothing: the bookkeeping under test happens after the statement has run.
+    /// </summary>
+    private const string SelectWithoutForUpdate =
+        "SELECT * FROM {0}LOCKS WHERE SCHED_NAME = @schedulerName AND LOCK_NAME = @lockName";
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-row-lock-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    private static IEnumerable<TestCaseData> RowLockHandlers()
+    {
+        yield return new TestCaseData(new Func<IDbProvider, DbLockHandler>(
+            provider => new UpdateRowLockHandler(provider))) { TestName = "{m}(UpdateRowLockHandler)" };
+
+        yield return new TestCaseData(new Func<IDbProvider, DbLockHandler>(
+            provider => new SelectForUpdateLockHandler(
+                AdoConstants.DefaultTablePrefix,
+                SchedulerName,
+                SelectWithoutForUpdate,
+                provider))) { TestName = "{m}(SelectForUpdateLockHandler)" };
+    }
+
+    /// <summary>
+    /// The caller asked to stop, so that is what comes back — not a <see cref="LockException" />, which
+    /// would say the database refused the lock, and not <see langword="false" />, which would say the
+    /// caller already had it.
+    /// </summary>
+    [TestCaseSource(nameof(RowLockHandlers))]
+    public async Task ACancelledAcquireReportsTheCancellation(Func<IDbProvider, DbLockHandler> create)
+    {
+        await ProvisionSchema();
+
+        DbLockHandler lockHandler = Initialize(create);
+
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+        using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> act = async () => await lockHandler.AcquireLock(Guid.NewGuid(), holder, SchedulerLock.TriggerAccess, cancellation.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "cancellation is the caller stopping rather than the lock being refused, and false is the "
+            + "store's word for a re-entrant acquire");
+    }
+
+    /// <summary>
+    /// And the requestor whose acquire was cancelled is not left recorded as an owner: its next acquire
+    /// is a fresh one, answered <see langword="true" />, so the caller knows it has to release.
+    /// </summary>
+    [TestCaseSource(nameof(RowLockHandlers))]
+    public async Task ACancelledAcquireLeavesNoOwnershipBehind(Func<IDbProvider, DbLockHandler> create)
+    {
+        await ProvisionSchema();
+
+        DbLockHandler lockHandler = Initialize(create);
+
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+        using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
+
+        Guid requestorId = Guid.NewGuid();
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> cancelled = async () => await lockHandler.AcquireLock(requestorId, holder, SchedulerLock.TriggerAccess, cancellation.Token);
+        await cancelled.Should().ThrowAsync<OperationCanceledException>();
+
+        bool obtained = await lockHandler.AcquireLock(requestorId, holder, SchedulerLock.TriggerAccess);
+
+        obtained.Should().BeTrue(
+            "the attempt that was cancelled took nothing, so this one takes the lock; had the handler "
+            + "recorded the requestor as an owner on its way out, this would come back false and the "
+            + "caller would run its operation unlocked and never release anything");
+    }
+
+    private DbLockHandler Initialize(Func<IDbProvider, DbLockHandler> create)
+    {
+        DbMetadata metadata = DbMetadataResolver.BuiltIn().ResolveWithoutTypes("SQLite-Microsoft");
+        ProviderFactoryDbProvider provider = new(metadata, SqliteFactory.Instance, connectionString);
+
+        DbLockHandler lockHandler = create(provider);
+        lockHandler.Initialize(new LockHandlerContext
+        {
+            SchedulerName = SchedulerName,
+            InstanceId = "node-1",
+            TablePrefix = AdoConstants.DefaultTablePrefix,
+        });
+
+        return lockHandler;
+    }
+
+    /// <summary>
+    /// Creates the tables the way an application would, so the lock table this test writes to is the
+    /// shipped one rather than one the test invented.
+    /// </summary>
+    private async Task ProvisionSchema()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "row-lock-schema";
+                options.InstanceId = "provisioning";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+        });
+
+        await using ServiceProvider container = services.BuildServiceProvider();
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        await scheduler.Shutdown();
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/InProcessLockHandlerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/InProcessLockHandlerTest.cs
@@ -157,13 +157,18 @@ public class InProcessLockHandlerTest
     }
 
     /// <summary>
-    /// A waiter whose token is cancelled while it is queued. It reports that it took nothing rather than
-    /// throwing, which is what lets the store's <c>finally</c> release only what it actually holds — and
-    /// it must leave the queue without consuming the handover, or the lock would be lost to a caller
-    /// that has already given up.
+    /// A waiter whose token is cancelled while it is queued. It reports the cancellation, and it must
+    /// leave the queue without consuming the handover, or the lock would be lost to a caller that has
+    /// already given up.
     /// </summary>
+    /// <remarks>
+    /// It used to answer <see langword="false" />, which reads as "I took nothing" but is not what
+    /// <see langword="false" /> means to the store: the store's word for that is a re-entrant acquire —
+    /// "you already hold this, do not release it" — and a caller told that goes on to run its guarded
+    /// operation with no lock at all. #3583.
+    /// </remarks>
     [Test]
-    public async Task AWaiterCancelledWhileQueuedTakesNothingAndLeavesTheLockWhereItWas()
+    public async Task AWaiterCancelledWhileQueuedReportsTheCancellationAndLeavesTheLockWhereItWas()
     {
         InProcessLockHandler lockHandler = new();
         Guid holder = Guid.NewGuid();
@@ -178,9 +183,16 @@ public class InProcessLockHandlerTest
 
         await cancellation.CancelAsync();
 
-        (await abandoned.WaitAsync(GiveUpAfter)).Should().BeFalse(
-            "a cancelled wait answers 'I do not hold this' rather than throwing, so the caller's cleanup "
-            + "does not go on to release a lock it never took");
+        // Deadlined rather than awaited bare, so a handler that swallowed the cancellation and went back
+        // to waiting fails this test instead of hanging the run.
+        Func<Task> awaitAbandoned = () => abandoned.WaitAsync(GiveUpAfter);
+        await awaitAbandoned.Should().ThrowAsync<OperationCanceledException>(
+            "answering false would tell the store the caller already held the lock, and the guarded "
+            + "operation would then run with nothing holding it");
+
+        abandoned.IsCanceled.Should().BeTrue(
+            "the caller asked to stop, so this is a cancelled task rather than a faulted one — which is "
+            + "what lets a caller matching on cancellation tell it from the store falling over");
 
         Task<bool> queued = lockHandler.AcquireLock(patient, conn: null, SchedulerLock.TriggerAccess).AsTask();
         queued.IsCompleted.Should().BeFalse("the lock is still the holder's, cancellation notwithstanding");
@@ -191,6 +203,31 @@ public class InProcessLockHandlerTest
             "the abandoned waiter left the queue without consuming the handover; had it taken the lock on "
             + "its way out, this release would have gone to a caller that no longer exists and the store "
             + "would be stuck");
+    }
+
+    /// <summary>
+    /// The same rule when the token has already fired before the call: still an exception, and still no
+    /// mark on the lock — the requestor that gave up is not recorded as an owner, so nothing has to be
+    /// released on its behalf and the next caller is served immediately.
+    /// </summary>
+    [Test]
+    public async Task AnAcquireWhoseTokenHasAlreadyFiredTakesNothingAtAll()
+    {
+        InProcessLockHandler lockHandler = new();
+        Guid abandoning = Guid.NewGuid();
+        Guid next = Guid.NewGuid();
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> act = async () => await lockHandler.AcquireLock(abandoning, conn: null, SchedulerLock.TriggerAccess, cancellation.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        Task<bool> unclaimed = lockHandler.AcquireLock(next, conn: null, SchedulerLock.TriggerAccess).AsTask();
+
+        unclaimed.IsCompleted.Should().BeTrue(
+            "the cancelled call never took the lock, so there is nothing for this one to queue behind");
+        (await unclaimed).Should().BeTrue();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqliteLockHandlerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqliteLockHandlerTest.cs
@@ -4,6 +4,12 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 
 public class SqliteLockHandlerTest
 {
+    /// <summary>
+    /// How long an awaited handover may take before the test gives up. Not a timing assertion — it only
+    /// decides whether a handler that never answers is reported as a failure or hangs the run.
+    /// </summary>
+    private static readonly TimeSpan GiveUpAfter = TimeSpan.FromSeconds(30);
+
     private SqliteLockHandler lockHandler = null!;
 
     [SetUp]
@@ -40,9 +46,8 @@ public class SqliteLockHandlerTest
         obtained.Should().BeTrue();
 
         // Second requestor tries STATE_ACCESS — should block because it's the same global lock
-        using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
-        bool obtained2 = await lockHandler.AcquireLock(requestor2, null, SchedulerLock.StateAccess, cts.Token);
-        obtained2.Should().BeFalse("the global lock is held by another requestor");
+        await ShouldQueueBehindTheGate(requestor2, SchedulerLock.StateAccess,
+            "the global lock is held by another requestor");
 
         await lockHandler.ReleaseLock(requestor1, SchedulerLock.TriggerAccess);
     }
@@ -56,10 +61,9 @@ public class SqliteLockHandlerTest
         bool obtained1 = await lockHandler.AcquireLock(requestor1, null, SchedulerLock.TriggerAccess);
         obtained1.Should().BeTrue();
 
-        // Second requestor should block and fail to acquire
-        using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
-        bool blocked = await lockHandler.AcquireLock(requestor2, null, SchedulerLock.TriggerAccess, cts.Token);
-        blocked.Should().BeFalse("the lock is held by another requestor");
+        // Second requestor should block and never be granted the lock
+        await ShouldQueueBehindTheGate(requestor2, SchedulerLock.TriggerAccess,
+            "the lock is held by another requestor");
 
         // Release first, then second should succeed
         await lockHandler.ReleaseLock(requestor1, SchedulerLock.TriggerAccess);
@@ -87,9 +91,8 @@ public class SqliteLockHandlerTest
 
         // Another requestor should still be blocked
         Guid otherRequestor = Guid.NewGuid();
-        using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
-        bool blocked = await lockHandler.AcquireLock(otherRequestor, null, SchedulerLock.TriggerAccess, cts.Token);
-        blocked.Should().BeFalse("the lock is still held after partial release");
+        await ShouldQueueBehindTheGate(otherRequestor, SchedulerLock.TriggerAccess,
+            "the lock is still held after partial release");
 
         // Release the remaining lock — the lock should now be free
         await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
@@ -116,9 +119,8 @@ public class SqliteLockHandlerTest
         await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
 
         Guid otherRequestor = Guid.NewGuid();
-        using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
-        bool blocked = await lockHandler.AcquireLock(otherRequestor, null, SchedulerLock.TriggerAccess, cts.Token);
-        blocked.Should().BeFalse("the lock is still held after one of two releases");
+        await ShouldQueueBehindTheGate(otherRequestor, SchedulerLock.TriggerAccess,
+            "the lock is still held after one of two releases");
 
         // Release second time — the lock should now be free
         await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
@@ -145,15 +147,99 @@ public class SqliteLockHandlerTest
         await lockHandler.ReleaseLock(requestorId, SchedulerLock.TriggerAccess);
     }
 
+    /// <summary>
+    /// A cancelled acquire reports the cancellation. It used to answer <see langword="false" />, which
+    /// the job store reads as "this context already holds the lock, do not release it" — so the caller
+    /// would have gone on to run the operation the lock exists to guard with nothing holding it. #3583.
+    /// </summary>
     [Test]
-    public async Task AcquireLock_Cancelled_ShouldReturnFalse()
+    public async Task AcquireLock_Cancelled_ShouldThrowRatherThanAnswerFalse()
     {
         Guid requestorId = Guid.NewGuid();
 
-        using CancellationTokenSource cts = new();
-        cts.Cancel();
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
 
-        bool obtained = await lockHandler.AcquireLock(requestorId, null, SchedulerLock.TriggerAccess, cts.Token);
-        obtained.Should().BeFalse();
+        Task<bool> cancelled = lockHandler.AcquireLock(requestorId, null, SchedulerLock.TriggerAccess, cancellation.Token).AsTask();
+
+        Func<Task> act = () => cancelled;
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "false is reserved for a re-entrant acquire, and a caller told that runs unlocked");
+
+        cancelled.IsCanceled.Should().BeTrue(
+            "the caller asked to stop, so this is a cancelled task rather than a faulted one");
+    }
+
+    /// <summary>
+    /// And it leaves the gate as it found it, whether it was free or held: a cancelled wait takes no
+    /// hold and consumes no handover, so the next requestor is served exactly as it would have been.
+    /// </summary>
+    [Test]
+    public async Task AcquireLock_Cancelled_ShouldLeaveTheGateFreeForTheNextRequestor()
+    {
+        Guid abandoning = Guid.NewGuid();
+        Guid next = Guid.NewGuid();
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> act = async () => await lockHandler.AcquireLock(abandoning, null, SchedulerLock.TriggerAccess, cancellation.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+
+        Task<bool> unclaimed = lockHandler.AcquireLock(next, null, SchedulerLock.TriggerAccess).AsTask();
+
+        unclaimed.IsCompleted.Should().BeTrue(
+            "the cancelled call took no hold on the gate, so there is nothing for this one to queue behind");
+        (await unclaimed).Should().BeTrue();
+
+        await lockHandler.ReleaseLock(next, SchedulerLock.TriggerAccess);
+    }
+
+    /// <summary>
+    /// And when the gate was held, a waiter that gives up leaves it with its owner rather than stealing
+    /// the handover on its way out.
+    /// </summary>
+    [Test]
+    public async Task AcquireLock_CancelledWhileQueued_ShouldLeaveTheGateWithItsOwner()
+    {
+        Guid owner = Guid.NewGuid();
+        Guid abandoning = Guid.NewGuid();
+        Guid patient = Guid.NewGuid();
+
+        (await lockHandler.AcquireLock(owner, null, SchedulerLock.TriggerAccess)).Should().BeTrue();
+
+        await ShouldQueueBehindTheGate(abandoning, SchedulerLock.TriggerAccess, "the gate is the owner's");
+
+        Task<bool> queued = lockHandler.AcquireLock(patient, null, SchedulerLock.TriggerAccess).AsTask();
+        queued.IsCompleted.Should().BeFalse("the gate is still the owner's, cancellation notwithstanding");
+
+        await lockHandler.ReleaseLock(owner, SchedulerLock.TriggerAccess);
+
+        (await queued.WaitAsync(GiveUpAfter)).Should().BeTrue(
+            "the abandoned waiter left without consuming the handover; had it taken the gate on its way "
+            + "out, this release would have gone to a caller that no longer exists");
+
+        await lockHandler.ReleaseLock(patient, SchedulerLock.TriggerAccess);
+    }
+
+    /// <summary>
+    /// Waits for the gate on <paramref name="requestorId" />'s behalf, and asserts the wait never
+    /// completes: it is still queued when the test cancels it, and the cancellation is what ends it.
+    /// </summary>
+    /// <remarks>
+    /// The handler's answer is never <see langword="false" />, so "blocked" cannot be asserted by
+    /// reading a return value — it is asserted by the request still being outstanding.
+    /// </remarks>
+    private async Task ShouldQueueBehindTheGate(Guid requestorId, SchedulerLock lockKind, string because)
+    {
+        using CancellationTokenSource cancellation = new();
+
+        Task<bool> queued = lockHandler.AcquireLock(requestorId, null, lockKind, cancellation.Token).AsTask();
+        queued.IsCompleted.Should().BeFalse(because);
+
+        await cancellation.CancelAsync();
+
+        Func<Task> act = () => queued.WaitAsync(GiveUpAfter);
+        await act.Should().ThrowAsync<OperationCanceledException>();
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/DbLockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/DbLockHandler.cs
@@ -120,11 +120,13 @@ public abstract class DbLockHandler : ILockHandler
         string expandedInsertSql,
         CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Grants a lock on the identified resource to the calling thread (blocking
-    /// until it is available).
-    /// </summary>
-    /// <returns>true if the lock was obtained.</returns>
+    /// <inheritdoc />
+    /// <remarks>
+    /// Ownership is recorded only once <see cref="ExecuteSql" /> has returned, so a statement that
+    /// fails — including one the caller cancelled — leaves this handler holding nothing and the next
+    /// acquire by the same requestor is a fresh one rather than a re-entrant one. The row lock itself
+    /// belongs to <paramref name="conn" />'s transaction and is given back when that transaction ends.
+    /// </remarks>
     public async ValueTask<bool> AcquireLock(
         Guid requestorId,
         ConnectionAndTransactionHolder? conn,

--- a/src/Quartz/Impl/AdoJobStore/ILockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/ILockHandler.cs
@@ -37,11 +37,60 @@ public interface ILockHandler
     }
 
     /// <summary>
-    /// Grants a lock on the identified resource to the calling thread (blocking
-    /// until it is available).
+    /// Grants a lock on the identified resource to the calling context, waiting until it is
+    /// available.
     /// </summary>
-    /// <returns> true if the lock was obtained.
+    /// <remarks>
+    /// <para>
+    /// The answer is a release obligation rather than a report of success. <see langword="true" />
+    /// says this call took the lock and its caller is the one that has to give it back;
+    /// <see langword="false" /> says <paramref name="requestorId" /> already held it — a re-entrant
+    /// acquire — so the outer caller's single release is what frees it, and releasing here would
+    /// drop a lock that operation is still relying on. A handler that instead counts its holds may
+    /// answer <see langword="true" /> to a re-entrant acquire, because there the inner release is
+    /// the one that decrements; either way the caller releases exactly when it was told
+    /// <see langword="true" />.
+    /// </para>
+    /// <para>
+    /// <b>Re-entry is the only thing <see langword="false" /> may mean.</b> A handler that could not
+    /// take the lock says so by throwing: <see cref="LockException" /> when the lock was refused,
+    /// and <see cref="OperationCanceledException" /> when
+    /// <paramref name="cancellationToken" /> fired. Answering <see langword="false" /> on
+    /// cancellation is not a harmless approximation — the job store reads it as "already held, do
+    /// not release" and goes on to run the guarded operation with no lock at all, which is the whole
+    /// point of taking one.
+    /// </para>
+    /// <para>
+    /// The store's own ordering must not be relied on to cover for a handler that gets this wrong. A
+    /// handler answering <see langword="false" /> to <see cref="RequiresConnection" /> is followed
+    /// immediately by a connection open on the same token, so a mistake here is masked today by that
+    /// open throwing first. That is an accident of statement order rather than a guarantee, and it
+    /// does not hold wherever the store reaches the lock in a different sequence.
+    /// </para>
+    /// <para>
+    /// A handler that gives up leaves nothing behind: an abandoned wait must not consume a handover
+    /// meant for the next waiter, and a partially taken lock is released before the exception
+    /// escapes, so that the next caller can still be served.
+    /// </para>
+    /// </remarks>
+    /// <param name="requestorId">
+    /// Identifies the calling context, so that a re-entrant acquire can be told from a competing one.
+    /// </param>
+    /// <param name="conn">
+    /// The unit of work to take the lock on. It is <see langword="null" /> when the store has not
+    /// opened a connection yet, which it delays for a handler whose <see cref="RequiresConnection" />
+    /// is <see langword="false" />.
+    /// </param>
+    /// <param name="lockKind">Which of the two locks to take.</param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>
+    /// <see langword="true" /> if this call took the lock and its caller must release it;
+    /// <see langword="false" /> if <paramref name="requestorId" /> already held it and must not.
     /// </returns>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken" /> fired before the lock was taken.
+    /// </exception>
+    /// <exception cref="LockException">The lock could not be obtained.</exception>
     ValueTask<bool> AcquireLock(
         Guid requestorId,
         ConnectionAndTransactionHolder? conn,

--- a/src/Quartz/Impl/AdoJobStore/InProcessLockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/InProcessLockHandler.cs
@@ -51,11 +51,13 @@ internal sealed class InProcessLockHandler : ILockHandler
         logger = context.LoggerFactory.CreateLogger<InProcessLockHandler>();
     }
 
-    /// <summary>
-    /// Grants a lock on the identified resource to the calling thread (blocking
-    /// until it is available).
-    /// </summary>
-    /// <returns>True if the lock was obtained.</returns>
+    /// <inheritdoc />
+    /// <remarks>
+    /// A waiter abandoned by its token leaves the queue without consuming the handover, because
+    /// <see cref="SemaphoreSlim.WaitAsync(CancellationToken)" /> does not take the count it was
+    /// cancelled out of. The lock therefore stays with whoever holds it and is handed to the next
+    /// waiter on release.
+    /// </remarks>
     public async ValueTask<bool> AcquireLock(
         Guid requestorId,
         ConnectionAndTransactionHolder? conn,
@@ -82,15 +84,22 @@ internal sealed class InProcessLockHandler : ILockHandler
             try
             {
                 await lockHandle.Acquire(requestorId, cancellationToken).ConfigureAwait(false);
-                gotLock = true;
             }
             catch (OperationCanceledException)
             {
+                // Reported as itself rather than answered with false. False is the store's word for
+                // "you already hold this, do not release it", so a cancelled wait dressed up as false
+                // would send the caller on to run its guarded operation with no lock at all - see the
+                // contract on ILockHandler.AcquireLock.
                 if (isDebugEnabled)
                 {
                     logger.LockNotObtained(lockName, requestorId);
                 }
+
+                throw;
             }
+
+            gotLock = true;
 
             if (isDebugEnabled)
             {

--- a/src/Quartz/Impl/AdoJobStore/SqliteLockHandler.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqliteLockHandler.cs
@@ -70,11 +70,13 @@ internal sealed class SqliteLockHandler : ILockHandler
         logger = context.LoggerFactory.CreateLogger<SqliteLockHandler>();
     }
 
-    /// <summary>
-    /// Grants a lock on the identified resource to the calling thread (blocking
-    /// until it is available).
-    /// </summary>
-    /// <returns>True if the lock was obtained.</returns>
+    /// <inheritdoc />
+    /// <remarks>
+    /// This is the counted variant the contract allows: a re-entrant acquire is answered
+    /// <see langword="true" /> and bumps a hold count, so every acquire is matched by a release and
+    /// only the last one opens the gate. <see langword="false" /> is therefore never returned at all
+    /// — a wait this handler cannot complete ends in an exception.
+    /// </remarks>
     public ValueTask<bool> AcquireLock(
         Guid requestorId,
         ConnectionAndTransactionHolder? conn,
@@ -124,12 +126,17 @@ internal sealed class SqliteLockHandler : ILockHandler
         }
         catch (OperationCanceledException)
         {
+            // Reported as itself rather than answered with false. False is the store's word for "you
+            // already hold this, do not release it", so a cancelled wait dressed up as false would send
+            // the caller on to run its guarded operation with no lock at all - see the contract on
+            // ILockHandler.AcquireLock. The gate itself is untouched: a cancelled WaitAsync does not
+            // take the count it was cancelled out of, so currentOwner and lockCount stay as they were.
             if (isDebugEnabled)
             {
                 logger.LockNotObtained(lockName, requestorId);
             }
 
-            return false;
+            throw;
         }
 
         lock (syncRoot)


### PR DESCRIPTION
Closes #3583

## The hole

`ILockHandler.AcquireLock` returns a *release obligation*, not a report of success, and the job store
reads it that way: `true` means "you took the lock, give it back", `false` means "you already held it,
do not release it". Nothing said so, and three shipped handlers took advantage of the gap — they
swallowed an `OperationCanceledException` and answered `false`:

- `InProcessLockHandler.AcquireLock`
- `SqliteLockHandler.AcquireLockCore`
- `RedisLockHandler.AcquireLock`, in **two** places: the local gate, and the `SET NX` poll loop (the
  issue named two offenders; the audit it asked for found the third)

Taken literally, a caller told `false` runs the operation the lock exists to guard with nothing holding
it, and releases nothing on the way out. Nothing does that in a shipped configuration, because all
three answer `false` to `RequiresConnection` and the connection open on the very next statement
observes the same token — but that is statement ordering, not a guarantee, and an `ILockHandler`
written elsewhere inherits the hole silently. This PR does not rely on the ordering.

## What changed

**The contract, on the interface.** `ILockHandler.AcquireLock`'s XML docs now say what the `bool`
means: `true` is an obligation to release, `false` is re-entry *and nothing else*, a refused lock is a
`LockException`, a cancelled one is an `OperationCanceledException`, and a handler that gives up leaves
neither a consumed handover nor a partially taken lock behind. The ordering accident is called out
there as the thing not to lean on. No signature changed, so the public-API baselines do not move.

**The three offenders throw.** The Redis handler keeps releasing its local gate on the way out, so a
cancelled acquire does not lock every other requestor in the process out of a lock nobody owns.

**The audit.** Five shipped handler families, seven concrete types:

| Handler | Before | Now |
|---|---|---|
| `InProcessLockHandler` | returned `false` on cancellation | throws; the `SemaphoreSlim` wait takes no count it was cancelled out of, so nothing leaks |
| `SqliteLockHandler` | returned `false` on cancellation | throws; `currentOwner`/`lockCount` untouched |
| `RedisLockHandler` | returned `false` twice | throws twice; the local gate is released before the exception escapes |
| `SelectForUpdateLockHandler` (+ `PostgreSqlSelectForUpdateLockHandler`) | already correct | unchanged; regression tests added |
| `UpdateRowLockHandler` (+ `SqlServerMemoryOptimizedUpdateRowLockHandler`) | already correct | unchanged; regression tests added |

The two row-lock families record ownership only *after* `ExecuteSql` returns, so a cancelled statement
leaves no mark that would make the requestor's next acquire look re-entrant. That was true already and
untested; it is tested now.

## Tests, and which leg they land in

Per the brief, coverage is pushed into the unit leg wherever the handler can be reached without its
engine:

- **`InProcessLockHandlerTest`** — a queued waiter cancelled mid-wait throws, the task is `Canceled`
  rather than faulted (#3581's classification), the lock stays with its holder and the next waiter is
  still served. Plus a token that has already fired: throws, and takes no hold at all.
- **`SqliteLockHandlerTest`** — the same two facts. The three existing "blocked" assertions read a
  `false` that no longer exists, so they now assert the request is still *outstanding* and the
  cancellation is what ends it. That also takes the 200 ms wall-clock sleeps out of the fixture.
- **`DbLockHandlerCancellationSqliteTest`** (new) — both row-lock handlers against a real file SQLite
  database provisioned with `ProvisionSchema()`: a cancelled acquire throws, and the same requestor's
  next acquire is answered `true` rather than `false`.
- **`RedisLockHandlerCancellationTest`** (new, unit) — the Redis handler's local-gate cancellation path
  and its failure path, with the handler pointed at an endpoint nothing listens on. No server needed;
  ~50 ms.
- **`Quartz.Tests.Integration/Redis/RedisLockHandlerTest`** — the one path that genuinely needs a live
  server: a cancellation *inside* the `SET NX` poll loop, which is only reachable once a second handler
  instance has got past its own local gate. Three existing tests asserted the old `false`.

Verified the tests fail without the product change: 11 of them do.

## Docs

- `how-tos/lock-handler.md` gains "And `false` means nothing else" beside the existing re-entry rule,
  and a third bullet in "Testing one".
- `migration-guide.md` gains a section and an appendix row — 3.x's `SimpleSemaphore.ObtainLock` and
  `RedisSemaphore.ObtainLock` have the same shape (checked against `origin/3.x`), so anyone porting a
  custom `ISemaphore` needs to know.
- `quartz-3.x/` untouched.

## For a reviewer to decide

**Should the store also refuse a `false` it was handed with a cancelled token?** A contract in XML docs
does not stop the next third-party handler from repeating this. A one-line guard at each of the seven
`LockHandler.AcquireLock` call sites — or a wrapper — would. I left it out: the issue framed the fix as
contractual, the guard touches hot paths in `AdoJobStoreBase`, and another stream owns ADO surface
reshaping. Say the word and it is a small follow-up.

**`SqliteLockHandler` answers `true` to a re-entrant acquire**, unlike the other four, because it counts
its holds and expects a matching release. That is consistent with the obligation framing and is left
alone; the interface docs now name the counted variant explicitly rather than pretending every handler
returns `false` there.

## Verification

```
dotnet build Quartz.slnx                     Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit            Passed! Failed: 0, Passed: 4291, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore      Passed! Failed: 0, Passed:  548, Skipped: 0
dotnet test src/Quartz.Tests.Integration --filter RedisLockHandlerTest
                                             Passed! Failed: 0, Passed:   12, Skipped: 0  (real Redis container)
dotnet fallout VerifyDocsSnippets            Documentation snippets are up to date (102 markdown files checked)
dotnet run --project src/Quartz.Benchmark -c Release -- --smoke     exit 0, 284 benchmarks
```

The public-API Verify baselines did not move, as expected for an XML-docs-only interface change.