### PR TITLE
A wildcard in a day field restricts nothing

### DIFF
--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -44,9 +44,9 @@ NOTE: There are many cron standards/implementations. The results from some gener
 ## Special characters
 
 * `*` ("all values") - used to select all values within a field. For example, `*` in the minute field means "every minute".
-* `?` ("no specific value") - useful when you need to specify something in one of the two fields in which the character is allowed, but not the other.
-For example, if I want my trigger to fire on a particular day of the month (say, the 10th), but don't care what day of the week that happens to be,
-I would put `10` in the day-of-month field, and `?` in the day-of-week field. See the examples below for clarification.
+* `?` ("no specific value") - allowed in the day-of-month and day-of-week fields, where it is a synonym for `*`: both say that the field names no days.
+Use it when you need to specify something in one of the two fields but not the other. For example, if I want my trigger to fire on a particular day of the month (say, the 10th),
+but don't care what day of the week that happens to be, I would put `10` in the day-of-month field, and `?` in the day-of-week field. See the examples below for clarification.
 * `-` - used to specify ranges. For example, `10-12` in the hour field means "the hours 10, 11 and 12".
 * `,` - used to specify additional values. For example, `MON,WED,FRI` in the day-of-week field means "the days Monday, Wednesday, and Friday".
 * `/` - used to specify increments. For example, `0/15` in the seconds field means "the seconds 0, 15, 30, and 45".
@@ -248,7 +248,13 @@ Here are some full examples:
 | `0 H/15 * * * ?`           | Fire every 15 minutes, starting from a hash-derived offset                                                                          |
 
 ::: tip
-Pay attention to the effects of '?' and '*' in the day-of-week and day-of-month fields!
+Pay attention to the effects of `?` and `*` in the day-of-week and day-of-month fields. A day field
+written exactly `*` or `?` names no days, so it restricts nothing and the other day field decides:
+`0 15 10 1 * *` fires on the 1st of the month, and `0 15 10 * * MON` fires every Monday. Only when
+**both** fields name days does the expression fire on the union of the two, as
+`0 15 10 1,2,3 * MON,FRI` above does; when neither names days, every day matches. This is the Unix
+`crontab(5)` rule - some other cron implementations intersect the two fields instead, so an expression
+copied from one of those fires more often here than it did there.
 :::
 
 ## Notes

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4572,7 +4572,15 @@ The cron expression parser now supports additional syntax:
 
 * `L` and `LW` combinations in day-of-month expressions (e.g., `LW` for last weekday of the month)
 * `LW-<OFFSET>` for offset from the last weekday (e.g., `LW-2` for two days before the last weekday). If the calculated day crosses a month boundary, it resets to the 1st.
-* Day-of-month and day-of-week can now be specified together in the same expression
+* Day-of-month and day-of-week can be specified together. A field written `*` or `?` **restricts
+  nothing**, so the other field decides: `0 15 10 1 * *` is the 1st of the month, and
+  `0 15 10 * * MON` is every Monday. When **both** fields name days, the expression fires on the union
+  of the two — `0 15 10 1,2,3 * MON,FRI` is the 1st, 2nd and 3rd **and** every Monday and Friday.
+  This is the Unix `crontab(5)` rule. It is deliberately **not** Cronos's, which ANDs even when both
+  fields are restricted; the union is what Quartz has always documented and what 4.0 alpha shipped.
+  `?` and `*` are now full synonyms in a day field, so `? * ?` is legal and means every day.
+  **Changed since alpha.4:** an expression with a wildcard in one day field and values in the other
+  fired on every day of the month; it now fires only on the days the restricted field names.
 * `H` (hash) tokens for [load distribution](cron-expressions.md#h-hash-for-load-distribution) across triggers
 
 Parse errors name the fix instead of only the constraint. A 5-field Unix/crontab expression — the shape every

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -359,7 +359,9 @@ public class CronExpressionBuilderTest
                 (from, to) => builder.WithMonthRange(from, to),
                 (from, increment) => builder.WithMonthIncrements(from, increment));
 
-            // The builder refuses to configure both day fields, exactly as the parser refuses to read both.
+            // The builder refuses to configure both day fields, so exactly one of them is drawn. The
+            // parser reads both, but the builder has never offered a way to say which days the union
+            // should hold.
             bool useDayOfWeek = random.Next(2) == 0;
             HashSet<int> daysOfMonth = [];
             HashSet<int> daysOfWeek = [];
