### PR TITLE
A cron expression can be written in the Unix five-field form

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -488,7 +488,13 @@ how the clock and the zone are two separate axes.
 
 One more cron trap, since it accounts for more "my job ran fifty times" reports in this project than
 daylight saving does: Quartz cron puts **seconds first**, so `* 0/5 * * * ?` means *every second of
-every fifth minute*, not every five minutes. That is `0 0/5 * * * ?`. See
+every fifth minute*, not every five minutes. That is `0 0/5 * * * ?`. The same shift is why a
+five-field line copied from a crontab is not a Quartz expression: prepending a `0` fixes the layout
+but not the day-of-week numbering, which is 0-6 from Sunday in crontab and 1-7 from Sunday here. On
+**4.x**, don't translate it by hand — `CronExpression.Parse(line, CronFormat.Unix)` and
+`CronScheduleBuilder.Create(line, CronFormat.Unix)` read the five-field form as written, renumbering
+included, and store the canonical Quartz spelling. On **3.x** there is no such reader, so the
+translation is manual and the day-of-week digit is the part to check. See
 [Cron Triggers (4.x)](/documentation/quartz-4.x/tutorial/crontriggers) and
 [Cron Triggers (3.x)](/documentation/quartz-3.x/tutorial/crontriggers).
 

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -38,7 +38,8 @@ For easy generation of cron intervals using UI you can use some of these service
 - [Cron Expression Generator & Explainer](https://www.freeformatter.com/cron-expression-generator-quartz.html)
 - [CronMaker](http://www.cronmaker.com/)
 
-NOTE: There are many cron standards/implementations. The results from some generators may not always be correct for Quartz.NET
+NOTE: There are many cron standards/implementations. The results from some generators may not always be correct for Quartz.NET.
+A generator that emits the five-field Unix form can be read as written - see [The Unix five-field form](#the-unix-five-field-form).
 :::
 
 ## Special characters
@@ -75,9 +76,117 @@ as it will not 'jump' over the boundary of a month's days. The `W` character can
 "the third Friday of the month" (day 6 = Friday and "#3" = the 3rd one in the month).
 Other examples: `2#1` = the first Monday of the month and `4#5` = the fifth Wednesday of the month.
 Note that if you specify `#5` and there is not 5 of the given day-of-week in the month, then no firing will occur that month.
+
+* `@` - names a whole schedule instead of one field. `@daily` *is* the expression; there is nothing else in it.
+See [Macros](#macros) below for the set.
+
 ::: tip
 The legal characters and the names of months and days of the week are not case sensitive. MON is the same as mon.
 :::
+
+## Macros
+
+The `@` macros are the ones Unix cron has had since Vixie's, and they mean the same thing here:
+
+| **Macro**             | **Expands to** | **Meaning**                           |
+|:----------------------|:---------------|:--------------------------------------|
+| `@yearly`, `@annually` | `0 0 0 1 1 ?`  | Midnight on 1 January                 |
+| `@monthly`            | `0 0 0 1 * ?`  | Midnight on the 1st of every month    |
+| `@weekly`             | `0 0 0 ? * SUN` | Midnight every Sunday                |
+| `@daily`, `@midnight` | `0 0 0 * * ?`  | Midnight every day                    |
+| `@hourly`             | `0 0 * * * ?`  | The top of every hour                 |
+
+A macro needs no dialect and no opt-in, so it works wherever an expression string is read - in code, in an
+XML scheduling file's `<cron-expression>@daily</cron-expression>`, in the dashboard's expression box and over
+the HTTP API:
+
+<!-- snippet: sample_cron_expressions_macro -->
+```csharp
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("nightly")
+    .WithCronSchedule("@daily") // stored, and shown, as "0 0 0 * * ?"
+    .Build();
+```
+<!-- endSnippet -->
+
+The expansion is what gets stored: a trigger written with `@daily` reports its expression as `0 0 0 * * ?`.
+
+`@reboot` is rejected by name - a scheduler has no reboot to fire on, so schedule the work at startup
+instead - and any other `@name` is rejected with the list above. There is deliberately no `@every_minute`
+or `@every_second`: `0 * * * * ?` is already short, and where the point is to spread load,
+[`H`](#h-hash-for-load-distribution) does it deterministically.
+
+## The Unix five-field form
+
+A cron expression copied from a crontab, a Kubernetes `CronJob` or almost any online generator has **five**
+fields rather than six: it has no seconds field, and it numbers the days of the week 0-7 from Sunday rather
+than 1-7. Quartz reads that form when you ask it to, with `CronFormat.Unix`:
+
+<!-- snippet: sample_cron_expressions_unix_format -->
+```csharp
+// "at 04:30 on Mondays", written the way crontab writes it
+CronExpression expression = CronExpression.Parse("30 4 * * 1", CronFormat.Unix);
+
+// ...and held the way Quartz writes it: "0 30 4 ? * MON"
+string canonical = expression.CronExpressionString;
+```
+<!-- endSnippet -->
+
+The format is a way of reading the string, and that is all it is. There are three doors -
+`CronExpression.Parse`, `CronExpression.TryParse` and `CronScheduleBuilder.Create` - and past them the
+expression is an ordinary `CronExpression`:
+
+<!-- snippet: sample_cron_expressions_unix_format_trigger -->
+```csharp
+ITrigger trigger = TriggerBuilder.Create()
+    .WithIdentity("weekday-report")
+    .WithSchedule(CronScheduleBuilder.Create("15 10 * * 1-5", CronFormat.Unix))
+    .Build();
+
+// WithCronSchedule has no format overload; compose one when you need its other options
+ITrigger composed = TriggerBuilder.Create()
+    .WithIdentity("weekday-report-2")
+    .WithCronSchedule(CronExpression.Parse("15 10 * * 1-5", CronFormat.Unix))
+    .Build();
+```
+<!-- endSnippet -->
+
+A time zone composes the same way: `CronExpression.Parse(s, CronFormat.Unix).WithTimeZone(tz)`.
+
+| **Crontab**     | **Read as**          | **Meaning**                                           |
+|:----------------|:---------------------|:------------------------------------------------------|
+| `30 4 * * 1`    | `0 30 4 ? * MON`     | 04:30 every Monday                                    |
+| `0 12 1 * *`    | `0 0 12 1 * ?`       | Noon on the 1st of every month                        |
+| `* * * * *`     | `0 * * * * ?`        | Every minute                                          |
+| `15 10 * * 1-5` | `0 15 10 ? * MON-FRI` | 10:15 on weekdays                                    |
+| `0 0 * * 0-6`   | `0 0 0 * * ?`        | Midnight every day - `0-6` is the whole week          |
+| `0 0 * * 5-1`   | `0 0 0 ? * FRI-MON`  | Midnight Friday through Monday                        |
+| `0 0 13 * 5`    | `0 0 0 13 * FRI`     | The 13th **and** every Friday - both fields name days |
+
+Two things differ between the dialects and nothing else does. The **layout**: five fields, minutes first,
+with no seconds and no year. The **day-of-week numbering**: 0-7 with both 0 and 7 meaning Sunday, so `1-5` is
+Monday to Friday as it is in crontab, and `5` is Friday rather than the Thursday the same digit means in a
+Quartz expression. Everything above is one grammar - `L`, `W`, `#` and `H` all work inside the five-field
+layout, and `L` alone in day-of-week still means Saturday, because it is not a number and so has nothing to
+renumber.
+
+::: warning
+The expression is **normalised** to the canonical Quartz form, and the original text is not recoverable.
+`CronExpressionString`, the dashboard, the HTTP API and `QRTZ_CRON_TRIGGERS.CRON_EXPRESSION` all show
+`0 30 4 ? * MON` for a trigger written as `30 4 * * 1`. That is deliberate: a stored string that parses only
+under a flag the store does not persist would be a trap, so there is no format column and there will not be
+one. It is the same trade as the uppercasing that has always turned `mon-fri` into `MON-FRI`.
+
+The consequence is that the format is a parse-time argument only: the XML schema, the HTTP API and the
+dashboard do not take one, so a five-field expression is something you write in C#, not something you store.
+The macros above have no such limit.
+:::
+
+There is no auto-detection, and the field count alone does not choose the dialect. Letting it would make a
+*dropped* field silent: `0 0 12 * * ?` without its month field is `0 0 12 * ?`, a well-formed crontab line
+meaning midnight on the 12th rather than noon every day. The same digit also names a different day in each
+dialect. So Quartz asks, and the error a five-field expression gets when nobody asked names the method that
+does read it.
 
 ## H (hash) for load distribution
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4632,12 +4632,81 @@ The cron expression parser now supports additional syntax:
 * `H` (hash) tokens for [load distribution](cron-expressions.md#h-hash-for-load-distribution) across triggers
 
 Parse errors name the fix instead of only the constraint. A 5-field Unix/crontab expression — the shape every
-online cron generator emits — is still rejected (Quartz cron puts seconds first), but the error now shows the
-corrected 6-field expression to use, and the day-of-week range error explains that Quartz numbers days 1-7
-starting at Sunday where Unix cron uses 0-6, recommending names (`SUN`, `MON`, …) as the unambiguous spelling.
-When the 5-field expression's day-of-week is a bare number the error goes one step further and shows the
-renumbered expression too: prepending a seconds field to `30 4 * * 1` keeps the `1`, and `1` is Monday in
-crontab but Sunday in Quartz, so the message names `"0 30 4 ? * MON"` as the schedule that was meant.
+online cron generator emits — is not Quartz's own form (Quartz cron puts seconds first), so reading one *as
+Quartz* is still an error; but the error now shows the corrected 6-field expression to use, names
+`CronFormat.Unix` as the way to read it as written instead, and the day-of-week range error explains that
+Quartz numbers days 1-7 starting at Sunday where Unix cron uses 0-6, recommending names (`SUN`, `MON`, …) as
+the unambiguous spelling. When the 5-field expression's day-of-week is a bare number the error goes one step
+further and shows the renumbered expression too: prepending a seconds field to `30 4 * * 1` keeps the `1`, and
+`1` is Monday in crontab but Sunday in Quartz, so the message names `"0 30 4 ? * MON"` as the schedule that was
+meant.
+
+A day name in the **month** field gets the same advice, because that is what a pasted crontab line looks like
+from the parser's side: `0 12 * * MON` never reaches the field count, since crontab's fifth field is
+day-of-week and Quartz's fifth is month, so `MON` is rejected as a month name first.
+
+### A cron expression can be written in the Unix five-field form
+
+`CronFormat.Quartz` is the default and nothing changes without asking for it. `CronFormat.Unix` reads the
+five-field crontab form, and there are exactly three doors:
+
+```csharp
+CronExpression.Parse("30 4 * * 1", CronFormat.Unix);
+CronExpression.TryParse(candidate, CronFormat.Unix, out CronExpression? expression);
+CronScheduleBuilder.Create("30 4 * * 1", CronFormat.Unix);
+```
+
+`WithCronSchedule` has no format overload; compose one —
+`WithCronSchedule(CronExpression.Parse(s, CronFormat.Unix))`. A time zone composes the same way:
+`CronExpression.Parse(s, CronFormat.Unix).WithTimeZone(tz)`.
+
+The format decides two things and nothing else. **The field layout**: five fields, minutes first, with no
+seconds and no year. **The day-of-week numbering**: 0-7, with both 0 and 7 meaning Sunday, so `1-5` is Monday
+to Friday as it is in crontab. Everything else is one grammar — `L`, `W`, `#` and `H` all work inside the
+five-field layout, and `L` alone in day-of-week still means Saturday, because it is not a number and so has
+nothing to renumber. When both day fields name days the expression fires on the union, which is
+`crontab(5)`'s rule and the same one Quartz applies to its own expressions.
+
+**The expression is normalised to the canonical Quartz form, and the original is not recoverable.**
+`CronExpression.Parse("30 4 * * 1", CronFormat.Unix).CronExpressionString` is `"0 30 4 ? * MON"`, and that is
+what `QRTZ_CRON_TRIGGERS.CRON_EXPRESSION`, the dashboard and the HTTP API all show. That is deliberate: a
+stored string that parses only under a flag the store does not persist would be a trap, so there is no
+`CRON_FORMAT` column and there will not be one. It is the same trade as the uppercasing that has always
+turned `mon-fri` into `MON-FRI`.
+
+| crontab | stored, and shown, as |
+|---|---|
+| `30 4 * * 1` | `0 30 4 ? * MON` |
+| `0 12 1 * *` | `0 0 12 1 * ?` |
+| `* * * * *` | `0 * * * * ?` |
+| `0 0 13 * 5` | `0 0 0 13 * FRI` — the 13th **and** every Friday, by the union rule |
+| `0 0 * * 0-6` | `0 0 0 * * ?` |
+| `0 0 * * 5-1` | `0 0 0 ? * FRI-MON` |
+| `0 0 * * 1/2` | `0 0 0 ? * 2/2` — numeric, because `MON/2` is [rejected](#the-parser-refuses-what-it-used-to-ignore) |
+
+Because the format is an argument to the parse, **the XML schema, the HTTP API and the dashboard do not take
+one**: a five-field expression is something you write in C#, not something you store. The `@` macros below
+have no such limit.
+
+### `@daily` and the rest of the macros work everywhere
+
+The `@` macros need no format, because they name the same schedule in every cron there is. They are expanded
+by the `CronExpression` constructor, which is what every entry point goes through, so they are read wherever
+an expression string is — `<cron-expression>@daily</cron-expression>` in an XML scheduling file, the
+dashboard's expression box and the HTTP API included.
+
+| macro | expands to |
+|---|---|
+| `@yearly`, `@annually` | `0 0 0 1 1 ?` |
+| `@monthly` | `0 0 0 1 * ?` |
+| `@weekly` | `0 0 0 ? * SUN` |
+| `@daily`, `@midnight` | `0 0 0 * * ?` |
+| `@hourly` | `0 0 * * * ?` |
+
+This is Vixie's set and only Vixie's set: there is no `@every_minute` or `@every_second`, and no jittered
+variant, because `0 * * * * ?` is already short and `H` spreads load deterministically. `@reboot` is rejected
+by name — a scheduler has no reboot to fire on — and any other `@name` is rejected with the supported list.
+The expansion is what gets stored, so a trigger written with `@daily` shows `0 0 0 * * ?`.
 
 ### The parser refuses what it used to ignore
 

--- a/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
+++ b/src/Quartz.Documentation.Samples/CronExpressionsSamples.cs
@@ -37,6 +37,49 @@ public static class CronExpressionsSamples
         #endregion
     }
 
+    public static void ReadingACrontabLine()
+    {
+        #region sample_cron_expressions_unix_format
+
+        // "at 04:30 on Mondays", written the way crontab writes it
+        CronExpression expression = CronExpression.Parse("30 4 * * 1", CronFormat.Unix);
+
+        // ...and held the way Quartz writes it: "0 30 4 ? * MON"
+        string canonical = expression.CronExpressionString;
+
+        #endregion
+    }
+
+    public static void SchedulingFromACrontabLine()
+    {
+        #region sample_cron_expressions_unix_format_trigger
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("weekday-report")
+            .WithSchedule(CronScheduleBuilder.Create("15 10 * * 1-5", CronFormat.Unix))
+            .Build();
+
+        // WithCronSchedule has no format overload; compose one when you need its other options
+        ITrigger composed = TriggerBuilder.Create()
+            .WithIdentity("weekday-report-2")
+            .WithCronSchedule(CronExpression.Parse("15 10 * * 1-5", CronFormat.Unix))
+            .Build();
+
+        #endregion
+    }
+
+    public static void UsingAMacro()
+    {
+        #region sample_cron_expressions_macro
+
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .WithCronSchedule("@daily") // stored, and shown, as "0 0 0 * * ?"
+            .Build();
+
+        #endregion
+    }
+
     public static void BuildingAnExpression()
     {
         #region sample_cron_expressions_builder

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -45,6 +45,12 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!--
+      NCrontab is a Vixie-faithful five-field cron parser, and it is here for one reason: it is the
+      reference the Unix-dialect rewrite is differentially tested against, so that "this is what
+      crontab means" is an assertion about someone else's implementation rather than about ours.
+    -->
+    <PackageReference Include="NCrontab" />
     <PackageReference Include="Npgsql.DependencyInjection" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers">

--- a/src/Quartz.Tests.Unit/UnixCronDifferentialTest.cs
+++ b/src/Quartz.Tests.Unit/UnixCronDifferentialTest.cs
@@ -1,0 +1,143 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using NCrontab;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// Reads the same crontab lines with <see cref="CronFormat.Unix" /> and with NCrontab, and requires
+/// them to name the same instants.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rewrite's whole claim is "this string means what crontab says it means", and the only way to
+/// test that claim is against something that is not us. NCrontab is a Vixie-faithful five-field
+/// parser, so it is the reference here.
+/// </para>
+/// <para>
+/// One thing has to be kept out of the comparison: NCrontab has no union rule - it requires both day
+/// fields to agree, where crontab and Quartz fire on either when both name days. Every expression
+/// below therefore leaves at least one day field as <c>*</c>, which is the case the two
+/// implementations do agree on. The union itself is pinned directly in
+/// <see cref="UnixCronFormatTest" />.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class UnixCronDifferentialTest
+{
+    // '5-1' is deliberately absent. Quartz reads a range that wraps the end of the week as a wrap, so
+    // 'FRI-MON' is Friday through Monday; NCrontab sorts the endpoints and reads it as Monday through
+    // Friday instead. Vixie's own loop sets no bits at all for it. There is no portable answer to
+    // compare against, so the wrap is pinned directly in UnixCronFormatTest rather than differentially.
+    // '7', '1-7' and '0-7' stay: NCrontab rejects a day-of-week of 7 where crontab has always taken it
+    // for Sunday, so those rows skip themselves below and are pinned directly too.
+    private static readonly string[] daysOfWeek =
+    [
+        "0", "1", "5", "6", "7", "1-5", "2-4", "0-6", "0-7", "1-7", "0-6/2", "1-5/2", "1,3,5", "*/2", "1/2", "0/3",
+        "SUN", "MON-FRI"
+    ];
+
+    private static readonly string[] daysOfMonth = ["1", "1,15", "*/5", "10-20", "29"];
+
+    // "minute hour", the two fields ahead of the day fields.
+    private static readonly string[] times = ["0 *", "30 4", "*/15 *", "5,35 9-17"];
+
+    private static readonly string[] months = ["*", "3", "1,7"];
+
+    public static IEnumerable<TestCaseData> Expressions()
+    {
+        foreach (string dayOfWeek in daysOfWeek)
+        {
+            foreach (string time in times)
+            {
+                foreach (string month in months)
+                {
+                    yield return new TestCaseData($"{time} * {month} {dayOfWeek}");
+                }
+            }
+        }
+
+        foreach (string dayOfMonth in daysOfMonth)
+        {
+            foreach (string time in times)
+            {
+                foreach (string month in months)
+                {
+                    yield return new TestCaseData($"{time} {dayOfMonth} {month} *");
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(Expressions))]
+    public void QuartzReadsACrontabLineTheWayCrontabDoes(string unix)
+    {
+        CrontabSchedule? reference = CrontabSchedule.TryParse(unix);
+        if (reference is null)
+        {
+            Assert.Ignore($"NCrontab does not read '{unix}', so it cannot be the reference for it.");
+            return;
+        }
+
+        DateTime start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Unspecified);
+        DateTime end = start.AddDays(60);
+
+        List<DateTime> expected = reference.GetNextOccurrences(start, end).ToList();
+        List<DateTime> actual = FireTimes(CronExpression.Parse(unix, CronFormat.Unix).WithTimeZone(TimeZoneInfo.Utc), start, end);
+
+        actual.Should().Equal(expected,
+            $"'{unix}' read as CronFormat.Unix must name the instants crontab names, and Quartz reads it as "
+            + $"'{CronExpression.Parse(unix, CronFormat.Unix).CronExpressionString}'");
+    }
+
+    [Test]
+    public void TheOracleActuallyRanOnMostOfTheGrid()
+    {
+        int readable = Expressions()
+            .Select(x => (string) x.Arguments[0]!)
+            .Count(x => CrontabSchedule.TryParse(x) is not null);
+
+        readable.Should().BeGreaterThan(Expressions().Count() * 3 / 4,
+            "a differential test whose reference rejects most of the grid is not testing anything, "
+            + "so the skip count is worth watching rather than tolerating");
+    }
+
+    private static List<DateTime> FireTimes(CronExpression expression, DateTime start, DateTime end)
+    {
+        List<DateTime> times = new List<DateTime>();
+        DateTimeOffset cursor = new DateTimeOffset(start, TimeSpan.Zero);
+        DateTimeOffset until = new DateTimeOffset(end, TimeSpan.Zero);
+        while (true)
+        {
+            DateTimeOffset? next = expression.GetNextValidTimeAfter(cursor);
+            if (next is null || next.Value >= until)
+            {
+                return times;
+            }
+
+            times.Add(next.Value.UtcDateTime);
+            cursor = next.Value;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/UnixCronFormatTest.cs
+++ b/src/Quartz.Tests.Unit/UnixCronFormatTest.cs
@@ -1,0 +1,446 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The five-field Unix crontab dialect, which <see cref="CronFormat.Unix" /> reads, and the
+/// <c>@</c> macros, which need no dialect at all.
+/// </summary>
+/// <remarks>
+/// The dialect is a reading of a string and nothing more: every expression here is rewritten into
+/// Quartz's own six-field form before the parser sees it, which is why these tests assert on
+/// <see cref="CronExpression.CronExpressionString" /> as much as on fire times. Nothing downstream
+/// of the parser - the evaluator, the serializers, the dashboard, the database - knows a format
+/// was ever chosen.
+/// </remarks>
+[TestFixture]
+public class UnixCronFormatTest
+{
+    #region The rewrite
+
+    [TestCase("30 4 * * 1", "0 30 4 ? * MON", "crontab's day-of-week 1 is Monday, where Quartz's 1 is Sunday")]
+    [TestCase("0 12 1 * *", "0 0 12 1 * ?", "a wildcard day-of-week is spelled '?' so the other day field reads as the one that decides")]
+    [TestCase("* * * * *", "0 * * * * ?", "every minute of every day")]
+    [TestCase("0 0 * * 0-6", "0 0 0 * * ?", "SUN through SAT is the whole week, which renumbering would otherwise collapse")]
+    [TestCase("0 0 * * 0-7", "0 0 0 * * ?", "crontab has two Sundays, 0 and 7, so 0-7 is also the whole week")]
+    [TestCase("0 0 * * 1-7", "0 0 0 * * ?", "MON through SUN is seven days, so it too is the whole week")]
+    [TestCase("0 0 * * 5-1", "0 0 0 ? * FRI-MON", "a range may wrap the end of the week")]
+    [TestCase("0 0 * * 1/2", "0 0 0 ? * 2/2", "a step start renumbers as a number, never as a name - Quartz rejects 'MON/2' outright, so a name here would make the rewrite emit an expression its own parser refuses")]
+    [TestCase("15 10 * * 1-5", "0 15 10 ? * MON-FRI", "the crontab weekday range everybody writes")]
+    [TestCase("0 0 * * MON-FRI", "0 0 0 ? * MON-FRI", "names mean the same day in both dialects, so they pass through")]
+    [TestCase("0 0 * * 0", "0 0 0 ? * SUN", "crontab's 0 is Sunday")]
+    [TestCase("0 0 * * 7", "0 0 0 ? * SUN", "and so is crontab's 7")]
+    [TestCase("0 0 * * 6", "0 0 0 ? * SAT", "crontab's 6 is Saturday, which is Quartz's 7")]
+    [TestCase("0 0 * * 1,3,5", "0 0 0 ? * MON,WED,FRI", "every member of a list renumbers")]
+    [TestCase("0 0 * * */2", "0 0 0 ? * */2", "a wildcard step names no day to renumber and picks the same days either way")]
+    [TestCase("0 0 * * 0-6/2", "0 0 0 ? * 1-7/2", "a step through the whole week keeps the phase its first day gave it, so it cannot degenerate to '*/2'")]
+    [TestCase("0 0 * * 1-7/2", "0 0 0 ? * 2-1/2", "and when that first day is Monday the range has to wrap to hold seven days")]
+    [TestCase("0 0 * * 0-7/3", "0 0 0 ? * 1-7/3", "crontab's second Sunday at the end of the range adds no day a step could land on")]
+    [TestCase("0 0 ? * *", "0 0 0 ? * ?", "'?' is a wildcard in both dialects and in both day fields")]
+    [TestCase("0 0 * * 1,", "0 0 0 ? * MON,", "a trailing comma leaves an empty token, which is nothing to renumber - the rewrite passes it on for the parser to have its own opinion about, as it would in a Quartz expression")]
+    [TestCase("0 0 * * 0L", "0 0 0 ? * 1L", "'L' after a day renumbers with it - the last Sunday of the month")]
+    [TestCase("0 0 * * 5#3", "0 0 0 ? * 6#3", "'#' after a day renumbers with it - the third Friday of the month")]
+    [TestCase("0 0 L * *", "0 0 0 L * ?", "'L' in day-of-month is Quartz's, and works inside the five-field layout")]
+    [TestCase("0 0 15W * *", "0 0 0 15W * ?", "'W' likewise")]
+    [TestCase("0 0 * * L", "0 0 0 ? * L", "'L' alone in day-of-week is not a number, so it keeps its Quartz meaning of Saturday")]
+    [TestCase("  30   4  *  *  1  ", "0 30 4 ? * MON", "runs of whitespace separate fields, as they do in crontab")]
+    [TestCase("30 4 * * mon", "0 30 4 ? * MON", "the expression is upper-cased, as every expression is")]
+    public void AUnixExpressionIsRewrittenIntoTheCanonicalQuartzForm(string unix, string canonical, string because)
+    {
+        CronExpression expression = CronExpression.Parse(unix, CronFormat.Unix);
+
+        expression.CronExpressionString.Should().Be(canonical, because);
+    }
+
+    [Test]
+    public void BothDayFieldsRestrictedFiresOnTheUnionAsCrontabDoes()
+    {
+        CronExpression expression = CronExpression.Parse("0 0 13 * 5", CronFormat.Unix);
+
+        expression.CronExpressionString.Should().Be("0 0 0 13 * FRI",
+            "both day fields name days, so both are kept and the expression fires on the union - crontab's rule, "
+            + "and deliberately not Cronos's, which ANDs the two and would fire only on Friday the 13th");
+
+        DateTimeOffset october2010 = new DateTimeOffset(2010, 10, 1, 0, 0, 0, TimeSpan.Zero);
+        List<int> days = FireDays(expression.WithTimeZone(TimeZoneInfo.Utc), october2010, 31);
+
+        days.Should().Equal([1, 8, 13, 15, 22, 29],
+            "October 2010's Fridays are the 1st, 8th, 15th, 22nd and 29th, and the 13th joins them by union");
+    }
+
+    [Test]
+    public void ARewrittenExpressionReParsesAsItself()
+    {
+        CronExpression unix = CronExpression.Parse("30 4 * * 1", CronFormat.Unix);
+
+        CronExpression reread = CronExpression.Parse(unix.CronExpressionString);
+
+        reread.CronExpressionString.Should().Be(unix.CronExpressionString,
+            "the canonical form is what the store writes and reads back, so it must parse with no format");
+    }
+
+    [Test]
+    public void TheOriginalTextIsNotRecoverable()
+    {
+        CronExpression unix = CronExpression.Parse("30 4 * * 1", CronFormat.Unix);
+
+        unix.ToString().Should().Be("0 30 4 ? * MON",
+            "the format is a way of reading the string, not a property of the expression - there is no column "
+            + "for it and nothing downstream would know what to do with one");
+    }
+
+    [Test]
+    public void AHashTokenSurvivesTheRewriteAndIsSpreadByTheTriggerKey()
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("spread-me", "unix")
+            .WithSchedule(CronScheduleBuilder.Create("H 3 * * 1", CronFormat.Unix))
+            .Build();
+
+        string expression = ((ICronTrigger) trigger).CronExpressionString!;
+
+        expression.Should().MatchRegex(@"^0 \d{1,2} 3 \? \* MON$",
+            "the rewrite runs ahead of the parser, so H is still an H when the trigger key resolves it, "
+            + "and it is hashed over the Quartz field it has by then landed in");
+    }
+
+    [Test]
+    public void ADayOfWeekOutsideTheCrontabRangeIsNamedInTheError()
+    {
+        Action act = () => CronExpression.Parse("0 0 * * 8", CronFormat.Unix);
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*'8' is not a day of the week*")
+            .WithMessage("*0-7*", "crontab's range is what the caller was writing against, so that is the range to quote");
+    }
+
+    #endregion
+
+    #region Field counts
+
+    [TestCase("0 0 12 * * ?", 6)]
+    [TestCase("0 0 12 * * ? 2030", 7)]
+    public void AQuartzExpressionReadAsUnixIsRejectedByItsFieldCount(string quartz, int fields)
+    {
+        Action act = () => CronExpression.Parse(quartz, CronFormat.Unix);
+
+        act.Should().Throw<FormatException>()
+            .WithMessage($"*has {fields} fields*", "the count is the thing that is wrong, so the message says the count")
+            .WithMessage("*CronFormat.Quartz*", "and names the format that does read it");
+    }
+
+    [Test]
+    public void AFiveFieldExpressionReadAsQuartzKeepsItsOwnMessageAndNowNamesTheFormatThatReadsIt()
+    {
+        Action act = () => CronExpression.Parse("30 4 * * 1", CronFormat.Quartz);
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*Unix/crontab*", "the most common first-run failure is a 5-field expression copied from crontab or Kubernetes")
+            .WithMessage("*\"0 30 4 * * 1\"*", "the error must show the fixed expression, not just the constraint")
+            .WithMessage("*CronFormat.Unix*", "prepending a zero is no longer the only way out");
+    }
+
+    [Test]
+    public void ADayNameInTheMonthFieldPointsAtTheUnixFormat()
+    {
+        // '0 12 * * MON' never reaches the field count: the fifth field is Quartz's month, and 'MON' is
+        // rejected as a month name before anything counts. That is the shape a real crontab line has.
+        Action act = () => new CronExpression("0 12 * * MON");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*Invalid Month value: 'MON'*", "the field really is invalid, and saying so first is honest")
+            .WithMessage("*5-field Unix/crontab*", "but a day name in the month field is what a pasted crontab line looks like")
+            .WithMessage("*CronFormat.Unix*", "and the way out is worth naming where the failure happens");
+    }
+
+    [Test]
+    public void AnUnknownFormatIsARejectedArgumentRatherThanAParseFailure()
+    {
+        Action act = () => CronExpression.Parse("0 0 12 * * ?", (CronFormat) 42);
+
+        act.Should().Throw<ArgumentOutOfRangeException>("an undefined format is a mistake in the caller's code, not in the expression");
+    }
+
+    #endregion
+
+    #region TryParse and the builder
+
+    [Test]
+    public void TryParseReadsTheUnixForm()
+    {
+        CronExpression.TryParse("30 4 * * 1", CronFormat.Unix, out CronExpression? result).Should().BeTrue();
+
+        result!.CronExpressionString.Should().Be("0 30 4 ? * MON");
+    }
+
+    [TestCase(null, "there is nothing to parse")]
+    [TestCase("0 0 12 * * ?", "six fields is not the Unix form")]
+    [TestCase("nonsense", "and neither is this")]
+    public void TryParseReturnsFalseRatherThanThrowing(string? expression, string because)
+    {
+        CronExpression.TryParse(expression, CronFormat.Unix, out CronExpression? result).Should().BeFalse(because);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void TheScheduleBuilderReadsTheUnixFormAndStoresTheCanonicalOne()
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("crontab")
+            .WithSchedule(CronScheduleBuilder.Create("30 4 * * 1", CronFormat.Unix))
+            .Build();
+
+        ((ICronTrigger) trigger).CronExpressionString.Should().Be("0 30 4 ? * MON",
+            "a trigger carries the canonical expression, whichever dialect the caller wrote");
+    }
+
+    [Test]
+    public void TheScheduleBuilderRefusesAnExpressionThatIsNotTheFormatItWasToldTo()
+    {
+        Action act = () => CronScheduleBuilder.Create("0 0 12 * * ?", CronFormat.Unix);
+
+        act.Should().Throw<FormatException>("the builder rewrites before it validates, so the count is checked at the call that named it");
+    }
+
+    [Test]
+    public void TheScheduleBuilderRefusesANullExpression()
+    {
+        Action act = () => CronScheduleBuilder.Create(null!, CronFormat.Unix);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void ParseRefusesANullExpression()
+    {
+        Action act = () => CronExpression.Parse(null!, CronFormat.Unix);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void ATimeZoneComposesWithTheFormat()
+    {
+        CronExpression expression = CronExpression.Parse("30 4 * * 1", CronFormat.Unix)
+            .WithTimeZone(TimeZoneInfo.Utc);
+
+        expression.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        expression.CronExpressionString.Should().Be("0 30 4 ? * MON");
+    }
+
+    #endregion
+
+    #region Macros
+
+    [TestCase("@yearly", "0 0 0 1 1 ?")]
+    [TestCase("@annually", "0 0 0 1 1 ?")]
+    [TestCase("@monthly", "0 0 0 1 * ?")]
+    [TestCase("@weekly", "0 0 0 ? * SUN")]
+    [TestCase("@daily", "0 0 0 * * ?")]
+    [TestCase("@midnight", "0 0 0 * * ?")]
+    [TestCase("@hourly", "0 0 * * * ?")]
+    [TestCase("@DAILY", "0 0 0 * * ?")]
+    [TestCase("  @daily  ", "0 0 0 * * ?")]
+    public void AMacroExpandsToItsCanonicalExpression(string macro, string canonical)
+    {
+        new CronExpression(macro).CronExpressionString.Should().Be(canonical,
+            "a macro is a name for a schedule, and the schedule is what gets stored");
+    }
+
+    [TestCase("@yearly")]
+    [TestCase("@annually")]
+    [TestCase("@monthly")]
+    [TestCase("@weekly")]
+    [TestCase("@daily")]
+    [TestCase("@midnight")]
+    [TestCase("@hourly")]
+    public void AMacroNeedsNoFormat(string macro)
+    {
+        CronExpression quartz = CronExpression.Parse(macro, CronFormat.Quartz);
+        CronExpression unix = CronExpression.Parse(macro, CronFormat.Unix);
+
+        unix.CronExpressionString.Should().Be(quartz.CronExpressionString,
+            "'@daily' is '@daily' in every cron there is, so the format has nothing to say about it");
+    }
+
+    [Test]
+    public void AMacroWorksWhereverAnExpressionStringIsRead()
+    {
+        ITrigger trigger = TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .WithCronSchedule("@daily")
+            .Build();
+
+        ((ICronTrigger) trigger).CronExpressionString.Should().Be("0 0 0 * * ?",
+            "macros are expanded by the constructor, which is what every entry point goes through - "
+            + "the XML scheduling files and the HTTP API included");
+    }
+
+    [Test]
+    public void AMacroIsExpandedByTheSetterTheStoreAndTheHttpApiGoThrough()
+    {
+        Quartz.Impl.Triggers.CronTriggerImpl trigger = new Quartz.Impl.Triggers.CronTriggerImpl();
+
+        trigger.CronExpressionString = "@hourly";
+
+        trigger.CronExpressionString.Should().Be("0 0 * * * ?",
+            "this setter is what materialises a trigger out of a database row and out of the HTTP API's "
+            + "payload, so a macro written anywhere at all arrives here and leaves canonical");
+    }
+
+    [Test]
+    public void RebootIsRejectedByName()
+    {
+        Action act = () => new CronExpression("@reboot");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*'@reboot' is not supported*")
+            .WithMessage("*a scheduler has no reboot*",
+                "the generic unknown-macro message would send the reader looking for a spelling mistake "
+                + "instead of telling them the concept does not apply");
+    }
+
+    [Test]
+    public void AnUnknownMacroListsTheOnesThatExist()
+    {
+        Action act = () => new CronExpression("@fortnightly");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*Unknown cron macro '@FORTNIGHTLY'*")
+            .WithMessage("*@yearly (@annually), @monthly, @weekly, @daily (@midnight) and @hourly*",
+                "the whole set is short enough to print, and printing it saves a trip to the documentation");
+    }
+
+    [Test]
+    public void ThereIsNoEveryMinuteMacro()
+    {
+        Action act = () => new CronExpression("@every_minute");
+
+        act.Should().Throw<FormatException>("Cronos has this one and Vixie does not; '0 * * * * ?' is already short");
+    }
+
+    [Test]
+    public void AnAtSignInTheMiddleOfAnExpressionIsStillJustAnUnexpectedCharacter()
+    {
+        Action act = () => new CronExpression("0 0 @ * * ?");
+
+        act.Should().Throw<FormatException>()
+            .WithMessage("*Unexpected character: @*", "only a leading '@' names a macro");
+    }
+
+    [TestCase("@hourly", "0 0 * * * ?")]
+    [TestCase("@daily", "0 0 0 * * ?")]
+    public void AMacroFiresWhatItSays(string macro, string equivalent)
+    {
+        DateTimeOffset from = new DateTimeOffset(2024, 5, 1, 0, 0, 0, TimeSpan.Zero);
+
+        FireTimes(new CronExpression(macro).WithTimeZone(TimeZoneInfo.Utc), from, 50)
+            .Should().Equal(FireTimes(new CronExpression(equivalent).WithTimeZone(TimeZoneInfo.Utc), from, 50));
+    }
+
+    #endregion
+
+    #region Fire-time equivalence
+
+    [TestCase("* * * * *", "0 * * * * ?")]
+    [TestCase("30 4 * * 1", "0 30 4 ? * MON")]
+    [TestCase("0 12 1 * *", "0 0 12 1 * ?")]
+    [TestCase("0 0 13 * 5", "0 0 0 13 * FRI")]
+    [TestCase("15 10 * * 1-5", "0 15 10 ? * MON-FRI")]
+    [TestCase("0 */6 * * *", "0 0 */6 * * ?")]
+    [TestCase("0 0 * * 0", "0 0 0 ? * SUN")]
+    [TestCase("0 0 * * 7", "0 0 0 ? * SUN")]
+    [TestCase("0 0 * * 6", "0 0 0 ? * SAT")]
+    [TestCase("0 0 * * 5-1", "0 0 0 ? * FRI-MON")]
+    [TestCase("0 0 * * 1/2", "0 0 0 ? * 2/2")]
+    [TestCase("0 0 * * 0-6", "0 0 0 * * ?")]
+    [TestCase("0 0 * * 0-6/2", "0 0 0 ? * 1-7/2")]
+    [TestCase("0 0 * * 1-7/2", "0 0 0 ? * 2-1/2")]
+    [TestCase("0 0 * * 1,3,5", "0 0 0 ? * MON,WED,FRI")]
+    [TestCase("5 0 1,15 * *", "0 5 0 1,15 * ?")]
+    [TestCase("0 0 * * 0L", "0 0 0 ? * 1L")]
+    public void TheTwoSpellingsFireAtTheSameInstantsForSixtyDays(string unix, string quartz)
+    {
+        DateTimeOffset start = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset end = start.AddDays(60);
+
+        List<DateTimeOffset> fromUnix = FireTimesUntil(CronExpression.Parse(unix, CronFormat.Unix).WithTimeZone(TimeZoneInfo.Utc), start, end);
+        List<DateTimeOffset> fromQuartz = FireTimesUntil(CronExpression.Parse(quartz).WithTimeZone(TimeZoneInfo.Utc), start, end);
+
+        fromUnix.Should().NotBeEmpty("an expression that never fires would make this comparison vacuous");
+        fromUnix.Should().Equal(fromQuartz,
+            "the format decides how the string is read and nothing else - the schedule it names is the same schedule");
+    }
+
+    #endregion
+
+    private static List<DateTimeOffset> FireTimes(CronExpression expression, DateTimeOffset from, int count)
+    {
+        List<DateTimeOffset> times = new List<DateTimeOffset>(count);
+        DateTimeOffset cursor = from;
+        for (int i = 0; i < count; i++)
+        {
+            DateTimeOffset? next = expression.GetNextValidTimeAfter(cursor);
+            if (next is null)
+            {
+                break;
+            }
+
+            times.Add(next.Value);
+            cursor = next.Value;
+        }
+
+        return times;
+    }
+
+    private static List<DateTimeOffset> FireTimesUntil(CronExpression expression, DateTimeOffset from, DateTimeOffset until)
+    {
+        List<DateTimeOffset> times = new List<DateTimeOffset>();
+        DateTimeOffset cursor = from;
+        while (true)
+        {
+            DateTimeOffset? next = expression.GetNextValidTimeAfter(cursor);
+            if (next is null || next.Value >= until)
+            {
+                return times;
+            }
+
+            times.Add(next.Value);
+            cursor = next.Value;
+        }
+    }
+
+    private static List<int> FireDays(CronExpression expression, DateTimeOffset from, int days)
+    {
+        DateTimeOffset until = from.AddDays(days);
+        List<int> result = new List<int>();
+        foreach (DateTimeOffset fire in FireTimesUntil(expression, from.AddSeconds(-1), until))
+        {
+            result.Add(fire.Day);
+        }
+
+        return result;
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -130,9 +130,11 @@ namespace Quartz
         public static bool IsValidExpression(string cronExpression) { }
         public static bool IsValidExpression(string cronExpression, string hashKey) { }
         public static Quartz.CronExpression Parse(string cronExpression) { }
+        public static Quartz.CronExpression Parse(string cronExpression, Quartz.CronFormat format) { }
         public static string ResolveHash(string cronExpression, int hashSeed) { }
         public static string ResolveHash(string cronExpression, string hashKey) { }
         public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? cronExpression, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Quartz.CronExpression? result) { }
+        public static bool TryParse([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] string? cronExpression, Quartz.CronFormat format, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Quartz.CronExpression? result) { }
         public static void ValidateExpression(string cronExpression) { }
         public static void ValidateExpression(string cronExpression, string hashKey) { }
     }
@@ -183,6 +185,11 @@ namespace Quartz
         public Quartz.CronExpressionBuilder WithYears(params int[] years) { }
         public static Quartz.CronExpressionBuilder Create() { }
     }
+    public enum CronFormat
+    {
+        Quartz = 0,
+        Unix = 1,
+    }
     public sealed class CronScheduleBuilder : Quartz.IScheduleBuilder
     {
         public Quartz.Extensibility.IMutableTrigger Build() { }
@@ -190,6 +197,7 @@ namespace Quartz
         public Quartz.CronScheduleBuilder WithMisfireInstruction(Quartz.CronTriggerMisfireInstruction instruction) { }
         public static Quartz.CronScheduleBuilder Create(Quartz.CronExpression cronExpression) { }
         public static Quartz.CronScheduleBuilder Create(string cronExpression) { }
+        public static Quartz.CronScheduleBuilder Create(string cronExpression, Quartz.CronFormat format) { }
     }
     public enum CronTriggerMisfireInstruction
     {

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -262,14 +262,23 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     private static readonly int[] HashFieldMaxes = { 59, 59, 23, 31, 12, 7 };
 
     // Day-of-week names and RFC 5545 BYDAY codes, indexed by Quartz's 1-7 numbering (1 = Sunday).
-    // Only error messages read these; the parser maps the other way, through GetDayOfWeekNumber.
-    private static readonly string[] DayOfWeekNames = { "", "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
+    // The parser maps the other way, through GetDayOfWeekNumber. Error messages read both; the names
+    // are also read by UnixCronRewriter, which renumbers crontab's 0-6 into them - hence internal, so
+    // that there is one such table rather than two.
+    internal static readonly string[] DayOfWeekNames = { "", "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" };
     private static readonly string[] RecurrenceDayCodes = { "", "SU", "MO", "TU", "WE", "TH", "FR", "SA" };
 
     ///<summary>
     /// Constructs a new <see cref="CronExpressionString" /> based on the specified
     /// parameter.
     /// </summary>
+    /// <remarks>
+    /// An <c>@</c> macro - <c>@yearly</c>, <c>@annually</c>, <c>@monthly</c>, <c>@weekly</c>,
+    /// <c>@daily</c>, <c>@midnight</c> or <c>@hourly</c> - is expanded here, which is what puts it
+    /// behind every entry point that reads an expression string. The expansion is what
+    /// <see cref="CronExpressionString" /> then holds, in the same way that it holds
+    /// <c>MON-FRI</c> for a caller who wrote <c>mon-fri</c>.
+    /// </remarks>
     /// <param name="cronExpression">String representation of the cron expression the new object should represent</param>
     /// <see cref="CronExpressionString" />
     public CronExpression(string cronExpression)
@@ -279,7 +288,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             Throw.ArgumentException("cronExpression cannot be null", nameof(cronExpression));
         }
 
-        CronExpressionString = CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression).Trim();
+        CronExpressionString = CronMacros.Expand(CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression).Trim());
         BuildExpression(CronExpressionString);
     }
 
@@ -508,6 +517,79 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         {
             result = null;
             return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses a cron expression string written in the given format into a <see cref="CronExpression" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronFormat.Unix" /> reads the five-field crontab form, whose day-of-week is numbered
+    /// 0-7 with both 0 and 7 meaning Sunday. The result is an ordinary <see cref="CronExpression" />
+    /// holding the canonical Quartz spelling of the same schedule, so <c>"30 4 * * 1"</c> becomes
+    /// <c>"0 30 4 ? * MON"</c> and that is what <see cref="CronExpressionString" />, the dashboard and
+    /// the database show. The format is not recorded anywhere and the original text is not recoverable.
+    /// </para>
+    /// <para>
+    /// A time zone composes: <c>CronExpression.Parse(s, CronFormat.Unix).WithTimeZone(tz)</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="cronExpression">String representation of the cron expression.</param>
+    /// <param name="format">The dialect <paramref name="cronExpression"/> is written in.</param>
+    /// <returns>The parsed expression.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="cronExpression"/> is <see langword="null" />.</exception>
+    /// <exception cref="FormatException"><paramref name="cronExpression"/> is not a valid cron expression in <paramref name="format"/>.</exception>
+    public static CronExpression Parse(string cronExpression, CronFormat format)
+    {
+        ArgumentNullException.ThrowIfNull(cronExpression);
+        return new CronExpression(ToQuartzForm(cronExpression, format));
+    }
+
+    /// <summary>
+    /// Attempts to parse a cron expression string written in the given format into a
+    /// <see cref="CronExpression" />.
+    /// </summary>
+    /// <param name="cronExpression">String representation of the cron expression; may be <see langword="null" />.</param>
+    /// <param name="format">The dialect <paramref name="cronExpression"/> is written in.</param>
+    /// <param name="result">The parsed expression, or <see langword="null" /> when parsing failed.</param>
+    /// <returns><see langword="true" /> when <paramref name="cronExpression"/> is a valid cron expression in <paramref name="format"/>.</returns>
+    /// <seealso cref="Parse(string, CronFormat)" />
+    public static bool TryParse([NotNullWhen(true)] string? cronExpression, CronFormat format, [NotNullWhen(true)] out CronExpression? result)
+    {
+        if (cronExpression is null)
+        {
+            result = null;
+            return false;
+        }
+
+        try
+        {
+            result = new CronExpression(ToQuartzForm(cronExpression, format));
+            return true;
+        }
+        catch (FormatException)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads an expression written in <paramref name="format"/> as the Quartz expression that says the
+    /// same thing. Only the string changes; nothing downstream of the parser knows about formats.
+    /// </summary>
+    internal static string ToQuartzForm(string cronExpression, CronFormat format)
+    {
+        switch (format)
+        {
+            case CronFormat.Quartz:
+                return cronExpression;
+            case CronFormat.Unix:
+                return UnixCronRewriter.ToQuartz(cronExpression);
+            default:
+                Throw.ArgumentOutOfRangeException(nameof(format), $"'{format}' is not a cron format.");
+                return cronExpression;
         }
     }
 
@@ -1137,6 +1219,18 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             sval = CronExpression.GetMonthNumber(sub) + 1;
             if (sval <= 0)
             {
+                // A day name in the month field is nearly always a five-field crontab line: crontab's
+                // fifth field is day-of-week and Quartz's fifth is month, so the two land on top of each
+                // other and the field is rejected before anything counts the fields. Say so here, or the
+                // count message below - which is the one that explains the dialect - is never reached.
+                if (GetDayOfWeekNumber(sub) >= 0)
+                {
+                    Throw.FormatException(
+                        $"Invalid Month value: '{sub.ToString()}' names a day of the week, and this is the month field. "
+                        + "That is usually a 5-field Unix/crontab expression; Quartz cron has 6 or 7 fields with seconds first. "
+                        + "Prepend a seconds field, or read the expression as written with CronExpression.Parse(expression, CronFormat.Unix).");
+                }
+
                 Throw.FormatException($"Invalid Month value: '{sub.ToString()}'");
             }
 
@@ -1820,11 +1914,16 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// day-of-week field is a bare number - the Quartz spelling of the day that number named in crontab.
     /// Prepending a seconds field keeps the digit, and the same digit is a different day in the two
     /// dialects, so advice that stopped at the rewrite moved the schedule by a day without saying so.
+    /// It ends by naming <see cref="CronFormat.Unix" />, which does the whole rewrite for the caller.
     /// </summary>
     private static string FiveFieldAdvice(string expression)
     {
         string prepend = $"Prepend a seconds field: \"0 {expression}\". "
                          + "Note that Quartz numbers days of week 1-7 starting at Sunday where Unix cron uses 0-6, so ";
+
+        // Rewriting by hand is one way out; the other is not to rewrite at all, because the five-field
+        // form is a dialect Quartz reads and not only a mistake it rejects.
+        const string orReadItAsUnix = " Or read it as written, renumbering and all, with CronExpression.Parse(expression, CronFormat.Unix).";
 
         string[] fields = expression.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
         if (fields.Length == 5
@@ -1836,10 +1935,11 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             string dayOfMonth = fields[2] is "*" or "?" ? "?" : fields[2];
             return prepend
                    + $"if '{fields[4]}' meant {(DayOfWeek) (quartzDayOfWeek - 1)} the Quartz spelling is "
-                   + $"\"0 {fields[0]} {fields[1]} {dayOfMonth} {fields[3]} {DayOfWeekNames[quartzDayOfWeek]}\".";
+                   + $"\"0 {fields[0]} {fields[1]} {dayOfMonth} {fields[3]} {DayOfWeekNames[quartzDayOfWeek]}\"."
+                   + orReadItAsUnix;
         }
 
-        return prepend + "respell numeric day-of-week values or use names (SUN, MON, ...).";
+        return prepend + "respell numeric day-of-week values or use names (SUN, MON, ...)." + orReadItAsUnix;
     }
 
     /// <summary>

--- a/src/Quartz/CronFormat.cs
+++ b/src/Quartz/CronFormat.cs
@@ -1,0 +1,55 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// The field layout and day-of-week numbering a cron expression string is read with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The format is chosen at the moment the string is read and is not carried anywhere afterwards:
+/// <see cref="CronExpression.Parse(string, CronFormat)" /> normalises what it reads into the
+/// canonical Quartz form, which is what <see cref="CronExpression.CronExpressionString" />, the
+/// dashboard and the database all hold.
+/// </para>
+/// <para>
+/// The <c>@</c> macros — <c>@yearly</c>, <c>@annually</c>, <c>@monthly</c>, <c>@weekly</c>,
+/// <c>@daily</c>, <c>@midnight</c> and <c>@hourly</c> — need no format: they mean the same thing in
+/// every cron there is, so they are read by every entry point, including the XML scheduling data
+/// files and the HTTP API.
+/// </para>
+/// </remarks>
+/// <seealso cref="CronExpression.Parse(string, CronFormat)" />
+/// <seealso cref="CronExpression.TryParse(string, CronFormat, out CronExpression)" />
+/// <seealso cref="CronScheduleBuilder.Create(string, CronFormat)" />
+public enum CronFormat
+{
+    /// <summary>
+    /// Quartz's own dialect: six or seven fields - seconds, minutes, hours, day-of-month, month,
+    /// day-of-week and optionally year - with day-of-week numbered 1-7 starting at Sunday.
+    /// </summary>
+    Quartz = 0,
+
+    /// <summary>
+    /// The Unix crontab dialect: five fields - minutes, hours, day-of-month, month, day-of-week -
+    /// with no seconds and no year, and day-of-week numbered 0-7 where both 0 and 7 are Sunday.
+    /// </summary>
+    Unix = 1,
+}

--- a/src/Quartz/CronMacros.cs
+++ b/src/Quartz/CronMacros.cs
@@ -1,0 +1,69 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// The <c>@</c> macros every cron implementation since Vixie's has understood.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A macro names a schedule rather than spelling one, and it names the same schedule in every cron
+/// there is, so it carries no dialect: <see cref="CronFormat" /> has nothing to say about it and it
+/// is expanded by the constructor, which puts it behind every entry point at once - the XML
+/// scheduling files, the HTTP API and the dashboard's expression box included.
+/// </para>
+/// <para>
+/// This is Vixie's set and only Vixie's set. There is no <c>@every_minute</c> or <c>@every_second</c>
+/// - <c>0 * * * * ?</c> and <c>* * * * * ?</c> are already short - and no jittered variant, because
+/// Quartz's <c>H</c> token spreads load deterministically, which is better than a random one.
+/// </para>
+/// </remarks>
+internal static class CronMacros
+{
+    /// <summary>
+    /// Expands a leading <c>@</c> macro into its canonical Quartz expression, or returns
+    /// <paramref name="upperExpression" /> unchanged when it is not a macro.
+    /// </summary>
+    /// <param name="upperExpression">A trimmed, upper-cased cron expression string.</param>
+    /// <exception cref="FormatException">The string starts with <c>@</c> but names no known macro.</exception>
+    internal static string Expand(string upperExpression)
+    {
+        if (upperExpression.Length == 0 || upperExpression[0] != '@')
+        {
+            return upperExpression;
+        }
+
+        return upperExpression switch
+        {
+            "@YEARLY" or "@ANNUALLY" => "0 0 0 1 1 ?",
+            "@MONTHLY" => "0 0 0 1 * ?",
+            "@WEEKLY" => "0 0 0 ? * SUN",
+            "@DAILY" or "@MIDNIGHT" => "0 0 0 * * ?",
+            "@HOURLY" => "0 0 * * * ?",
+            "@REBOOT" => throw new FormatException(
+                "'@reboot' is not supported: a scheduler has no reboot to fire on. Run the work as the "
+                + "application starts instead - schedule the job with a trigger that starts now - or give "
+                + "the trigger a start time and let it fire on its own schedule from there."),
+            _ => throw new FormatException(
+                $"Unknown cron macro '{upperExpression}'. The supported macros are @yearly (@annually), "
+                + "@monthly, @weekly, @daily (@midnight) and @hourly."),
+        };
+    }
+}

--- a/src/Quartz/CronScheduleBuilder.cs
+++ b/src/Quartz/CronScheduleBuilder.cs
@@ -181,6 +181,36 @@ public sealed class CronScheduleBuilder : IScheduleBuilder, IHashKeyAwareSchedul
     }
 
     /// <summary>
+    /// Create a CronScheduleBuilder from an expression written in the given format.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CronFormat.Unix" /> reads the five-field crontab form. What the schedule holds
+    /// afterwards is the canonical Quartz expression that says the same thing, so a trigger built from
+    /// <c>"30 4 * * 1"</c> stores and displays <c>"0 30 4 ? * MON"</c>.
+    /// </para>
+    /// <para>
+    /// There is no <c>WithCronSchedule</c> overload taking a format; compose one from the expression
+    /// instead: <c>WithCronSchedule(CronExpression.Parse(s, CronFormat.Unix))</c>.
+    /// </para>
+    /// </remarks>
+    /// <param name="cronExpression">the cron expression to base the schedule on.</param>
+    /// <param name="format">the dialect <paramref name="cronExpression"/> is written in.</param>
+    /// <returns>the new CronScheduleBuilder</returns>
+    /// <seealso cref="CronExpression.Parse(string, CronFormat)" />
+    public static CronScheduleBuilder Create(string cronExpression, CronFormat format)
+    {
+        if (cronExpression is null)
+        {
+            Throw.ArgumentException("cronExpression cannot be null", nameof(cronExpression));
+        }
+
+        // Rewriting first means the H handling, the validation and the deferral below all see one
+        // dialect, so CronFormat.Unix costs this method nothing but the call.
+        return Create(CronExpression.ToQuartzForm(cronExpression, format));
+    }
+
+    /// <summary>
     /// Resolves a deferred <c>H</c> expression against the key that was finally supplied.
     /// </summary>
     /// <remarks>

--- a/src/Quartz/UnixCronRewriter.cs
+++ b/src/Quartz/UnixCronRewriter.cs
@@ -1,0 +1,202 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using System.Globalization;
+
+namespace Quartz;
+
+/// <summary>
+/// Rewrites a five-field Unix crontab expression into the canonical six-field Quartz form.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CronFormat.Unix" /> is a way of reading a string, not a second parser. Everything past
+/// this class - the parser, the evaluator, the serializers, the dashboard and the database - only
+/// ever sees Quartz's own form, which is what lets a crontab line be scheduled, stored, displayed
+/// and read back with no format recorded anywhere.
+/// </para>
+/// <para>
+/// Two things differ between the dialects. The layout: crontab has no seconds and no year, so a
+/// seconds field of <c>0</c> is prepended. And the day-of-week numbering: crontab counts 0-6 from
+/// Sunday and accepts 7 for Sunday as well, where Quartz counts 1-7 from Sunday, so every bare
+/// integer in that field maps <c>n</c> to <c>(n % 7) + 1</c>. Everything else - names, ranges,
+/// steps, lists, and Quartz's own <c>L</c>, <c>W</c>, <c>#</c> and <c>H</c> - is spelled the same
+/// way in both and travels through untouched.
+/// </para>
+/// <para>
+/// The rewrite runs before the parser, and therefore before <c>H</c> tokens are resolved: an
+/// <c>H</c> in a five-field day-of-week is hashed over Quartz's 1-7 range, which is the right range
+/// by the time anything looks at it.
+/// </para>
+/// </remarks>
+internal static class UnixCronRewriter
+{
+    private static readonly char[] fieldSeparators = { ' ', '\t' };
+
+    /// <summary>
+    /// Rewrites a Unix crontab expression into the equivalent Quartz expression.
+    /// </summary>
+    /// <param name="cronExpression">A five-field crontab expression, or an <c>@</c> macro.</param>
+    /// <exception cref="FormatException">The expression does not have five fields, or its day-of-week
+    /// field names a day the crontab form does not have.</exception>
+    internal static string ToQuartz(string cronExpression)
+    {
+        string expression = CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression).Trim();
+
+        // A macro carries no dialect, so it is left for the constructor to expand once for both formats.
+        if (expression.Length > 0 && expression[0] == '@')
+        {
+            return expression;
+        }
+
+        string[] fields = expression.Split(fieldSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (fields.Length != 5)
+        {
+            Throw.FormatException(
+                $"Cron expression '{expression}' has {fields.Length} fields, but the Unix/crontab form read by "
+                + "CronFormat.Unix has exactly 5: minutes, hours, day-of-month, month and day-of-week. "
+                + (fields.Length is 6 or 7
+                    ? "Six or seven fields is Quartz's own form, which CronFormat.Quartz reads."
+                    : "Quartz's own form has six or seven fields, seconds first, and CronFormat.Quartz reads that."));
+        }
+
+        string dayOfMonth = fields[2];
+        string dayOfWeek = RewriteDayOfWeek(fields[4]);
+
+        // Quartz writes "this field names no days" as '?' in one of the two day fields and '*' in the
+        // other. The two say the same thing, so this decides only how the canonical string reads.
+        if (dayOfWeek is "*" or "?")
+        {
+            dayOfWeek = "?";
+        }
+        else if (dayOfMonth is "*" or "?")
+        {
+            dayOfMonth = "?";
+        }
+
+        return $"0 {fields[0]} {fields[1]} {dayOfMonth} {fields[3]} {dayOfWeek}";
+    }
+
+    private static string RewriteDayOfWeek(string field)
+    {
+        if (!field.Contains(','))
+        {
+            return RewriteToken(field);
+        }
+
+        string[] tokens = field.Split(',');
+        for (int i = 0; i < tokens.Length; i++)
+        {
+            tokens[i] = RewriteToken(tokens[i]);
+        }
+
+        return string.Join(",", tokens);
+    }
+
+    private static string RewriteToken(string token)
+    {
+        if (token.Length == 0)
+        {
+            return token;
+        }
+
+        // '*' and '?' name no day, 'L' on its own is Saturday in both readings, and an 'H' token is a
+        // hash over the whole field - none of them carries a Unix day number, and a step on any of them
+        // walks the same days whichever dialect wrote it.
+        if (token[0] is '*' or '?' or 'L' or 'H')
+        {
+            return token;
+        }
+
+        int slash = token.IndexOf('/');
+        bool stepped = slash >= 0;
+        string body = stepped ? token.Substring(0, slash) : token;
+        string step = stepped ? token.Substring(slash) : "";
+
+        int dash = body.IndexOf('-');
+        if (dash <= 0)
+        {
+            return RewriteValue(body, stepped) + step;
+        }
+
+        string start = body.Substring(0, dash);
+        string end = body.Substring(dash + 1);
+
+        if (TryReadUnixDay(start, out int rawStart) && TryReadUnixDay(end, out int rawEnd) && rawEnd - rawStart >= 6)
+        {
+            // The range spans the whole week, which renumbering alone would collapse: '0-7' becomes
+            // 'SUN-SUN'. Say "every day" instead - or, when a step picks days out of the range, a range
+            // that wraps around to the day before it started, so the step keeps the phase Unix gave it.
+            if (!stepped)
+            {
+                return "*";
+            }
+
+            int first = ToQuartzDay(rawStart);
+            int last = first == 1 ? 7 : first - 1;
+            return $"{first}-{last}{step}";
+        }
+
+        return RewriteValue(start, stepped) + "-" + RewriteValue(end, stepped) + step;
+    }
+
+    /// <summary>
+    /// Renumbers one day-of-week value, keeping whatever <c>L</c> or <c>#n</c> suffix follows it.
+    /// </summary>
+    private static string RewriteValue(string value, bool stepped)
+    {
+        int digits = 0;
+        while (digits < value.Length && char.IsAsciiDigit(value[digits]))
+        {
+            digits++;
+        }
+
+        if (digits == 0)
+        {
+            // A name, or something the parser will have its own opinion about; either way it reads the
+            // same in both dialects.
+            return value;
+        }
+
+        if (!int.TryParse(value.AsSpan(0, digits), NumberStyles.None, CultureInfo.InvariantCulture, out int raw) || raw > 7)
+        {
+            Throw.FormatException(
+                $"'{value}' is not a day of the week: the Unix/crontab form numbers them 0-7, with both 0 and 7 meaning Sunday.");
+        }
+
+        int day = ToQuartzDay(raw);
+
+        // The name is the clearer thing to store - nobody reads 'MON' as the Unix 1 it came from - but
+        // only where it can stand on its own. A name in front of a step is 'MON/2', which Quartz rejects
+        // outright, and a name in front of a suffix would make 'SUNL' and '1L' two spellings of one day.
+        return digits == value.Length && !stepped
+            ? CronExpression.DayOfWeekNames[day]
+            : string.Concat(day.ToString(CultureInfo.InvariantCulture), value.AsSpan(digits));
+    }
+
+    private static bool TryReadUnixDay(string value, out int day)
+    {
+        return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out day) && day <= 7;
+    }
+
+    private static int ToQuartzDay(int unixDay)
+    {
+        return unixDay % 7 + 1;
+    }
+}


### PR DESCRIPTION
Closes #1253.

A five-field crontab line is what every online generator emits, what Kubernetes `CronJob` takes, and what people paste into issues. Quartz has only ever answered it with an error. It reads it now — when asked.

## The surface

One enum and three members, and nothing else:

```csharp
public enum CronFormat { Quartz = 0, Unix = 1 }

CronExpression.Parse(string cronExpression, CronFormat format);
CronExpression.TryParse(string? cronExpression, CronFormat format, out CronExpression? result);
CronScheduleBuilder.Create(string cronExpression, CronFormat format);
```

No constructor overload — that keeps the constructor set at two and `new CronExpression(expr, null)` unambiguous forever. No `WithCronSchedule(string, CronFormat, …)` — compose `WithCronSchedule(CronExpression.Parse(s, CronFormat.Unix))`, which is one of the four overloads it already has. A time zone composes the same way. The public-API baseline moves by exactly those four lines plus the enum.

## Explicit, not auto-detected

Field counts of 5/6/7 are unambiguous *as counts*; reinterpreting a five-field string on sight is what is unsafe.

* **A dropped field would become silent.** `0 0 12 * * ?` minus its *month* is `0 0 12 * ?` — a well-formed crontab line meaning midnight on the 12th instead of noon daily. Today that is a `FormatException` naming the fix.
* **The same digit is a different day.** Quartz `5` is Thursday; crontab `5` is Friday. Field count would silently pick which.
* **This repository already means something by "five fields".** `Xml/TestData/InvalidCronExpression.xml` is `0 * * * *` with the comment *"Invalid: missing seconds field"*, read by four tests; `CronExpressionTest` asserts `"* * ? */5 *"` is invalid (a valid crontab line); and `FiveFieldUnixExpressionsAreRejectedWithGuidance` is a whole test whose subject would disappear.
* **Auto-detect cannot grow.** Spring's `@Scheduled(cron=…)` is six fields with seconds first and *Unix* day numbering — indistinguishable from Quartz's own six-field form, so it can only ever be an explicit opt-in. `CronFormat` extends to it; detection has nowhere to go.

Adding detection in 4.1 only ever makes previously-throwing strings work, which is additive. Removing it would be impossible. At a semantics freeze, take the reversible option.

## The rewrite

`UnixCronRewriter` is a pure string transform ahead of the existing parser. It checks the field count, renumbers every **bare integer** in day-of-week `n → (n % 7) + 1` (so 0 and 7 both land on Sunday), degenerates a whole-week range to `*`, spells one day field `?`, and hands `0 {min} {hour} {dom} {month} {dow}` to the constructor.

Nothing past that point — the parser, the evaluator, `CronField`, the serializers, the dashboard, the store — learns that a format was ever chosen. That is what lets a crontab line be scheduled, stored, displayed and read back with **no format column anywhere**, and it is why `L`, `W`, `#` and `H` all work inside the five-field layout: it is one grammar, not two. `H` in particular works because the rewrite runs *before* `ResolveHashTokens`, whose field tables are indexed by Quartz field position — `CronScheduleBuilder.Create("H 3 * * 1", CronFormat.Unix)` resolves against the trigger key exactly as it does for a Quartz expression.

| crontab | stored, and shown, as |
|---|---|
| `30 4 * * 1` | `0 30 4 ? * MON` |
| `0 12 1 * *` | `0 0 12 1 * ?` |
| `* * * * *` | `0 * * * * ?` |
| `0 0 13 * 5` | `0 0 0 13 * FRI` — the 13th **and** every Friday |
| `0 0 * * 0-6`, `0 0 * * 0-7`, `0 0 * * 1-7` | `0 0 0 * * ?` |
| `0 0 * * 5-1` | `0 0 0 ? * FRI-MON` |
| `0 0 * * 1/2` | `0 0 0 ? * 2/2` |
| `0 0 * * 0L` | `0 0 0 ? * 1L` |

`L` alone in a five-field day-of-week keeps its Quartz meaning of Saturday, because it is not a number and so has nothing to renumber. Documented.

The union rule for `0 0 13 * 5` is pinned with a reason string naming the divergence: we union when both day fields name days, **Cronos ANDs**. Switching that to AND would silently halve everyone's fire count, so the test says so rather than leaving the next reader to "finish" the alignment.

## Normalisation

`CronExpressionString` and `ToString()` return the canonical six-field Quartz form, and **the original is deliberately unrecoverable**. A stored string that parses only under a flag the store does not persist is a data-corruption trap; the dashboard and HTTP API display `CronExpressionString` and `CronNextFires.razor` re-parses it, so a form the dashboard's own parser rejects would be a bug on the page. There is no `CRON_FORMAT` column and no migration. This is the same trade as the uppercasing that has always turned `mon-fri` into `MON-FRI`.

The consequence is stated in the docs: the XML schema, the HTTP API and the dashboard take no format, so a five-field expression is something you write in C#, not something you store.

## Macros — unconditional, dialect-free, everywhere

| macro | expands to |
|---|---|
| `@yearly`, `@annually` | `0 0 0 1 1 ?` |
| `@monthly` | `0 0 0 1 * ?` |
| `@weekly` | `0 0 0 ? * SUN` |
| `@daily`, `@midnight` | `0 0 0 * * ?` |
| `@hourly` | `0 0 * * * ?` |

Vixie's set and only Vixie's set — no `@every_minute`/`@every_second` (`0 * * * * ?` is already short) and no jittered variants (`H` is deterministic and therefore better). They are expanded by the `CronExpression` constructor, so they arrive through **every** entry point with zero new API: `<cron-expression>@daily</cron-expression>` in an XML scheduling file, the dashboard's box, the HTTP API and `CronTriggerImpl.CronExpressionString`'s setter (the one the ADO store materialises rows through) are all tested. `@reboot` is rejected **by name** — a scheduler has no reboot to fire on — and any other `@name` gets the supported list. `@` was previously rejected outright, so this is purely additive.

This is also the mitigation for the ergonomic cost of choosing explicit over auto-detect: it recovers most of the paste-from-crontab experience at surfaces the format switch cannot reach.

## Error messages

`FiveFieldAdvice` (from #3614) gained a closing sentence naming `CronFormat.Unix`, so both its branches and both its call sites carry it.

**The message it belongs to is not the one a real crontab line hits.** `BuildExpression` parses the fifth field as a *month* before anything counts fields, so `0 12 * * MON` dies on `Invalid Month value: 'MON'` and never reaches the count check — only a numerically-valid fifth field gets there. Rather than leave the advice unreachable for the common shape, the month error now recognises a day name in the month field and gives the same advice. It only ever fires on input that was already an error, and no legitimate expression has a day name in its month field.

## Testing

* `UnixCronFormatTest` — the rewrite table, both day-field normalisation branches, whole-week ranges (bare and stepped), `L`/`W`/`#`/`H` inside the five-field layout, out-of-range days, format-mismatch errors in both directions, an undefined enum value, `TryParse`, the builder, time-zone composition, round-tripping the canonical form, every macro, `@reboot`, an unknown macro, and a 60-day fire-time equivalence sweep against the hand-written Quartz equivalent for 17 expression pairs.
* `UnixCronDifferentialTest` — the same crontab lines read by **NCrontab**, a Vixie-faithful five-field parser, over a 60-day window across a grid of 264 expressions. The unit project gains the `NCrontab` package reference (the version was already in `Directory.Packages.props`, for `Quartz.Benchmark`). 228 rows compare; the 36 that skip are day-of-week `7`, `1-7` and `0-7`, which NCrontab rejects and crontab has always taken for Sunday, and which are pinned directly instead. A guard test fails if the skip rate ever climbs, so the oracle cannot quietly stop testing anything.

## Decisions a reviewer should confirm

1. **`0 0 * * 5-1` → `FRI-MON`, i.e. a wrapping range.** NCrontab sorts the endpoints and reads it as `MON-FRI`; Vixie's own loop sets no bits at all for it. There is no portable answer, so `5-1` is excluded from the differential grid with that reason written down and pinned directly instead. The ratified table asks for the wrap, and the wrap is what a reader means.
2. **Day names, except inside a step.** `1` becomes `MON` and `5-1` becomes `FRI-MON`, because a name cannot be misread as the crontab digit it came from — but a step start stays numeric (`1/2` → `2/2`), since `MON/2` is rejected by #3614 and would make the rewriter emit an invalid expression.
3. **Whole-week ranges with a step.** The ratified rule "`end - start >= 6` → emit `*`" is right for a bare range but loses the phase when a step follows: `1-7/2` is Mon/Wed/Fri/Sun, and `*/2` is Sun/Tue/Thu/Sat. The stepped case therefore emits a full-week range anchored on the renumbered start — `0-6/2` → `1-7/2`, `1-7/2` → `2-1/2` — which the differential oracle confirms for the rows NCrontab can read.
4. **The month-field error message**, per the note above. It is a scope addition to what the design note asked for.

## Deviations from the design note

* §6.7's expected value for `0 0 13 * 5` is written as `0 0 13 * FRI`, which is five fields; the transcription dropped the seconds. Pinned as `0 0 0 13 * FRI`.
* §6.3's whole-week rule is applied as ratified only when the token has no step; see decision 3.
* The month-field error message is not in the note; see decision 4.

## Verification

`dotnet build Quartz.slnx` — clean. `Quartz.Tests.Unit` — 4,784 passed, 0 failed, 36 skipped. `Quartz.Tests.AspNetCore` — 548 passed. `dotnet fallout VerifyDocsSnippets` — up to date (102 markdown files). `dotnet fallout BenchmarkSmoke` — succeeded, 284 benchmarks.

`npm run docs:check-links` was **not** run: the repository's `node_modules` is not installed in this worktree and disk was tight. Every anchor added here (`#macros`, `#the-unix-five-field-form`, `#the-parser-refuses-what-it-used-to-ignore`, `#h-hash-for-load-distribution`) follows the same slug shape as anchors already linked in the same files; CI's docs job is the check.

## Documentation

* `cron-expressions.md` — a `Macros` section and a `The Unix five-field form` section, with three compiled `#region sample_*` blocks in `Quartz.Documentation.Samples`.
* `migration-guide.md` — the "is still rejected" paragraph corrected, two new sections, and the day-name-in-the-month-field note.
* `best-practices.md` — the "seconds first" trap paragraph now version-splits: 4.x has `CronFormat.Unix`, 3.x does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
