### PR TITLE
The cron parser refuses the expressions it used to quietly reinterpret

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -435,16 +435,22 @@ families answer "what time is it" in genuinely different ways.
 | Repeatedly inside a daily window | `DailyTimeIntervalTrigger` | The window is wall-clock, so a transition lengthens or shortens the day's run. |
 
 Quartz cron says more than most cron dialects, so check it before assuming a pattern needs something
-else: `0 0 0 ? * MON#2` is the second Monday of the month, `0 0 0 LW 3 ?` the last weekday of March,
-and `0 0 0 ? * MON/2` every other Monday, holding its fortnightly cadence across month and year
-boundaries. What it genuinely cannot state is a position counted from the *end* of a month other
-than the last one — `#` counts forwards, and only as far as 5 — and any cadence its fields cannot
-divide: `0 0 0 1/3 * ?` reads like "every third day" but restarts at the 1st of each month, so 31
-January is followed by 1 February. `RecurrenceTrigger` and its RFC 5545 rule state both,
-`FREQ=MONTHLY;BYDAY=-2FR` for the second-to-last Friday and `FREQ=DAILY;INTERVAL=3` for a three-day
-cadence that does not reset, on [4.x](/documentation/quartz-4.x/tutorial/recurrencetrigger) and
+else: `0 0 0 ? * MON#2` is the second Monday of the month and `0 0 0 LW 3 ?` the last weekday of
+March. What it genuinely cannot state is a position counted from the *end* of a month other
+than the last one — `#` counts forwards, and only as far as 5 — a fortnight, and any cadence its
+fields cannot divide: `0 0 0 1/3 * ?` reads like "every third day" but restarts at the 1st of each
+month, so 31 January is followed by 1 February. `RecurrenceTrigger` and its RFC 5545 rule state all
+three, `FREQ=MONTHLY;BYDAY=-2FR` for the second-to-last Friday, `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO`
+for every other Monday and `FREQ=DAILY;INTERVAL=3` for a three-day cadence that does not reset, on
+[4.x](/documentation/quartz-4.x/tutorial/recurrencetrigger) and
 [3.x](/documentation/quartz-3.x/tutorial/recurrencetrigger). Reaching for several cron triggers, or
 for a cron expression with a workaround in it, is usually the sign.
+
+**Quartz 3.x only:** `0 0 0 ? * MON/2` — a textual day-of-week with a step — means every other
+Monday there. 4.x rejects it, because the fortnight's phase was anchored to whatever last asked the
+expression a question: a misfire, a restart or a failover recomputed it from a different day and
+moved it. `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO` anchors on the trigger's start time instead, so the
+fortnight is a property of the trigger rather than of the caller.
 
 ### The two daylight saving rules
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4579,6 +4579,60 @@ Parse errors name the fix instead of only the constraint. A 5-field Unix/crontab
 online cron generator emits — is still rejected (Quartz cron puts seconds first), but the error now shows the
 corrected 6-field expression to use, and the day-of-week range error explains that Quartz numbers days 1-7
 starting at Sunday where Unix cron uses 0-6, recommending names (`SUN`, `MON`, …) as the unambiguous spelling.
+When the 5-field expression's day-of-week is a bare number the error goes one step further and shows the
+renumbered expression too: prepending a seconds field to `30 4 * * 1` keeps the `1`, and `1` is Monday in
+crontab but Sunday in Quartz, so the message names `"0 30 4 ? * MON"` as the schedule that was meant.
+
+### The parser refuses what it used to ignore
+
+A handful of expressions parsed, and then meant something other than what they said. Each is now a
+`FormatException` whose message names the expression that says what the author meant.
+
+| Expression | 3.x / 4.0 alpha | 4.0 |
+|---|---|---|
+| `1-5W` | the `W` was dropped; meant `1-5` | `FormatException` — write `1W,2W,3W,4W,5W` or drop the `W` |
+| `? * L-3`, `? * LW` | the suffix was dropped; meant Saturday | `FormatException` — those forms belong to day-of-month. A bare `L` in day-of-week is still Saturday |
+| `MON,FRI#3` | fired on the third **Monday**; the Friday was ignored | `FormatException` — `#` cannot appear beside other days |
+| `5C`, `1C` | parsed, meant `5` / `1`; `C` was never implemented | `FormatException` — use `ModifiedByCalendar` |
+| `*/0`, `5/0`, `0-10/0` | a step of 0 degenerated to no step | `FormatException` |
+| `0-10/120` | the step was never range-checked | `FormatException` — `Increment > 59 : 120`, as `0/120` already did |
+| `MON/2` | every second week — a fortnight with **no stable phase** | `FormatException` — `MON,WED,FRI` for a step through the week, or `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")` for every second Monday |
+
+`MON/2` is the one that changes a schedule rather than only a spelling, so it is worth the paragraph. A
+textual day-of-week followed by `/` meant "every N weeks", and the numeric `2/2` beside it meant an ordinary
+step — two readings of the same grammar. The fortnight also had no stable phase: it counted whole weeks from
+wherever the search started, so a misfire, a restart, a failover or a dashboard query recomputed it from a
+different day and moved it. It is rejected rather than quietly re-read as a step, because re-reading it would
+turn a fortnightly job into a thrice-weekly one — 26 fires a year become 156 — with nothing logged. Every
+second Monday is `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")`, which anchors the
+interval on the trigger's start time and so keeps its phase.
+
+### Before you upgrade
+
+Every row in that table is a string 3.x stored happily. The exception is thrown from
+`CronTriggerImpl.CronExpressionString`'s setter, which the ADO.NET job store calls while materialising a row,
+so a surviving expression fails the *read* rather than only the trigger. Audit the stored expressions first:
+
+```sql
+-- run against every scheduler's tables before upgrading; substitute your table prefix
+SELECT SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION
+FROM   QRTZ_CRON_TRIGGERS
+WHERE  CRON_EXPRESSION LIKE '%C%'    -- 'C' (calendar), never implemented
+   OR  CRON_EXPRESSION LIKE '%/0%'   -- step of zero
+   OR  CRON_EXPRESSION LIKE '%#%,%'  -- '#' beside other days
+   OR  CRON_EXPRESSION LIKE '%,%#%'
+   OR  CRON_EXPRESSION LIKE '%/%'    -- then eyeball for a textual day-of-week step
+   OR  CRON_EXPRESSION LIKE '%W%';   -- then eyeball for 'W' after a range
+```
+
+Several of those clauses are deliberately over-wide and need reading by eye: most `/` is an ordinary step, most
+`W` is a legitimate `15W` or `LW`, and `%C%` also matches the month names `DEC` and `OCT`, because expressions
+are stored upper-cased. `CronExpression.TryParse` against the 4.0 assembly is the authoritative check once you
+have a candidate list.
+
+Two sources are **not** reachable from this query. `CronCalendar` expressions live inside the serialized blob
+in `QRTZ_CALENDARS` and surface only at deserialization, and expressions built in code or held in
+configuration files never reach the database at all.
 
 ## Daylight saving time
 

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -88,8 +88,8 @@ public class CronExpressionBuilderTest
     public void TestDayOfWeekIncrementsMatchNumericIncrementSemantics()
     {
         // numeric "2/2" means day 2 (MON) through SAT stepping by 2; the builder emits
-        // the equivalent explicit day name list instead, since textual "MON/2" would
-        // mean Quartz's every-second-week feature
+        // the equivalent explicit day name list instead, since a textual "MON/2" is
+        // rejected by the parser
         CronExpression expanded = CronExpressionBuilder.Create()
             .WithSecond(0)
             .WithMinute(0)
@@ -443,36 +443,6 @@ public class CronExpressionBuilderTest
 
         FirstFireAfter(CronExpressionBuilder.Create().WithSecond(0).WithMinute(0).WithHour(12).OnWeekdays(), march)
             .Should().Be(new DateTimeOffset(2024, 3, 1, 12, 0, 0, TimeSpan.Zero), "the 1st is a Friday");
-    }
-
-    /// <summary>
-    /// <c>MON/2</c> is a Quartz extension meaning every second week, and it is why
-    /// <see cref="CronExpressionBuilder.WithDayOfWeekIncrements" /> renders an explicit list instead of
-    /// the token its name suggests: the numeric <c>2/2</c> the builder means and the textual
-    /// <c>MON/2</c> the reader would guess are two different schedules.
-    /// </summary>
-    [Test]
-    public void TestTheBuilderNeverRendersTheTextualEveryNthWeekExtension()
-    {
-        CronExpressionBuilder builder = CronExpressionBuilder.Create()
-            .WithSecond(0).WithMinute(0).WithHour(12)
-            .WithDayOfWeekIncrements(DayOfWeek.Monday, 2);
-
-        builder.ToString().Should().NotContain("/", "a textual day-of-week step is read as every-second-week, not as a step through the week");
-
-        CronExpression everySecondWeek = new CronExpression("0 0 12 ? * MON/2", TimeZoneInfo.Utc);
-        CronExpression everySecondDayOfWeek = new CronExpression(builder.ToString(), TimeZoneInfo.Utc);
-
-        DateTimeOffset start = new DateTimeOffset(2024, 3, 1, 0, 0, 0, TimeSpan.Zero);
-
-        DateTimeOffset firstMonday = new DateTimeOffset(2024, 3, 11, 12, 0, 0, TimeSpan.Zero);
-        everySecondWeek.GetNextValidTimeAfter(start).Should().Be(firstMonday,
-            "the extension counts whole weeks from where the search starts, so it skips the Monday two days later");
-        everySecondWeek.GetNextValidTimeAfter(firstMonday).Should().Be(new DateTimeOffset(2024, 3, 25, 12, 0, 0, TimeSpan.Zero),
-            "and then a fortnight at a time");
-
-        everySecondDayOfWeek.GetNextValidTimeAfter(start).Should().Be(new DateTimeOffset(2024, 3, 1, 12, 0, 0, TimeSpan.Zero),
-            "what the builder means is MON,WED,FRI, which includes the Friday the window opens on");
     }
 
     private static DateTimeOffset? FirstFireAfter(CronExpressionBuilder builder, DateTimeOffset after)

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -426,7 +426,104 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         act.Should().Throw<FormatException>()
             .WithMessage("*Unix/crontab*", "the most common first-run failure is a 5-field expression copied from crontab or Kubernetes")
             .WithMessage("*\"0 30 4 * * 1\"*", "the error must show the fixed expression, not just the constraint")
-            .WithMessage("*days of week 1-7*", "a Unix expression's numeric day-of-week also means a different day in Quartz");
+            .WithMessage("*days of week 1-7*", "a Unix expression's numeric day-of-week also means a different day in Quartz")
+            .WithMessage("*\"0 30 4 ? * MON\"*",
+                "prepending a seconds field keeps the digit, and '1' is Monday in crontab but Sunday in Quartz, so advice that stops at the rewrite moves the schedule by a day");
+    }
+
+    [TestCase("30 4 1 * 1", "\"0 30 4 1 * MON\"", "a day-of-month the crontab named is carried over as written")]
+    [TestCase("0 12 * * 7", "\"0 0 12 ? * SUN\"", "Unix spells Sunday both 0 and 7, and Quartz spells it 1")]
+    public void TheFiveFieldMessageRenumbersTheDayOfWeekItWasGiven(string expression, string expectedInMessage, string reason)
+    {
+        Action act = () => new CronExpression(expression);
+
+        act.Should().Throw<FormatException>(reason).WithMessage($"*{expectedInMessage}*", reason);
+    }
+
+    /// <summary>
+    /// The hash resolver counts the fields before anything is parsed, so it reaches the five-field
+    /// message with expressions the parser never gets far enough to reject - a five-field string's last
+    /// field is read as a month, so <c>0 12 * * MON</c> fails on the month long before the count is
+    /// looked at. The advice has to be the same on both paths.
+    /// </summary>
+    [TestCase("H 4 * * 1", "\"0 H 4 ? * MON\"", "the rewrite keeps the H token, because the token is not what is wrong")]
+    [TestCase("H 12 * * 0", "\"0 H 12 ? * SUN\"", "Unix numbers Sunday 0 where Quartz numbers it 1")]
+    [TestCase("H 12 * * MON", "respell numeric day-of-week values", "a day-of-week already spelled as a name needs no renumbering, so the generic advice stands")]
+    public void TheFiveFieldMessageIsTheSameOnTheHashResolvingPath(string expression, string expectedInMessage, string reason)
+    {
+        Action act = () => new CronExpression(expression, "a-trigger");
+
+        act.Should().Throw<FormatException>(reason)
+            .WithMessage("*Unix/crontab*", "the two paths must not disagree about what a five-field expression is")
+            .WithMessage($"*{expectedInMessage}*", reason);
+    }
+
+    /// <summary>
+    /// Every shape the parser used to accept and then quietly reinterpret. Each one now throws, and the
+    /// message has to name the expression that says what the author meant: a rejection that only states
+    /// the rule leaves them guessing at a schedule they believed they had already written.
+    /// </summary>
+    [TestCase("0 15 10 1-5W * ?", "1W,2W,3W,4W,5W", "the 'W' was dropped, so this quietly meant days 1 through 5")]
+    [TestCase("0 15 10 1-20W * ?", "1W,2W,...,20W", "a long range is abbreviated rather than spelled out over twenty days")]
+    [TestCase("0 15 10 1-5X * ?", "Unexpected character 'X' after the range '1-5'", "anything left over after a range was dropped, whatever it was")]
+    [TestCase("0 0 0 ? * L-3", "day-of-month", "everything after the 'L' was discarded, so this quietly meant every Saturday")]
+    [TestCase("0 0 0 ? * LW", "day-of-month", "'LW' in day-of-week was read as a bare 'L', which is Saturday")]
+    [TestCase("0 0 0 ? * MON,FRI#3", "one trigger per day", "the evaluator reads the smallest day in the field, so the Friday never fired at all")]
+    [TestCase("0 15 10 5C * ?", "ModifiedByCalendar", "'C' was never implemented, so '5C' behaved exactly like '5'")]
+    [TestCase("0 15 10 ? * 5C", "ModifiedByCalendar", "'C' was equally inert in day-of-week")]
+    [TestCase("0 */0 * * * ?", "a step of 1 or more", "a step of zero degenerated to no step, so '*/0' was '*'")]
+    [TestCase("0 5/0 * * * ?", "a step of 1 or more", "a step of zero after a value degenerated to the plain value")]
+    [TestCase("0 0-10/0 * * * ?", "a step of 1 or more", "a step of zero inside a range degenerated to the range's start")]
+    [TestCase("0 0-10/ * * * ?", "'/' must be followed by an integer", "a range with an empty step said nothing at all")]
+    [TestCase("0 0 12 ? * MON/2", "MON,WED,FRI", "the numeric twin '2/2' is what a step through the week means")]
+    [TestCase("0 0 12 ? * MON/2", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a fortnight that keeps its phase is a recurrence rule, not a cron expression")]
+    [TestCase("0 0 12 ? * MON/2", "not stable", "the message has to say why the extension went, or it reads as an arbitrary removal")]
+    [TestCase("0 0 12 ? * MON/X", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a step that is not a number is still a textual day-of-week step")]
+    [TestCase("0 0 12 ? * SUN/9", "FREQ=WEEKLY;INTERVAL=2;BYDAY=SU", "a step outside 1-7 is rejected as the same construct, not as a range error")]
+    public void ExpressionsThatSaidOneThingAndDidAnotherAreRejected(string expression, string expectedInMessage, string reason)
+    {
+        Action act = () => new CronExpression(expression);
+
+        act.Should().Throw<FormatException>(reason).WithMessage($"*{expectedInMessage}*", reason);
+    }
+
+    [TestCase("0-10/120 0 8-18 ? * 2-6", "Increment > 59 : 120")]
+    [TestCase("0 0-10/120 8-18 ? * 2-6", "Increment > 59 : 120")]
+    [TestCase("0 0 0-10/120 ? * 2-6", "Increment > 23 : 120")]
+    [TestCase("0 0 0 1-10/120 * 2-6", "Increment > 31 : 120")]
+    [TestCase("0 0 0 ? 1-10/120 2-6", "Increment > 12 : 120")]
+    [TestCase("0 0 0 ? * 1-6/120", "Increment > 7 : 120")]
+    public void AStepInsideARangeIsRangeCheckedLikeAnyOtherStep(string expression, string expectedMessage)
+    {
+        Action act = () => new CronExpression(expression);
+
+        act.Should().Throw<FormatException>(
+                "'0/120' has always thrown, and there is no reading of cron in which putting a range in front of the same step makes it legal")
+            .WithMessage(expectedMessage);
+    }
+
+    /// <summary>
+    /// The legitimate forms the new rejections stand next to. Each reads like one of them, so pin the
+    /// pair: bare <c>L</c> in day-of-week is Saturday while <c>L-3</c> there is not a form at all, and
+    /// <c>15W</c> shifts a single day while <c>1-5W</c> is a range with a stray character on the end.
+    /// </summary>
+    [TestCase("0 15 10 ? * L 2010", "'L' on its own in day-of-week is Saturday")]
+    [TestCase("0 15 10 ? * 6L 2010", "'6L' is the last Friday of the month")]
+    [TestCase("0 15 10 ? * FRIL 2010", "'FRIL' is the same schedule spelled with a name")]
+    [TestCase("0 15 10 LW-2 * ? 2010", "'LW-n' counts back from the last weekday of the month")]
+    [TestCase("0 15 10 L-5W * ? 2010", "'L-nW' is the nearest weekday to a day counted back from the end")]
+    [TestCase("0 15 10 15W * ? 2010", "a 'W' on a single day-of-month still shifts that day")]
+    [TestCase("0 15 10 ? * 6#3 2010", "'#' with no other day in the field is the nth day of the month")]
+    [TestCase("0 15 10 ? * FRI#3 2010", "and the same written with a name")]
+    [TestCase("0 15 10 1-5 * ? 2010", "a range with nothing after it is a range")]
+    [TestCase("0 0 18-21/1 ? * MON-FRI", "a step of 1 inside a range is a step, and a textual range is not a dash option")]
+    [TestCase("0 0 12 ? * 2/2", "the numeric twin of 'MON/2' is an ordinary step and is untouched")]
+    [TestCase("0 15 10 ? DEC * 2010", "'DEC' is a month name that happens to end in 'C', not a calendar option")]
+    public void ExpressionsTheNewRejectionsMustNotCatchStillParse(string expression, string reason)
+    {
+        Action act = () => new CronExpression(expression);
+
+        act.Should().NotThrow(reason);
     }
 
     [Test]
@@ -517,34 +614,6 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
 
         int[] arrJuneDaysThatShouldFire =
             [1, 8, 15, 22, 29];
-        List<int> juneDays = new List<int>(arrJuneDaysThatShouldFire);
-
-        TestCorrectWeekFireDays(cronExpression, juneDays);
-    }
-
-    [Test]
-    public void TestCronExpressionWeekdaysFridayEveryTwoWeeks()
-    {
-        CronExpression cronExpression = new CronExpression("0 0 12 ? * FRI/2");
-        var nextRunTime = cronExpression.GetTimeAfter(DateTimeOffset.Now);
-        var nextRunTime2 = cronExpression.GetTimeAfter((DateTimeOffset) nextRunTime);
-
-        int[] arrJuneDaysThatShouldFire =
-            [1, 15, 29];
-        List<int> juneDays = new List<int>(arrJuneDaysThatShouldFire);
-
-        TestCorrectWeekFireDays(cronExpression, juneDays);
-    }
-
-    [Test]
-    public void TestCronExpressionWeekdaysThirsdayAndFridayEveryTwoWeeks()
-    {
-        CronExpression cronExpression = new CronExpression("0 0 12 ? * THU,FRI/2");
-        var nextRunTime = cronExpression.GetTimeAfter(DateTimeOffset.Now);
-        var nextRunTime2 = cronExpression.GetTimeAfter((DateTimeOffset) nextRunTime);
-
-        int[] arrJuneDaysThatShouldFire =
-            [1, 14, 15, 28, 29];
         List<int> juneDays = new List<int>(arrJuneDaysThatShouldFire);
 
         TestCorrectWeekFireDays(cronExpression, juneDays);

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -176,15 +176,6 @@ namespace Quartz;
 /// not valid, since there are two expressions).
 /// </para>
 /// <para>
-/// <!--The 'C' character is allowed for the day-of-month and day-of-week fields.
-/// This character is short-hand for "calendar". This means values are
-/// calculated against the associated calendar, if any. If no calendar is
-/// associated, then it is equivalent to having an all-inclusive calendar. A
-/// value of "5C" in the day-of-month field means "the first day included by the
-/// calendar on or after the 5th". A value of "1C" in the day-of-week field
-/// means "the first day included by the calendar on or after Sunday". -->
-/// </para>
-/// <para>
 /// The legal characters and the names of months and days of the week are not
 /// case-sensitive.
 /// </para>
@@ -241,11 +232,6 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     [NonSerialized] private bool lastDayOfWeek;
 
     /// <summary>
-    /// N number of weeks.
-    /// </summary>
-    [NonSerialized] private int everyNthWeek;
-
-    /// <summary>
     /// Nth day of the week.
     /// </summary>
     [NonSerialized] private int nthdayOfWeek;
@@ -265,16 +251,6 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// </summary>
     [NonSerialized] private List<LastDaySpec>? lastDaySpecs;
 
-    /// <summary>
-    /// Calendar day of the week.
-    /// </summary>
-    [NonSerialized] private bool calendarDayOfWeek;
-
-    /// <summary>
-    /// Calendar day of the month.
-    /// </summary>
-    [NonSerialized] private bool calendarDayOfMonth;
-
     //e.g. LW L-0W L-4 L-12W LW-4 (out-of-range offsets are rejected in the 'L' parse)
     [GeneratedRegex("^L(-\\d+)?(W(-\\d+)?)?$", RegexOptions.ExplicitCapture, matchTimeoutMilliseconds: 5000)]
     private static partial Regex LastDayExpression();
@@ -282,6 +258,11 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     // Field ranges for H (hash) token resolution: [min, max] indexed by field type (Second=0 through DayOfWeek=5)
     private static readonly int[] HashFieldMins = { 0, 0, 0, 1, 1, 1 };
     private static readonly int[] HashFieldMaxes = { 59, 59, 23, 31, 12, 7 };
+
+    // Day-of-week names and RFC 5545 BYDAY codes, indexed by Quartz's 1-7 numbering (1 = Sunday).
+    // Only error messages read these; the parser maps the other way, through GetDayOfWeekNumber.
+    private static readonly string[] DayOfWeekNames = { "", "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
+    private static readonly string[] RecurrenceDayCodes = { "", "SU", "MO", "TU", "WE", "TH", "FR", "SA" };
 
     ///<summary>
     /// Constructs a new <see cref="CronExpressionString" /> based on the specified
@@ -726,7 +707,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         if (fieldCount < 6 || fieldCount > 7)
         {
             string unixHint = fieldCount == 5
-                ? $" A 5-field expression is the Unix/crontab form; Quartz cron puts seconds first - prepend a seconds field: \"0 {upperExpression}\"."
+                ? $" A 5-field expression is the Unix/crontab form; Quartz cron puts seconds first. {FiveFieldAdvice(upperExpression)}"
                 : "";
             throw new FormatException($"Invalid cron expression (expected 6-7 fields, got {fieldCount}): {upperExpression}.{unixHint}");
         }
@@ -906,6 +887,15 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
                     Throw.FormatException("Support for specifying multiple \"nth\" days is not implemented.");
                 }
 
+                // '#' names one day's nth occurrence, and the evaluator reads the smallest day in the field
+                // to find it, so 'MON,FRI#3' fired on the third Monday and never on a Friday at all
+                if (exprOn == CronExpressionConstants.DayOfWeek && expr.IndexOf('#') != -1 && expr.IndexOf(',') >= 0)
+                {
+                    Throw.FormatException(
+                        $"'#' applies to the whole day-of-week field, so it cannot appear beside other days: '{expr.ToString()}' would fire "
+                        + "on the nth occurrence of one day and never on the others. Use one trigger per day, or drop the '#'.");
+                }
+
                 // A second, minute or hour field written as a wildcard, step or range expresses an
                 // interval ("keep firing every ...") rather than a fixed time of day. The
                 // distinction drives the fall-back behavior in GetTimeAfter: interval expressions
@@ -939,8 +929,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
                 {
                     Throw.FormatException(
                         $"Cron expression '{expression}' has 5 fields, which is the Unix/crontab form; Quartz cron has 6 or 7 fields with seconds first. "
-                        + $"Prepend a seconds field: \"0 {expression}\". "
-                        + "Note that Quartz numbers days of week 1-7 starting at Sunday where Unix cron uses 0-6, so respell numeric day-of-week values or use names (SUN, MON, ...).");
+                        + FiveFieldAdvice(expression));
                 }
 
                 Throw.FormatException(
@@ -1092,6 +1081,16 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             }
 
             case CronExpressionConstants.DayOfWeek:
+                // The 'L(-n)?(W(-n)?)?' shapes all reach here, but only a bare 'L' means anything in this
+                // field; the rest used to be read and thrown away, so '? * L-3' quietly meant every Saturday.
+                if (s.Length > i)
+                {
+                    Throw.FormatException(
+                        $"'{s.ToString()}' is not valid in the day-of-week field. There, 'L' on its own means Saturday; the '-n' offset "
+                        + $"and the 'W' (nearest weekday) forms belong to day-of-month. Write '{s.ToString()}' in the day-of-month field, "
+                        + "where the end of the month is what those forms count from, or '6L' (or 'FRIL') for the last Friday of the month.");
+                }
+
                 AddToSet(7, 7, 0, type);
                 break;
             default:
@@ -1196,20 +1195,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
 
                         break;
                     case '/':
-                        try
-                        {
-                            i += 4;
-                            everyNthWeek = ToInt32(s.Slice(i));
-                            if (everyNthWeek is < 1 or > 5)
-                            {
-                                Throw.FormatException("everyNthWeek is < 1 or > 5");
-                            }
-                        }
-                        catch (Exception)
-                        {
-                            Throw.FormatException("A numeric value between 1 and 5 must follow the '/' option");
-                        }
-
+                        Throw.FormatException(TextualDayOfWeekStepMessage(sub, sval, s.Slice(i + 4)));
                         break;
                     case 'L':
                         lastDayOfWeek = true;
@@ -1278,6 +1264,13 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     // ReSharper disable once UnusedParameter.Local
     private static void CheckIncrementRange(int incr, int type)
     {
+        // AddToSet reads a non-positive increment as "this is a plain value", which is what its internal
+        // callers mean by it - but written down, '*/0' asked for a step and got a wildcard instead.
+        if (incr < 1)
+        {
+            Throw.FormatException("A step of 0 is not a step: '*/0' would advance by nothing. Use '*' for every value, or a step of 1 or more.");
+        }
+
         switch (type)
         {
             case CronExpressionConstants.Second or CronExpressionConstants.Minute when incr > 59:
@@ -1321,7 +1314,9 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
                 return;
 
             case 'C':
-                HandleCOption(val, type, pos);
+                Throw.FormatException(
+                    $"'C' (calendar) is not supported. It was never implemented - '{val}C' behaved exactly like '{val}' - so remove it. "
+                    + "To skip days a calendar excludes, attach the calendar to the trigger with .ModifiedByCalendar(name).");
                 return;
 
             case '-':
@@ -1395,47 +1390,75 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         if (i < s.Length && s[i] == '/')
         {
             i++;
+            if (i >= s.Length || char.IsWhiteSpace(s[i]))
+            {
+                Throw.FormatException("'/' must be followed by an integer.");
+            }
+
             c = s[i];
-            var v2 = ToInt32(c);
+            var incr = ToInt32(c);
             i++;
-            if (i >= s.Length)
+            if (i < s.Length && char.IsDigit(s[i]))
             {
-                AddToSet(val, end, v2, type);
-                return;
+                (incr, i) = GetValue(incr, s, i);
             }
 
-            c = s[i];
-            if (char.IsDigit(c))
-            {
-                var (v3, _) = GetValue(v2, s, i);
-                AddToSet(val, end, v3, type);
-                return;
-            }
-
-            AddToSet(val, end, v2, type);
+            // The step of a range was never range-checked, so '0-10/120' parsed where '0/120' threw.
+            CheckIncrementRange(incr, type);
+            CheckNothingFollowsRange(s, i, val, end);
+            AddToSet(val, end, incr, type);
             return;
         }
 
+        CheckNothingFollowsRange(s, i, val, end);
         AddToSet(val, end, 1, type);
     }
 
-    private void HandleCOption(int val, int type, int i)
+    /// <summary>
+    /// Rejects anything left over after a range. The range parser used to stop reading and drop the
+    /// remainder, so '1-5W' silently meant '1-5' - an expression that says one thing and does another.
+    /// </summary>
+    private static void CheckNothingFollowsRange(ReadOnlySpan<char> s, int i, int val, int end)
     {
-        switch (type)
+        if (i >= s.Length || char.IsWhiteSpace(s[i]))
         {
-            case CronExpressionConstants.DayOfWeek:
-                calendarDayOfWeek = true;
-                break;
-            case CronExpressionConstants.DayOfMonth:
-                calendarDayOfMonth = true;
-                break;
-            default:
-                Throw.FormatException($"'C' option is not valid here. (pos={i})");
-                break;
+            return;
         }
 
-        var data = GetSet(type);
-        data.Add(val);
+        if (s[i] == 'W')
+        {
+            Throw.FormatException(
+                $"Unexpected character 'W' after the range '{val}-{end}'. The 'W' option shifts a single day-of-month to its nearest "
+                + $"weekday, so it cannot follow a range - write '{NearestWeekdayList(val, end)}' for that, or drop the 'W' to fire on "
+                + $"days {val} through {end}.");
+        }
+
+        Throw.FormatException($"Unexpected character '{s[i]}' after the range '{val}-{end}'.");
+    }
+
+    /// <summary>
+    /// Spells out the per-day 'W' list a range with a 'W' on it was probably reaching for, abbreviating
+    /// once the list would be longer than the sentence containing it.
+    /// </summary>
+    private static string NearestWeekdayList(int val, int end)
+    {
+        if (end < val || end - val > 6)
+        {
+            return $"{val}W,{val + 1}W,...,{end}W";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        for (int day = val; day <= end; day++)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append(day).Append('W');
+        }
+
+        return builder.ToString();
     }
 
     private void HandleHashOption(ReadOnlySpan<char> s, int val, int type, int i)
@@ -1536,8 +1559,9 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             nearestWeekdays is not null || (lastDaySpecs is not null && lastDaySpecs.Exists(spec => spec.NearestWeekday)),
             nthdayOfWeek,
             lastDaySpecs is not null,
-            calendarDayOfWeek,
-            calendarDayOfMonth,
+            // calendarDayOfWeek and calendarDayOfMonth: 'C' is rejected by the parser, so no expression carries one
+            false,
+            false,
             years
         ).ToString();
     }
@@ -1790,6 +1814,74 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             "SAT" => 7,
             _ => -1
         };
+    }
+
+    /// <summary>
+    /// The advice half of the five-field error message: the seconds-first rewrite, and - when the
+    /// day-of-week field is a bare number - the Quartz spelling of the day that number named in crontab.
+    /// Prepending a seconds field keeps the digit, and the same digit is a different day in the two
+    /// dialects, so advice that stopped at the rewrite moved the schedule by a day without saying so.
+    /// </summary>
+    private static string FiveFieldAdvice(string expression)
+    {
+        string prepend = $"Prepend a seconds field: \"0 {expression}\". "
+                         + "Note that Quartz numbers days of week 1-7 starting at Sunday where Unix cron uses 0-6, so ";
+
+        string[] fields = expression.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+        if (fields.Length == 5
+            && int.TryParse(fields[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out int unixDayOfWeek)
+            && unixDayOfWeek is >= 0 and <= 7)
+        {
+            int quartzDayOfWeek = unixDayOfWeek % 7 + 1;
+            // day-of-month has to yield, or the two day fields would both name days
+            string dayOfMonth = fields[2] is "*" or "?" ? "?" : fields[2];
+            return prepend
+                   + $"if '{fields[4]}' meant {(DayOfWeek) (quartzDayOfWeek - 1)} the Quartz spelling is "
+                   + $"\"0 {fields[0]} {fields[1]} {dayOfMonth} {fields[3]} {DayOfWeekNames[quartzDayOfWeek]}\".";
+        }
+
+        return prepend + "respell numeric day-of-week values or use names (SUN, MON, ...).";
+    }
+
+    /// <summary>
+    /// Builds the rejection message for a textual day-of-week followed by a step, such as <c>MON/2</c>.
+    /// Up to Quartz.NET 3.x that token meant "every second week"; the extension is gone, and the two
+    /// things a caller might have meant by it now live in two different places, so the message names both.
+    /// </summary>
+    /// <param name="dayName">the three-letter day name that was written, e.g. <c>MON</c></param>
+    /// <param name="dayOfWeek">that day in Quartz's 1-7 numbering</param>
+    /// <param name="stepText">everything after the <c>/</c>, which need not be a number</param>
+    private static string TextualDayOfWeekStepMessage(ReadOnlySpan<char> dayName, int dayOfWeek, ReadOnlySpan<char> stepText)
+    {
+        int step = int.TryParse(stepText, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed) && parsed is >= 1 and <= 7
+            ? parsed
+            : 2;
+
+        return $"'{dayName.ToString()}/{stepText.ToString()}' is not supported. A textual day-of-week followed by '/' meant \"every second week\" "
+               + "in Quartz.NET 3.x, and that extension has been removed because its fortnight is not stable - a misfire, a restart or a "
+               + $"failover recomputes it from a different day and shifts the phase. Write '{StepThroughWeek(dayOfWeek, step)}' if you meant a "
+               + $"step through the week, or RecurrenceScheduleBuilder.Create(\"FREQ=WEEKLY;INTERVAL={step};BYDAY={RecurrenceDayCodes[dayOfWeek]}\") "
+               + $"if you meant one {DayOfWeekNames[dayOfWeek]} every {step} weeks.";
+    }
+
+    /// <summary>
+    /// Renders the day names a numeric step through the week would have produced, e.g. Monday by 2 is
+    /// <c>MON,WED,FRI</c>. The list stops at Saturday and does not wrap, which is what <c>2/2</c> means.
+    /// </summary>
+    private static string StepThroughWeek(int dayOfWeek, int step)
+    {
+        StringBuilder builder = new StringBuilder();
+        for (int day = dayOfWeek; day <= 7; day += step)
+        {
+            if (builder.Length > 0)
+            {
+                builder.Append(',');
+            }
+
+            builder.Append(DayOfWeekNames[day]);
+        }
+
+        return builder.ToString();
     }
 
     /// <summary>
@@ -2215,34 +2307,6 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             {
                 // we are NOT promoting the month
                 return new NextFireTimeCursor(true, new DateTimeOffset(d.Year, mon, day, 0, 0, 0, d.Offset));
-            }
-        }
-        else if (everyNthWeek != 0)
-        {
-            var cDow = (int) d.DayOfWeek + 1; // current d-o-w
-            // desired d-o-w: next allowed at or after the current one, else the field minimum
-            if (!daysOfWeek.TryGetMinValueStartingFrom(cDow, out var dow))
-            {
-                dow = daysOfWeek.Min;
-            }
-
-            var daysToAdd = 0;
-            if (cDow < dow)
-            {
-                daysToAdd = (dow - cDow) + (7 * (everyNthWeek - 1));
-            }
-
-            if (cDow > dow)
-            {
-                daysToAdd = (dow + (7 - cDow)) + (7 * (everyNthWeek - 1));
-            }
-
-            if (daysToAdd > 0)
-            {
-                // are we switching days?
-                d = new DateTimeOffset(d.Year, mon, day, 0, 0, 0, d.Offset);
-                d = d.AddDays(daysToAdd);
-                return new NextFireTimeCursor(true, d);
             }
         }
         else

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -467,9 +467,7 @@ public sealed class CronExpressionBuilder
     /// </summary>
     /// <remarks>
     /// The list stops at Saturday and does not wrap around, matching the