@@ -403,15 +405,17 @@ public class CronExpressionBuilderTest
             parsed.GetSet(CronExpressionConstants.Month).Should().BeEquivalentTo(months, "expression '{0}'", text);
             parsed.GetSet(CronExpressionConstants.Year).Should().BeEquivalentTo(years, "expression '{0}'", text);
 
+            // The builder renders the unused day field as '?', which the parser stores as the wildcard:
+            // '?' and '*' are the same statement about a day field, so they are held the same way.
             if (useDayOfWeek)
             {
                 parsed.GetSet(CronExpressionConstants.DayOfWeek).Should().BeEquivalentTo(daysOfWeek, "expression '{0}'", text);
-                parsed.GetSet(CronExpressionConstants.DayOfMonth).Should().Equal([CronExpressionConstants.NoSpec], "expression '{0}'", text);
+                parsed.GetSet(CronExpressionConstants.DayOfMonth).Should().Equal([CronExpressionConstants.AllSpec], "expression '{0}'", text);
             }
             else
             {
                 parsed.GetSet(CronExpressionConstants.DayOfMonth).Should().BeEquivalentTo(daysOfMonth, "expression '{0}'", text);
-                parsed.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal([CronExpressionConstants.NoSpec], "expression '{0}'", text);
+                parsed.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal([CronExpressionConstants.AllSpec], "expression '{0}'", text);
             }
         }
     }

--- a/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDifferentialTest.cs
@@ -323,10 +323,12 @@ public class CronExpressionDifferentialTest
     /// <remarks>
     /// The membership rule is this file's own arithmetic, so a field parsed into the wrong set is caught
     /// as well as a search that lands in the wrong place. The generated grammar is deliberately the part
-    /// the worked examples cover thinnest: wrapping ranges in every field, step values, and the
-    /// day-of-week forms — a plain set, <c>d#n</c> and <c>dL</c>. The day-of-month special forms are left
-    /// out because <see cref="GetNextValidTimeAfter_MatchesBruteForce_LastDayAndWeekday" /> already walks
-    /// those against a reference of their own.
+    /// the worked examples cover thinnest: wrapping ranges in every field, step values, the
+    /// day-of-week forms — a plain set, <c>d#n</c> and <c>dL</c> — and expressions that fill
+    /// <em>both</em> day fields, which is where the day rule decides between deferring to one field and
+    /// unioning the two. The day-of-month special forms are left out because
+    /// <see cref="GetNextValidTimeAfter_MatchesBruteForce_LastDayAndWeekday" /> already walks those
+    /// against a reference of their own.
     /// </remarks>
     /// <param name="seed">
     /// Fixed, and part of the case name: a fuzz that draws from the clock reports a failure nobody can
@@ -479,18 +481,45 @@ public class CronExpressionDifferentialTest
         string dayOfWeekToken;
         Func<DateTimeOffset, bool> dayMatches;
 
-        // Exactly one of the two day fields carries a value and the other a '?', which is the only
-        // combination Quartz reads without complaint.
-        if (random.Next(2) == 0)
+        // Three shapes: a day-of-week with '?' opposite it, a day-of-month with '?' opposite it, and
+        // both fields filled. The third is the one that reaches the union branch, and because either
+        // field can come out a wildcard it reaches the whole 2x2 of the day rule rather than only the
+        // union: a field written '*' or '?' names no days, so the other decides; two fields that both
+        // name days are unioned; two that name none match every day.
+        switch (random.Next(3))
         {
-            (dayOfWeekToken, dayMatches) = NextDayOfWeek(random);
-            dayOfMonthToken = "?";
-        }
-        else
-        {
-            (dayOfMonthToken, HashSet<int> daysOfMonth) = NextField(random, 1, 31);
-            dayMatches = moment => daysOfMonth.Contains(moment.Day);
-            dayOfWeekToken = "?";
+            case 0:
+            {
+                (dayOfWeekToken, dayMatches) = NextDayOfWeek(random);
+                dayOfMonthToken = "?";
+                break;
+            }
+
+            case 1:
+            {
+                (dayOfMonthToken, HashSet<int> daysOfMonth) = NextField(random, 1, 31);
+                dayMatches = moment => daysOfMonth.Contains(moment.Day);
+                dayOfWeekToken = "?";
+                break;
+            }
+
+            default:
+            {
+                (dayOfMonthToken, HashSet<int> daysOfMonth) = NextField(random, 1, 31);
+                (dayOfWeekToken, Func<DateTimeOffset, bool> dayOfWeekMatches) = NextDayOfWeek(random);
+
+                bool dayOfMonthRestricted = RestrictsDays(dayOfMonthToken);
+                bool dayOfWeekRestricted = RestrictsDays(dayOfWeekToken);
+
+                dayMatches = dayOfMonthRestricted && dayOfWeekRestricted
+                    ? moment => daysOfMonth.Contains(moment.Day) || dayOfWeekMatches(moment)
+                    : dayOfMonthRestricted
+                        ? moment => daysOfMonth.Contains(moment.Day)
+                        : dayOfWeekRestricted
+                            ? dayOfWeekMatches
+                            : _ => true;
+                break;
+            }
         }
 
         return new GeneratedExpression
@@ -503,6 +532,12 @@ public class CronExpressionDifferentialTest
             DayMatches = dayMatches
         };
     }
+
+    /// <summary>
+    /// Whether a day field names days. Written out here rather than asked of <see cref="CronExpression" />,
+    /// because a reference rule that reads its answer out of the class under test proves nothing.
+    /// </summary>
+    private static bool RestrictsDays(string token) => token is not ("*" or "?");
 
     private static (string Token, Func<DateTimeOffset, bool> Matches) NextDayOfWeek(Random random)
     {

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -207,11 +207,42 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         return numbers.ToArray();
     }
 
+    /// <summary>
+    /// The whole 2x2 of the day rule. A day field written exactly '*' or '?' names no days, so it
+    /// restricts nothing and the other field decides; only when both fields name days are the two
+    /// unioned. October 2010 starts on a Friday and ends on a Sunday, which is what makes every
+    /// weekday form below land on a day the reason string can spell.
+    /// </summary>
+    // Both fields name days: the expression fires on the union of the two.
     [TestCase("0 15 10 5/5 * MON 2010", new[] { 4, 11, 18, 25, 5, 10, 15, 20, 25, 30 }, "10:15am every 5th day of the month from 5 to 31, and on Mondays in October 2010")]
     [TestCase("0 15 10 3 * MON,THU,FRI 2010", new[] { 1, 3, 4, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 3rd of month and every mon,thu,fri October 2010")]
     [TestCase("0 15 10 1,2,3,4,5,6 * MON,THU,FRI 2010", new[] { 1, 2, 3, 4, 5, 6, 11, 18, 25, 7, 14, 21, 28, 8, 15, 22, 29 }, "10:15am 1-6th of mon and every Mon,Thu,Fri October 2010")]
-    [TestCase("0 15 10 * * MON,THU,FRI 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am EveryDay of Month October 2010, Wildcard specified")]
-    [TestCase("0 15 10 1 * * 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 }, "10:15am Every Day of Month October 2010, Wildcard specified")]
+
+    // One field names days and the other does not: the one that does decides.
+    [TestCase("0 15 10 * * MON,THU,FRI 2010", new[] { 1, 4, 7, 8, 11, 14, 15, 18, 21, 22, 25, 28, 29 },
+        "10:15am every Mon, Thu, Fri in October 2010 - a wildcard day-of-month restricts nothing, so day-of-week decides")]
+    [TestCase("0 15 10 1 * * 2010", new[] { 1 },
+        "10:15am on the 1st of October 2010 - a wildcard day-of-week restricts nothing, so day-of-month decides")]
+    [TestCase("0 15 10 ? * MON,THU,FRI 2010", new[] { 1, 4, 7, 8, 11, 14, 15, 18, 21, 22, 25, 28, 29 },
+        "'?' and '*' say the same thing, so this is the wildcard day-of-month case spelled the older way")]
+    [TestCase("0 15 10 1 * ? 2010", new[] { 1 },
+        "'?' and '*' say the same thing, so this is the wildcard day-of-week case spelled the older way")]
+
+    // Neither field names days: every day.
+    [TestCase("0 15 10 * * ? 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 },
+        "neither field restricts")]
+    [TestCase("0 15 10 ? * * 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 },
+        "neither field restricts")]
+    [TestCase("0 15 10 * * * 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 },
+        "two wildcards spelled the same way")]
+    [TestCase("0 15 10 ? * ? 2010", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31 },
+        "two wildcards spelled the same way")]
+
+    // The special day forms name days, so they restrict, and the wildcard opposite them yields.
+    [TestCase("0 15 10 L * * 2010", new[] { 31 }, "'L' restricts, so the wildcard day-of-week yields")]
+    [TestCase("0 15 10 15W * * 2010", new[] { 15 }, "'W' restricts - 15 Oct 2010 is a Friday, so it needs no shift")]
+    [TestCase("0 15 10 * * 6#3 2010", new[] { 15 }, "'#' restricts - the third Friday of October 2010")]
+    [TestCase("0 15 10 * * 6L 2010", new[] { 29 }, "'dL' restricts - the last Friday of October 2010")]
     public void CanUse_DayOfMonth_And_DayOfWeek_Together(string cronExpression, int[] expectedDays, string scenario = "")
     {
         var expr = new CronExpression(cronExpression, TimeZoneInfo.Utc);
@@ -463,6 +494,24 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     {
         Action act = () => new CronExpression($"0 0 * * * ?{allowedChar}");
         act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// '?' says the same thing as '*' in the two day fields, and is accepted in no other field. Some
+    /// other implementations take it anywhere; that is surface with no demand behind it, and this test
+    /// is here because the sibling rule - '?' in only one of the two day fields - was dropped when the
+    /// two spellings became synonyms, and the survivor should not go with it by accident.
+    /// </summary>
+    [TestCase("? 0 12 * * ?", "seconds")]
+    [TestCase("0 ? 12 * * ?", "minutes")]
+    [TestCase("0 0 ? * * ?", "hours")]
+    [TestCase("0 0 12 * ? ?", "month")]
+    [TestCase("0 0 12 * * ? ?", "year")]
+    public void QuestionMark_IsRejectedOutsideTheTwoDayFields(string cronExpression, string field)
+    {
+        Action act = () => new CronExpression(cronExpression);
+        act.Should().Throw<FormatException>("'?' has never been legal in the {0} field", field)
+            .WithMessage("*Day-of-Month or Day-of-Week*");
     }
 
     [Test]
@@ -1120,7 +1169,7 @@ minutes: 15
 hours: 15
 daysOfMonth: 5
 months: 11
-daysOfWeek: ?
+daysOfWeek: *
 lastdayOfWeek: False
 nearestWeekday: False
 NthDayOfWeek: 0

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -106,8 +106,10 @@ namespace Quartz;
 /// </para>
 /// <para>
 /// The '?' character is allowed for the day-of-month and day-of-week fields. It
-/// is used to specify 'no specific value'. This is useful when you need to
-/// specify something in one of the two fields, but not the other.
+/// is used to specify 'no specific value', and is a synonym for '*' there: both
+/// say that the field names no days, so the other field decides. When both day
+/// fields name days the expression fires on the union of the two, and when
+/// neither does it fires every day.
 /// </para>
 /// <para>
 /// The '-' character is used to specify ranges. For example &quot;10-12&quot; in
@@ -977,6 +979,12 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         hasIntervalSemantics = false;
     }
 
+    /// <summary>
+    /// Stores a '?' day field. '?' says "no opinion about this field", which is what '*' says too, so
+    /// the two are stored as the same thing: the wildcard. That makes '?' walkable — a field stored as
+    /// the '?' sentinel has no values to advance through — and it makes '? * ?' mean every day rather
+    /// than being a spelling the parser refuses. '?' remains legal only in the two day fields.
+    /// </summary>
     private void StoreExpressionQuestionMark(int type, ReadOnlySpan<char> s, int i)
     {
         i++;
@@ -990,16 +998,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             Throw.FormatException("'?' can only be specified for Day-of-Month or Day-of-Week.");
         }
 
-        if (type == CronExpressionConstants.DayOfWeek && lastDaySpecs is null)
-        {
-            var val = daysOfMonth.LastOrDefault();
-            if (val == CronExpressionConstants.NoSpec)
-            {
-                Throw.FormatException("'?' can only be specified for Day-of-Month -OR- Day-of-Week.");
-            }
-        }
-
-        AddToSet(CronExpressionConstants.NoSpec, -1, 0, type);
+        AddToSet(CronExpressionConstants.AllSpec, -1, 0, type);
     }
 
     private void StoreExpressionStarOrSlash(int type, ReadOnlySpan<char> s, int i)
@@ -2299,19 +2298,40 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     }
 
     /// <summary>
+    /// A day field written exactly '*' or '?' names no days, so it restricts nothing. Anything else -
+    /// a list, a range, a step, 'L', 'W', '#', 'nL' - names days, and restricts.
+    /// </summary>
+    /// <remarks>
+    /// 'L', 'W' and the 'L-n' family add no values to the field; they are held in
+    /// <c>lastDaySpecs</c>/<c>nearestWeekdays</c> and resolved per month. The field is therefore empty of
+    /// both bits and markers for them, which reads as restricted - correct, and it needs no special case.
+    /// </remarks>
+    private static bool IsRestrictedDayField(CronField field)
+    {
+        return !field.Contains(CronExpressionConstants.AllSpec) && !field.Contains(CronExpressionConstants.NoSpec);
+    }
+
+    /// <summary>
     /// Progress next fire time day
     /// </summary>
+    /// <remarks>
+    /// A field that restricts nothing defers to the other one, and only two fields that both name days
+    /// are unioned. This is the Unix <c>crontab(5)</c> rule: <c>0 15 10 1 * *</c> is the 1st of the
+    /// month, <c>0 15 10 * * MON</c> is every Monday, and <c>0 15 10 1 * MON</c> is both. When neither
+    /// field restricts, every day matches, and walking the unrestricted day-of-month field leaves the
+    /// cursor exactly where it is - which is what "every day" means to the caller.
+    /// </remarks>
     /// <param name="d">NextFireTimeCheck</param>
     private NextFireTimeCursor ProgressNextFireTimeDay(DateTimeOffset d)
     {
-        var dayOfMSpec = !daysOfMonth.Contains(CronExpressionConstants.NoSpec);
-        var dayOfWSpec = !daysOfWeek.Contains(CronExpressionConstants.NoSpec);
-        if (dayOfMSpec && !dayOfWSpec)
+        bool dayOfMonthRestricted = IsRestrictedDayField(daysOfMonth);
+        bool dayOfWeekRestricted = IsRestrictedDayField(daysOfWeek);
+        if (!dayOfWeekRestricted)
         {
             return ProgressNextFireTimeDayOfMonth(d);
         }
 
-        if (dayOfWSpec && !dayOfMSpec)
+        if (!dayOfMonthRestricted)
         {
             return ProgressNextFireTimeDayOfWeek(d);
         }


### PR DESCRIPTION
Closes #3589. This is PR-1 of the alpha.5 cron-semantics stream.

## The rule

`ProgressNextFireTimeDay` decided which day field to walk with `!field.Contains(NoSpec)` — "is this
field not a `?`". `*` is not a `?`, so `0 15 10 1 * *` and `0 15 10 * * MON,THU,FRI` both took the
union branch and unioned "every day" with the days the other field named, which is every day. The
first of those is the natural Unix spelling of "the 1st at 10:15", and 4.0 accepted it and silently
scheduled daily where 3.x had forced a loud `?`.

A day field written **exactly** `*` or `?` now names no days, so it restricts nothing and defers to
the other field:

| day-of-month | day-of-week | result |
|---|---|---|
| restricted | unrestricted | day-of-month decides |
| unrestricted | restricted | day-of-week decides |
| restricted | restricted | union — unchanged |
| unrestricted | unrestricted | every day |

`*/n`, ranges, lists, `L`, `W`, `#` and `nL` are all **restricted**. That falls out of the existing
representation rather than being spelled out: `AddToSet` routes a bare `*` to `CronField`'s wildcard
flag and adds no bits, while `*/2` goes down the range loop and sets concrete bits; `L`/`W` add no
bits but fill `lastDaySpecs`/`nearestWeekdays`, which leaves the field empty of both bits and markers
and therefore reads as restricted. No parse-time flag, no new field, no serialization impact.

**This is Vixie, not Cronos, and the divergence is deliberate.** Cronos always ANDs the two day
fields — its `CronExpressionFlag` has no star flag at all, because with an unconditional AND it needs
none. Quartz unions when both fields are restricted, which is the `crontab(5)` rule, is what
`cron-expressions.md` has always documented (`0 15 10 1,2,3 * MON,FRI` is "the 1st, 2nd, 3rd **and**
every Monday and Friday"), and is what the 4.0 alphas shipped. A reviewer who "finishes" the Cronos
alignment by making the both-restricted case AND would halve everyone's fire count. It is written down
as a ratified divergence in the migration guide row.

`*/n` in a day field is restricted, which is where we diverge from Vixie a second time: Vixie sets
`DOM_STAR` from the leading `*` *before* consuming `/2`, so `*/2` there is a wildcard. That is a parse
accident that makes `*/1` behave differently from `1-31/1`, which are the same set. The rule as
written — a field that says nothing about which day lets the other field decide; two fields that each
name days are unioned — needs no reference to parser internals.

## `?` and `*` become synonyms

`StoreExpressionQuestionMark` now stores the wildcard instead of the `NoSpec` sentinel, and the
`'?' can only be specified for Day-of-Month -OR- Day-of-Week.` rejection is gone. Two reasons, and the
first is mechanical: a `?` field is not walkable — `CronField.TryGetMinValueStartingFrom` returns the
sentinel `98` for it — and the both-unrestricted case has to walk *one* of the two fields. Normalising
at parse time makes either choice safe. The second is that forbidding two spellings of the same
statement is arbitrary once they are the same statement, so `? * ?` is now legal and means every day.

`?` stays legal **only** in the two day fields; `QuestionMark_IsRejectedOutsideTheTwoDayFields` pins
that, because the sibling rule it used to sit beside is gone and the survivor should not go with it by
accident.

## What flips

An independent scan of every cron-shaped 6/7-field literal in the worktree (85,905 candidates across
`.cs`/`.md`/`.xml`/`.json`/`.razor`/`.yml`/…) for "neither day field is `?`, at least one is `*`, and
not both are `*`" found **exactly the two pinned `TestCase`s** that #3589 named, plus
`CronExpressionTest.cs`'s five-field error-message assertion, which is message text and is never
evaluated as an expression. Nothing in `docs/`, no XML fixture, no benchmark, no sample.

* `0 15 10 * * MON,THU,FRI 2010` — all 31 days of October 2010 → `1, 4, 7, 8, 11, 14, 15, 18, 21, 22, 25, 28, 29`
* `0 15 10 1 * * 2010` — all 31 days → `1`

The three both-restricted cases in the same grid are unchanged.

## Tests

* `CanUse_DayOfMonth_And_DayOfWeek_Together` now pins the whole 2×2, the `?`↔`*` synonymy in both
  directions, both-wildcard in all four spellings, and that `L`, `15W`, `6#3` and `6L` each restrict
  and make the wildcard opposite them yield.
* `CronExpressionDifferentialTest.NextExpression` grew a third shape that fills **both** day fields,
  with the reference rule written out longhand. Either field can come out a wildcard, so the fuzz
  reaches the whole 2×2 rather than only the union — and the union branch had never been fuzzed at
  all, because the old generator put a `?` in exactly one day field by construction.
* Verified the new tests fail without the product change: reverting the router alone fails eight of
  the new `TestCase`s and the differential seeds (I saw the first three fail before truncating the output).

## Reviewer decisions

* **The Vixie-not-Cronos divergence** is the one thing worth ratifying again in review. It is recorded
  in the migration-guide row so the next reader does not "fix" it.
* **`*/n` in a day field is restricted** (see above). If you would rather be Vixie-literal here, that
  is a one-line change in `IsRestrictedDayField` and a note in the guide — but it is a worse rule.
* A **set-based** rule — "unrestricted = the field admits every day", so `1-31` and `SUN-SAT` join
  `*` and `?` — was considered and declined: it makes `1-30` and `1-31` behave differently, and it is
  not what was ratified. Adopting it later only ever narrows a schedule, so it stays available as a
  4.1 refinement.

## Deliberately left alone

`CanGetExpressionSummary`'s pinned text changes by one line (`daysOfWeek: ?` → `daysOfWeek: *`), which
is the expected consequence of the `?` normalisation. The member is slated for removal in a later PR of
this stream; this one only updates the assertion.

`CronField.isNoSpec` stays. It is unreachable from the parser now, but `CronFieldTest` pins it directly
and removing it is unrelated cleanup.

## Verification

```
dotnet build Quartz.slnx                                    Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                           Passed! Failed: 0, Passed: 4311
dotnet test src/Quartz.Tests.AspNetCore                     Passed! Failed: 0, Passed:  548
dotnet fallout VerifyDocsSnippets                           Succeeded (102 markdown files checked)
dotnet fallout BenchmarkSmoke                               Succeeded (284 benchmarks)
```

No public-API baseline moved — no public member changed shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX

