### PR TITLE
Both serializers write a string dictionary the same way

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -374,6 +374,9 @@ here moved for you; if you called `GetInt` and `GetBoolean`, all of it did.
 * **Both serializers refuse a job data value they cannot read back**, at write time rather than at the next
   read, and both refuse the same set — see
   [Both serializers refuse a job data value they cannot read back](#both-serializers-refuse-a-job-data-value-they-cannot-read-back).
+* **A `Dictionary<string, string>` job data value is written the same way by both serializers**, which is
+  a change to what Newtonsoft writes — see
+  [A string dictionary is written the same way by both serializers](#a-string-dictionary-is-written-the-same-way-by-both-serializers).
 * **Five calendar types serialize to a new shape.** 4.x reads both forms and 3.x reads only its own, so
   this is invisible on a clean cut-over and fatal in a mixed window — see
   [A mixed 3.x and 4.0 window](operations.md#a-mixed-3-x-and-4-0-window).
@@ -3517,6 +3520,51 @@ own, a `JobKey` or `TriggerKey` held as a job data value, and a collection. A `T
 `JobDataMap` are past declaring — Json.NET could not read either back — so store a zone's `Id`, and
 serialize a nested structure in the job and store the result as a string. `StoreJobDataAsStrings` was
 never affected by any of this.
+
+### A string dictionary is written the same way by both serializers
+
+A `Dictionary<string, string>` is the one job data value with structure that both formats carry, and until
+4.0 they did not write it the same way. Json.NET names the type of any value an `object`-typed slot cannot,
+so the Newtonsoft serializer wrote the map with the type beside it:
+
+```json
+{"headers":{"$type":"System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]], System.Private.CoreLib","tenant":"acme"}}
+```
+
+System.Text.Json wrote the plain object, and its reader takes every property of an object as an entry of
+the map — so a value written by a Newtonsoft-configured scheduler and read by a System.Text.Json-configured
+one came back carrying an assembly-qualified type name under a `$type` key, in the same key space as the
+application's own data, with nothing said about it.
+
+4.0's Newtonsoft serializer writes the plain object, which is byte for byte what System.Text.Json writes:
+
+```json
+{"headers":{"tenant":"acme"}}
+```
+
+**This is a change to the bytes Newtonsoft writes, and both readers read both forms.** A blob already in
+the database keeps loading: Json.NET still builds the map out of the type it named, and the
+System.Text.Json reader now treats a `$type` property as the metadata it always was rather than handing it
+back as an entry. Nothing has to be rewritten, and there is no migration to run.
+
+The one direction that does not hold is backwards: 3.x's Newtonsoft reader has no answer for an object with
+no type beside it, and hands back a Json.NET `JObject` instead of the dictionary. That matters only while a
+3.x node is reading what a 4.0 node wrote — see
+[A mixed 3.x and 4.0 window](operations.md#a-mixed-3-x-and-4-0-window).
+
+**`$type` is now a reserved name inside a stored string map.** Both serializers refuse a map that stores an
+entry under it, the same way and at the same moment as any other value they cannot read back:
+
+```
+Job data entry 'headers' holds a string map with an entry named '$type'. '$type' is the name Json.NET
+writes a value's type under, so Quartz's JSON format reads it as metadata rather than as an entry and no
+reader can hand it back. Store that entry under a name of its own.
+```
+
+Nothing is lost by that refusal, because such a map never survived a round trip: Json.NET wrote the name
+twice and then failed to read its own blob, and a map System.Text.Json wrote was one Json.NET could not
+load at all. The refusal is what turns a blob in the column that nobody can read into a failure the
+application that wrote it hears about.
 
 ### Custom trigger and calendar serializers are no longer static
 

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -94,7 +94,8 @@ anyway.
 (`WAITING`, `ACQUIRED`, `EXECUTING`, `COMPLETE`, `BLOCKED`, `PAUSED`, `PAUSED_BLOCKED`, `ERROR`,
 `DELETED`), the pause-all marker, the trigger-type discriminators (`SIMPLE`, `CRON`, `CAL_INT`,
 `DAILY_I`, `RECUR`, `BLOB` — `RECUR` since 3.18), the lock names and the check-in row's columns are the
-same constants on both branches, and job data serializes to the same JSON. The failure predicate is the
+same constants on both branches, and job data serializes to the same JSON but for one value shape, below.
+The failure predicate is the
 same code, so the two versions judge and recover each other by it; the acquisition compare-and-swap is
 the same statement, so neither takes a trigger the other has; the stale-acquired sweep is scoped to the
 sweeping node's own rows on both, so neither disturbs the other's reservations; and node-affinity pins
@@ -117,6 +118,16 @@ that does the damage. Route calendar changes through the 3.x nodes until the las
 **Both versions have to be on JSON, and on the same serializer.** 4.0 refuses `quartz.serializer.type
 = binary` at startup, so a cluster whose 3.x nodes wrote binary job data has no window at all — that is
 a migration to do before the rollout, not during it.
+
+**A `Dictionary<string, string>` job data value is the one shape whose JSON differs**, and only on the
+Newtonsoft serializer. 4.0 writes it as the plain object System.Text.Json has always written, where 3.x
+wrote the type name Json.NET puts beside a value an `object`-typed slot cannot name — see
+[A string dictionary is written the same way by both serializers](migration-guide.md#a-string-dictionary-is-written-the-same-way-by-both-serializers).
+The compatibility runs the same way round as the calendars': 4.0 reads both forms, and 3.x's Newtonsoft
+reader reads only its own, handing back a Json.NET `JObject` where the job put a dictionary. A job that
+stores a string map therefore has to keep its writes on the 3.x nodes until the last one is retired, or
+store the map as a string it serializes itself. Nothing else in job data is affected, and a cluster on
+System.Text.Json is not affected at all.
 
 **Defer section 5 of the migration until the last 3.x node is gone.** Sections 1 to 4 are the required
 ones; section 5 realigns the index set, and it *drops seven indexes that the 3.20 migration created for

--- a/docs/documentation/quartz-4.x/packages/json-serialization.md
+++ b/docs/documentation/quartz-4.x/packages/json-serialization.md
@@ -95,7 +95,12 @@ enum — or a `Dictionary<string, string>`; anything else is refused when the jo
 with a `Quartz.JsonSerializationException` naming the entry and the type, rather than written as a blob
 that fails to load on the next fire. That is the same set the System.Text.Json serializer accepts, and
 literally the same declaration, so a value one of them writes is a value the other's reader has an answer
-for.
+for — down to the bytes: a `Dictionary<string, string>` is written as a plain JSON object here as well,
+where this serializer used to name the type it had written the map under.
+
+The one name a string map's own entries cannot use is `$type`. That is where Json.NET writes a value's
+type, so both readers take it as metadata rather than data, and a map that stores an entry under it is
+refused along with everything else neither reader could hand back.
 
 To store a type of your own, declare it — which is your word that Json.NET can build it back, and a
 versioning commitment for as long as the value sits in the database:

--- a/docs/documentation/quartz-4.x/tutorial/job-data-map.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-data-map.md
@@ -199,8 +199,10 @@ types are a versioning commitment.
 A persistent store accepts exactly the types the accessors above cover (`string`, `bool`, `char`, the
 numeric types, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Guid`, `DateOnly`, `TimeOnly` and enums) plus
 `Dictionary<string, string>`, and refuses anything else when the job is stored rather than writing a blob
-that fails to load later. Both serializers refuse the same set, so a value you can store is one either of
-them can be switched to. To store a type of your own, declare it — with
+that fails to load later. Both serializers refuse the same set and write it the same way, so a value you
+can store is one either of them can be switched to. The one name a string map's own entries cannot use is
+`$type`, which is where Json.NET writes a value's type: both readers take it as metadata rather than data,
+so a map storing an entry under it is refused with the rest. To store a type of your own, declare it — with
 `SystemTextJsonSerializerRegistry.AddTypeInfoResolver` on the default serializer, which is the same
 registration a trimmed or native-AOT publish needs, or with
 `NewtonsoftJsonSerializerRegistry.AddJobDataValueType<T>()` on the Newtonsoft one — or serialize it

--- a/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
@@ -14,13 +14,22 @@ internal sealed class StringKeyDirtyFlagMapConverter(NewtonsoftJsonSerializerReg
             JobDataValues.Refuse(jobDataMap, registry);
         }
 
-        var map = new Dictionary<string, object?>((IDictionary<string, object?>) value!);
-        serializer.Serialize(writer, map);
+        // Written entry by entry rather than by handing Json.NET a Dictionary<string, object>, because
+        // the slot a value sits in is what decides whether a $type goes beside it - and a string map
+        // has to go out as the plain object the built-in serializer writes.
+        writer.WriteStartObject();
+        foreach (KeyValuePair<string, object?> pair in (IDictionary<string, object?>) value!)
+        {
+            writer.WritePropertyName(pair.Key);
+            JobDataValues.Write(writer, pair.Value, serializer);
+        }
+
+        writer.WriteEndObject();
     }
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
-        IDictionary<string, object?> innerMap = serializer.Deserialize<IDictionary<string, object?>>(reader)!;
+        IDictionary<string, object?> innerMap = JobDataValues.ReadMap(reader, serializer);
 
         // The declared type decides what comes back; unconditionally returning a JobDataMap would hand
         // job code the wrong runtime type for a SchedulerContext-typed read.

--- a/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
+++ b/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
@@ -1,8 +1,11 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Quartz.Serialization.Newtonsoft;
 
 /// <summary>
 /// What a job data value may be when this serializer writes one, which is what it may be when the
-/// built-in one does.
+/// built-in one does — and, since the two halves belong together, how one is written and read.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -56,6 +59,9 @@ internal static class JobDataValues
         // read back as one, and no list can enumerate an application's own.
         if (SystemTextJson.JobDataValues.Accepted.Contains(type) || type.IsEnum || registry.DeclaresJobDataValueType(type))
         {
+            // Refused against the same declaration as the accepted set, and for the same reason: the one
+            // name a stored string map cannot use is the one Json.NET writes a type under.
+            SystemTextJson.JobDataValues.RefuseTypeMarker(key, value);
             return;
         }
 
@@ -77,5 +83,136 @@ internal static class JobDataValues
         {
             Refuse(pair.Key, pair.Value, registry);
         }
+    }
+
+    /// <summary>
+    /// Writes one entry's value, as the bytes the System.Text.Json serializer writes for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>Dictionary&lt;string, string&gt;</c> is written by hand as a plain JSON object. Handing it to
+    /// Json.NET would put a <c>$type</c> beside it — an object-typed slot cannot name a dictionary, and
+    /// <see cref="TypeNameHandling.Auto" /> writes the type when the slot cannot — and the built-in
+    /// serializer writes no such thing, so a map written here and read there came back carrying an
+    /// assembly-qualified type name as an entry of the application's own. Both are documented store
+    /// formats and an application is free to switch between them, so the two have to write the same map.
+    /// </para>
+    /// <para>
+    /// Everything else keeps the <see cref="object" />-typed slot it has always been written in. That is
+    /// what puts a <c>$type</c> beside a type the application declared through
+    /// <see cref="NewtonsoftJsonSerializerRegistry.AddJobDataValueType{T}" />, which is the whole of how
+    /// this serializer reads one back as itself.
+    /// </para>
+    /// </remarks>
+    public static void Write(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        // The exact type rather than a derived one: a subclass is only written at all because the
+        // application declared it, and a declaration asks for that type back.
+        if (value is Dictionary<string, string> stringMap && value.GetType() == typeof(Dictionary<string, string>))
+        {
+            writer.WriteStartObject();
+            foreach (KeyValuePair<string, string> pair in stringMap)
+            {
+                writer.WritePropertyName(pair.Key);
+                writer.WriteValue(pair.Value);
+            }
+
+            writer.WriteEndObject();
+            return;
+        }
+
+        serializer.Serialize(writer, value, typeof(object));
+    }
+
+    /// <summary>
+    /// Reads a job data map's entries from the object the reader is positioned on.
+    /// </summary>
+    /// <remarks>
+    /// Read entry by entry rather than as a <c>Dictionary&lt;string, object&gt;</c>, because an object with
+    /// no <c>$type</c> on it is a shape Json.NET has no answer for: it hands back a <see cref="JObject" />,
+    /// so a string map written by the built-in serializer — or by this one, now — came back as something
+    /// the job that stored it cannot cast. <see cref="ReadValue" /> is where that is decided.
+    /// </remarks>
+    public static Dictionary<string, object?> ReadMap(JsonReader reader, JsonSerializer serializer)
+    {
+        // A converter is handed the value's first token, and a map that is not an object is a blob written
+        // by something else. Saying so is the whole diagnostic; reading on would report a map with nothing
+        // in it, which is a job that quietly runs without the data it was given.
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new Quartz.JsonSerializationException(
+                $"A job data map is stored as a JSON object, and this payload holds {reader.TokenType} where the map should be.");
+        }
+
+        Dictionary<string, object?> map = new();
+
+        while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
+        {
+            string name = (string) reader.Value!;
+            reader.Read();
+            map[name] = ReadValue(reader, serializer);
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Reads one entry's value, which is a string map when the payload holds an object Json.NET wrote no
+    /// type beside.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <c>$type</c> means Json.NET wrote the value and Json.NET builds it back: a type the application
+    /// declared, or a string map written before they went out plain. Both keep reading exactly as they
+    /// did, which is what an upgrade needs — the payloads are in databases already.
+    /// </para>
+    /// <para>
+    /// The object is loaded with date parsing off, so an entry that merely looks like a timestamp stays
+    /// the string the application stored. Json.NET would otherwise hand back a
+    /// <see cref="DateTimeOffset" /> and rendering it as a string again would reformat it — in the
+    /// reading machine's culture, at that — which is a quieter way to lose a value than any this fixes.
+    /// </para>
+    /// </remarks>
+    private static object? ReadValue(JsonReader reader, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            return serializer.Deserialize<object>(reader);
+        }
+
+        DateParseHandling previous = reader.DateParseHandling;
+        reader.DateParseHandling = DateParseHandling.None;
+
+        JObject source;
+        try
+        {
+            source = JObject.Load(reader);
+        }
+        finally
+        {
+            reader.DateParseHandling = previous;
+        }
+
+        if (source[SystemTextJson.JobDataValues.TypeMarker] is not null)
+        {
+            return source.ToObject<object>(serializer);
+        }
+
+        Dictionary<string, string> stringMap = new(source.Count);
+        foreach (JProperty property in source.Properties())
+        {
+            // Structure inside the map is a blob no reader has an answer for - the built-in one fails on
+            // it too - and saying so as Quartz's own exception is what keeps Json.NET's from escaping.
+            if (property.Value is not JValue entry)
+            {
+                throw new Quartz.JsonSerializationException(
+                    $"A stored string map holds structure under '{property.Name}', and a string map's values are strings. " +
+                    "A value with structure of its own has to be serialized by the job and stored as a string.");
+            }
+
+            stringMap[property.Name] = entry.Value<string>()!;
+        }
+
+        return stringMap;
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -36,9 +36,13 @@ namespace Quartz.Tests.Unit.Simpl;
 /// a one-way door nobody is warned about.
 /// </summary>
 /// <remarks>
-/// The set covered here is the set <see cref="DataMapExtensions" /> declares an accessor for: those
+/// The set covered here is the set <see cref="DataMapExtensions" /> declares an accessor for — those
 /// are the types Quartz teaches an application to store, and so the ones the store format owes an
-/// answer for. Everything past them is the application's own choice — see <c>JobDataValues</c>, which
+/// answer for — plus the one shape past them the format carries, a <c>Dictionary&lt;string, string&gt;</c>.
+/// It has no accessor of its own, and it is the entry the two serializers disagreed about longest: one
+/// wrote the type name beside it and the other did not, so a map written by the first and read by the
+/// second came back with a type name sitting in the application's own key space.
+/// Everything past that set is the application's own choice — see <c>JobDataValues</c>, which
 /// declares what the store format will write and what it hands back, and refuses the rest at the one
 /// moment anyone can still be told. Both serializers refuse against that same declaration, so the
 /// negative cases below are asserted of both: a value only one of them accepts is a blob only one of
@@ -77,6 +81,14 @@ public class JobDataMapPortabilityTest
         yield return Case("timeOnly", new TimeOnly(1, 2, 3), map => map.GetTimeOnly("timeOnly").Should().Be(new TimeOnly(1, 2, 3)));
         yield return Case("enum", IntervalUnit.Hour, map => map.GetEnum<IntervalUnit>("enum").Should().Be(IntervalUnit.Hour));
         yield return Case("null", null, map => map["null"].Should().BeNull());
+        // The timestamp-shaped entry is not decoration: Json.NET parses a string that looks like one into
+        // a DateTimeOffset wherever it reads a value, and rendering that back as a string would reformat
+        // it — in the reading machine's culture, and with the reading machine's offset when the text
+        // carried none. A string map has to hand back the strings that went into it.
+        yield return Case("dictionary", new Dictionary<string, string> { ["one"] = "1", ["when"] = "1982-06-28T01:01:01+03:00" },
+            map => map["dictionary"].Should().BeOfType<Dictionary<string, string>>(
+                    "a string map is the one shape past the scalars the store format carries, and it has to come back as itself whichever serializer wrote it")
+                .Which.Should().Equal(new Dictionary<string, string> { ["one"] = "1", ["when"] = "1982-06-28T01:01:01+03:00" }));
     }
 
     private static TestCaseData Case(string key, object value, Action<JobDataMap> assert)
@@ -99,7 +111,14 @@ public class JobDataMapPortabilityTest
             {
                 assert(restored);
             }
-            catch (Exception e) when (e is not AssertionException)
+            // The pairing is half of what the failure has to say: the same value read back wrong is a
+            // different bug depending on which serializer wrote the blob, so the label goes on both
+            // the assertion failures and the throws.
+            catch (AssertionException e)
+            {
+                throw new AssertionException($"{label}: {e.Message}", e);
+            }
+            catch (Exception e)
             {
                 throw new AssertionException($"{label}: reading '{key}' back threw {e.GetType().Name}: {e.Message}", e);
             }
@@ -120,6 +139,71 @@ public class JobDataMapPortabilityTest
             JobDataMap restored = reader.Deserialize<JobDataMap>(writer.Serialize(original))!;
 
             restored.Dirty.Should().BeFalse("{0}: a map loaded from the store has not been modified since it was written", label);
+        }
+    }
+
+    /// <summary>
+    /// The two serializers write a string map as the same bytes, which is the whole of why it crosses
+    /// between them. Json.NET used to name the type it wrote the map under, and a reader that treats that
+    /// name as data — as the built-in one did — handed the application a <c>$type</c> entry beside its own.
+    /// </summary>
+    [Test]
+    public void AStringMapIsWrittenAsThePlainObjectByEitherSerializer()
+    {
+        JobDataMap original = new JobDataMap { { "dictionary", new Dictionary<string, string> { ["one"] = "1" } } };
+
+        foreach ((string label, IObjectSerializer writer, string _) in Writers())
+        {
+            Encoding.UTF8.GetString(writer.Serialize(original)).Should().Be("""{"dictionary":{"one":"1"}}""",
+                "{0}: a value both formats carry has to be the same bytes in both, or a blob written by one is a blob the other reads differently", label);
+        }
+    }
+
+    /// <summary>
+    /// The payloads that are already in databases: Json.NET wrote a string map with the type it had
+    /// written it under, and both readers still have to hand back the map the application stored, without
+    /// the type name in it.
+    /// </summary>
+    /// <remarks>
+    /// The payload is written out here rather than produced by the current writer on purpose — it is the
+    /// shape of a blob nothing writes any more, so a writer that changes again must not be able to change
+    /// what this asserts.
+    /// </remarks>
+    [Test]
+    public void ABlobThatNamesTheTypeBesideAStringMapStillReadsBackAsTheMap()
+    {
+        byte[] written = Encoding.UTF8.GetBytes(
+            """{"dictionary":{"$type":"System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]], System.Private.CoreLib","one":"1","when":"1982-06-28T01:01:01+03:00"}}""");
+
+        foreach ((string label, IObjectSerializer reader) in Readers())
+        {
+            JobDataMap restored = reader.Deserialize<JobDataMap>(written)!;
+
+            restored["dictionary"].Should().BeOfType<Dictionary<string, string>>("{0}: an upgrade does not get to make a stored map unreadable", label)
+                .Which.Should().Equal(new Dictionary<string, string> { ["one"] = "1", ["when"] = "1982-06-28T01:01:01+03:00" },
+                    "{0}: the type Json.NET wrote the map under is metadata, not an entry of the application's", label);
+        }
+    }
+
+    /// <summary>
+    /// <c>$type</c> is the name Json.NET writes a value's type under, so a map that stores an entry of its
+    /// own under it has never crossed anywhere: Json.NET wrote the name twice and could not read its own
+    /// blob back, and a map the built-in serializer wrote was one Json.NET could not load at all. Both
+    /// refuse it now, at the one moment there is still someone to tell.
+    /// </summary>
+    [Test]
+    public void AStringMapStoringAnEntryUnderTheTypeNameIsRefusedByEitherSerializer()
+    {
+        JobDataMap original = new JobDataMap { { "dictionary", new Dictionary<string, string> { ["$type"] = "mine" } } };
+
+        foreach ((string label, IObjectSerializer writer, string _) in Writers())
+        {
+            Action write = () => writer.Serialize(original);
+
+            write.Should().Throw<JsonSerializationException>(
+                    "{0}: a map that cannot be read back is refused while the application that wrote it can still hear about it", label)
+                .Which.Message.Should().Contain("dictionary", "the failure has to say which entry it is about")
+                .And.Contain("$type", "and which name inside it is the problem");
         }
     }
 
@@ -220,11 +304,32 @@ public class JobDataMapPortabilityTest
     }
 
     /// <summary>
+    /// The Newtonsoft reader loads a job data value's object without parsing dates, so that a string map's
+    /// entries come back as the strings that went into them. A declared type's own members are unaffected:
+    /// what turns text into a <see cref="DateTimeOffset" /> there is the member's type, not the reader's
+    /// guess at what the text looks like.
+    /// </summary>
+    [Test]
+    public void ATypeTheApplicationDeclaredStillReadsItsOwnDateBack()
+    {
+        NewtonsoftJsonSerializerRegistry registry = new();
+        registry.AddJobDataValueType<ApplicationSchedule>();
+        IObjectSerializer declared = new NewtonsoftJsonObjectSerializer(registry);
+
+        DateTimeOffset due = new(1982, 6, 28, 1, 1, 1, TimeSpan.FromHours(3));
+        JobDataMap original = new JobDataMap { { "schedule", new ApplicationSchedule { DueUtc = due } } };
+
+        JobDataMap restored = declared.Deserialize<JobDataMap>(declared.Serialize(original))!;
+
+        restored["schedule"].Should().BeOfType<ApplicationSchedule>().Which.DueUtc.Should().Be(due);
+    }
+
+    /// <summary>
     /// Nesting is where the two formats stopped agreeing, so this is the guarantee an application gets:
-    /// none. Neither reader hands a nested <see cref="JobDataMap" /> back — Newtonsoft gives its own
-    /// <c>JObject</c>, System.Text.Json a string map — which is why both now refuse to write one, and
-    /// why a blob that already holds one still has to be read for what it is. Job code that needs
-    /// structure has to serialize the structure itself and store the result as a string.
+    /// none. Neither reader hands a nested <see cref="JobDataMap" /> back — an object with no type beside
+    /// it is a string map to both of them — which is why both now refuse to write one, and why a blob that
+    /// already holds one still has to be read for what it is. Job code that needs structure has to
+    /// serialize the structure itself and store the result as a string.
     /// </summary>
     /// <remarks>
     /// The payload is what the Newtonsoft writer produced for a nested map before it was refused: the
@@ -236,12 +341,14 @@ public class JobDataMapPortabilityTest
     {
         byte[] written = Encoding.UTF8.GetBytes("""{"nested":{"inner":"value"}}""");
 
-        foreach (IObjectSerializer reader in new[] { newtonsoftSerializer, systemTextJsonSerializer })
+        foreach ((string label, IObjectSerializer reader) in Readers())
         {
             JobDataMap restored = reader.Deserialize<JobDataMap>(written)!;
 
             restored["nested"].Should().NotBeOfType<JobDataMap>(
-                "neither format carries a nested map's identity, so job code must not expect one back");
+                    "{0}: neither format carries a nested map's identity, so job code must not expect one back", label)
+                .And.BeOfType<Dictionary<string, string>>(
+                    "{0}: what it is instead is the one object shape the store format has, and both readers say the same thing about it", label);
         }
     }
 
@@ -262,12 +369,31 @@ public class JobDataMapPortabilityTest
         yield return ("newtonsoft", newtonsoftSerializer, "AddJobDataValueType");
         yield return ("system.text.json", systemTextJsonSerializer, "AddTypeInfoResolver");
     }
+
+    /// <summary>
+    /// Both readers, for the payloads that are already stored: whichever wrote a blob, either has to be
+    /// able to load it.
+    /// </summary>
+    private IEnumerable<(string Label, IObjectSerializer Reader)> Readers()
+    {
+        yield return ("newtonsoft", newtonsoftSerializer);
+        yield return ("system.text.json", systemTextJsonSerializer);
+    }
 }
 
 /// <summary>A job data value type of the application's own, which no contract of Quartz's can name.</summary>
 public sealed class ApplicationJobDataValue
 {
     public string Name { get; set; }
+}
+
+/// <summary>
+/// A declared job data value type with a date in it, for the members whose conversion belongs to the
+/// member rather than to whatever the reader makes of the text.
+/// </summary>
+public sealed class ApplicationSchedule
+{
+    public DateTimeOffset DueUtc { get; set; }
 }
 
 /// <summary>

--- a/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonDeserializationFailureTest.cs
@@ -149,6 +149,42 @@ public class NewtonsoftJsonDeserializationFailureTest
     }
 
     [Test]
+    public void JobDataMapPayloadThatIsNotAnObjectSaysSoRatherThanReadingBackEmpty()
+    {
+        NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+
+        const string NotAMap = """["not", "a", "map"]""";
+
+        Action act = () => serializer.Deserialize<JobDataMap>(Encoding.UTF8.GetBytes(NotAMap));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a map read entry by entry has to say when there are no entries to read, or a job runs without the data it was given")
+            .Which;
+
+        thrown.Message.Should().Contain(NotAMap, "the payload that could not be read is the whole diagnostic");
+        thrown.InnerException.Should().BeOfType<Quartz.JsonSerializationException>()
+            .Which.Message.Should().Contain("StartArray", "and what was found where the map should have been");
+    }
+
+    [Test]
+    public void StructureInsideAStoredStringMapFailsAsQuartzsExceptionRatherThanJsonNetsOwn()
+    {
+        NewtonsoftJsonObjectSerializer serializer = new NewtonsoftJsonObjectSerializer();
+
+        // A shape neither writer produces and an old blob can hold: an object inside the object a job data
+        // value comes back from. The built-in reader fails on it too, so what matters is failing the same way.
+        const string NestedTwice = """{"headers":{"inner":{"deep":"value"}}}""";
+
+        Action act = () => serializer.Deserialize<JobDataMap>(Encoding.UTF8.GetBytes(NestedTwice));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Message.Should().Contain(NestedTwice);
+        thrown.InnerException.Should().BeOfType<Quartz.JsonSerializationException>()
+            .Which.Message.Should().Contain("inner", "the failure has to say which entry of the map it is about");
+    }
+
+    [Test]
     public void ConverterFailureStillSurfacesAsQuartzsExceptionWithThePayload()
     {
         // The trigger converter already throws Quartz's exception; wrapping it is what attaches the

--- a/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
+++ b/src/Quartz/Serialization/SystemTextJson/JobDataValues.cs
@@ -65,6 +65,19 @@ namespace Quartz.Serialization.SystemTextJson;
 internal static class JobDataValues
 {
     /// <summary>
+    /// The property name Json.NET writes a value's type under, and the one name a stored string map
+    /// cannot use for an entry of its own.
+    /// </summary>
+    /// <remarks>
+    /// It is metadata rather than data on every path that reads it: <c>Quartz.Serialization.Newtonsoft</c>
+    /// consumes it to decide what to build, and this reader drops it (see <see cref="Read" />), so a blob
+    /// written before string maps went out plain does not hand a type name back as if the application had
+    /// stored one. That makes the name reserved, which is what <see cref="RefuseTypeMarker" /> says at the
+    /// one moment anyone can still be told.
+    /// </remarks>
+    internal const string TypeMarker = "$type";
+
+    /// <summary>
     /// The value types a persistent store's JSON accepts by name. Every one of them is answered by
     /// <see cref="QuartzStoreJsonContext" /> too, so a trimmed publish can write them all;
     /// <c>StoreFormatSourceGenerationTest</c> is what fails when the two stop agreeing.
@@ -117,6 +130,7 @@ internal static class JobDataValues
         Type type = value.GetType();
         if (Accepted.Contains(type) || type.IsEnum || registry.DeclaresJobDataValueType(type, options))
         {
+            RefuseTypeMarker(key, value);
             return;
         }
 
@@ -126,6 +140,30 @@ internal static class JobDataValues
             "(string, bool, char, int, long, float, double, decimal, DateTime, DateTimeOffset, TimeSpan, Guid, DateOnly, TimeOnly or an enum), " +
             "a Dictionary<string, string>, or a type the application declares through SystemTextJsonSerializerRegistry.AddTypeInfoResolver. " +
             "Anything with structure of its own has to be serialized by the job and stored as a string.");
+    }
+
+    /// <summary>
+    /// Throws when a string map holds an entry named <see cref="TypeMarker" />, which no reader will hand
+    /// back as one.
+    /// </summary>
+    /// <remarks>
+    /// The name belongs to Json.NET, which writes a value's type under it and reads it as metadata, so a
+    /// map carrying it has never survived a crossing: <c>Quartz.Serialization.Newtonsoft</c> wrote the name
+    /// twice and could not read its own blob back, and a map this serializer wrote was one that serializer
+    /// could not load at all. Refusing it on the way in is what turns a blob nobody can read into a failure
+    /// the application that wrote it hears about — and it is what lets both readers treat the name as
+    /// metadata without ever dropping an entry an application meant.
+    /// </remarks>
+    /// <exception cref="JsonSerializationException">The map holds an entry under the reserved name.</exception>
+    public static void RefuseTypeMarker(string key, object value)
+    {
+        if (value is Dictionary<string, string> stringMap && stringMap.ContainsKey(TypeMarker))
+        {
+            throw new JsonSerializationException(
+                $"Job data entry '{key}' holds a string map with an entry named '{TypeMarker}'. " +
+                $"'{TypeMarker}' is the name Json.NET writes a value's type under, so Quartz's JSON format reads it as metadata " +
+                "rather than as an entry and no reader can hand it back. Store that entry under a name of its own.");
+        }
     }
 
     /// <summary>
@@ -164,7 +202,14 @@ internal static class JobDataValues
             case JsonValueKind.Object:
                 // The one shape past the primitives a job data value comes back as, and the reason
                 // Dictionary<string, string> is both named in QuartzStoreJsonContext and accepted above.
-                return value.Deserialize((JsonTypeInfo<Dictionary<string, string>>) options.GetTypeInfo(typeof(Dictionary<string, string>)));
+                Dictionary<string, string>? stringMap = value.Deserialize((JsonTypeInfo<Dictionary<string, string>>) options.GetTypeInfo(typeof(Dictionary<string, string>)));
+
+                // A blob Quartz.Serialization.Newtonsoft wrote before string maps went out plain carries
+                // the type it wrote the map under. That is metadata to the reader that wrote it, and it has
+                // to be metadata here too: handing it back would put an assembly-qualified type name in the
+                // application's own key space, under a name RefuseTypeMarker keeps anything from storing.
+                stringMap?.Remove(TypeMarker);
+                return stringMap;
 
             default:
                 throw new JsonException($"Unsupported value kind: {value.ValueKind}");


### PR DESCRIPTION
A `Dictionary<string, string>` is the one job data value with structure that both serializers carry, and
they did not write it the same way. Json.NET names the type of any value an `object`-typed slot cannot, so
`Quartz.Serialization.Newtonsoft` wrote the map with `$type` beside it, while System.Text.Json wrote the
plain object — and the System.Text.Json reader takes every property of an object as an entry of the map.

The reproduction was written as a failing test first, since #3582 came from a probe rather than a pinned
test. `JobDataMapPortabilityTest` now round-trips a string map across all four writer/reader pairings, and
on the base commit it failed exactly as reported:

```
Failed AValueTheAccessorsCoverReadsBackWhicheverSerializerWroteIt(dictionary)
  newtonsoft -> system.text.json: Expected map["dictionary"] to be equal to {["one"] = "1", ["two"] = "2"},
  but found additional keys {"$type"}.
```

Probing the other three pairings turned up the same bug facing the other way, which the issue does not
mention: an object with no `$type` on it is a shape Json.NET has no answer for, so a map the built-in
serializer wrote came back from the Newtonsoft reader as a `JObject` — not something the job that stored a
dictionary can cast. Fixing only the write side would have converted the first failure into that one, so
both halves moved.

## What changed

**Write (`Quartz.Serialization.Newtonsoft`).** A job data map is written entry by entry rather than by
handing Json.NET a `Dictionary<string, object>`, because the slot a value sits in is what decides whether a
`$type` goes beside it. A `Dictionary<string, string>` goes out as a plain JSON object — byte for byte what
System.Text.Json writes, and smaller; everything else keeps the `object`-typed slot it has always had, which
is what still puts a `$type` beside a type declared through `AddJobDataValueType<T>()` and reads it back as
itself.

**Read (`Quartz.Serialization.Newtonsoft`).** An object with a `$type` is still handed to Json.NET, so the
payloads that are already in databases keep loading; an object without one is read back as the
`Dictionary<string, string>` it is. The object is loaded with `DateParseHandling.None`, which is not
incidental: Json.NET parses any string that looks like a timestamp into a `DateTimeOffset`, and rendering
that back as a string reformats it in the *reading machine's* culture — `1982-06-28T01:01:01+03:00` became
`06/28/1982 01:01:01 +03:00` in the naive version of this fix, and an offsetless timestamp would have picked
up the reading machine's offset. A string map hands back the strings that went into it.

**Read (System.Text.Json).** The reader drops a `$type` property when it materialises the map. Fixing only
the writer would leave every blob written before this PR — and every blob written by 3.x — still leaking a
type name into the application's key space on the first read by a System.Text.Json-configured scheduler.

**`$type` is now a reserved name inside a stored string map**, refused on write by both serializers, in the
same place and shape as the rest of the write gate from #3580. Nothing is lost by that refusal: such a map
never survived a round trip in either direction. Json.NET wrote the name twice and then failed to read its
own blob (`Could not deserialize JSON: {"dictionary":{"$type":"System.Collections.Generic.Dictionary…",
"$type":"mine","one":"1"}}`), and a map System.Text.Json wrote was one Json.NET could not load at all. This
is the one behaviour change that can fail an application that is working today — a System.Text.Json-only
application storing a literal `$type` key — and it is what lets both readers treat the name as metadata
without ever dropping an entry someone meant.

## This is a wire-format change on the Newtonsoft side

```json
{"headers":{"$type":"System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]], System.Private.CoreLib","tenant":"acme"}}
```

becomes

```json
{"headers":{"tenant":"acme"}}
```

It is read-compatible in both directions **within 4.0** — both readers read both forms — so nothing has to
be rewritten and there is no migration. It is *not* backwards compatible: 3.x's Newtonsoft reader hands a
`JObject` back for the plain form. That matters in a mixed 3.x/4.0 window and on a rollback, so it is
written up in the migration guide and added to the mixed-window list in `operations.md`, whose "job data
serializes to the same JSON" claim this PR would otherwise have made false.

Docs: a new migration-guide section (**A string dictionary is written the same way by both serializers**)
with a summary bullet, the mixed-window paragraph in `operations.md`, and the reserved-name rule in
`packages/json-serialization.md` and `tutorial/job-data-map.md`.

## For the reviewer to decide

* **3.x has the identical bug and this PR does not touch it.** Verified in the source, not assumed:
  `origin/3.x` `StringKeyDirtyFlagMapConverter` writes through `serializer.Serialize(writer, map.WrappedMap)`
  with `TypeNameHandling.Auto` (so `$type`), and 3.x's System.Text.Json `GetJobDataMap` deserializes the
  object straight into a `Dictionary<string, string>` (so the `$type` entry comes back). Whether to change
  what 3.x writes is a wire decision on a released branch, and it is yours — flagged, not made. A cheaper
  half is available there on its own: dropping `$type` on the 3.x *System.Text.Json read* side would fix the
  leak for existing data without changing a single byte 3.x writes.
* **The Newtonsoft trigger converter path is left alone, deliberately.** With
  `RegisterTriggerConverters = true`, a trigger whose job data map holds a `Dictionary<string, string>`
  cannot be written at all today — `SerializationExtensions.WriteJobDataMapValue` writes each value with
  `JsonWriter.WriteValue(object)`, which throws

  ```
  Unsupported type: System.Collections.Generic.Dictionary`2[System.String,System.String].
  Use the JsonSerializer class to get the object's JSON representation. Path 'JobDataMap'.
  ```

  even though the write gate accepts the value; and a map written by System.Text.Json comes back from that
  path as a `JObject`. I did not fix it here because the write half alone would turn a loud failure into a
  silent one,
  and the read half cannot be made exact: `TriggerConverter` loads the whole trigger with `JObject.Load`, so
  the nested timestamps are already parsed by the time the job data map is reached, and the only way to keep
  them verbatim is to load the entire trigger with `DateParseHandling.None` — which changes what a *trigger*
  blob's top-level date-shaped values read back as, and affects third-party `ITriggerSerializer`
  implementations. That is a second wire decision, not a tidy-up, and it belongs in its own issue. The
  default path (`RegisterTriggerConverters = false`) goes through the converter this PR fixes, so a trigger's
  job data map is correct out of the box.
* **A `SchedulerContext` gets the same treatment**, since it shares the converter: a string map in one is
  written plain and read back as a string map rather than a `JObject`. It is not stored, so this is only
  visible to something that serializes one itself.

## Neighbouring shapes checked

The write gate admits exactly one dictionary type, so there is no second flavour to align. The rest of the
accepted set is written as JSON primitives by both serializers and was already identical — the portability
matrix covers each of them, and it now carries the string map (including a timestamp-shaped entry, which is
the trap above), a legacy `$type` payload written out as a literal rather than produced by the current
writer, and the reserved-name refusal.

Two defensive gaps the entry-by-entry read opened are closed with tests rather than left to chance: a job
data map payload that is not a JSON object, and structure nested inside a stored string map, both now fail
as `Quartz.JsonSerializationException` carrying the payload instead of letting a Json.NET or `Argument`
exception escape.

## Verification

* `dotnet build Quartz.slnx` — Build succeeded, 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — Passed! Failed: 0, Passed: 4288
* `dotnet test src/Quartz.Tests.AspNetCore` — Passed! Failed: 0, Passed: 548
* `dotnet test src/Quartz.Tests.Integration --filter SQLiteJobStoreContractTest` — Passed! Failed: 0,
  Passed: 93 (the container-free slice; the full integration suite needs several database images, which the
  worktree's ~6 GB disk budget did not allow, and this PR touches no ADO store code)
* `dotnet fallout VerifyDocsSnippets` — Succeeded, 102 markdown files checked
* `dotnet fallout BenchmarkSmoke` — Succeeded, 284 benchmarks executed

No public API moved, so no baseline changed.

Closes #3582
