### PR TITLE
A cron time the clock skips fires when the gap ends, and the expression agrees it fired

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -450,19 +450,26 @@ for a cron expression with a workaround in it, is usually the sign.
 
 Java Quartz's page warns that a cron trigger may fire twice or not at all across a transition. That
 is not what this implementation does, and the difference matters enough to state precisely. For a
-**fixed-time** expression such as `0 30 2 * * ?`, on both versions:
+**fixed-time** expression such as `0 30 2 * * ?`:
 
-- A wall-clock time that **does not exist** on a spring-forward day fires exactly **once**, shifted
-  forward by the transition delta. A daily 02:30 over a 02:00–03:00 gap fires at 03:30. It is not
-  skipped.
+- A wall-clock time that **does not exist** on a spring-forward day fires exactly **once**, and is
+  never skipped. *Where* it fires differs by version. On 4.x it fires at the **end of the gap**, the
+  instant the clocks moved: a daily 02:30 over a 02:00–03:00 gap fires at 03:00. On 3.x the fire is
+  shifted forward by the transition delta instead, to 03:30. In a zone whose delta is not a whole
+  hour — Australia/Lord_Howe — the two rules read 02:30 and 02:45. Only 4.x's answer is an instant
+  the expression itself matches: ask `IsSatisfiedBy` about the fire time and 4.x says yes where 3.x
+  says no.
 - A wall-clock time that **occurs twice** on a fall-back day fires **once**, at the first of the two
-  occurrences.
+  occurrences. This is the same on both versions.
 
 **Quartz 4.x only:** an *interval* expression — one with a wildcard, step or range in the second,
 minute or hour field, such as `0 * * * * ?` or `0 0/30 * * * ?` — fires through **both** passes of
 the repeated hour. On 3.x the repeated hour is fired once, which means an "every minute" schedule
-silently loses an hour of real time each autumn. Fixed-time expressions, including comma lists like
-`0 0,30 2 * * ?`, are unchanged between the versions.
+silently loses an hour of real time each autumn. Over the fall-back hour, fixed-time expressions —
+including comma lists like `0 0,30 2 * * ?` — are unchanged between the versions. On the
+spring-forward day the gap-end rule shows in an interval expression as an extra fire rather than a
+moved one: 4.x runs `0 30 * * * ?` at 03:00 for the occurrence the gap swallowed and again at 03:30
+for the next hour's, where 3.x resumes from the shifted 03:30 and runs once.
 
 Whatever the family, **name the time zone**. A cron trigger with no zone uses `TimeZoneInfo.Local`,
 which is the developer's machine in development and very often UTC in a container, so the schedule

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4582,15 +4582,30 @@ starting at Sunday where Unix cron uses 0-6, recommending names (`SUN`, `MON`, �
 
 ## Daylight saving time
 
-Two schedules fire at different times than they did on 3.x. Neither needs a code change, but both change
+Three schedules fire at different times than they did on 3.x. None needs a code change, but all three change
 *when* existing triggers run, so review any schedule that crosses a transition.
 
 **Interval cron expressions fire through both halves of a fall-back hour.** A cron expression whose second,
 minute or hour field uses a wildcard, a step or a range — `0 * * * * ?`, `0 0/30 * * * ?` — now fires through
 **both** occurrences of the wall-clock window that repeats when the clock goes back. Previously the repeated
-window fired only once, so an "every minute" schedule silently skipped an hour of real time. Fixed-time
-expressions such as `0 30 2 * * ?`, including comma lists like `0 0,30 2 * * ?`, are unchanged: they still fire
-once per day, at the first occurrence of an ambiguous wall-clock time.
+window fired only once, so an "every minute" schedule silently skipped an hour of real time. Over a fall-back
+hour, fixed-time expressions such as `0 30 2 * * ?` — including comma lists like `0 0,30 2 * * ?` — are
+unchanged: they still fire once per day, at the first occurrence of an ambiguous wall-clock time.
+
+**A cron time that does not exist fires when the gap ends, not shifted by the transition delta.** A daily
+`0 30 2 * * ?` over a 02:00–03:00 spring-forward gap now fires at **03:00**, the instant the clocks moved,
+where 3.x and 4.0 alpha fired at 03:30. In a zone whose daylight delta is not a whole hour —
+Australia/Lord_Howe — the fire reads 02:30 rather than 02:45. Every wall clock the gap swallowed names that
+one instant, so an expression matching several of them still fires once: `0 0,30 2 * * ?` fires once, as it
+did before. What *can* change a fire count is a match between the gap's end and where the delta shift used to
+land, which the search now reaches instead of resuming past it. An hourly `0 30 * * * ?` is the common shape:
+it fires at 03:00 for the occurrence the gap swallowed and again at 03:30 for the next hour's, where the delta
+shift moved the first onto 03:30 and the two collided into a single fire. `IsSatisfiedBy` now agrees with the
+fire time, which it did not before: a spring-forward gap takes no real time, so its start and its end are the
+same instant, and that makes the gap's end the one in-gap answer a search starting a second earlier can
+reproduce. A trigger therefore no longer fires at an instant its own expression rejects. For the same reason a
+`CronCalendar` written over the skipped hour now excludes that instant, where it used to exclude nothing at
+all on the transition day. Fall-back behaviour is untouched.
 
 **`CalendarIntervalTrigger` with `PreserveHourOfDayAcrossDaylightSavings` steps in local wall-clock time.**
 Fire times are now always exactly on schedule and strictly increasing; the previous implementation could return

--- a/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionDstTests.cs
@@ -37,8 +37,10 @@ namespace Quartz.Tests.Unit;
 /// resulting local date and time. That re-resolution prefers the DAYLIGHT (first) occurrence of an
 /// ambiguous local time, and demotes to the standard offset only when the daylight interpretation
 /// would land at or before the "after" instant. Local times that fall inside a spring-forward gap
-/// do not exist, so the re-resolution yields the pre-transition offset and the fire lands shifted
-/// forward in real time by the transition delta.
+/// do not exist, so the re-resolution answers with the instant the clocks moved — the end of the
+/// gap — and the walk's own starting wall clock is rewound into the gap whenever the wall clock a
+/// second before it is one the gap swallowed. That rewind is what keeps a fire the gap produced a
+/// fire the expression still matches.
 /// </para>
 /// <para>
 /// These tests never touch <c>SystemTime</c>, so they are safe to run in parallel with the rest of
@@ -85,25 +87,26 @@ public class CronExpressionDstTests
     }
 
     /// <summary>
-    /// A daily trigger whose fire time falls inside the spring-forward gap still fires exactly once
-    /// on the transition day, but shifted forward in real time by the transition delta: the
-    /// non-existent local time is resolved with the pre-transition offset, so 02:30 -05:00 becomes
-    /// the instant that reads 03:30 -04:00. The following day is back to the nominal wall clock
-    /// time, which shows the shift is confined to the transition day.
+    /// A daily trigger whose fire time falls inside the spring-forward gap fires exactly once on
+    /// the transition day, at the END of the gap: the non-existent local time is answered with the
+    /// instant the clocks moved, so 02:30 fires at 03:00 -04:00. The following day is back to the
+    /// nominal wall clock time, which shows the move is confined to the transition day.
     /// </summary>
     /// <remarks>
-    /// This is a deliberate deviation from Cronos-style semantics, which fire such a trigger at the
-    /// END of the gap (03:00 in the Eastern case, i.e. the moment the skipped wall clock time would
-    /// have been reached). Quartz.NET instead fires delta-shifted (03:30) to keep parity with Java
-    /// Quartz, whose <c>CronExpression</c> performs the same "advance in wall clock, resolve the
-    /// offset last" walk. The Lord Howe case is the one that tells the two rules apart beyond
-    /// doubt: its delta is 30 minutes, so a gap-END rule would fire at 02:30 while the delta-shift
-    /// rule fires at 02:45.
+    /// This is the Cronos rule, and it is the only in-gap resolution that can be self-consistent: a
+    /// spring-forward gap takes no real time, so the gap's start and the gap's end are one instant,
+    /// and that instant is therefore the one an <see cref="CronExpression.IsSatisfiedBy" /> probe
+    /// starting a second earlier can reach. The delta shift this replaced (03:30 in the Eastern
+    /// case) could never be, whatever the search was taught. The Lord Howe case is the one that
+    /// tells the two rules apart beyond doubt: its delta is 30 minutes, so the gap-end rule fires at
+    /// 02:30 where the delta shift fired at 02:45. Santiago is the case where the two agree — its
+    /// scheduled 00:00 is the FIRST wall clock of the gap, and for that one reading the delta shift
+    /// and the gap's end name the same instant.
     /// </remarks>
-    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 02:30", "2024-03-10 00:00 -05:00", "2024-03-10 03:30 -04:00", "2024-03-11 02:30 -04:00")]
-    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-06 02:15", "2019-10-06 00:00 +10:30", "2019-10-06 02:45 +11:00", "2019-10-07 02:15 +11:00")]
+    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 02:30", "2024-03-10 00:00 -05:00", "2024-03-10 03:00 -04:00", "2024-03-11 02:30 -04:00")]
+    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-06 02:15", "2019-10-06 00:00 +10:30", "2019-10-06 02:30 +11:00", "2019-10-07 02:15 +11:00")]
     [TestCase("0 0 0 * * ?", "Santiago", "2019-09-08 00:00", "2019-09-07 12:00 -04:00", "2019-09-08 01:00 -03:00", "2019-09-09 00:00 -03:00")]
-    public void GetTimeAfter_FixedTimeInsideGap_FiresOnceShiftedByTransitionDelta(
+    public void GetTimeAfter_FixedTimeInsideGap_FiresOnceAtTheEndOfTheGap(
         string cronExpression,
         string zoneKey,
         string gapLocalTime,
@@ -207,7 +210,14 @@ public class CronExpressionDstTests
     /// The -5 minute probes on the fall-back transitions land just after a fire inside the repeated
     /// hour; they used to break the round trip until the sub-second demotion defect was fixed (see
     /// <see cref="GetTimeBefore_ProbeJustAfterFireTimeInRepeatedHour_ReturnsRealPrecedingFire" />).
+    /// The fixed-time spring-forward rows are the ones the gap's end has to satisfy: the +5 minute
+    /// probe returns the in-gap fire, and "asking one second earlier reproduces it" is exactly the
+    /// property the delta shift could not have.
     /// </remarks>
+    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0,30 2 * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-05 15:30 +00:00", new int[] { -60, -5, 5, 60 })]
+    [TestCase("0 0 0 * * ?", "Santiago", "2019-09-08 04:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 0 * * * ?", "Eastern", "2024-03-10 07:00 +00:00", new int[] { -60, -5, 5, 60 })]
     [TestCase("0 * * * * ?", "Eastern", "2024-11-03 06:00 +00:00", new int[] { -60, -5, 5, 60 })]
@@ -409,28 +419,28 @@ public class CronExpressionDstTests
         fireTimes.Should().Contain(TestTimeZones.Local("2019-04-07 01:45 +10:30"), "second pass of the repeated half hour");
     }
 
-    #region Current-behavior pins (decision points)
-
     /// <summary>
-    /// CURRENT BEHAVIOR PIN — known internal inconsistency, expected to change on main/4.0.
+    /// A trigger never fires at an instant its own expression rejects, not even for a wall clock
+    /// the spring-forward gap swallowed.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The mirror image of the fall-back inconsistency, on the spring-forward side. For a fixed
-    /// time inside the gap, <see cref="CronExpression.GetTimeAfter" /> returns the delta-shifted
-    /// instant 03:30 -04:00 (07:30Z), yet <see cref="CronExpression.IsSatisfiedBy" /> returns FALSE
-    /// for that very instant, because its local reading is hour 03 and the expression asks for hour
-    /// 02. The trigger therefore fires at an instant its own expression does not match.
+    /// <see cref="CronExpression.IsSatisfiedBy" /> is defined as "the next fire one second earlier
+    /// is this instant", so it holds only for an in-gap fire whose resolution a one-second-earlier
+    /// search can reproduce. It can: <see cref="CronExpression.GetTimeAfter" /> converts that
+    /// earlier instant to wall clock 03:00, sees that 02:59:59 is a reading the gap swallowed, and
+    /// rewinds its walk to the gap's start — arriving back at 02:30 and resolving it to the gap's
+    /// end, the same instant.
     /// </para>
     /// <para>
-    /// Whatever rule replaces the delta shift on main/4.0 should make these two agree: either the
-    /// fire moves to the gap END (03:00, which the expression still does not match literally, so
-    /// <c>IsSatisfiedBy</c> would need to special-case the gap), or <c>IsSatisfiedBy</c> learns to
-    /// accept the shifted instant. Flip target: this assertion becomes <c>BeTrue</c>.
+    /// This is why the gap's END is the only resolution that can work. The delta shift this
+    /// replaced returned 03:30 -04:00, which no earlier probe could ever reach, so the trigger
+    /// fired at an instant its own expression did not match. <c>IsSatisfiedBy</c> needs no
+    /// knowledge of daylight saving time to reach this answer.
     /// </para>
     /// </remarks>
     [Test]
-    public void IsSatisfiedBy_InstantReturnedForInGapFixedTime_IsCurrentlyFalse()
+    public void IsSatisfiedBy_InstantReturnedForInGapFixedTime_IsTrue()
     {
         TimeZoneInfo zone = TestTimeZones.Eastern;
         TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
@@ -440,12 +450,158 @@ public class CronExpressionDstTests
         DateTimeOffset? fire = cron.GetTimeAfter(TestTimeZones.Local("2024-03-10 00:00 -05:00"));
 
         fire.Should().NotBeNull();
-        fire!.Value.Should().Be(TestTimeZones.Local("2024-03-10 03:30 -04:00"));
+        fire!.Value.Should().Be(TestTimeZones.Local("2024-03-10 03:00 -04:00"));
 
-        cron.IsSatisfiedBy(fire.Value).Should().BeFalse("the fire instant reads as local 03:30, and the expression asks for hour 02");
+        cron.IsSatisfiedBy(fire.Value).Should().BeTrue(
+            "the gap's end is the instant the schedule's wall clock was reached, and it is the one instant a one-second-earlier probe can find");
     }
 
-    #endregion
+    /// <summary>
+    /// Every wall clock a gap swallowed names the same instant, so an expression matching several
+    /// of them fires once rather than once per match.
+    /// </summary>
+    /// <remarks>
+    /// This expression fired once before the gap-end rule too, because 02:00 is the FIRST reading of
+    /// the gap and the delta shift moved it to exactly the gap's end; it is pinned so that a later
+    /// change cannot quietly turn one fire into two. What the rule did move is covered by
+    /// <see cref="GetTimeAfter_MatchBetweenGapEndAndTheOldDeltaShift_IsNoLongerSwallowed" />.
+    /// </remarks>
+    [Test]
+    public void GetTimeAfter_SeveralMatchesInsideOneGap_FireOnceAtTheGapsEnd()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:00"));
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 0,30 2 * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            after => cron.GetTimeAfter(after),
+            TestTimeZones.Local("2024-03-10 00:00 -05:00"),
+            TestTimeZones.Local("2024-03-11 00:00 -04:00"));
+
+        fireTimes.Should().Equal(
+            [TestTimeZones.Local("2024-03-10 03:00 -04:00")],
+            "both 02:00 and 02:30 name the instant the clocks moved, and one instant is one fire");
+    }
+
+    /// <summary>
+    /// A match that falls between the gap's end and where the delta shift used to land is no longer
+    /// swallowed: the walk resumes from the gap's end, which is earlier, so it still sees 02:40.
+    /// </summary>
+    [Test]
+    public void GetTimeAfter_MatchBetweenGapEndAndTheOldDeltaShift_IsNoLongerSwallowed()
+    {
+        TimeZoneInfo zone = TestTimeZones.LordHowe;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2019-10-06 02:15"));
+
+        CronExpression cron = CronIn("0 15,40 2 * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            after => cron.GetTimeAfter(after),
+            TestTimeZones.Local("2019-10-06 00:00 +10:30"),
+            TestTimeZones.Local("2019-10-07 00:00 +11:00"));
+
+        fireTimes.Should().Equal(
+            [TestTimeZones.Local("2019-10-06 02:30 +11:00"), TestTimeZones.Local("2019-10-06 02:40 +11:00")],
+            "02:15 is answered with the gap's end 02:30, and 02:40 exists a quarter of an hour later; the delta shift used to answer 02:45 and lose 02:40 behind it");
+    }
+
+    /// <summary>
+    /// An hourly-at-half-past schedule gains a fire on the spring-forward day: the occurrence the
+    /// gap swallowed runs when the clocks move, and the next hour's occurrence still runs at its own
+    /// wall clock half an hour later.
+    /// </summary>
+    /// <remarks>
+    /// The interval-expression face of the same rule, and the shape most likely to be noticed in
+    /// production. The delta shift moved the 02:30 occurrence onto 03:30, where the next hour's
+    /// occurrence already stood, and the two collided into a single fire. The gap's end is earlier,
+    /// so 03:30 is still ahead of the search when it resumes and both occurrences survive. Two fires
+    /// half an hour apart is what never losing an occurrence costs, and it is confined to the
+    /// transition.
+    /// </remarks>
+    [Test]
+    public void GetTimeAfter_HourlyAtHalfPast_FiresAtTheGapsEndAndAgainAtTheNextHalfHour()
+    {
+        TimeZoneInfo zone = TestTimeZones.Eastern;
+        TestTimeZones.AssumeInvalidLocalTime(zone, WallClock("2024-03-10 02:30"));
+
+        CronExpression cron = CronIn("0 30 * * * ?", zone);
+
+        List<DateTimeOffset> fireTimes = TestTimeZones.Walk(
+            after => cron.GetTimeAfter(after),
+            TestTimeZones.Local("2024-03-10 01:30 -05:00"),
+            TestTimeZones.Local("2024-03-10 04:30 -04:00"));
+
+        fireTimes.Should().Equal(
+            [
+                TestTimeZones.Local("2024-03-10 03:00 -04:00"),
+                TestTimeZones.Local("2024-03-10 03:30 -04:00")
+            ],
+            "02:30 is reached the moment the clocks move, and 03:30 is an ordinary reading half an hour later");
+    }
+
+    /// <summary>
+    /// The search makes strict progress and stays monotone in its input across a spring-forward
+    /// transition, including at the transition second itself where the walk rewinds into the gap.
+    /// </summary>
+    /// <remarks>
+    /// Both properties are load-bearing. A result at or before the input would wedge
+    /// <see cref="CronExpression.GetNextValidTimeAfter" /> into an endless fire; a result that fell
+    /// as the input rose would break the binary search
+    /// <see cref="CronExpression.GetTimeBefore" /> layers on top of it. The rewind fires exactly
+    /// when the probe's whole-second floor is the transition instant, so this sweeps every second
+    /// on either side of it.
+    /// </remarks>
+    [TestCase("0 30 2 * * ?", "Eastern", "2024-03-10 07:00 +00:00")]
+    [TestCase("0 0,30 2 * * ?", "Eastern", "2024-03-10 07:00 +00:00")]
+    [TestCase("0 * * * * ?", "Eastern", "2024-03-10 07:00 +00:00")]
+    [TestCase("0 15 2 * * ?", "LordHowe", "2019-10-05 15:30 +00:00")]
+    [TestCase("0 0 0 * * ?", "Santiago", "2019-09-08 04:00 +00:00")]
+    public void GetTimeAfter_AcrossSpringForward_MakesStrictProgressAndStaysMonotone(
+        string cronExpression,
+        string zoneKey,
+        string transitionUtc)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        CronExpression cron = CronIn(cronExpression, zone);
+
+        DateTimeOffset transition = TestTimeZones.Local(transitionUtc);
+        DateTimeOffset? previousAnswer = null;
+
+        for (int offsetInSeconds = -90; offsetInSeconds <= 90; offsetInSeconds++)
+        {
+            DateTimeOffset probe = transition.AddSeconds(offsetInSeconds);
+            DateTimeOffset? answer = cron.GetTimeAfter(probe);
+
+            answer.Should().NotBeNull($"probe {probe:O}");
+            answer!.Value.Should().BeAfter(probe, $"the next fire must be strictly after the probe; probe {probe:O}");
+
+            if (previousAnswer is not null)
+            {
+                answer.Value.Should().BeOnOrAfter(previousAnswer.Value,
+                    $"a later probe may never answer earlier, or GetTimeBefore's binary search loses its predicate; probe {probe:O}");
+            }
+
+            previousAnswer = answer;
+        }
+    }
+
+    /// <summary>
+    /// Regression guard for the walk-start rewind: the wall clock a second before the search's
+    /// start is only asked about when there is one. A caller probing from the minimum instant would
+    /// otherwise underflow, because a zone west of UTC clamps that conversion to the very first
+    /// representable wall clock.
+    /// </summary>
+    [Test]
+    public void GetTimeAfter_ProbeAtTheMinimumInstant_DoesNotThrow()
+    {
+        CronExpression cron = CronIn("0 30 2 * * ?", TestTimeZones.Eastern);
+
+        Func<DateTimeOffset?> act = () => cron.GetTimeAfter(DateTimeOffset.MinValue);
+
+        act.Should().NotThrow();
+    }
 
     /// <summary>
     /// Regression test: a sub-second after-time inside the repeated fall-back hour must return the

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -877,7 +877,9 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         DateTimeOffset before = daylightChange.Start.ToUniversalTime().AddMinutes(-5); // keep outside the potentially undefined interval
         DateTimeOffset? after = expression.GetNextValidTimeAfter(before);
         Assert.That(after.HasValue, Is.True);
-        DateTimeOffset expected = daylightChange.Start.Add(daylightChange.Delta).AddMinutes(15).ToUniversalTime();
+        // The :15 of the hour the gap swallowed does not exist, so the fire lands at the end of the
+        // gap - the instant the clocks moved, which is the start of the change plus its delta.
+        DateTimeOffset expected = daylightChange.Start.Add(daylightChange.Delta).ToUniversalTime();
         Assert.That(after.Value, Is.EqualTo(expected));
     }
 

--- a/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
+++ b/src/Quartz.Tests.Unit/DaylightSavingTimeTests.cs
@@ -50,8 +50,9 @@ public class DaylightSavingTimeTest
         DateTimeOffset midnight = new DateTimeOffset(2016, 3, 13, 0, 0, 0, TimeSpan.FromHours(-8));
         DateTimeOffset? fireTime = trigger.GetFireTimeAfter(midnight);
 
-        // It should fire at the equivalent valid local time.  2:30-8 does not exist, so it should run at 3:30-7.
-        DateTimeOffset expectedTime = new DateTimeOffset(2016, 3, 13, 3, 30, 0, TimeSpan.FromHours(-7));
+        // 2:30-8 does not exist, so it fires when the clocks move and the local time first reads
+        // past it - the end of the gap, 3:00-7.
+        DateTimeOffset expectedTime = new DateTimeOffset(2016, 3, 13, 3, 0, 0, TimeSpan.FromHours(-7));
 
         // We should definitely have a value
         Assert.That(fireTime, Is.Not.Null);

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CalendarDstTests.cs
@@ -126,10 +126,19 @@ public class CalendarDstTests
 
     /// <summary>
     /// A cron exclusion is wall-clock matching, so an expression that names an hour the
-    /// spring-forward day does not have excludes nothing at all on that day.
+    /// spring-forward day does not have excludes exactly the one instant that hour collapsed onto:
+    /// the moment the clocks moved.
     /// </summary>
+    /// <remarks>
+    /// <see cref="CronCalendar" /> answers through <see cref="CronExpression.IsSatisfiedBy" />, so
+    /// it says whatever the expression says. Under the delta-shift rule that was "nothing on this
+    /// day is excluded", while a trigger written with the same expression still fired — a calendar
+    /// meant to hold a job back over the skipped hour held nothing back. The gap's end is the one
+    /// instant every wall clock the gap swallowed names, so it is both when the trigger fires and
+    /// when the calendar excludes, and the two agree again.
+    /// </remarks>
     [Test]
-    public void CronCalendar_ExclusionInsideTheSpringForwardGap_ExcludesNothing()
+    public void CronCalendar_ExclusionInsideTheSpringForwardGap_ExcludesTheInstantTheClocksMoved()
     {
         TimeZoneInfo zone = TestTimeZones.Helsinki;
         TestTimeZones.AssumeInvalidLocalTime(zone, new DateTime(2024, 3, 31, 3, 30, 0));
@@ -139,16 +148,24 @@ public class CalendarDstTests
 
         DateTimeOffset transition = ParseUtc("2024-03-31T01:00:00Z");
 
+        calendar.IsTimeIncluded(transition).Should().BeFalse(
+            "the instant the clocks moved is the first instant the zone's clock reads past local 03:00, so that is where the excluded hour landed");
+
         for (int minute = -60; minute <= 60; minute++)
         {
+            if (minute == 0)
+            {
+                continue;
+            }
+
             DateTimeOffset instant = transition.AddMinutes(minute);
             calendar.IsTimeIncluded(instant).Should().BeTrue(
-                "{0:O} reads as {1:HH:mm} local, and no instant of this day reads as an hour that the day skipped",
+                "{0:O} reads as {1:HH:mm} local, and no other instant of this day reads as an hour that the day skipped",
                 instant, TimeZoneInfo.ConvertTime(instant, zone));
         }
 
-        // and the next included time after any of them is simply the next millisecond
-        calendar.GetNextIncludedTimeUtc(transition).Should().Be(transition.AddMilliseconds(1));
+        // a cron match ignores milliseconds, so the whole of the transition second is excluded
+        calendar.GetNextIncludedTimeUtc(transition).Should().Be(transition.AddSeconds(1));
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/TimeZonesTest.cs
+++ b/src/Quartz.Tests.Unit/TimeZonesTest.cs
@@ -188,6 +188,40 @@ public class TimeZonesTest
         TimeZones.WalkToGapEnd(alreadyValid, zone).Should().Be(alreadyValid, "a valid time is returned unchanged");
     }
 
+    // The mirror of WalkToGapEnd: from the first wall clock that exists after the gap, back to the
+    // first one the gap swallowed. A wall-clock walk that converted the transition instant has to
+    // rewind this far to see the readings the gap removed, because the two boundaries are one
+    // instant and converting it can only ever produce the later reading.
+    [TestCase("Eastern", "2024-03-10 03:00", "2024-03-10 02:00")]
+    [TestCase("LordHowe", "2019-10-06 02:30", "2019-10-06 02:00")]
+    [TestCase("Santiago", "2019-09-08 01:00", "2019-09-08 00:00")]
+    public void WalkToGapStart_ReturnsFirstWallClockTheGapSwallowed(string zoneKey, string gapEnd, string expectedGapStart)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+        DateTime end = DateTime.Parse(gapEnd, CultureInfo.InvariantCulture);
+        DateTime start = DateTime.Parse(expectedGapStart, CultureInfo.InvariantCulture);
+        TestTimeZones.AssumeInvalidLocalTime(zone, start);
+
+        TimeZones.WalkToGapStart(end, zone).Should().Be(start);
+
+        zone.IsInvalidTime(start.AddMinutes(-1)).Should().BeFalse("the returned time is the FIRST reading the gap swallowed");
+        TimeZones.WalkToGapEnd(start, zone).Should().Be(end, "walking back and forth again returns to where it started");
+    }
+
+    [TestCase("Eastern", "2024-03-10")]
+    [TestCase("LordHowe", "2019-10-06")]
+    [TestCase("Santiago", "2019-09-08")]
+    public void WalkToGapStart_WallClockPrecededByOneThatExists_IsReturnedUnchanged(string zoneKey, string transitionDay)
+    {
+        TimeZoneInfo zone = ResolveZone(zoneKey);
+
+        // noon, not midnight - in a midnight-gap zone like Santiago the date's own 00:00 is invalid
+        DateTime noon = DateTime.Parse(transitionDay, CultureInfo.InvariantCulture).AddHours(12);
+
+        TimeZones.WalkToGapStart(noon, zone).Should().Be(noon,
+            "nothing before noon on a transition day is missing, so there is no gap to rewind into");
+    }
+
     // A boundary inside a spring-forward gap is crossed the moment the clocks move, which is earlier
     // than the instant ResolveLocal hands a trigger for the same wall clock. The second case is why
     // the gap is walked from the whole minute: a boundary a millisecond into the gap is still crossed

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -2433,11 +2433,20 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// Gets the next fire time after the given time.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Daylight saving time transitions in the configured <see cref="TimeZone"/> are handled as
-    /// follows: a scheduled wall-clock time that does not exist (spring-forward gap) fires exactly
-    /// once, shifted forward by the transition delta — a daily 02:30 schedule over a 02:00-03:00
-    /// gap fires at 03:30. This matches Java Quartz. A wall-clock time that occurs twice
-    /// (fall-back overlap) fires at its first occurrence.
+    /// follows: a scheduled wall-clock time that does not exist (spring-forward gap) fires at the
+    /// end of the gap — the instant the clocks moved, which is the first instant the zone's clock
+    /// reads at or past the scheduled time. A daily 02:30 schedule over a 02:00-03:00 gap fires at
+    /// 03:00. A wall-clock time that occurs twice (fall-back overlap) fires at its first occurrence.
+    /// </para>
+    /// <para>
+    /// The gap's end is also the only in-gap answer <see cref="IsSatisfiedBy" /> can reproduce,
+    /// because a spring-forward gap takes no real time: its start and its end are the same instant,
+    /// so a search that begins one second earlier rewinds into the gap and arrives back at it. Every
+    /// wall clock the gap swallowed therefore names that one instant, and an expression matching
+    /// several of them fires once rather than once per match.
+    /// </para>
     /// </remarks>
     /// <param name="afterTimeUtc">The UTC time to start searching from.</param>
     /// <returns></returns>
@@ -2456,6 +2465,23 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
 
         // change to specified time zone
         d = TimeZones.ConvertTime(d, TimeZone);
+
+        // The walk runs in wall clock, so it has to start at the earliest wall clock the search has
+        // not already examined. Converting the instant gives that wall clock everywhere except at
+        // the end of a spring-forward gap, where it is the first reading AFTER the wall clocks the
+        // gap swallowed - and those have not been examined, because the instant one second earlier
+        // is still before the gap. Rewinding into the gap is what makes GetTimeAfter(t - 1s) == t
+        // hold for a fire the gap produced, and so what makes IsSatisfiedBy agree with it. The guard
+        // is false at every fall-back transition, so the ambiguous-time rules below are untouched by
+        // construction rather than by argument, and a zone that never moves its clocks pays one bool
+        // read. The tick test keeps a caller asking from DateTimeOffset.MinValue - which a zone west
+        // of UTC clamps to - from underflowing.
+        if (TimeZone.SupportsDaylightSavingTime
+            && d.Ticks >= TimeSpan.TicksPerSecond
+            && TimeZone.IsInvalidTime(d.DateTime.AddSeconds(-1)))
+        {
+            d = new DateTimeOffset(TimeZones.WalkToGapStart(d.DateTime, TimeZone), d.Offset);
+        }
 
         var nextFireTimeCursor = new NextFireTimeCursor(false, d);
         var foundNextFireTime = false;
@@ -2478,9 +2504,11 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
                 continue;
             }
 
-            // apply the proper offset for this date
+            // apply the proper offset for this date. A wall clock that exists resolves exactly as
+            // ResolveLocal would; one the spring-forward gap swallowed is answered with the instant
+            // the clocks moved, which is the first instant the zone's clock reads at or past it.
             var localDateTime = nextFireTimeCursor.Date.Value.DateTime;
-            d = TimeZones.ResolveLocal(localDateTime, TimeZone);
+            d = TimeZones.FirstInstantAtOrAfterLocal(localDateTime, TimeZone);
             foundNextFireTime = true;
 
             // During DST fall-back transitions an ambiguous local time resolves to its first

--- a/src/Quartz/TimeZones.cs
+++ b/src/Quartz/TimeZones.cs
@@ -354,6 +354,30 @@ public static class TimeZones
     }
 
     /// <summary>
+    /// Walks backward from the first wall-clock time after a spring-forward gap to the first
+    /// wall-clock time the gap swallowed (the start of the gap). Returns the input unchanged when
+    /// the wall clock a minute before it exists, so a time that is not a gap's end does not move.
+    /// </summary>
+    /// <remarks>
+    /// The mirror of <see cref="WalkToGapEnd" />: together the two name the gap's boundaries from
+    /// whichever side the caller arrived at. A search that advances in wall clock has to begin at
+    /// the gap's first swallowed reading to see the readings the gap removed, and converting the
+    /// instant the clocks moved lands past them - the gap's end and the gap's start are the same
+    /// instant, so the instant alone cannot say which of the two wall clocks was meant.
+    /// </remarks>
+    internal static DateTime WalkToGapStart(DateTime firstValidAfterGap, TimeZoneInfo timeZoneInfo)
+    {
+        DateTime probe = firstValidAfterGap;
+        int guard = 0;
+        while (timeZoneInfo.IsInvalidTime(probe.AddMinutes(-1)) && guard++ < MaxTransitionScanMinutes)
+        {
+            probe = probe.AddMinutes(-1);
+        }
+
+        return probe;
+    }
+
+    /// <summary>
     /// Tries to find time zone with given id, has ability do some fallbacks when necessary.
     /// </summary>
     /// <param name="id">System id of the time zone.</param>


### PR DESCRIPTION
A fixed-time cron expression whose local time falls inside a spring-forward gap fired delta-shifted — 02:30 became 03:30 — because `TimeZones.ResolveLocal` pairs a non-existent wall clock with the offset in force just before the gap. That instant is one the expression itself rejects: `IsSatisfiedBy(03:30)` was false for hour 02, so a trigger fired at a time its own schedule did not match. The DST suite pinned that as a decision left open.

This lands the ratified gap-end rule (§2 of the alpha.5 cron design note): the in-gap wall clock is answered with **the instant the clocks moved**.

## What changed

**`CronExpression.GetTimeAfter` resolves through `TimeZones.FirstInstantAtOrAfterLocal`** instead of `ResolveLocal`. That helper already existed and was already tested — it was written for `DailyCalendar`/`CalendarIntervalTriggerImpl` — and it delegates to `ResolveLocal` for a wall clock that exists, so every non-gap path is byte-identical. `ResolveLocal` itself is untouched: `DailyTimeIntervalTriggerImpl`, `CalendarIntervalTriggerImpl`, `RecurrenceRule` and `DailyTimeIntervalScheduleBuilder` keep its delta-shift semantics and its pin.

**A second edit is required, and it is the interesting one.** Gap-end alone does *not* make `GetTimeAfter` and `IsSatisfiedBy` agree. `IsSatisfiedBy(t)` is `GetTimeAfter(t − 1s) == t`, and `GetTimeAfter` converts `after + 1s` as an *instant* before walking in wall clock — at the transition instant that conversion already reads past the gap, so the search never examines the wall clocks the gap swallowed. The walk's starting wall clock is therefore rewound to the gap's first swallowed reading (new `internal TimeZones.WalkToGapStart`, the mirror of `WalkToGapEnd`) exactly when the wall clock one second before it does not exist:

```csharp
if (TimeZone.SupportsDaylightSavingTime
    && d.Ticks >= TimeSpan.TicksPerSecond
    && TimeZone.IsInvalidTime(d.DateTime.AddSeconds(-1)))
{
    d = new DateTimeOffset(TimeZones.WalkToGapStart(d.DateTime, TimeZone), d.Offset);
}
```

`IsInvalidTime(start − 1s)` is false at every fall-back transition, so the fall-back demotion and `ApplySecondAmbiguousPassIfNeeded` are untouched **by construction** rather than by argument. Cost on the hottest path in the library is one `IsInvalidTime` behind a `SupportsDaylightSavingTime` bool; UTC and fixed-offset zones pay the bool.

With the rewind, gap-end is the *unique* in-gap resolution a one-second-earlier probe can reproduce — a spring-forward gap takes no real time, so its start and its end are the same instant. The delta shift could never have been a fixed point of that definition, whatever the search was taught. `IsSatisfiedBy` needs no knowledge of daylight saving time.

## Two findings that correct the design note

The note's §2.5 says an expression with several matches inside the gap "now fires once rather than once per match", and the drafted migration-guide paragraph repeated it. **That is backwards, and I verified it empirically at the base commit before editing anything.** Under the delta shift the walk resumed at the shifted wall clock + 1s, which is always at or after the gap's end, so any further in-gap match was already swallowed: `0 0,30 2 * * ?` Eastern on 2024-03-10 fired *once* at 07:00Z before this change and fires once now.

What actually changes the fire count is the opposite. The gap's end is *earlier* than the delta-shifted instant, so a match in the wall-clock window between them is no longer stepped over:

- Lord Howe `0 15,40 2 * * ?` fired only at 02:45; it now fires at 02:30 and 02:40.
- **An hourly `0 30 * * * ?` in Eastern now fires at 03:00 and again at 03:30**, where the shift moved the 02:30 occurrence onto 03:30 and the two collided into one fire. The note's §2.4 called interval expressions "verified unchanged", but it only checked `0 * * * * ?` and `0 0 * * * ?`, whose first in-gap match is the gap's *first* wall clock — the one reading where the two rules agree. This is the shape most likely to be noticed in production, so it is pinned by a test and stated in both docs pages.

§2.6's flipped-case table was also incomplete: three tests outside `CronExpressionDstTests` pinned the delta shift and are updated here — `CronExpressionTest.TestDaylightSaving_QRTZNETZ186`, `DaylightSavingTimeTest.ShouldHandleDstSpringForwardTransition`, and `CalendarDstTests.CronCalendar_ExclusionInsideTheSpringForwardGap_ExcludesNothing`. The last is the `CronCalendar` consequence §2.5 predicted: a calendar written over the skipped hour now excludes the instant the clocks moved, where it excluded nothing at all on the transition day — the coherent answer, since that is also when the matching trigger fires.

## Tests

- The three delta-shift `[TestCase]` rows flip (`03:30` → `03:00`, Lord Howe `02:45` → `02:30`; Santiago is unchanged, because its 00:00 is the gap's first reading and the two rules agree there), the `#region Current-behavior pins` goes, and `IsSatisfiedBy_..._IsCurrentlyFalse` becomes `..._IsTrue`.
- New: several matches in one gap fire once; a match between the gap's end and the old delta shift is no longer swallowed; the hourly-at-half-past extra fire; a 181-second sweep across each transition asserting strict progress *and* monotonicity in the input (the property `GetTimeBefore`'s binary search depends on); fixed-time rows added to the `GetTimeBefore` round-trip grid, whose "asking one second earlier reproduces it" assertion is exactly what the delta shift could not satisfy.
- `WalkToGapStart` is unit-tested directly beside `WalkToGapEnd`'s tests, including the round trip back through `WalkToGapEnd`.
- One guard worth a reviewer's eye: `d.Ticks >= TimeSpan.TicksPerSecond`. Without it, `GetNextValidTimeAfter(DateTimeOffset.MinValue)` on a DST zone throws, because a zone west of UTC clamps that conversion to the first representable wall clock and `AddSeconds(-1)` underflows. That is a new throw the rewind would otherwise introduce; `GetTimeAfter_ProbeAtTheMinimumInstant_DoesNotThrow` fails without the guard (verified by removing it).

## For a reviewer to decide

- Whether the hourly `0 30 * * * ?` extra fire is acceptable. It follows from the ratified rule — the occurrence the gap swallowed runs when the clock passes it, and the next hour's occurrence still runs at its own wall clock — but it is a fire-count increase on the transition day for a very common expression, and it is the one thing here nobody signed off on, because the note did not find it.
- `docs/documentation/faq.md:300-308` still says such a trigger "will be skipped", which is wrong for 3.x and 4.x alike and has been for years. Deliberately left alone; it is tracked separately. `docs/documentation/quartz-4.x/cron-expressions.md:257` is vague in the same direction ("a skip or a repeat") and is also untouched.

No public API changed (`WalkToGapStart` is `internal`), so the Verify baselines do not move.

## Verification

```
dotnet build Quartz.slnx                                 Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit                        Passed! Failed: 0, Passed: 4300, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore                  Passed! Failed: 0, Passed: 548, Skipped: 0
dotnet test src/Quartz.Tests.Integration
  --filter ~AcrossDstTransition                          Passed! Failed: 0, Passed: 20, Skipped: 0
dotnet fallout VerifyDocsSnippets                        Succeeded (102 markdown files checked)
dotnet fallout BenchmarkSmoke                            Succeeded (284 benchmarks executed)
```

Closes #3590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
