### PR TITLE
The ADO telemetry contract and two shapes are written down

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/dialect-delegate.md
@@ -84,23 +84,27 @@ The default is the ANSI form, understood by SQL Server 2012+, Oracle 12c+, Postg
 
 MySQL and SQLite have no such clause, so they override both members — and they must override
 `AddPagingParameters` too, because their clause names the parameters in the other order and providers
-that bind positionally take them in the order the statement mentions them:
+that bind positionally take them in the order the statement mentions them.
+
+The two parameter names are the one thing the two overrides have to agree about, so they are constants
+rather than literals: `AdoConstants.ParameterPageSkip` and `AdoConstants.ParameterPageTake`, spliced
+into the statement with an `@` and bound by the bare name.
 
 <!-- snippet: sample_dialect_delegate_paging -->
 ```csharp
 protected override string ApplyPaging(string sql, bool takeLimited)
     => takeLimited
-        ? sql + " LIMIT @pageTake OFFSET @pageSkip"
-        : sql + " LIMIT -1 OFFSET @pageSkip";
+        ? sql + " LIMIT @" + AdoConstants.ParameterPageTake + " OFFSET @" + AdoConstants.ParameterPageSkip
+        : sql + " LIMIT -1 OFFSET @" + AdoConstants.ParameterPageSkip;
 
 protected override void AddPagingParameters(DbCommand cmd, int skip, int take, bool takeLimited)
 {
     if (takeLimited)
     {
-        AddCommandParameter(cmd, "pageTake", take);
+        AddCommandParameter(cmd, AdoConstants.ParameterPageTake, take);
     }
 
-    AddCommandParameter(cmd, "pageSkip", skip);
+    AddCommandParameter(cmd, AdoConstants.ParameterPageSkip, skip);
 }
 ```
 <!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6034,7 +6034,10 @@ Subclassing `StdAdoDelegate` gets you all of it. A database whose row-limiting s
 clause and **`AddPagingParameters(cmd, skip, take, takeLimited)`** binds it (`skip` and `take` are `int`,
 matching the query objects they serve). Override both together when your clause names the two parameters
 in the other order, because providers that bind positionally take parameters in the order the statement
-mentions them. `MySQLDelegate` and `SQLiteDelegate` do exactly this for `LIMIT … OFFSET`.
+mentions them. `MySQLDelegate` and `SQLiteDelegate` do exactly this for `LIMIT … OFFSET`. The two
+parameter names the pair has to agree on are `AdoConstants.ParameterPageSkip` and
+`AdoConstants.ParameterPageTake` — new in 4.0, and public because a delegate outside Quartz has to
+spell them.
 
 The value-conversion pairs on `IDbAccessor` are no longer all overridable on `StdAdoDelegate`: the
 boolean pair (`GetDbBooleanValue` / `GetBooleanFromDbValue`) stays virtual, because Oracle genuinely
@@ -10276,6 +10279,7 @@ removals on types that are still public and still open, which no section above n
 |---|---|---|
 | `AbstractTrigger.CompareTo(ITrigger)` | Removed; neither `TriggerBase` nor `ITrigger` itself implements `IComparable<ITrigger>` any more | It compared keys — `trigger.Key.CompareTo(other.Key)`, or `triggers.OrderBy(t => t.Key)`, both of which sort properly now that the key types implement `IComparable<JobKey>` / `IComparable<TriggerKey>`. `List<ITrigger>.Sort()` and friends still compile and now throw — see [The trigger family interfaces are read models](#the-trigger-family-interfaces-are-read-models) |
 | `AbstractTrigger.FullJobName` | Removed | `JobKey.ToString()`, alongside the rest in [TriggerBase Property Removals](#triggerbase-property-removals) |
+| `AdoConstants.AliasColumnNextFireTime` | Removed | No replacement, and none is needed: it named a column alias (`ALIAS_NXT_FR_TM`) that no 4.x statement uses and the schema has never had a column for. It was a carryover from the Java acquisition sub-select, and a delegate that copied 3.x SQL is the only thing that could have named it |
 | `new CronExpression(expr, hashKey)`, `new CronExpression(expr, hashSeed)` | Removed; they made `new CronExpression(expr, null)` ambiguous with the time-zone overload, so the null literal did not compile | `CronExpression.ParseWithHash(expr, hashKey)` / `ParseWithHash(expr, hashSeed)` — see [The hash key is a `Parse` argument, not a constructor overload](#the-hash-key-is-a-parse-argument-not-a-constructor-overload) |
 | `CronExpression`'s `protected` constants, fields and parse hooks, and `OnDeserialization` | Gone with the type, which is `sealed` now and no longer implements `IDeserializationCallback` | No replacement; the parsed sets were never a contract — see [The parser is not a subclassing seam](#the-parser-is-not-a-subclassing-seam) |
 | `CronExpression.GetExpressionSummary()`, `ICronTrigger.GetExpressionSummary()`, `CronTriggerImpl.GetExpressionSummary()` | Removed | No replacement. It dumped the parsed field sets in an undocumented format; `CronExpressionString` is the expression, and the parsed sets were never a supported view — see [The parser is not a subclassing seam](#the-parser-is-not-a-subclassing-seam) |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6170,10 +6170,11 @@ states, and that
 | `StatePausedBlocked` | `PAUSED_BLOCKED` | `StoredTriggerState.PausedBlocked` |
 | `StateDeleted` | `DELETED` | `StoredTriggerState.Deleted` |
 
-Both directions are public, because a custom delegate binds the string into its own statements:
+Both directions are public, because a custom delegate binds the string into its own statements, and both
+are plain static methods — one mapping, one call shape:
 
 ```csharp
-string stored = StoredTriggerState.PausedBlocked.ToStoredValue();   // "PAUSED_BLOCKED"
+string stored = StoredTriggerStates.ToStoredValue(StoredTriggerState.PausedBlocked);   // "PAUSED_BLOCKED"
 StoredTriggerState state = StoredTriggerStates.FromStoredValue(stored);
 ```
 

--- a/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
+++ b/src/Quartz.Benchmark/AcquisitionIndexBenchmark.cs
@@ -272,7 +272,7 @@ public class AcquisitionIndexBenchmark
         Dictionary<string, object?> parameters = new(StringComparer.Ordinal)
         {
             ["schedulerName"] = SchedulerName,
-            ["state"] = StoredTriggerState.Waiting.ToStoredValue(),
+            ["state"] = StoredTriggerStates.ToStoredValue(StoredTriggerState.Waiting),
             ["noLaterThan"] = NoLaterThan.UtcTicks,
             ["noEarlierThan"] = noEarlierThan.UtcTicks,
             ["instanceId"] = InstanceId,

--- a/src/Quartz.Benchmark/TriggerFirePathBenchmark.cs
+++ b/src/Quartz.Benchmark/TriggerFirePathBenchmark.cs
@@ -157,7 +157,7 @@ public class TriggerFirePathBenchmark
         driverDelegate.AddCommandParameter(cmd, "instanceName", "NODE-01");
         driverDelegate.AddCommandParameter(cmd, "firedTime", driverDelegate.GetDbDateTimeValue(TimeProvider.System.GetUtcNow()));
         driverDelegate.AddCommandParameter(cmd, "scheduledTime", driverDelegate.GetDbDateTimeValue(trigger.NextFireTimeUtc));
-        driverDelegate.AddCommandParameter(cmd, "entryState", StoredTriggerState.Executing.ToStoredValue());
+        driverDelegate.AddCommandParameter(cmd, "entryState", StoredTriggerStates.ToStoredValue(StoredTriggerState.Executing));
         driverDelegate.AddCommandParameter(cmd, "jobName", trigger.JobKey.Name);
         driverDelegate.AddCommandParameter(cmd, "jobGroup", trigger.JobKey.Group);
         driverDelegate.AddCommandParameter(cmd, "isNonConcurrent", driverDelegate.GetDbBooleanValue(job.ConcurrentExecutionDisallowed));

--- a/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
+++ b/src/Quartz.Documentation.Samples/HowTos/DialectDelegateSamples.cs
@@ -37,17 +37,17 @@ internal sealed class DialectDelegateOverrides : StdAdoDelegate
 
     protected override string ApplyPaging(string sql, bool takeLimited)
         => takeLimited
-            ? sql + " LIMIT @pageTake OFFSET @pageSkip"
-            : sql + " LIMIT -1 OFFSET @pageSkip";
+            ? sql + " LIMIT @" + AdoConstants.ParameterPageTake + " OFFSET @" + AdoConstants.ParameterPageSkip
+            : sql + " LIMIT -1 OFFSET @" + AdoConstants.ParameterPageSkip;
 
     protected override void AddPagingParameters(DbCommand cmd, int skip, int take, bool takeLimited)
     {
         if (takeLimited)
         {
-            AddCommandParameter(cmd, "pageTake", take);
+            AddCommandParameter(cmd, AdoConstants.ParameterPageTake, take);
         }
 
-        AddCommandParameter(cmd, "pageSkip", skip);
+        AddCommandParameter(cmd, AdoConstants.ParameterPageSkip, skip);
     }
 
     #endregion

--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -23,7 +23,6 @@
 
 using System.Collections.Specialized;
 using System.Reflection;
-using System.Reflection.Emit;
 
 using Quartz.Configuration;
 
@@ -41,9 +40,10 @@ namespace Quartz.Tests.Unit.Configuration;
 /// here check that the guard fires; this one checks that it fires only on real mistakes.
 /// </para>
 /// <para>
-/// The key inventory is extracted mechanically rather than curated, by walking the IL of every type
-/// in the <c>Quartz.Configuration</c> namespace and collecting the <c>ldstr</c> literals that begin
-/// with <c>quartz.</c>. That is where every reader of the flat format lives — the bridge, the plugin
+/// The key inventory is extracted mechanically rather than curated, by asking
+/// <see cref="MethodBodyStrings" /> for the literals every type in the <c>Quartz.Configuration</c>
+/// namespace names and keeping the ones that begin with <c>quartz.</c>. That is where every reader of
+/// the flat format lives — the bridge, the plugin
 /// and listener factories, the execution-limit parser, the scheduler content initializer — and
 /// because <c>const</c> strings are inlined at their use sites, a key named through
 /// <see cref="LegacyPropertyKeys" /> shows up at the reader just as a literal one does.
@@ -61,11 +61,6 @@ public class LegacyPropertyKeyExhaustivenessTest
     private const string ConfigurationNamespace = "Quartz.Configuration";
 
     private static readonly Assembly quartzAssembly = typeof(IScheduler).Assembly;
-
-    // Declared before the scan: static field initializers run in textual order, and the walk needs
-    // these tables to know how long each instruction is.
-    private static readonly OpCode?[] singleByteOpCodes = BuildOpCodeTable(twoByte: false);
-    private static readonly OpCode?[] twoByteOpCodes = BuildOpCodeTable(twoByte: true);
 
     /// <summary>
     /// Every <c>quartz.*</c> key or key prefix the flat-format readers name, as found in their IL.
@@ -340,126 +335,16 @@ public class LegacyPropertyKeyExhaustivenessTest
                 continue;
             }
 
-            foreach (MethodBase method in DeclaredMethods(type))
+            foreach (string literal in MethodBodyStrings.In(type))
             {
-                foreach (string literal in StringLiterals(method))
+                // The bare prefix is manufactured by QuartzConfigurationHelper rather than read.
+                if (literal.Length > Prefix.Length && literal.StartsWith(Prefix, StringComparison.Ordinal))
                 {
-                    // The bare prefix is manufactured by QuartzConfigurationHelper rather than read.
-                    if (literal.Length > Prefix.Length && literal.StartsWith(Prefix, StringComparison.Ordinal))
-                    {
-                        keys.Add(literal);
-                    }
+                    keys.Add(literal);
                 }
             }
         }
 
         return keys.ToList();
     }
-
-    private static IEnumerable<MethodBase> DeclaredMethods(Type type)
-    {
-        const BindingFlags Declared = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
-                                      | BindingFlags.Static | BindingFlags.DeclaredOnly;
-
-        return type.GetMethods(Declared).Cast<MethodBase>().Concat(type.GetConstructors(Declared));
-    }
-
-    /// <summary>
-    /// The IL opcode table, read off <see cref="OpCodes" /> rather than transcribed, so that the
-    /// operand sizes the walk relies on come from the runtime's own definitions.
-    /// </summary>
-    private static OpCode?[] BuildOpCodeTable(bool twoByte)
-    {
-        OpCode?[] table = new OpCode?[0x100];
-        foreach (FieldInfo field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
-        {
-            if (field.GetValue(null) is not OpCode opCode)
-            {
-                continue;
-            }
-
-            ushort value = unchecked((ushort) opCode.Value);
-            if (twoByte && (value & 0xFF00) == 0xFE00)
-            {
-                table[value & 0xFF] = opCode;
-            }
-            else if (!twoByte && value < 0x100)
-            {
-                table[value] = opCode;
-            }
-        }
-
-        return table;
-    }
-
-    /// <summary>
-    /// Walks a method body instruction by instruction, resolving every <c>ldstr</c> against the
-    /// module's string heap. Stepping over operands properly is what keeps an operand byte from being
-    /// misread as an opcode and inventing keys that are not there.
-    /// </summary>
-    private static List<string> StringLiterals(MethodBase method)
-    {
-        List<string> literals = [];
-
-        byte[]? il;
-        try
-        {
-            il = method.GetMethodBody()?.GetILAsByteArray();
-        }
-        catch (Exception)
-        {
-            // abstract, extern or otherwise bodiless
-            return literals;
-        }
-
-        if (il is null)
-        {
-            return literals;
-        }
-
-        Module module = method.Module;
-        int position = 0;
-        while (position < il.Length)
-        {
-            if (ReadOpCode(il, ref position) is not { } instruction)
-            {
-                // An opcode this table does not know means the walk has lost the instruction boundary;
-                // stopping is honest, and TheScanFoundTheKeysTheReadersConsult notices if it happens often.
-                break;
-            }
-
-            if (instruction.OperandType == OperandType.InlineString && position + 4 <= il.Length)
-            {
-                literals.Add(module.ResolveString(BitConverter.ToInt32(il, position)));
-            }
-
-            position += OperandSize(instruction, il, position);
-        }
-
-        return literals;
-    }
-
-    private static OpCode? ReadOpCode(byte[] il, ref int position)
-    {
-        byte first = il[position++];
-        if (first != 0xFE)
-        {
-            return singleByteOpCodes[first];
-        }
-
-        return position < il.Length ? twoByteOpCodes[il[position++]] : null;
-    }
-
-    private static int OperandSize(OpCode opCode, byte[] il, int position) => opCode.OperandType switch
-    {
-        OperandType.InlineNone => 0,
-        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
-        OperandType.InlineVar => 2,
-        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or OperandType.InlineMethod
-            or OperandType.InlineSig or OperandType.InlineString or OperandType.InlineTok
-            or OperandType.InlineType or OperandType.ShortInlineR => 4,
-        OperandType.InlineI8 or OperandType.InlineR => 8,
-        OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, position),
-        _ => 0
-    };
 }

--- a/src/Quartz.Tests.Unit/Diagnostics/OperationNameTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/OperationNameTest.cs
@@ -1,0 +1,217 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Reflection;
+
+using Quartz.Diagnostics;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Diagnostics;
+
+/// <summary>
+/// The subset rule <see cref="OperationName.JobStore" /> documents, held to the code on both sides.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A span name is a telemetry contract — a dashboard filters on it, an alert fires off it — so the set
+/// of them is worth guarding as carefully as a public signature. Three things can go wrong and none of
+/// them fails a build on its own: a constant is added and no store operation ever begins that span, a
+/// span is begun under a name spelled inline instead of through a constant, and a mutating member is
+/// added to <see cref="IJobStore" /> with no span at all. The first two are a bijection, the third is a
+/// completeness property, and the exclusion list below is the written form of the rule that decides it.
+/// </para>
+/// <para>
+/// The spans the tracing store begins are read out of its IL rather than from a list kept beside it: a
+/// <c>const</c> reaches its use site inlined, so the literals in <c>TracingJobStore</c>'s method bodies
+/// are exactly the names it passes to <c>Begin</c>, whether it named a constant or typed the string.
+/// That is the point — a hand-typed name is the failure this catches.
+/// </para>
+/// </remarks>
+public class OperationNameTest
+{
+    private const string JobStorePrefix = "Quartz.JobStore.";
+    private const string DiagnosticsNamespace = "Quartz.Diagnostics";
+
+    private static readonly Assembly quartzAssembly = typeof(IScheduler).Assembly;
+
+    /// <summary>
+    /// The constants, by the name they are declared under.
+    /// </summary>
+    private static readonly Dictionary<string, string> declaredOperations = typeof(OperationName.JobStore)
+        .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+        .Where(field => field is { IsLiteral: true, IsInitOnly: false })
+        .ToDictionary(field => field.Name, field => (string) field.GetRawConstantValue()!, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Every <c>Quartz.JobStore.*</c> name the diagnostics types actually begin a span under.
+    /// </summary>
+    private static readonly SortedSet<string> spansBegun = ScanForStoreSpanNames();
+
+    /// <summary>
+    /// The members of <see cref="IJobStore" /> that are deliberately not traced, and why. This list is
+    /// the rule <see cref="OperationName.JobStore" /> states, in a form the build can check: anything
+    /// not on it is a mutating operation and must have a constant.
+    /// </summary>
+    private static readonly string[] membersDeliberatelyNotTraced =
+    [
+        // Lifecycle. Each happens once, outside any request, so its span would be a root of its own
+        // with nothing to be a child of — and Initialize runs before the store knows its identity,
+        // which is the tag every other span here carries.
+        "Initialize",
+        "Shutdown",
+        "SchedulerStarted",
+        "SchedulerPaused",
+        "SchedulerResumed",
+
+        // Reads. One database round trip, already inside the caller's span, and the store has nothing
+        // to say about it that the caller does not already know it asked for.
+        "Exists",
+        "GetCalendar",
+        "GetJob",
+        "GetJobs",
+        "GetTrigger",
+        "GetTriggers",
+        "GetTriggersForJob",
+        "GetTriggerState",
+        "QueryCalendarNames",
+        "QueryClusterNodes",
+        "QueryFireInstances",
+        "QueryJobGroups",
+        "QueryJobs",
+        "QueryTriggerGroups",
+        "QueryTriggers",
+
+        // Advice, not an operation. It answers "how long should I wait before trying again" out of the
+        // store's own configuration, touches nothing and cannot fail, so there is nothing to time.
+        "GetAcquireRetryDelay"
+    ];
+
+    [Test]
+    public void TheScanFoundTheSpansTheTracingStoreBegins()
+    {
+        // Guards the guard: a walk that silently found nothing would make the bijection below vacuous,
+        // and reading IL is exactly the kind of code that fails that way.
+        spansBegun.Should().HaveCountGreaterThan(20,
+            "the tracing store begins a span for every mutating store operation, so a handful of names "
+            + "means the IL walk lost its footing rather than that the store stopped tracing");
+    }
+
+    [Test]
+    public void EveryDeclaredOperationNamesASpanTheTracingStoreBegins()
+    {
+        declaredOperations.Values.Except(spansBegun, StringComparer.Ordinal).Should().BeEmpty(
+            "a constant nothing begins a span under is a name that will never appear in anyone's "
+            + "telemetry, and it reads to the next person as an operation that is traced");
+    }
+
+    [Test]
+    public void EverySpanTheTracingStoreBeginsIsDeclared()
+    {
+        spansBegun.Except(declaredOperations.Values, StringComparer.Ordinal).Should().BeEmpty(
+            "the constants are what an application filters on, so a span begun under a name spelled "
+            + "inline is a span nobody can find by reading this class");
+    }
+
+    [Test]
+    public void EveryOperationIsNamedForTheOperation()
+    {
+        foreach ((string name, string value) in declaredOperations)
+        {
+            value.Should().Be(JobStorePrefix + name,
+                "the constant is how the name is read and the string is how it is filtered, so the two "
+                + "drifting apart hides the drift from everyone on both sides");
+        }
+    }
+
+    [Test]
+    public void EveryMutatingJobStoreMemberHasAnOperationName()
+    {
+        List<string> untraced = JobStoreMemberNames()
+            .Where(name => !membersDeliberatelyNotTraced.Contains(name, StringComparer.Ordinal))
+            .Where(name => !declaredOperations.ContainsKey(name))
+            .ToList();
+
+        untraced.Should().BeEmpty(
+            "a store operation that changes state is traced, and adding one to the interface without a "
+            + "span leaves a hole nobody notices until they go looking for the operation in a trace");
+    }
+
+    [Test]
+    public void EveryOperationNameIsAJobStoreMember()
+    {
+        declaredOperations.Keys.Except(JobStoreMemberNames(), StringComparer.Ordinal).Should().BeEmpty(
+            "a constant for an operation the interface no longer has outlives the span it named");
+    }
+
+    [Test]
+    public void TheUntracedListNamesOnlyRealMembers()
+    {
+        membersDeliberatelyNotTraced.Should().OnlyHaveUniqueItems();
+
+        membersDeliberatelyNotTraced.Except(JobStoreMemberNames(), StringComparer.Ordinal).Should().BeEmpty(
+            "an entry that matches no member is an exemption that has stopped exempting anything, and "
+            + "the list is the only written form of which operations are deliberately not traced");
+    }
+
+    /// <summary>
+    /// The distinct method names on <see cref="IJobStore" />, overload pairs collapsed — an operation is
+    /// one span whichever overload of it the scheduler called.
+    /// </summary>
+    private static HashSet<string> JobStoreMemberNames()
+    {
+        return typeof(IJobStore)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(method => !method.IsSpecialName)
+            .Select(method => method.Name)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Walks the diagnostics types for the literals they name. The tracing store is the only thing that
+    /// begins a store span, but scanning its whole namespace is what makes "somewhere else started one"
+    /// a failure rather than an invisible second source of span names.
+    /// </summary>
+    private static SortedSet<string> ScanForStoreSpanNames()
+    {
+        SortedSet<string> names = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (Type type in quartzAssembly.GetTypes())
+        {
+            // Nested display classes carry the lambdas, and they report their declaring type's namespace.
+            if (!string.Equals(type.Namespace, DiagnosticsNamespace, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (string literal in MethodBodyStrings.In(type))
+            {
+                if (literal.Length > JobStorePrefix.Length && literal.StartsWith(JobStorePrefix, StringComparison.Ordinal))
+                {
+                    names.Add(literal);
+                }
+            }
+        }
+
+        return names;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlParametersTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlParametersTest.cs
@@ -56,6 +56,24 @@ public class SqlParametersTest
             "every placeholder is spelled from a constant the binder also uses, so one that is not a constant is one nothing binds");
     }
 
+    /// <summary>
+    /// The paging pair is spelled twice: here, for the statements Quartz builds, and on
+    /// <see cref="AdoConstants" />, which is the public spelling a dialect delegate outside this
+    /// assembly binds by.
+    /// </summary>
+    /// <remarks>
+    /// Two constants rather than one because a delegate has to be able to name them and this class is
+    /// internal. Their drifting apart is silent in the worst way — the statement would carry one name
+    /// and the binder supply another, which a provider reports as an unbound parameter at run time, or
+    /// worse binds positionally to the wrong column — so it is worth a test rather than a comment.
+    /// </remarks>
+    [Test]
+    public void ThePagingParametersHaveOneSpellingBetweenTheirTwoHomes()
+    {
+        SqlParameters.PageSkip.Should().Be(AdoConstants.ParameterPageSkip);
+        SqlParameters.PageTake.Should().Be(AdoConstants.ParameterPageTake);
+    }
+
     private static IEnumerable<string> Placeholders(string sql)
     {
         for (int i = sql.IndexOf('@', StringComparison.Ordinal); i >= 0; i = sql.IndexOf('@', i + 1))

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateGroupMatcherTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateGroupMatcherTest.cs
@@ -300,7 +300,7 @@ public class StdAdoDelegateGroupMatcherTest
 
         await adoDelegate.UpdateTriggerStateFromOtherStates(conn, new TriggerKey("t1", "g1"), StoredTriggerState.Paused, states);
 
-        BoundOldStates().Should().BeEquivalentTo(states.Select(x => x.ToStoredValue()));
+        BoundOldStates().Should().BeEquivalentTo(states.Select(x => StoredTriggerStates.ToStoredValue(x)));
         command.CommandText.Split(" OR ").Should().HaveCount(stateCount, "the predicate is a disjunction over the set");
     }
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StoredTriggerStateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StoredTriggerStateTest.cs
@@ -56,7 +56,7 @@ public class StoredTriggerStateTest
     {
         foreach (string storedValue in storedValues)
         {
-            StoredTriggerStates.FromStoredValue(storedValue).ToStoredValue().Should().Be(storedValue,
+            StoredTriggerStates.ToStoredValue(StoredTriggerStates.FromStoredValue(storedValue)).Should().Be(storedValue,
                 "the value a state maps to has to be the one it was mapped from, or a stored row changes meaning");
         }
     }
@@ -92,7 +92,7 @@ public class StoredTriggerStateTest
     [Test]
     public void WritingAnUndefinedStateFailsLoudly()
     {
-        Action act = () => ((StoredTriggerState) 99).ToStoredValue();
+        Action act = () => StoredTriggerStates.ToStoredValue((StoredTriggerState) 99);
 
         act.Should().Throw<ArgumentOutOfRangeException>(
             "writing an unmapped state would put a value in the column that nothing can read back");

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateStatementsSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateStatementsSqliteTest.cs
@@ -1,0 +1,269 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Data.Common;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The seven <see cref="IDriverDelegate" /> members that write or read a trigger's state, run against a
+/// real database rather than a faked command.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every one of these binds a <see cref="StoredTriggerState" /> through
+/// <see cref="StoredTriggerStates.ToStoredValue" /> and then compares it against a column, so what they
+/// are worth checking for is exactly what a fake cannot show: that the string bound is the string
+/// stored, and that the <c>WHERE</c> clause therefore matches the rows it means to. A test over a stub
+/// command asserts the parameter was bound and learns nothing about whether the update hit anything.
+/// </para>
+/// <para>
+/// SQLite is a file, so a whole database costs a temporary path — which is what lets these be unit
+/// tests rather than a container leg. The statements are the standard ones;
+/// <c>SQLiteDelegate</c> overrides only row limiting and paging, neither of which appears here.
+/// </para>
+/// </remarks>
+public sealed class TriggerStateStatementsSqliteTest
+{
+    private const string Group = "state-statements";
+
+    private static readonly JobKey jobKey = new("job", Group);
+    private static readonly TriggerKey triggerKey = new("trigger", Group);
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-state-statements-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task AStateWrittenByKeyIsTheStateReadBack()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        (await harness.Delegate.UpdateTriggerState(harness.Connection, triggerKey, StoredTriggerState.Paused))
+            .Should().Be(1, "the trigger is there, so the update names a row that exists");
+
+        (await harness.StoredState()).Should().Be(AdoConstants.StatePaused,
+            "the value the enum maps to is the value the column holds — the whole point of binding the "
+            + "state through one mapping rather than spelling the string at each statement");
+    }
+
+    [Test]
+    public async Task AConditionalStateChangeAppliesOnlyFromTheStateItNames()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        (await harness.Delegate.UpdateTriggerStateFromOtherState(
+                harness.Connection, triggerKey, StoredTriggerState.Acquired, StoredTriggerState.Blocked))
+            .Should().Be(0, "the trigger is WAITING, so a change conditioned on BLOCKED must not apply");
+
+        (await harness.Delegate.UpdateTriggerStateFromOtherState(
+                harness.Connection, triggerKey, StoredTriggerState.Acquired, StoredTriggerState.Waiting))
+            .Should().Be(1);
+
+        (await harness.StoredState()).Should().Be(AdoConstants.StateAcquired);
+    }
+
+    [Test]
+    public async Task AJobsTriggersAreMovedByKeyAndConditionally()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        (await harness.Delegate.UpdateTriggerStatesForJob(harness.Connection, jobKey, StoredTriggerState.Blocked))
+            .Should().Be(1, "the job has one trigger, and it is named by the job rather than by its own key");
+
+        (await harness.Delegate.UpdateTriggerStatesForJobFromOtherState(
+                harness.Connection, jobKey, StoredTriggerState.Waiting, StoredTriggerState.Paused))
+            .Should().Be(0, "the trigger is BLOCKED, so a change conditioned on PAUSED must not apply");
+
+        (await harness.Delegate.UpdateTriggerStatesForJobFromOtherState(
+                harness.Connection, jobKey, StoredTriggerState.Waiting, StoredTriggerState.Blocked))
+            .Should().Be(1);
+
+        (await harness.StoredState()).Should().Be(AdoConstants.StateWaiting);
+    }
+
+    [Test]
+    public async Task MisfiredTriggersAreCountedInTheStateTheyAreIn()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        DateTimeOffset afterTheTrigger = DateTimeOffset.UtcNow.AddDays(2);
+
+        (await harness.Delegate.CountMisfiredTriggersInState(
+                harness.Connection, StoredTriggerState.Waiting, afterTheTrigger))
+            .Should().Be(1, "the trigger is waiting and its next fire time is behind the misfire cutoff");
+
+        (await harness.Delegate.CountMisfiredTriggersInState(
+                harness.Connection, StoredTriggerState.Paused, afterTheTrigger))
+            .Should().Be(0, "the count is per state, so a state no row is in counts nothing");
+
+        (await harness.Delegate.CountMisfiredTriggersInState(
+                harness.Connection, StoredTriggerState.Waiting, DateTimeOffset.UtcNow.AddDays(-2)))
+            .Should().Be(0, "a cutoff before the trigger's next fire time means it has not misfired");
+    }
+
+    [Test]
+    public async Task AJobWithNoFiredTriggerRowIsNotExecuting()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        (await harness.Delegate.IsJobCurrentlyExecuting(harness.Connection, jobKey)).Should().BeFalse(
+            "nothing has fired, so the EXECUTING count over FIRED_TRIGGERS is zero — and the state this "
+            + "compares against is bound through the same mapping the fire path writes with");
+    }
+
+    [Test]
+    public async Task ARetryWritesTheAttemptTheNextFireTimeAndTheState()
+    {
+        await using Harness harness = await Harness.Create(connectionString);
+
+        IOperableTrigger trigger = (await harness.Delegate.SelectTrigger(harness.Connection, triggerKey))!;
+
+        trigger.Should().NotBeNull();
+        trigger.RetryAttempt = 2;
+        trigger.NextFireTimeUtc = DateTimeOffset.UtcNow.AddMinutes(5);
+
+        (await harness.Delegate.UpdateTriggerForRetry(harness.Connection, trigger, StoredTriggerState.Waiting))
+            .Should().Be(1);
+
+        (await harness.StoredState()).Should().Be(AdoConstants.StateWaiting);
+        (await harness.Scalar($"SELECT {AdoConstants.ColumnRetryAttempt} FROM QRTZ_TRIGGERS")).Should().Be(2,
+            "the retry statement is the one place the attempt counter is written");
+    }
+
+    /// <summary>
+    /// A provisioned database with one job and one waiting trigger in it, plus the delegate and the
+    /// connection the tests drive.
+    /// </summary>
+    /// <remarks>
+    /// The scheduler is built only to create the schema and write the two rows, which is the shortest
+    /// way to a database whose contents the store itself considers valid. Everything under test then
+    /// happens against the delegate directly, because these members are below the store and a store
+    /// call would not reach several of them at all.
+    /// </remarks>
+    private sealed class Harness : IAsyncDisposable
+    {
+        private readonly ServiceProvider container;
+        private readonly DbConnection connection;
+
+        private Harness(ServiceProvider container, DbConnection connection, IDriverDelegate driverDelegate)
+        {
+            this.container = container;
+            this.connection = connection;
+            Delegate = driverDelegate;
+            Connection = new ConnectionAndTransactionHolder(connection, null);
+        }
+
+        public IDriverDelegate Delegate { get; }
+
+        public ConnectionAndTransactionHolder Connection { get; }
+
+        public static async Task<Harness> Create(string connectionString)
+        {
+            ServiceCollection services = new();
+            services.AddQuartz(q =>
+            {
+                q.ConfigureScheduler(options =>
+                {
+                    options.InstanceName = "state-statements";
+                    options.InstanceId = "one";
+                });
+
+                q.UsePersistentStore(store =>
+                {
+                    store.UseSqlite(SqliteFactory.Instance, connectionString);
+                    store.ProvisionSchema();
+                });
+            });
+
+            ServiceProvider container = services.BuildServiceProvider();
+            IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+            await scheduler.ScheduleJob(
+                JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).Build(),
+                TriggerBuilder.Create()
+                    .WithIdentity(triggerKey)
+                    .StartAt(DateTimeOffset.UtcNow.AddDays(1))
+                    .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                    .Build());
+
+            // Never started, so nothing acquires the trigger out from under the statements below.
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+
+            DbConnection connection = container.GetRequiredService<IDbProvider>().CreateConnection();
+            await connection.OpenAsync();
+
+            return new Harness(container, connection, container.GetRequiredService<IDriverDelegate>());
+        }
+
+        public Task<string?> StoredState()
+        {
+            return Read($"SELECT {AdoConstants.ColumnTriggerState} FROM QRTZ_TRIGGERS", value => (string?) value);
+        }
+
+        public Task<long> Scalar(string sql)
+        {
+            return Read(sql, Convert.ToInt64);
+        }
+
+        private async Task<T> Read<T>(string sql, Func<object?, T> convert)
+        {
+            await using DbCommand command = connection.CreateCommand();
+            command.CommandText = sql;
+
+            return convert(await command.ExecuteScalarAsync());
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await container.DisposeAsync();
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/MethodBodyStrings.cs
+++ b/src/Quartz.Tests.Unit/MethodBodyStrings.cs
@@ -1,0 +1,173 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The string literals a compiled method names, read out of its IL.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is how a test asks "which of these strings does the product actually use", mechanically rather
+/// than from a curated list that goes stale. It sees a <c>const</c> exactly as it sees a literal,
+/// because the compiler inlines one into the other's place — which is the property that makes it worth
+/// the IL walk: a name reaching a call site through a constant is still a name that call site says.
+/// </para>
+/// <para>
+/// Two tests need it for unrelated reasons — the <c>quartz.*</c> keys the configuration readers
+/// consult, and the span names the tracing store begins — so it lives here rather than in either.
+/// </para>
+/// </remarks>
+internal static class MethodBodyStrings
+{
+    // Declared before anything uses them: static field initializers run in textual order, and the walk
+    // needs these tables to know how long each instruction is.
+    private static readonly OpCode?[] singleByteOpCodes = BuildOpCodeTable(twoByte: false);
+    private static readonly OpCode?[] twoByteOpCodes = BuildOpCodeTable(twoByte: true);
+
+    private const BindingFlags Declared = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+                                          | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+    /// <summary>
+    /// Every string literal named by a method or constructor the type declares itself.
+    /// </summary>
+    /// <remarks>
+    /// Nested types are not walked. A compiler-generated one — the display class holding a lambda —
+    /// reports its declaring type's namespace, so a caller enumerating a namespace already has them;
+    /// a caller naming one type asks for its nested types itself, and says why.
+    /// </remarks>
+    public static List<string> In(Type type)
+    {
+        List<string> literals = [];
+
+        foreach (MethodBase method in type.GetMethods(Declared).Cast<MethodBase>().Concat(type.GetConstructors(Declared)))
+        {
+            literals.AddRange(Of(method));
+        }
+
+        return literals;
+    }
+
+    /// <summary>
+    /// Walks a method body instruction by instruction, resolving every <c>ldstr</c> against the
+    /// module's string heap. Stepping over operands properly is what keeps an operand byte from being
+    /// misread as an opcode and inventing literals that are not there.
+    /// </summary>
+    public static List<string> Of(MethodBase method)
+    {
+        List<string> literals = [];
+
+        byte[]? il;
+        try
+        {
+            il = method.GetMethodBody()?.GetILAsByteArray();
+        }
+        catch (Exception)
+        {
+            // abstract, extern or otherwise bodiless
+            return literals;
+        }
+
+        if (il is null)
+        {
+            return literals;
+        }
+
+        Module module = method.Module;
+        int position = 0;
+        while (position < il.Length)
+        {
+            if (ReadOpCode(il, ref position) is not { } instruction)
+            {
+                // An opcode this table does not know means the walk has lost the instruction boundary;
+                // stopping is honest, and each caller's "the scan found something" test notices if it
+                // starts happening.
+                break;
+            }
+
+            if (instruction.OperandType == OperandType.InlineString && position + 4 <= il.Length)
+            {
+                literals.Add(module.ResolveString(BitConverter.ToInt32(il, position)));
+            }
+
+            position += OperandSize(instruction, il, position);
+        }
+
+        return literals;
+    }
+
+    /// <summary>
+    /// The IL opcode table, read off <see cref="OpCodes" /> rather than transcribed, so that the
+    /// operand sizes the walk relies on come from the runtime's own definitions.
+    /// </summary>
+    private static OpCode?[] BuildOpCodeTable(bool twoByte)
+    {
+        OpCode?[] table = new OpCode?[0x100];
+        foreach (FieldInfo field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is not OpCode opCode)
+            {
+                continue;
+            }
+
+            ushort value = unchecked((ushort) opCode.Value);
+            if (twoByte && (value & 0xFF00) == 0xFE00)
+            {
+                table[value & 0xFF] = opCode;
+            }
+            else if (!twoByte && value < 0x100)
+            {
+                table[value] = opCode;
+            }
+        }
+
+        return table;
+    }
+
+    private static OpCode? ReadOpCode(byte[] il, ref int position)
+    {
+        byte first = il[position++];
+        if (first != 0xFE)
+        {
+            return singleByteOpCodes[first];
+        }
+
+        return position < il.Length ? twoByteOpCodes[il[position++]] : null;
+    }
+
+    private static int OperandSize(OpCode opCode, byte[] il, int position) => opCode.OperandType switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or OperandType.InlineMethod
+            or OperandType.InlineSig or OperandType.InlineString or OperandType.InlineTok
+            or OperandType.InlineType or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, position),
+        _ => 0
+    };
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -3125,7 +3125,7 @@ namespace Quartz.Impl.AdoJobStore
     public static class StoredTriggerStates
     {
         public static Quartz.Extensibility.StoredTriggerState FromStoredValue(string? storedValue) { }
-        public static string ToStoredValue(this Quartz.Extensibility.StoredTriggerState state) { }
+        public static string ToStoredValue(Quartz.Extensibility.StoredTriggerState state) { }
     }
     public readonly struct TriggerAcquireResult : System.IEquatable<Quartz.Impl.AdoJobStore.TriggerAcquireResult>
     {

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -2249,7 +2249,6 @@ namespace Quartz.Impl.AdoJobStore
 {
     public static class AdoConstants
     {
-        public const string AliasColumnNextFireTime = "ALIAS_NXT_FR_TM";
         public const string AllGroupsPaused = "_$_ALL_GROUPS_PAUSED_$_";
         public const string ColumnBlob = "BLOB_DATA";
         public const string ColumnCalendar = "CALENDAR";
@@ -2294,6 +2293,8 @@ namespace Quartz.Impl.AdoJobStore
         public const string ColumnTriggerState = "TRIGGER_STATE";
         public const string ColumnTriggerType = "TRIGGER_TYPE";
         public const string DefaultTablePrefix = "QRTZ_";
+        public const string ParameterPageSkip = "pageSkip";
+        public const string ParameterPageTake = "pageTake";
         public const string StateAcquired = "ACQUIRED";
         public const string StateBlocked = "BLOCKED";
         public const string StateComplete = "COMPLETE";

--- a/src/Quartz/Configuration/PersistentStoreBuilderExtensions.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilderExtensions.cs
@@ -30,6 +30,13 @@ namespace Quartz;
 /// it is the one a trimmed or ahead-of-time-compiled application uses. The others resolve the driver by
 /// name and say so.
 /// </para>
+/// <para>
+/// Every provider therefore has the same three overloads, and <c>UseOracle</c> has a fourth. That is not
+/// an oversight: the name path reaches <c>BindByName</c> and <c>OracleDbType.Blob</c> by reflecting over
+/// the types the driver description names, and a factory names none, so the factory form of Oracle alone
+/// needs somewhere to say those two things in code. Oracle is the only driver Quartz ships a description
+/// for that needs either.
+/// </para>
 /// </remarks>
 public static class PersistentStoreBuilderExtensions
 {

--- a/src/Quartz/Diagnostics/OperationName.cs
+++ b/src/Quartz/Diagnostics/OperationName.cs
@@ -18,6 +18,32 @@ public static class OperationName
         public const string Veto = "Quartz.Job.Veto";
     }
 
+    /// <summary>
+    /// The names of the spans a scheduler's calls into its store are traced under.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A constant exists for every store operation that changes state or drives the fire cycle, and
+    /// for nothing else.</b> Reads are not traced — the <c>Get*</c> and <c>Query*</c> members and the
+    /// three <c>Exists</c> overloads — because a read is one database round trip whose cost the caller's
+    /// own span already covers, and a span saying "the store was asked" adds a frame rather than a fact.
+    /// Neither are the lifecycle members <c>Initialize</c>, <c>Shutdown</c>, <c>SchedulerStarted</c>,
+    /// <c>SchedulerPaused</c> and <c>SchedulerResumed</c>: each happens once, outside any request, so a
+    /// span for it is a root of its own with nothing to be a child of. Nor is <c>GetAcquireRetryDelay</c>,
+    /// which is advice a store gives out of its own configuration rather than an operation it performs.
+    /// </para>
+    /// <para>
+    /// The subset is therefore deliberate rather than half-finished, and it is exact in both directions
+    /// — every constant here names a span <c>TracingJobStore</c> begins, and every span it begins is
+    /// named here. <c>OperationNameTest</c> holds both halves, and separately holds every mutating
+    /// member of <see cref="Quartz.Extensibility.IJobStore" /> to having a constant, so a member added
+    /// to the interface without a span fails the build rather than going quietly untraced.
+    /// </para>
+    /// <para>
+    /// These strings are the telemetry contract: dashboards, alerts and sampling rules match on them, so
+    /// a rename is a breaking change for everyone watching and not a refactoring.
+    /// </para>
+    /// </remarks>
     public static class JobStore
     {
         // Tier 1: scheduler loop hot path

--- a/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoConstants.cs
@@ -109,8 +109,6 @@ public static class AdoConstants
     public const string ColumnRetryPolicy = "RETRY_POLICY";
     public const string ColumnRetryAttempt = "RETRY_ATTEMPT";
 
-    public const string AliasColumnNextFireTime = "ALIAS_NXT_FR_TM";
-
     // TableSimpleTriggers columns names
     public const string ColumnRepeatCount = "REPEAT_COUNT";
     public const string ColumnRepeatInterval = "REPEAT_INTERVAL";
@@ -140,6 +138,35 @@ public static class AdoConstants
     // TableLocks columns names
     public const string ColumnLastCheckinTime = "LAST_CHECKIN_TIME";
     public const string ColumnCheckinInterval = "CHECKIN_INTERVAL";
+
+    // PARAMETER NAMES A DIALECT DELEGATE HAS TO AGREE WITH
+
+    /// <summary>
+    /// The name of the parameter carrying how many rows a page skips.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="StdAdoDelegate.ApplyPaging" /> splices these two names into the statement and
+    /// <see cref="StdAdoDelegate.AddPagingParameters" /> binds them, and a delegate that overrides one
+    /// of those members has to spell the same names in the other — so they are a contract between two
+    /// assemblies, not one delegate's private detail. They are here rather than only on the internal
+    /// list Quartz's own statements use, because this class is where the names a delegate must agree
+    /// with already live.
+    /// </para>
+    /// <para>
+    /// The value is the bare name; the statement carries it prefixed, as <c>"@" + ParameterPageSkip</c>.
+    /// </para>
+    /// </remarks>
+    public const string ParameterPageSkip = "pageSkip";
+
+    /// <summary>
+    /// The name of the parameter carrying how many rows a page reads.
+    /// </summary>
+    /// <remarks>
+    /// The other half of the pair <see cref="ParameterPageSkip" /> describes. It is absent from the
+    /// statement altogether when the caller asked for an unbounded page.
+    /// </remarks>
+    public const string ParameterPageTake = "pageTake";
 
     // MISC CONSTANTS
     public const string DefaultTablePrefix = "QRTZ_";

--- a/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
@@ -46,6 +46,13 @@ namespace Quartz.Impl.AdoJobStore;
 /// The lock statements' names are not here either: those statements and their binding live in the
 /// same lock handler, which is a seam of its own.
 /// </para>
+/// <para>
+/// The paging pair is the one that also has a public spelling. <c>@pageSkip</c> and <c>@pageTake</c>
+/// are an agreement with a delegate outside this assembly — it overrides
+/// <see cref="StdAdoDelegate.ApplyPaging" /> and binds the same names in
+/// <see cref="StdAdoDelegate.AddPagingParameters" /> — so they are on <see cref="AdoConstants" /> as
+/// well, where such a delegate can reach them. <c>SqlParametersTest</c> holds the two spellings equal.
+/// </para>
 /// </remarks>
 internal static class SqlParameters
 {
@@ -177,11 +184,8 @@ internal static class SqlParameters
     public const string Boolean1 = "boolean1";
     public const string Boolean2 = "boolean2";
 
-    // Paging, for the dialects whose clause takes its bounds as parameters. These two are the one pair
-    // a delegate outside this assembly has to agree with — it overrides ApplyPaging and binds the same
-    // names in AddPagingParameters — so the values live on AdoConstants, which is public, and this
-    // class names them from there rather than repeating the strings.
+    // Paging, for the dialects whose clause takes its bounds as parameters.
 
-    public const string PageSkip = AdoConstants.ParameterPageSkip;
-    public const string PageTake = AdoConstants.ParameterPageTake;
+    public const string PageSkip = "pageSkip";
+    public const string PageTake = "pageTake";
 }

--- a/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlParameters.cs
@@ -177,8 +177,11 @@ internal static class SqlParameters
     public const string Boolean1 = "boolean1";
     public const string Boolean2 = "boolean2";
 
-    // Paging, for the dialects whose clause takes its bounds as parameters
+    // Paging, for the dialects whose clause takes its bounds as parameters. These two are the one pair
+    // a delegate outside this assembly has to agree with — it overrides ApplyPaging and binds the same
+    // names in AddPagingParameters — so the values live on AdoConstants, which is public, and this
+    // class names them from there rather than repeating the strings.
 
-    public const string PageSkip = "pageSkip";
-    public const string PageTake = "pageTake";
+    public const string PageSkip = AdoConstants.ParameterPageSkip;
+    public const string PageTake = AdoConstants.ParameterPageTake;
 }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -111,7 +111,7 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
         if (state is not null)
         {
-            AddCommandParameter(cmd, SqlParameters.State, state.Value.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state.Value));
         }
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Queries.cs
@@ -697,7 +697,7 @@ public partial class StdAdoDelegate
             predicateBuilder.Append(query.State == FireInstanceState.Acquired
                 ? StdAdoConstants.SqlFireInstanceStateEqualsPredicate
                 : StdAdoConstants.SqlFireInstanceStateNotEqualsPredicate);
-            parameters.Add(new KeyValuePair<string, object?>("entryState", StoredTriggerState.Acquired.ToStoredValue()));
+            parameters.Add(new KeyValuePair<string, object?>("entryState", StoredTriggerStates.ToStoredValue(StoredTriggerState.Acquired)));
         }
 
         string predicate = predicateBuilder.ToString();

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -48,7 +48,7 @@ public partial class StdAdoDelegate
     {
         for (int i = 0; i < oldStates.Count; i++)
         {
-            AddCommandParameter(cmd, AdoUtil.TriggerStateParameter(i), oldStates[i].ToStoredValue());
+            AddCommandParameter(cmd, AdoUtil.TriggerStateParameter(i), StoredTriggerStates.ToStoredValue(oldStates[i]));
         }
     }
 
@@ -65,7 +65,7 @@ public partial class StdAdoDelegate
         // Bound in the order the statement names them, as every other binder in this file is: a provider
         // that binds by name does not care, but one configured to bind by position would take
         // @newState and @schedulerName the other way round.
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddOldStateParameters(cmd, states);
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -76,7 +76,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlSelectTriggersInState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         List<TriggerKey> list = [];
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -115,7 +115,7 @@ public partial class StdAdoDelegate
             // In the order the statement names them, so that a provider binding positionally does not
             // read the state where the scheduler name goes.
             AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-            AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
 
             for (int i = 0; i < paddedCount; i++)
             {
@@ -175,7 +175,7 @@ public partial class StdAdoDelegate
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(GetCountMisfiredTriggersInStateSql()));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(misfireTime));
-        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
 
         return Convert.ToInt32(await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false));
     }
@@ -319,7 +319,7 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
         AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
-        AddCommandParameter(cmd, SqlParameters.ExecutingState, StoredTriggerState.Executing.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.ExecutingState, StoredTriggerStates.ToStoredValue(StoredTriggerState.Executing));
 
         object? result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
         return Convert.ToInt32(result) > 0;
@@ -344,7 +344,7 @@ public partial class StdAdoDelegate
         AddCommandParameter(cmd, SqlParameters.TriggerDescription, trigger.Description);
         AddCommandParameter(cmd, SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc));
         AddCommandParameter(cmd, SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc));
-        AddCommandParameter(cmd, SqlParameters.TriggerState, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerState, StoredTriggerStates.ToStoredValue(state));
 
         var tDel = FindTriggerPersistenceDelegate(trigger);
         string type = AdoConstants.TriggerTypeBlob;
@@ -504,7 +504,7 @@ public partial class StdAdoDelegate
             new(SqlParameters.TriggerDescription, trigger.Description),
             new(SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
             new(SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
-            new(SqlParameters.TriggerState, state.ToStoredValue()),
+            new(SqlParameters.TriggerState, StoredTriggerStates.ToStoredValue(state)),
             new(SqlParameters.TriggerType, type),
             new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc)),
             new(SqlParameters.TriggerEndTime, GetDbDateTimeValue(trigger.EndTimeUtc)),
@@ -622,7 +622,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
         AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
 
@@ -643,7 +643,7 @@ public partial class StdAdoDelegate
         // Bound in the order the statement names them, as every other binder in this file is: a provider
         // that binds by name does not care, but one configured to bind by position would take
         // @newState and @schedulerName the other way round.
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
@@ -679,7 +679,7 @@ public partial class StdAdoDelegate
             using DbCommand cmd = PrepareCommand(conn, ReplaceTablePrefix(
                 StdAdoConstants.SqlUpdateTriggerStatesFromOtherStatesPrefix + statePredicate + " AND " + AdoUtil.BuildTriggerKeyPredicate(paddedCount)));
             // Parameters are added in SQL token order for providers with positional binding.
-            AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
             AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             AddOldStateParameters(cmd, states);
             AddTriggerKeyParameters(cmd, keys, offset, length, paddedCount);
@@ -703,7 +703,7 @@ public partial class StdAdoDelegate
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql + AdoUtil.BuildTriggerStatePredicate(states.Count)));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.GroupName, parameter);
         AddOldStateParameters(cmd, states);
 
@@ -722,11 +722,11 @@ public partial class StdAdoDelegate
         // Bound in the order the statement names them, as every other binder in this file is: a provider
         // that binds by name does not care, but one configured to bind by position would take
         // @newState and @schedulerName the other way round.
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
-        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.OldState, StoredTriggerStates.ToStoredValue(oldState));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -742,10 +742,10 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateTriggerStateFromStateWithNextFireTime));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.TriggerName, triggerKey.Name);
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, triggerKey.Group);
-        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.OldState, StoredTriggerStates.ToStoredValue(oldState));
         AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(nextFireTime));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
@@ -763,9 +763,9 @@ public partial class StdAdoDelegate
 
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(sql));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.NewState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.NewState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, parameter);
-        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.OldState, StoredTriggerStates.ToStoredValue(oldState));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -779,7 +779,7 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobTriggerStates));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
         AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
         AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
 
@@ -796,10 +796,10 @@ public partial class StdAdoDelegate
     {
         using var cmd = PrepareCommand(conn, ReplaceTablePrefix(StdAdoConstants.SqlUpdateJobTriggerStatesFromOtherState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.State, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.JobName, jobKey.Name);
         AddCommandParameter(cmd, SqlParameters.JobGroup, jobKey.Group);
-        AddCommandParameter(cmd, SqlParameters.OldState, oldState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.OldState, StoredTriggerStates.ToStoredValue(oldState));
 
         return await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -856,10 +856,10 @@ public partial class StdAdoDelegate
             into.Add(new SqlStatement(sql,
             [
                 new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),
-                new SqlStatementParameter(SqlParameters.State, transition.To.ToStoredValue()),
+                new SqlStatementParameter(SqlParameters.State, StoredTriggerStates.ToStoredValue(transition.To)),
                 new SqlStatementParameter(SqlParameters.JobName, jobKey.Name),
                 new SqlStatementParameter(SqlParameters.JobGroup, jobKey.Group),
-                new SqlStatementParameter(SqlParameters.OldState, transition.From.ToStoredValue())
+                new SqlStatementParameter(SqlParameters.OldState, StoredTriggerStates.ToStoredValue(transition.From))
             ]));
         }
     }
@@ -892,7 +892,7 @@ public partial class StdAdoDelegate
             new SqlStatementParameter(SqlParameters.InstanceName, instanceId),
             new SqlStatementParameter(SqlParameters.FiredTime, GetDbDateTimeValue(timeProvider.GetUtcNow())),
             new SqlStatementParameter(SqlParameters.ScheduledTime, GetDbDateTimeValue(update.ScheduledFireTimeUtc)),
-            new SqlStatementParameter(SqlParameters.EntryState, StoredTriggerState.Executing.ToStoredValue()),
+            new SqlStatementParameter(SqlParameters.EntryState, StoredTriggerStates.ToStoredValue(StoredTriggerState.Executing)),
             new SqlStatementParameter(SqlParameters.JobName, trigger.JobKey.Name),
             new SqlStatementParameter(SqlParameters.JobGroup, trigger.JobKey.Group),
             new SqlStatementParameter(SqlParameters.IsNonConcurrent, GetDbBooleanValue(update.JobDetail.ConcurrentExecutionDisallowed)),
@@ -1657,7 +1657,7 @@ public partial class StdAdoDelegate
         List<TriggerAcquireResult> nextTriggers = new();
 
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
-        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerState.Waiting.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(StoredTriggerState.Waiting));
         AddCommandParameter(cmd, SqlParameters.NoLaterThan, GetDbDateTimeValue(criteria.NoLaterThan));
         AddCommandParameter(cmd, SqlParameters.NoEarlierThan, GetDbDateTimeValue(criteria.NoEarlierThan));
         AddPreferredNodeParameters(cmd, criteria.LiveNodeCutoff);
@@ -1827,7 +1827,7 @@ public partial class StdAdoDelegate
             new SqlStatementParameter(SqlParameters.TriggerInstanceName, instanceId),
             new SqlStatementParameter(SqlParameters.TriggerFireTime, GetDbDateTimeValue(timeProvider.GetUtcNow())),
             new SqlStatementParameter(SqlParameters.TriggerScheduledTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
-            new SqlStatementParameter(SqlParameters.TriggerState, state.ToStoredValue()),
+            new SqlStatementParameter(SqlParameters.TriggerState, StoredTriggerStates.ToStoredValue(state)),
             // No job named yet is what an acquired row looks like, and it is what keeps the row out of
             // IsJobCurrentlyExecuting until the trigger actually fires.
             new SqlStatementParameter(SqlParameters.TriggerJobName, job is not null ? trigger.JobKey.Name : null),
@@ -2153,7 +2153,7 @@ public partial class StdAdoDelegate
         // Statement order.
         AddCommandParameter(cmd, SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc));
         AddCommandParameter(cmd, SqlParameters.TriggerRetryAttempt, trigger.RetryAttempt);
-        AddCommandParameter(cmd, SqlParameters.TriggerState, newState.ToStoredValue());
+        AddCommandParameter(cmd, SqlParameters.TriggerState, StoredTriggerStates.ToStoredValue(newState));
         AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
         AddCommandParameter(cmd, SqlParameters.TriggerName, trigger.Key.Name);
         AddCommandParameter(cmd, SqlParameters.TriggerGroup, trigger.Key.Group);
@@ -2202,7 +2202,7 @@ public partial class StdAdoDelegate
         {
             AddCommandParameter(cmd, SqlParameters.SchedulerName, schedulerName);
             AddCommandParameter(cmd, SqlParameters.NextFireTime, GetDbDateTimeValue(misfireTime));
-            AddCommandParameter(cmd, SqlParameters.State, state.ToStoredValue());
+            AddCommandParameter(cmd, SqlParameters.State, StoredTriggerStates.ToStoredValue(state));
 
             using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
             TriggerRowOrdinals? ordinals = null;
@@ -2527,7 +2527,7 @@ public partial class StdAdoDelegate
             new(SqlParameters.SchedulerName, schedulerName),
             new(SqlParameters.TriggerNextFireTime, GetDbDateTimeValue(trigger.NextFireTimeUtc)),
             new(SqlParameters.TriggerPreviousFireTime, GetDbDateTimeValue(trigger.PreviousFireTimeUtc)),
-            new(SqlParameters.TriggerState, update.NewState.ToStoredValue()),
+            new(SqlParameters.TriggerState, StoredTriggerStates.ToStoredValue(update.NewState)),
             new(SqlParameters.TriggerStartTime, GetDbDateTimeValue(trigger.StartTimeUtc)),
             // Misfire handling recomputed the trigger from its schedule, so the occurrence that was
             // waiting to be retried is gone and the attempt goes with it.

--- a/src/Quartz/Impl/AdoJobStore/StoredTriggerStates.cs
+++ b/src/Quartz/Impl/AdoJobStore/StoredTriggerStates.cs
@@ -27,8 +27,16 @@ namespace Quartz.Impl.AdoJobStore;
 /// Translates between <see cref="StoredTriggerState" /> and the strings the trigger state columns hold.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A custom <see cref="IDriverDelegate" /> binds these values into its own statements, so both directions
 /// are public. The strings themselves stay on <see cref="AdoConstants" />, which is the schema contract.
+/// </para>
+/// <para>
+/// Both halves are plain static methods. <see cref="ToStoredValue" /> used to be an extension, which made
+/// the two directions of one mapping read as two different things — <c>state.ToStoredValue()</c> beside
+/// <c>StoredTriggerStates.FromStoredValue(value)</c> — and the asymmetry was not fixable from the other
+/// side, because <see cref="string" /> is not Quartz's to extend with a Quartz verb.
+/// </para>
 /// </remarks>
 public static class StoredTriggerStates
 {
@@ -36,7 +44,7 @@ public static class StoredTriggerStates
     /// The value the trigger state column holds for this state.
     /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">The state is not a defined enum member.</exception>
-    public static string ToStoredValue(this StoredTriggerState state)
+    public static string ToStoredValue(StoredTriggerState state)
     {
         switch (state)
         {


### PR DESCRIPTION
Part 1 of #3596 — the zero-member-delta half of the ADO surface reduction, so the two baseline diffs that follow review on their own.

The design note behind #3596 refuted two of the issue's clauses on contact with the signatures, and this PR is what is left of the riders after that.

## `OperationName.JobStore` had not drifted (I18)

The issue says the span constants "either cover the interface or document the subset rule". They already cover exactly what they should: 29 constants against 35 `OperationName.JobStore.*` call sites in `TracingJobStore`, of which 6 are the second overload of a member pair — **an exact 29 ↔ 29 bijection, nothing unused and nothing missing**. What was missing was the rule, which lived in two `// Tier 1` / `// Tier 2` comments and otherwise nowhere.

The rule is now on the class: a constant exists for every store operation that changes state or drives the fire cycle, and for nothing else — reads are one round trip inside the caller's own span, lifecycle members happen once outside any request, and `GetAcquireRetryDelay` is advice rather than an operation.

Three guards hold the code to it, in `OperationNameTest`:

- the bijection, both directions. The span names come out of `TracingJobStore`'s IL rather than a list kept beside it — a `const` reaches its use site inlined, so the literals in its method bodies are exactly the names it begins spans under whether it named the constant or typed the string, and typing the string is the failure worth catching.
- every **mutating** `IJobStore` member has a constant, against an explicit exclusion list that is the written rule in a form the build can check. This one earned its keep immediately: it found `GetAcquireRetryDelay`, which I had not enumerated.

The IL walk moves out of `LegacyPropertyKeyExhaustivenessTest` into `MethodBodyStrings`; that test had it for the unrelated job of finding the `quartz.*` keys the configuration readers consult.

**Public API delta: none.**

## `StoredTriggerStates.ToStoredValue` drops its `this` (I7)

One mapping, two directions, two call shapes: `state.ToStoredValue()` beside `StoredTriggerStates.FromStoredValue(value)`. The extension is the odd half and the asymmetry is not fixable from the other side — `string` is not Quartz's to extend with a Quartz verb, and doing so would put a Quartz noun on IntelliSense for every string in a consuming application, for one call. 34 call sites move; the type was already in scope at every one.

`TriggerStateResolver` stays in `Quartz.Extensibility`: it resolves to `TriggerState`, which `RAMJobStore` answers with too, so it is not ADO-specific.

## `AdoConstants`: two corrections

- **`ParameterPageSkip` / `ParameterPageTake` are new.** `StdAdoDelegate.ApplyPaging` splices `@pageSkip`/`@pageTake` and an overriding dialect's `AddPagingParameters` must bind the same names — an agreement between Quartz and an assembly that is not Quartz, spelled only on the **internal** `SqlParameters`. That is why `MySQLDelegate` and `SQLiteDelegate` name constants while the documentation sample hard-codes the strings. `SqlParameters` now names the public constants so the two spellings cannot drift, and the sample uses them.
- **`AliasColumnNextFireTime` is deleted.** `ALIAS_NXT_FR_TM` is a column alias from the Java acquisition sub-select; no 4.x statement uses it, no version of the schema has a column for it, and it had zero references in the tree.

## `PersistentStoreBuilderExtensions`: a remark, and nothing else (D11)

The issue asks for an overload audit of "the 48-member provider-extension family". It is **30 members, not 48** — 18 of those baseline lines are `[RequiresUnreferencedCode]` attributes — and every overload earns its place: the connection-string form is the two-thirds case, the `Action<DataSourceOptions>` form expresses a *named* connection string out of `IConfiguration` which the string form cannot, and the `(DbProviderFactory, string)` form is the only trim-safe one and the one `trimming-and-native-aot.md` teaches. Cutting to two per provider means cutting one of those three.

The one genuine finding is `UseOracle`'s fourth overload, the only per-provider member outside the ×3 family. Its own remarks explain why; the class remarks now do too, so it stops reading as an oversight to someone counting the family. **No members were trimmed.**

## Baseline

`PublicApiTest_Quartz.verified.txt` moves by exactly three lines, reviewed and accepted:

```
-        public const string AliasColumnNextFireTime = "ALIAS_NXT_FR_TM";
+        public const string ParameterPageSkip = "pageSkip";
+        public const string ParameterPageTake = "pageTake";
-        public static string ToStoredValue(this Quartz.Extensibility.StoredTriggerState state) { }
+        public static string ToStoredValue(Quartz.Extensibility.StoredTriggerState state) { }
```

Migration-guide rows carried in the same PR: an appendix row for `AdoConstants.AliasColumnNextFireTime`, the two new parameter constants named in the paging-seam paragraph, and the `StoredTriggerStates` section's sample rewritten to the static form (with a note that both halves are plain statics now).

## For a reviewer to decide

- **The exclusion list in `OperationNameTest` is the rule.** If you disagree that `AcquireNextTriggers` is a mutating operation (it marks rows acquired, so I kept it traced as it already was) or that `GetAcquireRetryDelay` is not, the list is the one place to say so.
- **`MethodBodyStrings` is a shared test helper now.** The alternative was duplicating ninety lines of IL walking.

## Verification

```
dotnet build Quartz.slnx                 → Build succeeded, 0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit        → Passed! Failed: 0, Passed: 4816, Skipped: 36
dotnet test src/Quartz.Tests.AspNetCore  → Passed! Failed: 0, Passed: 548, Skipped: 0
dotnet fallout VerifyDocsSnippets        → Succeeded (102 markdown files checked)
dotnet fallout BenchmarkSmoke            → Succeeded (284 benchmarks executed)
```

Integration tests were not run: they need a Docker daemon and nothing here touches a path only they reach. The 36 skips are main’s Unix-cron differential cases, which need `crontab`.

Rebased onto `e21149daa`. One conflict, in the migration guide's alphabetical removals table, where #3619 added a `CronExpression` row at the same place — resolved by ordering `AdoConstants` before it. `PublicApiTest` passes there, which is the proof rather than the textual merge.

## Coverage

The first run's Sonar gate was red at 66.7 % of new lines, and both halves of the gap were real.

**Nine lines in `StdAdoDelegate.Triggers.cs`** were the `ToStoredValue` rewrites inside seven `IDriverDelegate` members no unit test called: `UpdateTriggerState`, `UpdateTriggerStateFromOtherState`, `UpdateTriggerStatesForJob`, `UpdateTriggerStatesForJobFromOtherState`, `CountMisfiredTriggersInState`, `IsJobCurrentlyExecuting` and `UpdateTriggerForRetry`. `TriggerStateStatementsSqliteTest` drives all seven against a real file-backed SQLite database, which is the only way to check the thing they are worth checking: that the string bound is the string stored, so the `WHERE` clause matches the rows it means to. A stub command asserts a parameter was bound and learns nothing about whether the update hit anything. Verified locally with `dotnet fallout Compile UnitTest --coverage` — all nine lines now report visits.

**Two lines in `SqlParameters.cs`** were `public const string PageSkip = AdoConstants.ParameterPageSkip;` and its twin. A `const` whose initializer is *another const* gets a sequence point from the instrumentation and no test can ever execute it — note that the two new literal-initialized constants on `AdoConstants` were counted as 0 lines to cover, which is the difference. So that indirection is walked back: both spellings stay, and `SqlParametersTest` holds them equal. The property that mattered was never "one declaration", it was "the statement and the binder cannot drift", and a test states that exactly. `SqlParameters.cs` now emits no sequence points at all.

Part 1 of #3596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX



