### PR TITLE
Configuration written in code beats a string, everywhere

### DIFF
--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -44,6 +44,27 @@ They hang off `IQuartzBuilder`, so they work the same under `AddQuartz` and on a
 [configuration reference](../configuration/reference.md#listeners-calendars-and-plugins) for how a plugin
 is registered and named.
 
+An options type in that table is the scheduler's own named options, so a plugin is configurable from
+`appsettings.json` like anything else the container builds — bind the section and the values reach the
+plugin:
+
+<!-- snippet: sample_plugins_options_from_configuration -->
+```csharp
+// A plugin's options are the scheduler's own named options, so a configuration section binds
+// onto them like any other. The callback below is applied over whatever the section said.
+services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Xml"));
+
+services.AddQuartz(q => q.UseXmlSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
+```
+<!-- endSnippet -->
+
+The three sources are applied in the order that makes code the last word: the flat
+`quartz.plugin.{name}.{property}` keys first, then the values bound onto the options, then the callback
+passed to the extension method. A setting the callback says nothing about keeps whatever the keys or the
+configuration section gave it, so configuring a plugin in code does not discard the rest of its
+configuration — it only overrides the parts it names. Under `AddQuartz("name", …)` the options are that
+scheduler's, so bind them with `services.Configure<TOptions>("name", section)`.
+
 ## Features
 
 ### LoggingJobHistoryPlugin

--- a/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -65,6 +66,19 @@ public static class QuartzPluginsSamples
         #region sample_plugins_shutdown_hook
 
         services.AddQuartz(q => q.UseShutdownHook(options => options.CleanShutdown = true));
+
+        #endregion
+    }
+
+    public static void PluginOptionsFromConfiguration(IServiceCollection services, IConfiguration configuration)
+    {
+        #region sample_plugins_options_from_configuration
+
+        // A plugin's options are the scheduler's own named options, so a configuration section binds
+        // onto them like any other. The callback below is applied over whatever the section said.
+        services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Xml"));
+
+        services.AddQuartz(q => q.UseXmlSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
 
         #endregion
     }

--- a/src/Quartz.Plugins/PluginConfigurationExtensions.cs
+++ b/src/Quartz.Plugins/PluginConfigurationExtensions.cs
@@ -1,13 +1,9 @@
-using System.Diagnostics.CodeAnalysis;
-
-using Microsoft.Extensions.DependencyInjection;
-
+using Quartz.Configuration;
 using Quartz.Plugins.History;
 using Quartz.Plugins.Interrupt;
 using Quartz.Plugins.Json;
 using Quartz.Plugins.Management;
 using Quartz.Plugins.Xml;
-using Quartz.Extensibility;
 
 namespace Quartz;
 
@@ -15,8 +11,18 @@ namespace Quartz;
 /// Adds the plugins shipped in <c>Quartz.Plugins</c> to a scheduler.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Each plugin is registered as an ordinary service, constructed by the container so it gets
 /// constructor injection, and then configured from typed options. No plugin is named by a string.
+/// </para>
+/// <para>
+/// The options are the scheduler's own named options, so a plugin is configurable from
+/// <c>appsettings.json</c> like anything else the container builds:
+/// <c>services.Configure&lt;FileSchedulingOptions&gt;(configuration.GetSection("…"))</c> reaches the
+/// plugin, and the callback passed here is applied over whatever bound onto them. The flat
+/// <c>quartz.plugin.&lt;name&gt;.*</c> keys still work and are applied first, so configuration written
+/// in code beats the same setting written as a string.
+/// </para>
 /// </remarks>
 public static class PluginConfigurationExtensions
 {
@@ -30,22 +36,20 @@ public static class PluginConfigurationExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var options = new FileSchedulingOptions();
-        configure(options);
-
-        return builder.AddConfiguredPlugin<XmlSchedulingDataProcessorPlugin>("xml", plugin =>
-        {
-            // Left unset, the plugin keeps its own default file name rather than being handed an empty
-            // one, which it would try to open as a path.
-            if (options.Files.Count > 0)
+        return builder.AddConfiguredPlugin<XmlSchedulingDataProcessorPlugin, FileSchedulingOptions>(
+            "xml", configure, static (plugin, options) =>
             {
-                plugin.FileNames = string.Join(",", options.Files);
-            }
+                // Left unset, the plugin keeps its own default file name rather than being handed an
+                // empty one, which it would try to open as a path.
+                if (options.Files.Count > 0)
+                {
+                    plugin.FileNames = string.Join(",", options.Files);
+                }
 
-            plugin.FailOnFileNotFound = options.FailOnFileNotFound;
-            plugin.FailOnSchedulingError = options.FailOnSchedulingError;
-            plugin.ScanInterval = options.ScanInterval;
-        });
+                plugin.FailOnFileNotFound = options.FailOnFileNotFound;
+                plugin.FailOnSchedulingError = options.FailOnSchedulingError;
+                plugin.ScanInterval = options.ScanInterval;
+            });
     }
 
     /// <summary>
@@ -58,20 +62,18 @@ public static class PluginConfigurationExtensions
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configure);
 
-        var options = new FileSchedulingOptions();
-        configure(options);
-
-        return builder.AddConfiguredPlugin<JsonSchedulingDataProcessorPlugin>("json", plugin =>
-        {
-            if (options.Files.Count > 0)
+        return builder.AddConfiguredPlugin<JsonSchedulingDataProcessorPlugin, FileSchedulingOptions>(
+            "json", configure, static (plugin, options) =>
             {
-                plugin.FileNames = string.Join(",", options.Files);
-            }
+                if (options.Files.Count > 0)
+                {
+                    plugin.FileNames = string.Join(",", options.Files);
+                }
 
-            plugin.FailOnFileNotFound = options.FailOnFileNotFound;
-            plugin.FailOnSchedulingError = options.FailOnSchedulingError;
-            plugin.ScanInterval = options.ScanInterval;
-        });
+                plugin.FailOnFileNotFound = options.FailOnFileNotFound;
+                plugin.FailOnSchedulingError = options.FailOnSchedulingError;
+                plugin.ScanInterval = options.ScanInterval;
+            });
     }
 
     /// <summary>
@@ -83,11 +85,8 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var options = new JobAutoInterruptOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<JobInterruptMonitorPlugin>(
-            "jobAutoInterrupt", plugin => plugin.DefaultMaxRunTime = options.DefaultMaxRunTime);
+        return builder.AddConfiguredPlugin<JobInterruptMonitorPlugin, JobAutoInterruptOptions>(
+            "jobAutoInterrupt", configure, static (plugin, options) => plugin.DefaultMaxRunTime = options.DefaultMaxRunTime);
     }
 
     /// <summary>
@@ -104,16 +103,14 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        JobHistoryLoggingOptions options = new JobHistoryLoggingOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<StructuredLoggingJobHistoryPlugin>("structuredJobHistory", plugin =>
-        {
-            Apply(options.JobSuccessMessage, value => plugin.JobSuccessMessage = value);
-            Apply(options.JobFailedMessage, value => plugin.JobFailedMessage = value);
-            Apply(options.JobToBeFiredMessage, value => plugin.JobToBeFiredMessage = value);
-            Apply(options.JobWasVetoedMessage, value => plugin.JobWasVetoedMessage = value);
-        });
+        return builder.AddConfiguredPlugin<StructuredLoggingJobHistoryPlugin, JobHistoryLoggingOptions>(
+            "structuredJobHistory", configure, static (plugin, options) =>
+            {
+                Apply(options.JobSuccessMessage, value => plugin.JobSuccessMessage = value);
+                Apply(options.JobFailedMessage, value => plugin.JobFailedMessage = value);
+                Apply(options.JobToBeFiredMessage, value => plugin.JobToBeFiredMessage = value);
+                Apply(options.JobWasVetoedMessage, value => plugin.JobWasVetoedMessage = value);
+            });
     }
 
     /// <summary>
@@ -126,15 +123,13 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        TriggerHistoryLoggingOptions options = new TriggerHistoryLoggingOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<StructuredLoggingTriggerHistoryPlugin>("structuredTriggerHistory", plugin =>
-        {
-            Apply(options.TriggerFiredMessage, value => plugin.TriggerFiredMessage = value);
-            Apply(options.TriggerMisfiredMessage, value => plugin.TriggerMisfiredMessage = value);
-            Apply(options.TriggerCompleteMessage, value => plugin.TriggerCompleteMessage = value);
-        });
+        return builder.AddConfiguredPlugin<StructuredLoggingTriggerHistoryPlugin, TriggerHistoryLoggingOptions>(
+            "structuredTriggerHistory", configure, static (plugin, options) =>
+            {
+                Apply(options.TriggerFiredMessage, value => plugin.TriggerFiredMessage = value);
+                Apply(options.TriggerMisfiredMessage, value => plugin.TriggerMisfiredMessage = value);
+                Apply(options.TriggerCompleteMessage, value => plugin.TriggerCompleteMessage = value);
+            });
     }
 
     /// <summary>
@@ -150,16 +145,14 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        JobHistoryLoggingOptions options = new JobHistoryLoggingOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<LoggingJobHistoryPlugin>("jobHistory", plugin =>
-        {
-            Apply(options.JobSuccessMessage, value => plugin.JobSuccessMessage = value);
-            Apply(options.JobFailedMessage, value => plugin.JobFailedMessage = value);
-            Apply(options.JobToBeFiredMessage, value => plugin.JobToBeFiredMessage = value);
-            Apply(options.JobWasVetoedMessage, value => plugin.JobWasVetoedMessage = value);
-        });
+        return builder.AddConfiguredPlugin<LoggingJobHistoryPlugin, JobHistoryLoggingOptions>(
+            "jobHistory", configure, static (plugin, options) =>
+            {
+                Apply(options.JobSuccessMessage, value => plugin.JobSuccessMessage = value);
+                Apply(options.JobFailedMessage, value => plugin.JobFailedMessage = value);
+                Apply(options.JobToBeFiredMessage, value => plugin.JobToBeFiredMessage = value);
+                Apply(options.JobWasVetoedMessage, value => plugin.JobWasVetoedMessage = value);
+            });
     }
 
     /// <summary>
@@ -175,15 +168,13 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        TriggerHistoryLoggingOptions options = new TriggerHistoryLoggingOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<LoggingTriggerHistoryPlugin>("triggerHistory", plugin =>
-        {
-            Apply(options.TriggerFiredMessage, value => plugin.TriggerFiredMessage = value);
-            Apply(options.TriggerMisfiredMessage, value => plugin.TriggerMisfiredMessage = value);
-            Apply(options.TriggerCompleteMessage, value => plugin.TriggerCompleteMessage = value);
-        });
+        return builder.AddConfiguredPlugin<LoggingTriggerHistoryPlugin, TriggerHistoryLoggingOptions>(
+            "triggerHistory", configure, static (plugin, options) =>
+            {
+                Apply(options.TriggerFiredMessage, value => plugin.TriggerFiredMessage = value);
+                Apply(options.TriggerMisfiredMessage, value => plugin.TriggerMisfiredMessage = value);
+                Apply(options.TriggerCompleteMessage, value => plugin.TriggerCompleteMessage = value);
+            });
     }
 
     /// <summary>
@@ -195,11 +186,8 @@ public static class PluginConfigurationExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        ShutdownHookOptions options = new ShutdownHookOptions();
-        configure?.Invoke(options);
-
-        return builder.AddConfiguredPlugin<ShutdownHookPlugin>(
-            "shutdownHook", plugin => plugin.CleanShutdown = options.CleanShutdown);
+        return builder.AddConfiguredPlugin<ShutdownHookPlugin, ShutdownHookOptions>(
+            "shutdownHook", configure, static (plugin, options) => plugin.CleanShutdown = options.CleanShutdown);
     }
 
     /// <summary>
@@ -214,24 +202,6 @@ public static class PluginConfigurationExtensions
         }
     }
 