-    /// semantics of a numeric cron day-of-week increment. Note that this
-    /// differs from Quartz's textual "MON/2" syntax, which means every second
-    /// week.
+    /// semantics of a numeric cron day-of-week increment.
     /// </remarks>
     /// <param name="start">the day of the week to start at</param>
     /// <param name="increment">the number of days between values (1-7)</param>


### PR DESCRIPTION
Closes #3591.

Seven cron shapes parsed, and then meant something other than what they said. Each is now a `FormatException` whose message names the expression the author meant.

| Expression | before | after |
|---|---|---|
| `1-5W` | the `W` was dropped; meant `1-5` | `FormatException` — write `1W,2W,3W,4W,5W`, or drop the `W` |
| `? * L-3`, `? * LW` | the suffix was dropped; meant Saturday | `FormatException` — those forms belong to day-of-month. A bare `L` in day-of-week is still Saturday |
| `MON,FRI#3` | fired on the third **Monday**; the Friday was ignored | `FormatException` — `#` cannot appear beside other days |
| `5C`, `1C` | parsed, meant `5` / `1`; `C` was never implemented | `FormatException` — use `ModifiedByCalendar` |
| `*/0`, `5/0`, `0-10/0` | a step of 0 degenerated to no step | `FormatException` |
| `0-10/120` | the step inside a range was never range-checked | `FormatException` — `Increment > 59 : 120`, as `0/120` already did |
| `MON/2` | every second week — a fortnight with **no stable phase** | `FormatException` — `MON,WED,FRI` for a step through the week, or `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")` for every second Monday |

`0-10/120` was found while writing the `1-5W` fix and is the same defect wearing a different hat: `HandleDashOption` stopped reading after the range and called `AddToSet` directly, so it neither checked what followed nor range-checked the step it had just parsed.

## The `MON/2` ruling a reviewer should confirm

**The issue body's plan for `MON/2` was superseded.** The body says a textual day with a step should parse exactly like its numeric twin; the ratification comment (https://github.com/quartznet/quartznet/issues/3591#issuecomment-5482697340) changed that to **reject**, and this PR implements the comment.

Reinterpreting `MON/2` as a plain step turns `{MON}` every fortnight into `{MON,WED,FRI}` every week — 26 fires a year become 156 — with no log line, no state change and no misfire. Rejecting is loud, joins the same blast-radius class as the other six, and stays open: a string that throws becoming valid breaks nobody, so 4.1 can adopt the step semantics additively and reach the originally ratified end state a release later.

The extension was also already broken. `everyNthWeek` had no stable phase — it counted whole weeks from wherever the search started, so misfire handling, `ComputeFirstFireTime` after a start-time change, a failover recovery and a dashboard `GetFireTimeAfter` each re-phased the fortnight. `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")` anchors `INTERVAL` on `DTSTART`, so the fortnight is a property of the trigger rather than of whoever asked last.

`everyNthWeek`, its parse branch and its evaluation branch are gone. Two tests that pinned the old behaviour (`TestCronExpressionWeekdaysFridayEveryTwoWeeks`, `TestCronExpressionWeekdaysThirsdayAndFridayEveryTwoWeeks`) go with it, as does `TestTheBuilderNeverRendersTheTextualEveryNthWeekExtension` — the trap it guarded no longer exists — and `CronExpressionBuilder.WithDayOfWeekIncrements`'s "and here is why" caveat.

## The five-field message

Its advice used to move the schedule by a day. Prepending a seconds field to `30 4 * * 1` keeps the `1`, and `1` is Monday in crontab but Sunday in Quartz, so following the message literally gave Sundays. When the day-of-week is a bare number the message now also names the renumbered form:

```
Cron expression '30 4 * * 1' has 5 fields, which is the Unix/crontab form; Quartz cron has 6 or 7
fields with seconds first. Prepend a seconds field: "0 30 4 * * 1". Note that Quartz numbers days of
week 1-7 starting at Sunday where Unix cron uses 0-6, so if '1' meant Monday the Quartz spelling is
"0 30 4 ? * MON".
```

The H-resolver's duplicate of that message gets the same advice from the same helper. That path matters more than it looks: it counts fields *before* anything is parsed, whereas the parser reads a five-field string's last field as a **month**, so `0 12 * * MON` fails on `Invalid Month value: 'MON'` and never reaches the count check at all.

## Docs

* `migration-guide.md` gains **The parser refuses what it used to ignore** (the table above, plus the `MON/2` reasoning) and a **Before you upgrade** section with the audit SQL for `QRTZ_CRON_TRIGGERS.CRON_EXPRESSION`. Every row is a value the ADO.NET store will now fail to **read**, not merely fail to schedule — the exception comes out of `CronTriggerImpl.CronExpressionString`'s setter while a row is being materialised. `CronCalendar` expressions live in the `QRTZ_CALENDARS` blob and are not queryable; they surface at deserialization.
* `best-practices.md` speaks for both branches, so its `MON/2` sentence is split the way its interval bullet already splits: the fortnight moves to the `RecurrenceTrigger` recommendation, and a **Quartz 3.x only** paragraph says where `MON/2` still works and why 4.x refuses it.
* `docs/documentation/quartz-3.x/` is untouched.

## Deviation from the brief

The brief said to leave `calendarDayOfWeek` / `calendarDayOfMonth` for the follow-up PR. Once `'C'` throws, nothing assigns them, and `CS0649` under `TreatWarningsAsErrors` fails the build. They are deleted here and `GetExpressionSummary` passes `false` at the call site; `GetExpressionSummary` and `CronExpressionSummary.cs` are untouched, so the follow-up's work is unchanged (and slightly smaller). The commented-out `'C'` documentation block on the type went with them, since it describes syntax the parser now rejects.

## Verification

* `dotnet build Quartz.slnx` — 0 warnings, 0 errors
* `dotnet test src/Quartz.Tests.Unit` — 4356 passed, 0 failed
* `dotnet fallout VerifyDocsSnippets` — succeeded, 102 markdown files checked
* `dotnet run --project src/Quartz.Benchmark -c Release -- --smoke` — 284 benchmarks executed, clean
* The public-API Verify baselines are unchanged; nothing removed here was public.

New tests: a table walking every newly rejected form and asserting the message names the fix; a per-field table for the range-step range check; a table of the legitimate forms these rejections stand next to (`? * L`, `6L`, `FRIL`, `LW-2`, `L-5W`, `15W`, `6#3`, `FRI#3`, `1-5`, `18-21/1`, `2/2`, `? DEC *`) asserting they still parse; and the renumbered five-field suggestion on both the parser and hash-resolver paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