-    /// <summary>
-    /// Registers a plugin that the container constructs and the caller then configures.
-    /// </summary>
-    private static IQuartzBuilder AddConfiguredPlugin<
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] TPlugin>(
-        this IQuartzBuilder builder,
-        string name,
-        Action<TPlugin> configure) where TPlugin : class, ISchedulerPlugin
-    {
-        return builder.AddPlugin<TPlugin>(
-            provider =>
-            {
-                var plugin = ActivatorUtilities.CreateInstance<TPlugin>(provider);
-                configure(plugin);
-                return plugin;
-            },
-            name);
-    }
 }
 
 /// <summary>

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationWrittenInCodeWinsTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationWrittenInCodeWinsTest.cs
@@ -1,0 +1,289 @@
+#nullable enable
+
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Plugins.History;
+using Quartz.Plugins.Interrupt;
+using Quartz.Plugins.Json;
+using Quartz.Plugins.Management;
+using Quartz.Plugins.Xml;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Guards the precedence <c>AddQuartz</c> documents: a setting written in code beats the same setting
+/// written as a string, and one setting is read by one reader.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The companion of <see cref="ConfigurationIsNeverSilentlyDroppedTest"/>. That one is about
+/// configuration nobody reads; this one is about configuration two things read, where the answer
+/// depends on which of them ran last. Both failures look the same from outside — a scheduler
+/// configured as if the application had said something else — and neither fails a build.
+/// </para>
+/// <para>
+/// Every case here is one that was wrong: plugins were configured while they were built and the
+/// <c>quartz.plugin.*</c> keys were applied on top, so for every plugin shipped with Quartz a leftover
+/// string beat the code that said otherwise; and <c>Quartz:ThreadPool:MaxConcurrency</c> was read by
+/// the typed binder and again by the property bridge.
+/// </para>
+/// </remarks>
+public class ConfigurationWrittenInCodeWinsTest
+{
+    private static IConfiguration Section(Dictionary<string, string?> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values.ToDictionary(x => "Quartz:" + x.Key, x => x.Value))
+            .Build()
+            .GetSection("Quartz");
+    }
+
+    /// <summary>
+    /// The plugins one scheduler ends up with, built the way the scheduler factory builds them.
+    /// </summary>
+    private static List<ISchedulerPlugin> Plugins(IServiceProvider provider, string? schedulerName = null)
+    {
+        SchedulerKey key = new(schedulerName);
+        return SchedulerPluginFactory.Create(
+                provider,
+                provider.GetSchedulerServices<ISchedulerPlugin>(key.Key),
+                provider.GetSchedulerProperties(key.OptionsName),
+                key)
+            .Select(x => x.Plugin)
+            .ToList();
+    }
+
+    private static T Plugin<T>(IServiceProvider provider, string? schedulerName = null) where T : ISchedulerPlugin
+    {
+        return Plugins(provider, schedulerName).OfType<T>().Single();
+    }
+
+    [Test]
+    public void APluginKeepsWhatCodeConfiguredWhenAFlatKeySaysOtherwise()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(
+            new NameValueCollection { ["quartz.plugin.jobHistory.jobSuccessMessage"] = "from the property bag" },
+            q => q.UseJobHistoryLogging(options => options.JobSuccessMessage = "from code"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<LoggingJobHistoryPlugin>(provider).JobSuccessMessage.Should().Be("from code",
+            "the flat keys are applied to a plugin before what it was configured with in code, because "
+            + "an old configuration file must not quietly override the value the application asked for");
+    }
+
+    [Test]
+    public void AFlatKeyStillReachesASettingCodeSaidNothingAbout()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(
+            new NameValueCollection { ["quartz.plugin.jobHistory.jobFailedMessage"] = "from the property bag" },
+            q => q.UseJobHistoryLogging(options => options.JobSuccessMessage = "from code"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        LoggingJobHistoryPlugin plugin = Plugin<LoggingJobHistoryPlugin>(provider);
+
+        plugin.JobFailedMessage.Should().Be("from the property bag",
+            "code beating strings is per setting, not per plugin — configuring a plugin in code must not "
+            + "silently discard the keys that configure the settings the code left alone");
+        plugin.JobSuccessMessage.Should().Be("from code");
+    }
+
+    [Test]
+    public void APluginOptionBoundFromConfigurationReachesThePlugin()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["JobHistory:JobSuccessMessage"] = "from appsettings" })
+            .Build();
+
+        ServiceCollection services = new();
+        services.Configure<JobHistoryLoggingOptions>(configuration.GetSection("JobHistory"));
+        services.AddQuartz(q => q.UseJobHistoryLogging());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<LoggingJobHistoryPlugin>(provider).JobSuccessMessage.Should().Be("from appsettings",
+            "a plugin's options are the scheduler's own named options, so everything that configures "
+            + "options — a configuration section most of all — reaches the plugin");
+    }
+
+    [Test]
+    public void ThePluginCallbackBeatsTheConfigurationItsOptionsWereBoundFrom()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["JobHistory:JobSuccessMessage"] = "from appsettings" })
+            .Build();
+
+        ServiceCollection services = new();
+        services.Configure<JobHistoryLoggingOptions>(configuration.GetSection("JobHistory"));
+        services.AddQuartz(q => q.UseJobHistoryLogging(options => options.JobSuccessMessage = "from code"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<LoggingJobHistoryPlugin>(provider).JobSuccessMessage.Should().Be("from code",
+            "the callback is applied over the bound values, which is what makes it code beating strings "
+            + "rather than a second source of them");
+    }
+
+    [Test]
+    public void ANamedSchedulersPluginOptionsAreItsOwn()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["JobHistory:JobSuccessMessage"] = "reporting only" })
+            .Build();
+
+        ServiceCollection services = new();
+        services.Configure<JobHistoryLoggingOptions>("reporting", configuration.GetSection("JobHistory"));
+        services.AddQuartz("reporting", q => q.UseJobHistoryLogging());
+        services.AddQuartz(q => q.UseJobHistoryLogging());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<LoggingJobHistoryPlugin>(provider, "reporting").JobSuccessMessage.Should().Be("reporting only");
+        Plugin<LoggingJobHistoryPlugin>(provider).JobSuccessMessage.Should().NotBe("reporting only",
+            "options named after a scheduler belong to that scheduler, or one tenant's configuration "
+            + "would configure another's plugin");
+    }
+
+    [Test]
+    public void TwoPluginsSharingAnOptionsTypeKeepTheirOwnConfiguration()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q
+            .UseXmlSchedulingConfiguration(options => options.Files.Add("jobs.xml"))
+            .UseJsonSchedulingConfiguration(options => options.Files.Add("jobs.json")));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<XmlSchedulingDataProcessorPlugin>(provider).FileNames.Should().Be("jobs.xml",
+            "both scheduling processors are configured by FileSchedulingOptions, so a callback registered "
+            + "against the type rather than against this registration would hand each of them the "
+            + "other's files");
+        Plugin<JsonSchedulingDataProcessorPlugin>(provider).FileNames.Should().Be("jobs.json");
+    }
+
+    [Test]
+    public void EveryShippedPluginIsConfiguredFromItsOwnRegistration()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q => q
+            .UseJobHistoryLogging(options => options.JobFailedMessage = "job failed")
+            .UseTriggerHistoryLogging(options => options.TriggerFiredMessage = "trigger fired")
+            .UseStructuredJobLogging(options => options.JobWasVetoedMessage = "job vetoed")
+            .UseStructuredTriggerLogging(options => options.TriggerCompleteMessage = "trigger complete")
+            .UseXmlSchedulingConfiguration(options => options.Files.Add("jobs.xml"))
+            .UseJsonSchedulingConfiguration(options => options.Files.Add("jobs.json"))
+            .UseJobAutoInterrupt(options => options.DefaultMaxRunTime = TimeSpan.FromMinutes(7))
+            .UseShutdownHook());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        Plugin<LoggingJobHistoryPlugin>(provider).JobFailedMessage.Should().Be("job failed");
+        Plugin<LoggingTriggerHistoryPlugin>(provider).TriggerFiredMessage.Should().Be("trigger fired");
+        Plugin<StructuredLoggingJobHistoryPlugin>(provider).JobWasVetoedMessage.Should().Be("job vetoed");
+        Plugin<StructuredLoggingTriggerHistoryPlugin>(provider).TriggerCompleteMessage.Should().Be("trigger complete");
+        Plugin<XmlSchedulingDataProcessorPlugin>(provider).FileNames.Should().Be("jobs.xml");
+        Plugin<JsonSchedulingDataProcessorPlugin>(provider).FileNames.Should().Be("jobs.json");
+        Plugin<JobInterruptMonitorPlugin>(provider).DefaultMaxRunTime.Should().Be(TimeSpan.FromMinutes(7));
+        Plugin<ShutdownHookPlugin>(provider).CleanShutdown.Should().BeTrue(
+            "an extension called without a callback still applies its options, whose defaults are the "
+            + "documented ones rather than whatever the plugin's own field happens to be");
+
+        Plugin<LoggingJobHistoryPlugin>(provider).JobWasVetoedMessage.Should().NotBe("job vetoed",
+            "the classic and structured history plugins share an options type, and a callback registered "
+            + "against the type rather than against one registration would configure both of them");
+        Plugin<StructuredLoggingJobHistoryPlugin>(provider).JobFailedMessage.Should().NotBe("job failed");
+    }
+
+    [Test]
+    public void TheThreadPoolSectionIsReadByExactlyOneReader()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(Section(new Dictionary<string, string?> { ["ThreadPool:MaxConcurrency"] = "7" }));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<ThreadPoolOptions>>().Value.MaxConcurrency.Should().Be(7);
+        provider.GetRequiredService<IOptions<QuartzOptions>>().Value.Properties
+            .Should().NotContainKey("quartz.threadPool.maxConcurrency",
+                "the section binds onto ThreadPoolOptions, so flattening it as well would have the one "
+                + "value written by two readers whose order decides the answer");
+    }
+
+    [Test]
+    public void TheThreadPoolKeysWithNoTypedHomeAreStillFlattened()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(Section(new Dictionary<string, string?>
+        {
+            ["ThreadPool:Type"] = "Quartz.Impl.DefaultThreadPool, Quartz",
+            ["ThreadPool:MaxConcurrency"] = "7",
+        }));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Dictionary<string, string?> properties = provider.GetRequiredService<IOptions<QuartzOptions>>().Value.Properties;
+
+        properties.Should().ContainKey("quartz.threadPool.type",
+            "the type key selects an implementation and the bridge is its only reader, so dropping the "
+            + "section from the flattened form would leave the pool unregistered");
+        provider.GetRequiredService<IThreadPool>().Should().BeOfType<DefaultThreadPool>()
+            .Which.MaxConcurrency.Should().Be(7,
+                "the two halves of one section are read by different readers, and both have to land on "
+                + "the same pool");
+    }
+
+    [Test]
+    public void TheLegacyThreadCountSpellingStillReaches()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(Section(new Dictionary<string, string?> { ["ThreadPool:ThreadCount"] = "5" }));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<ThreadPoolOptions>>().Value.MaxConcurrency.Should().Be(5,
+            "threadCount is not a property of ThreadPoolOptions, so the bridge is its only reader and "
+            + "the section has to keep reaching it");
+    }
+
+    [Test]
+    public void TheFlatSpellingOfMaxConcurrencyStillReaches()
+    {
+        ServiceCollection sections = new();
+        sections.AddQuartz(Section(new Dictionary<string, string?> { ["quartz.threadPool.maxConcurrency"] = "3" }));
+
+        ServiceCollection properties = new();
+        properties.AddQuartz(new NameValueCollection { ["quartz.threadPool.maxConcurrency"] = "3" });
+
+        using ServiceProvider fromSection = sections.BuildServiceProvider();
+        using ServiceProvider fromProperties = properties.BuildServiceProvider();
+
+        fromSection.GetRequiredService<IOptions<ThreadPoolOptions>>().Value.MaxConcurrency.Should().Be(3,
+            "a flat key written in a configuration section is passed through rather than synthesized, so "
+            + "the bridge still reads it");
+        fromProperties.GetRequiredService<IOptions<ThreadPoolOptions>>().Value.MaxConcurrency.Should().Be(3,
+            "AddQuartz(NameValueCollection) has no configuration to bind, so the bridge is the only "
+            + "reader that path ever had");
+    }
+
+    [Test]
+    public void CodeStillBeatsTheThreadPoolSection()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(
+            Section(new Dictionary<string, string?> { ["ThreadPool:MaxConcurrency"] = "7" }),
+            q => q.UseDefaultThreadPool(options => options.MaxConcurrency = 3));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<ThreadPoolOptions>>().Value.MaxConcurrency.Should().Be(3,
+            "options are last-wins and the callback runs after the section is bound");
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/QuartzConfigurationHelperTests.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzConfigurationHelperTests.cs
@@ -26,8 +26,43 @@ public class QuartzConfigurationHelperTests
 
         var result = QuartzConfigurationHelper.ToNameValueCollection(config);
         result["quartz.scheduler.instanceName"].Should().Be("Test");
-        result["quartz.threadPool.maxConcurrency"].Should().Be("10");
         result["quartz.jobStore.type"].Should().Be("Quartz.Impl.RAMJobStore, Quartz");
+        result["quartz.threadPool.maxConcurrency"].Should().BeNull(
+            "the section binds onto ThreadPoolOptions.MaxConcurrency, and a value flattened here as well "
+            + "would be read a second time by the property bridge");
+    }
+
+    [Test]
+    public void AKeyATypedOptionOwnsIsNotFlattenedTwice()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "ThreadPool:MaxConcurrency", "10" },
+            { "ThreadPool:ThreadCount", "8" },
+            { "ThreadPool:Type", "Quartz.Impl.DefaultThreadPool, Quartz" },
+            { "ThreadPool:Marker", "configured" },
+        });
+
+        var result = QuartzConfigurationHelper.ToNameValueCollection(config);
+
+        result["quartz.threadPool.maxConcurrency"].Should().BeNull();
+        result["quartz.threadPool.threadCount"].Should().Be("8",
+            "the legacy spelling is no property of the options type, so the bridge is its only reader");
+        result["quartz.threadPool.type"].Should().Be("Quartz.Impl.DefaultThreadPool, Quartz",
+            "the type key selects an implementation, which only the bridge can do");
+        result["quartz.threadPool.marker"].Should().Be("configured",
+            "a third-party pool's own settings are applied from the flat keys and have no typed home");
+    }
+
+    [Test]
+    public void AFlatKeyForATypedOptionIsPassedThroughUnchanged()
+    {
+        var config = BuildConfig(new Dictionary<string, string> { { "quartz.threadPool.maxConcurrency", "10" } });
+
+        QuartzConfigurationHelper.ToNameValueCollection(config)["quartz.threadPool.maxConcurrency"]
+            .Should().Be("10",
+                "only the spelling this synthesizes is left out; a key written flat has no typed binding "
+                + "to be read by, so dropping it would leave it read by nobody");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/HostApplicationBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/HostApplicationBuilderTest.cs
@@ -96,6 +96,39 @@ public sealed class HostApplicationBuilderTest
         host.Services.SchedulerOptions<ThreadPoolOptions>("billing").MaxConcurrency.Should().Be(5);
     }
 
+    /// <summary>
+    /// The one difference between the two receivers, said out loud: a builder holds its configuration
+    /// and a service collection is handed one.
+    /// </summary>
+    /// <remarks>
+    /// <c>AddQuartzSchedulers</c> takes an <see cref="IConfiguration"/> on <c>IServiceCollection</c> and
+    /// none on <c>IHostApplicationBuilder</c>, which reads like two contracts under one name until you
+    /// see that <c>AddQuartz</c> differs in exactly the same way and for the same reason. What would
+    /// make them genuinely incompatible is a service collection that read configuration it was never
+    /// given, so that is what this pins.
+    /// </remarks>
+    [Test]
+    public void AServiceCollectionReadsNoConfigurationItWasNotHanded()
+    {
+        HostApplicationBuilder builder = Builder(new Dictionary<string, string?>
+        {
+            ["Quartz:quartz.scheduler.instanceName"] = "from-configuration",
+            ["Quartz:ThreadPool:MaxConcurrency"] = "7",
+        });
+
+        // The container's own IConfiguration says all of that, and this overload was handed none of it.
+        builder.Services.AddQuartz();
+
+        using IHost host = builder.Build();
+
+        host.Services.GetRequiredService<IScheduler>().SchedulerName.Should().Be("QuartzScheduler",
+            "services.AddQuartz(configure) means a scheduler configured entirely in code; a receiver "
+            + "that went looking for an ambient section would configure schedulers a caller never "
+            + "described");
+        host.Services.SchedulerOptions<ThreadPoolOptions>().MaxConcurrency
+            .Should().Be(ThreadPoolOptions.DefaultMaxConcurrency);
+    }
+
     [Test]
     public void AddQuartzHostedService_RegistersTheHostedService()
     {

--- a/src/Quartz/Configuration/QuartzConfigurationHelper.cs
+++ b/src/Quartz/Configuration/QuartzConfigurationHelper.cs
@@ -28,6 +28,43 @@ internal static class QuartzConfigurationHelper
     };
 
     /// <summary>
+    /// The flat keys a typed options binding already owns, which are therefore not synthesized from the
+    /// hierarchical section they would come from.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A hierarchical section is read twice: it binds onto its typed options, and it is flattened onto
+    /// the <c>quartz.*</c> keys <see cref="QuartzPropertyBridge"/> translates. For nearly every key the
+    /// two have in common the second pass is doing something the binder cannot —
+    /// <c>Scheduler:InterruptJobsOnShutdown</c> is a spelling no property carries any more,
+    /// <c>Scheduler:IdleWaitTime</c> may be the legacy count of milliseconds that the binder would read
+    /// as a count of days, <c>ThreadPool:Type</c> selects an implementation rather than setting a value,
+    /// and a third-party component's own knobs have no options type at all. Those overlaps are
+    /// corrections and they stay.
+    /// </para>
+    /// <para>
+    /// <c>ThreadPool:MaxConcurrency</c> is the one key where both readers write the same property, from
+    /// the same key, in the same shape. Two writers of one value in a last-wins pipeline is a coin flip
+    /// rather than a fallback, so one of them has to go, and it is this one: the typed binder is the
+    /// reader the section has a first-class binding for, it is the one the source generator writes a
+    /// binder for, and a member added to <see cref="ThreadPoolOptions"/> later binds through it without
+    /// needing an entry anywhere else. Nothing else under <c>ThreadPool</c> is affected — the type key,
+    /// the legacy <c>threadCount</c> spelling and a third-party pool's own settings are all still
+    /// flattened, because the bridge is the only reader any of them has.
+    /// </para>
+    /// <para>
+    /// Only the <em>synthesized</em> spelling is dropped. A configuration that writes
+    /// <c>quartz.threadPool.maxConcurrency</c> as a flat key is passed through untouched and read by the
+    /// bridge, which is also the only reader on the paths that have no <see cref="IConfiguration"/> at
+    /// all — <c>AddQuartz(NameValueCollection)</c> and its dictionary twins.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> boundByTypedOptions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "quartz.threadPool.maxConcurrency",
+    };
+
+    /// <summary>
     /// Converts a hierarchical <see cref="IConfiguration"/> section into a flat <see cref="NameValueCollection"/>
     /// of Quartz configuration properties.
     /// </summary>
@@ -92,9 +129,10 @@ internal static class QuartzConfigurationHelper
 
     private static void FlattenSection(IConfigurationSection section, string currentPath, NameValueCollection properties)
     {
-        if (section.Value is not null)
+        var key = "quartz." + currentPath;
+        if (section.Value is not null && !boundByTypedOptions.Contains(key))
         {
-            properties["quartz." + currentPath] = section.Value;
+            properties[key] = section.Value;
         }
 
         foreach (var child in section.GetChildren())

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -161,6 +161,15 @@ public static partial class QuartzServiceCollectionExtensions
     /// out of the shape of a configuration file made <c>AddQuartz</c> mean two things depending on data
     /// it was handed.
     /// </para>
+    /// <para>
+    /// The section is a parameter because this receiver has no configuration of its own, which is the
+    /// rule every method here follows: a service collection is handed its configuration and never goes
+    /// looking for one, so <c>AddQuartz(configure)</c> means a scheduler configured entirely in code
+    /// rather than one that quietly reads whatever <see cref="IConfiguration"/> the container holds. On
+    /// a host application builder, which does hold configuration, this is
+    /// <c>builder.AddQuartzSchedulers(…)</c> and takes no section — the same difference
+    /// <c>AddQuartz</c> has between the two receivers.
+    /// </para>
     /// </remarks>
     /// <param name="services">The service collection to register into.</param>
     /// <param name="configuration">

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -154,11 +154,13 @@ public static partial class QuartzServiceCollectionExtensions
     /// Registers one named Quartz scheduler per child of the section's <c>Schedulers</c> sub-section.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Each child's key is the scheduler's name, and its contents are that scheduler's configuration —
     /// exactly what <c>AddQuartz(name, section)</c> would be given. The fan-out is its own method
     /// because registering several schedulers is a different act from registering one, and reading it
     /// out of the shape of a configuration file made <c>AddQuartz</c> mean two things depending on data
     /// it was handed.
+    /// </para>
     /// </remarks>
     /// <param name="services">The service collection to register into.</param>
     /// <param name="configuration">
@@ -375,6 +377,11 @@ public static partial class QuartzServiceCollectionExtensions
     /// implementation, and the knobs of components that have no options type at all. Splitting the
     /// sections between the two readers instead leaves anything that falls between them read by nobody,
     /// which is how a documented <c>JobStore:Type</c> came to be accepted and then ignored.
+    /// </para>
+    /// <para>
+    /// A key both readers would write identically is the exception, and there is one: it is dropped from
+    /// the flattened form rather than read twice. The list, and why nothing else is on it, is in
+    /// <see cref="QuartzConfigurationHelper" />.
     /// </para>
     /// <para>
     /// The two readers do disagree about the shape of a duration — <c>00:00:30</c> to the binder, a count

--- a/src/Quartz/Configuration/SchedulerPluginConfiguration.cs
+++ b/src/Quartz/Configuration/SchedulerPluginConfiguration.cs
@@ -1,0 +1,91 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// What a plugin added in code was configured with, kept as something that can be applied later.
+/// </summary>
+/// <remarks>
+/// Registered rather than baked into the plugin's construction, because <em>when</em> it is applied is
+/// the whole point: <see cref="SchedulerPluginFactory" /> applies these after the flat
+/// <c>quartz.plugin.&lt;name&gt;.*</c> keys, which is what makes configuration written in code beat the
+/// same setting written as a string.
+/// </remarks>
+/// <param name="SchedulerName">The scheduler the plugin belongs to; empty for the default scheduler.</param>
+/// <param name="PluginType">The plugin type this configures.</param>
+/// <param name="Apply">Applies the configuration to one instance of that type.</param>
+internal sealed record SchedulerPluginConfiguration(
+    string SchedulerName,
+    Type PluginType,
+    Action<ISchedulerPlugin, IServiceProvider> Apply);
+
+/// <summary>
+/// Registers a plugin shipped with Quartz together with the typed options it is configured from.
+/// </summary>
+/// <remarks>
+/// Internal, and used by the plugin packages through <c>InternalsVisibleTo</c>: it is the shape every
+/// <c>Use*</c> extension has, not a mechanism a third party needs. What it is built from is public —
+/// <c>AddPlugin&lt;T, TOptions&gt;</c> and <c>ConfigureOptions&lt;TOptions&gt;</c> — and a plugin
+/// outside Quartz says the same thing with those.
+/// </remarks>
+internal static class ConfiguredPluginExtensions
+{
+    /// <summary>
+    /// Adds a plugin the container builds, and configures it from <typeparamref name="TOptions" /> once
+    /// the string keys naming it have been applied.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The options are the scheduler's own named options, so anything that configures named options
+    /// reaches the plugin — <c>services.Configure&lt;TOptions&gt;(configuration.GetSection(…))</c> most
+    /// of all. That is what the closure this replaced could not do: it built an options object of its
+    /// own, which no configuration source could ever reach.
+    /// </para>
+    /// <para>
+    /// <paramref name="configure" /> is applied to this registration's own instance of the options
+    /// rather than being registered as another <c>IConfigureOptions&lt;TOptions&gt;</c>. Two shipped
+    /// plugins can share an options type — the XML and JSON scheduling processors both take
+    /// <c>FileSchedulingOptions</c> — and a callback registered against the type would be applied to
+    /// both of them, which is how one processor would come to be handed the other's files. It still
+    /// runs after the values bound from configuration, so code beats strings here as everywhere else.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TPlugin">The plugin's type.</typeparam>
+    /// <typeparam name="TOptions">The plugin's options type.</typeparam>
+    /// <param name="builder">The scheduler being configured.</param>
+    /// <param name="name">The name the scheduler knows the plugin by, and the name its flat keys use.</param>
+    /// <param name="configure">Configures the options, over whatever configuration bound onto them.</param>
+    /// <param name="apply">Copies the options onto the plugin.</param>
+    internal static IQuartzBuilder AddConfiguredPlugin<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] TPlugin,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+        this IQuartzBuilder builder,
+        string name,
+        Action<TOptions>? configure,
+        Action<TPlugin, TOptions> apply)
+        where TPlugin : class, ISchedulerPlugin
+        where TOptions : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddPlugin<TPlugin, TOptions>(name: name);
+
+        string optionsName = builder.SchedulerName;
+        builder.Services.AddSingleton(new SchedulerPluginConfiguration(
+            optionsName,
+            typeof(TPlugin),
+            (plugin, provider) =>
+            {
+                TOptions options = provider.GetRequiredService<IOptionsFactory<TOptions>>().Create(optionsName);
+                configure?.Invoke(options);
+                apply((TPlugin) plugin, options);
+            }));
+
+        return builder;
+    }
+}

--- a/src/Quartz/Configuration/SchedulerPluginFactory.cs
+++ b/src/Quartz/Configuration/SchedulerPluginFactory.cs
@@ -26,6 +26,15 @@ namespace Quartz.Configuration;
 /// configuration working.
 /// </para>
 /// <para>
+/// The order the two sources are applied in is the documented one: the string properties go on first,
+/// and what a plugin was configured with in code goes on last, so a leftover key in a configuration
+/// file cannot quietly override the value the application asked for. The one arrangement that cannot
+/// have that order is a plugin whose configuration is baked into a factory of the caller's own —
+/// <c>AddPlugin&lt;T&gt;(provider =&gt; …)</c> — because by the time there is an instance to apply
+/// anything to, the factory has already run. Every plugin shipped with Quartz is registered with its
+/// options instead, which is what this ordering is for.
+/// </para>
+/// <para>
 /// Everything here is one scheduler's: the property bag is that scheduler's, the names are read from
 /// it, and a plugin type registered as a service is looked for under that scheduler's key. Two
 /// schedulers each configuring an XML plugin therefore get two instances reading their own files,
@@ -70,6 +79,11 @@ internal static class SchedulerPluginFactory
             plugins.Add((chosenNames.TryGetValue(type, out var name) ? name : type.Name, plugin));
         }
 
+        // Everything added in code is in the list now, and the entries the property bag names are
+        // appended after it. Kept, because only the plugins added in code carry the configuration that
+        // is applied last: an entry the property bag named is configured by that bag and nothing else.
+        int addedInCode = plugins.Count;
+
         var loader = provider.GetService<ITypeLoader>() ?? typeLoader;
 
         foreach (var name in PluginNames(properties))
@@ -94,7 +108,50 @@ internal static class SchedulerPluginFactory
             plugins.Add((name, plugin));
         }
 
+        ApplyConfiguration(provider, plugins, addedInCode, schedulerName);
+
         return plugins;
+    }
+
+    /// <summary>
+    /// Applies what each plugin added in code was configured with, after the string properties.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the last word, and it is meant to be: options are last-wins everywhere else in the
+    /// configuration model, and a plugin was the one component where they were not — the plugin was
+    /// configured while it was being built and the <c>quartz.plugin.&lt;name&gt;.*</c> keys were
+    /// applied on top of the result, so for every plugin shipped with Quartz a string beat the code
+    /// that said otherwise.
+    /// </para>
+    /// <para>
+    /// Matched on the plugin's type, which is what the registration named and what a plugin's options
+    /// belong to: one instance per type per scheduler is what the registration gives, so there is
+    /// nothing finer to match on. Two instances of one plugin type that must differ are two schedulers,
+    /// which is the axis the property bag has always separated them on as well.
+    /// </para>
+    /// </remarks>
+    private static void ApplyConfiguration(
+        IServiceProvider provider,
+        List<(string Name, ISchedulerPlugin Plugin)> plugins,
+        int addedInCode,
+        string schedulerName)
+    {
+        foreach (SchedulerPluginConfiguration configuration in provider.GetServices<SchedulerPluginConfiguration>())
+        {
+            if (!string.Equals(configuration.SchedulerName, schedulerName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            for (int i = 0; i < addedInCode; i++)
+            {
+                if (configuration.PluginType == plugins[i].Plugin.GetType())
+                {
+                    configuration.Apply(plugins[i].Plugin, provider);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Quartz/Hosting/QuartzHostApplicationBuilderExtensions.cs
+++ b/src/Quartz/Hosting/QuartzHostApplicationBuilderExtensions.cs
@@ -78,6 +78,24 @@ public static class QuartzHostApplicationBuilderExtensions
     /// Registers one named Quartz scheduler per child of the <c>Quartz</c> section's <c>Schedulers</c>
     /// sub-section.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is <see cref="QuartzServiceCollectionExtensions.AddQuartzSchedulers(Microsoft.Extensions.DependencyInjection.IServiceCollection, IConfiguration, Action{IQuartzBuilder})"/>
+    /// with the section found for you, and it says exactly what that one says — including refusing a
+    /// section that describes one scheduler rather than several.
+    /// </para>
+    /// <para>
+    /// The receiver decides where configuration comes from, and it decides it the same way for every
+    /// method here: a service collection is <em>handed</em> its configuration, a builder already holds
+    /// its own. That is why this takes no <see cref="IConfiguration"/> and the service collection
+    /// overload requires one — the same difference <c>AddQuartz</c> has, for the same reason. Neither
+    /// receiver goes looking for a configuration it was not given: <c>services.AddQuartz(configure)</c>
+    /// means a scheduler configured entirely in code, not one that quietly reads whatever
+    /// <see cref="IConfiguration"/> the container happens to hold, and there is no
+    /// <c>services.AddQuartzSchedulers(configure)</c> because a fan-out with nothing to fan out over is
+    /// not a scheduler registration at all.
+    /// </para>
+    /// </remarks>
     /// <param name="builder">The host application builder.</param>
     /// <param name="configure">Applied to every scheduler described by the section.</param>
     public static IHostApplicationBuilder AddQuartzSchedulers(


### PR DESCRIPTION
Closes #3594.

Three places disagreed with the precedence `AddQuartz` documents (`QuartzServiceCollectionExtensions.cs:90-115`), and a fourth item asked whether two same-named overloads have the same contract. Two commits: the behavioural fixes, then the contract documentation.

## 1. Flat plugin keys no longer override the `Use*` lambda

`SchedulerPluginFactory.Create` built the container-registered plugins — running whatever configuration each carried — and then applied `quartz.plugin.<name>.*` on top. For every shipped plugin a leftover string beat the code.

The keys now go on first and the code goes on last. That needs the code configuration to survive construction, so it is no longer baked into a factory closure: each `Use*` registers its plugin through `AddPlugin<T, TOptions>` and records how the options are copied onto the plugin (`SchedulerPluginConfiguration`, internal, `Quartz.Plugins` is already a friend assembly), and the factory replays those records after the keys.

Granularity is per setting, not per plugin: a key that configures something the callback said nothing about still lands (`AFlatKeyStillReachesASettingCodeSaidNothingAbout`). A plugin registered with `AddPlugin<T>(provider => …)` — a caller's own factory — keeps the old order and cannot do otherwise, since that configuration has already happened by the time there is an instance; the type's remarks say so.

## 2. `Quartz:ThreadPool:MaxConcurrency` now has one reader

**Choice: the typed binder keeps the key; the flattener stops synthesizing it.** Reasoning, since the brief asked for it:

- *What the flattener feeds* decided it. Dropping the whole `ThreadPool` section from the flattened form would take `ThreadPool:Type` (selects the implementation — only the bridge can do that), the legacy `ThreadCount` spelling (no property to bind onto), and a third-party pool's own knobs (applied from the bag by reflection) with it. That is the `JobStore:Type`-accepted-then-ignored failure the `LegacyProperties` docs warn about. So the exclusion is one key, not one section.
- *Deleting the typed bind instead* was the alternative I rejected: `ThreadPoolOptions` would become the only options type the configuration binder does not bind, and three guards in `ConfigurationBindingIsSourceGeneratedTest` (the interception count, the generated-binder list, the every-member case) would have to be loosened to allow it. A member added to `ThreadPoolOptions` later would then bind from nowhere.
- Only the *synthesized* spelling is skipped. A flat `quartz.threadPool.maxConcurrency` — the only spelling `AddQuartz(NameValueCollection)` has — is passed through and read by the bridge as before.

**Reviewer's call:** the overlap is not unique to this key. `Scheduler:InstanceName`, `MaxBatchSize` and `Context:*` are also written by both readers. The rest of the overlaps are corrections rather than duplicates — a legacy spelling the binder cannot express (`InterruptJobsOnShutdown`), a unit it reads differently (`IdleWaitTime` in milliseconds), a value that selects rather than sets (`InstanceId = AUTO`) — but `InstanceName` and `MaxBatchSize` are genuinely the same case as `MaxConcurrency`. I fixed the one the issue names and left the list a one-entry list with the rule written next to it, rather than widen the change under a fix; say the word and the others follow in the same shape.

One consequence worth knowing: `QuartzOptions.Properties` no longer echoes `quartz.threadPool.maxConcurrency` for a scheduler configured from a section, so a third-party `IThreadPool` that is not a `TaskSchedulingThreadPool` and has a `MaxConcurrency` property of its own no longer gets it set by reflection from `Quartz:ThreadPool:MaxConcurrency`. Pools deriving from `TaskSchedulingThreadPool` take the typed value as they always did.

## 3. Shipped plugins bind their options from configuration

`AddPlugin<T, TOptions>` makes the options the scheduler's own named options, so `services.Configure<FileSchedulingOptions>(configuration.GetSection(…))` reaches the plugin — the closure could never be reached that way, since it built an options object of its own. Every `Use*` signature is unchanged, and the plugins themselves are untouched, so #3593 / #3588 / #3601 rebase over this cleanly.

The callback each extension takes is applied to that registration's own options instance rather than being registered as another `IConfigureOptions<TOptions>`: the XML and JSON processors share `FileSchedulingOptions`, and the classic and structured history plugins share their message-template types, so a callback registered against the type would hand each of them the other's configuration. `TwoPluginsSharingAnOptionsTypeKeepTheirOwnConfiguration` and `EveryShippedPluginIsConfiguredFromItsOwnRegistration` pin that. It also means a section bound onto `FileSchedulingOptions` is a baseline for *both* processors — the same thing sharing an options type has always meant.

No new configuration section convention was invented; a plugin's options bind the way any other options type does.

## 4. `AddQuartzSchedulers` — documented, not changed

**This is a deviation from the brief, and the reasoning is the evidence I found.** The two overloads look incompatible but are the same rule seen from two receivers, and it is the rule `AddQuartz` already follows: on `IServiceCollection` configuration is always a parameter, on `IHostApplicationBuilder` it is the builder's own. Adding `services.AddQuartzSchedulers(configure)` would mean hunting for a registered `IConfiguration`, which `services.AddQuartz(configure)` deliberately does not do — that overload means "configured entirely in code" — so the overload would break the consistency it was meant to restore, and a fan-out with nothing to fan out over is not a registration at all. Requiring `IConfiguration` on the builder receiver instead would undo the reason those overloads exist.

So both sides now say the rule out loud (the host-builder overload carried no remarks at all), and `AServiceCollectionReadsNoConfigurationItWasNotHanded` pins the half that would make them genuinely incompatible. No public API changed, so no Verify baseline moved and there is no migration-guide row. If you want the overload anyway, it is three lines and I will add it — but it should be a decision, not a symmetry fix.

## Verification

```
dotnet build src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj   → Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test  src/Quartz.Tests.Unit                            → Passed! Failed: 0, Passed: 4296
dotnet test  src/Quartz.Tests.AspNetCore                      → Passed! Failed: 0, Passed: 548
dotnet fallout VerifyDocsSnippets                             → Succeeded
Quartz.Benchmark --smoke                                      → 284 benchmarks executed, no failures
```

Integration tests were not run: no Docker daemon in this environment. Nothing here touches ADO store paths.

The ordering fix was confirmed to fail without it: moving the new configuration pass ahead of the property pass makes `APluginKeepsWhatCodeConfiguredWhenAFlatKeySaysOtherwise` fail with the property-bag value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
