### PR TITLE
A job store is told how to store, in the words the scheduler already uses

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -167,6 +167,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 | `MaxTransientRetries` | int | `3` | How many times a transient failure such as a deadlock is retried. Transient means the driver's own `DbException.IsTransient`, a SQLSTATE in class `40` — the standard's "transaction rollback", covering a serialization failure or a deadlock whichever provider reports it, with `40002` excepted because a deferred constraint violation fails identically on every retry — SQL Server's transient error numbers, SQLite's busy and locked codes, or a timeout. |
 | `TransientRetryInterval` | TimeSpan | `00:00:01` | Delay between transient retries. |
 | `RetryableActionErrorLogThreshold` | int | `4` | How many consecutive failures before they are logged as errors. |
+| `IsTransient` | `Func<Exception, bool>?` | `null` | An extra answer to the question above, for a driver that reports a retryable condition none of those signals recognise. Consulted first and only additive — returning `false` falls through to the built-in list, so it cannot make Quartz stop retrying something it already retries. The exception handed over is the store's own, so reach the driver's with `GetBaseException()`. Code only; there is no `quartz.*` key for a delegate. |
 | `UseDbLocks` | bool | `false` | Uses database row locks. Required for clustering, and implied by `UseClustering()`. |
 | `LockOnInsert` | bool | `true` | Takes a lock when inserting rows. |
 | `AcquireTriggersWithinLock` | bool | `false` | Acquires triggers inside the database lock. |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -7210,9 +7210,9 @@ if you only call `IScheduler`, nothing here affects you.
 | `IJobStore` in 3.x | `IJobStore` in 4.x |
 |---|---|
 | `StoreJobAndTrigger(job, trigger)` | `ScheduleJob(job, trigger)` |
-| `StoreJobsAndTriggers(triggersAndJobs, replace)` | `ScheduleJobs(triggersAndJobs, replace)` |
-| `StoreJob(job, replaceExisting)` | `AddJob(job, replace)` |
-| `StoreTrigger(trigger, replaceExisting)` | `AddTrigger(trigger, replace)` |
+| `StoreJobsAndTriggers(triggersAndJobs, replace)` | `ScheduleJobs(triggersAndJobs, ScheduleJobOptions?)` |
+| `StoreJob(job, replaceExisting)` | `AddJob(job, AddJobOptions?)` |
+| `StoreTrigger(trigger, replaceExisting)` | `AddTrigger(trigger, AddTriggerOptions?)` |
 | `RemoveJob(key)`, `RemoveJobs(keys)` | `DeleteJob(key)`, `DeleteJobs(keys)` |
 | `RemoveTrigger(key)`, `RemoveTriggers(keys)` | `DeleteTrigger(key)`, `DeleteTriggers(keys)` |
 | `RetrieveJob(key)` | `GetJob(key)` |
@@ -7223,9 +7223,12 @@ if you only call `IScheduler`, nothing here affects you.
 | `ClearAllSchedulingData()` | `Clear()` |
 | `AcquireNextTriggers(noLaterThan, maxCount, timeWindow, executionLimits)` | `AcquireNextTriggers(TriggerAcquisitionRequest)` |
 
-The `bool` that decides whether an existing item is over-written is called `replace` on every member; it was
-`replaceExisting` on some. The `protected` `AdoJobStoreBase` members that mirror these — the
-`ConnectionAndTransactionHolder` overloads, and `AcquireNextTrigger` — were renamed with them.
+3.x spelled the flag that decides whether an existing item is over-written `replaceExisting` on some members
+and `replace` on others. 4.x has no flag on any of them: each takes the same options record `IScheduler`
+does — see [The store takes the same options](#the-store-takes-the-same-options). The `protected`
+`AdoJobStoreBase` members that mirror these — the `ConnectionAndTransactionHolder` overloads, and
+`AcquireNextTrigger` — were renamed with them and keep the `bool`, being the store's own machinery rather
+than its contract.
 
 The activity names in `Quartz.Diagnostics.OperationName.JobStore` follow the methods they name, so a trace
 filter matching `"Quartz.JobStore.StoreJob"` now needs `"Quartz.JobStore.AddJob"`, and so on for every row
@@ -7278,9 +7281,10 @@ taking an optional record whose defaults are the conservative choice (`Replace =
 [Five shorthands for the common case](#five-shorthands-for-the-common-case). The initializer stays the way to
 say anything else.
 
-`AddJobOptions` and `AddCalendarOptions` are both in the `Quartz` namespace. `IJobStore.AddCalendar` takes
-`AddCalendarOptions` too; `IJobStore.AddJob` keeps its single `bool replace`, because durability is a
-scheduler-level rule the store never sees.
+`AddJobOptions` and `AddCalendarOptions` are both in the `Quartz` namespace, and `IJobStore` takes them as
+well — see [The store takes the same options](#the-store-takes-the-same-options).
+`AddJobOptions.StoreNonDurableWhileAwaitingScheduling` is a scheduler-level rule that `IScheduler` has
+already applied by the time the store is called, so a store reads only `Replace`.
 
 Both are `readonly record struct`s, and the parameter is `AddJobOptions options = default` rather than
 `AddJobOptions? options = null`. The defaults already were the conservative choice, so `default` *is* what
@@ -7320,10 +7324,28 @@ also carries `StoreNonDurableWhileAwaitingScheduling`, which has no meaning here
 supplied, so the job is never awaiting scheduling — and its `Replace` is about the job alone, where this
 one covers the job *and* its triggers.
 
-This is the `IScheduler` convenience only. `IJobStore.AddJob`, `IJobStore.AddTrigger` and
-`IJobStore.ScheduleJobs` keep their `bool replace`: at the store level it is a single primitive with
-nothing to disambiguate it from. The HTTP API's `ScheduleJobsRequest` keeps its `Replace` property too;
-the endpoint adapts.
+The HTTP API's `ScheduleJobsRequest` keeps its `Replace` property; the endpoint adapts.
+
+### The store takes the same options
+
+`IJobStore` had the same inconsistency the scheduler did, and for longer: `AddCalendar` took an options
+record while `AddJob`, `AddTrigger` and `ScheduleJobs` took a bare `bool`, so one interface spelled one
+decision two ways. All four take a record now, and it is the *same* record the scheduler takes — a
+decorator forwarding a call passes the value through rather than unpacking and rebuilding it.
+
+| 3.x | 4.x |
+|---|---|
+| `store.StoreJob(job, replaceExisting: false)` | `store.AddJob(job)` |
+| `store.StoreJob(job, replaceExisting: true)` | `store.AddJob(job, AddJobOptions.Replacing)` |
+| `store.StoreTrigger(trigger, replaceExisting: true)` | `store.AddTrigger(trigger, AddTriggerOptions.Replacing)` |
+| `store.StoreJobsAndTriggers(batch, replace: true)` | `store.ScheduleJobs(batch, ScheduleJobOptions.Replacing)` |
+
+`AddTriggerOptions` is new, and carries `Replace` alone. It has one call site, because `IScheduler` has no
+`AddTrigger`: a trigger reaches a scheduler through `ScheduleJob`, and `IJobStore.AddTrigger` is the
+storage half of that.
+
+If you implement `IJobStore`, the three signatures change and the argument you already had is
+`options.Replace`. If you only call `IScheduler`, nothing here affects you.
 
 ## A component of your own can have options of its own
 
@@ -8906,7 +8928,7 @@ A literal expression is still the shortest thing to write when you have one:
 Replacing a family of static factories with a builder makes the unusual call sayable and the usual one
 longer. Five additions give the usual one its short spelling back: an interval overload of
 `WithSimpleSchedule`, `CronExpressionBuilder.AtTime`, `IScheduler.ScheduleJob<TJob>`, a named static on each
-of the three option records, and `TriggerBuilder<TJob>.Key`. All are additive — nothing they shorten stopped
+of the four option records, and `TriggerBuilder<TJob>.Key`. All are additive — nothing they shorten stopped
 working, and the longer form is still what to reach for the moment the call needs more than the shorthand
 says.
 
@@ -8918,6 +8940,7 @@ says.
 | `scheduler.ScheduleJob(JobBuilder.Create<TJob>().WithIdentity(trigger.Key.Name, trigger.Key.Group).Build(), trigger)` | `scheduler.ScheduleJob<TJob>(trigger)` |
 | `new AddJobOptions { Replace = true }` | `AddJobOptions.Replacing` |
 | `new ScheduleJobOptions { Replace = true }` | `ScheduleJobOptions.Replacing` |
+| `new AddTriggerOptions { Replace = true }` | `AddTriggerOptions.Replacing` |
 | `new AddCalendarOptions { Replace = true }` | `AddCalendarOptions.Replacing` |
 | `new AddCalendarOptions { Replace = true, UpdateTriggers = true }` | `AddCalendarOptions.ReplacingAndUpdatingTriggers` |
 
@@ -10067,41 +10090,42 @@ having gone wrong.
 
 Derived the same mechanical way as the tables above: types in the 4.x `Quartz` namespace that are in the
 3.x `Quartz` namespace of none of `Quartz`, `Quartz.Extensions.DependencyInjection` or
-`Quartz.Extensions.Hosting`. **Ninety-three names.** A project that also referenced
+`Quartz.Extensions.Hosting`. **Ninety-four names.** A project that also referenced
 `Quartz.Serialization.SystemTextJson` on 3.x already had `JsonSerializationException`.
 
 ```text
-AddCalendarOptions                  AddJobOptions                              AdoJobStoreOptions
-AndMatcher<T>                       CalendarIntervalTriggerMisfireInstruction  CalendarNameMatcher
-CalendarQuery                       ClusteringOptions                          ClusterNode
-ClusterNodeState                    CronTriggerMisfireInstruction              DailyTimeIntervalTriggerMisfireInstruction
-DataMapExtensions                   DataSourceOptions                          EverythingMatcher<T>
-ExecutionGroupInFlight              ExecutionGroupLimit                        ExecutionGroupScope
-ExecutionLimitsBuilder              ExecutionLimitScope                        ExecutionSlots
-FireInstance                        FireInstanceQuery                          FireInstanceState
-GroupMatcher<T>                     IJob<T>                                    IJobConfigurator<T>
-IJobExecutionContextAccessor        IJobExecutionMiddleware                    InMemoryJobStoreOptions
-IPersistentStoreBuilder             IQuartzBuilder                             ISchedulerRegistry
-ITriggerConfigurator<T>             JobBuilder<T>                              JobDetailExtensions
-JobExecutionContextInputExtensions  JobExecutionDelegate                       JobExecutionProcessException
-JobGroup                            JobGroupQuery                              JobHeader
-JobInputBuilderExtensions           JobInstantiationException                  JobQuery
-JobType                             JsonSerializationException                 Key<T>
-KeyMatcher<T>                       Matchers                                   MonthDay
-NameMatcher<T>                      NotMatcher<T>                              OneOffJobOptions
-OrMatcher<T>                        PagedQuery                                 PagedResult<T>
-PersistentStoreBuilderExtensions    PreferredNode                              QuartzBuilderExtensions
-QuartzHealthCheckExtensions         QuartzHealthCheckOptions                   QuartzHostApplicationBuilderExtensions
-QuartzSchedulerBuilder              QuartzSchedulerOptions                     RecurrenceTriggerMisfireInstruction
-RetryPolicy                         ScheduleJobOptions                         SchedulerErrorContext
-SchedulerJobExtensions              SchedulerMetadata                          SchedulerOrigin
-SchedulerQueryExtensions            SchedulerRegistration                      SchedulerStatus
-SchedulingDataValidationException   SchemaProvisioning                         ShutdownJobInterruption
-SimpleTriggerMisfireInstruction     StandaloneSchedulerFactory                 StringMatcher<T>
-StringOperator                      SystemTextJsonConfigurationExtensions      ThreadPoolOptions
-TimeRange                           TimeZones                                  TriggerBuilder<T>
-TriggerConfiguratorExtensions       TriggerGroup                               TriggerGroupQuery
-TriggerHeader                       TriggerQuery                               TypeLoaderOptions
+AddCalendarOptions                          AddJobOptions                       AddTriggerOptions
+AdoJobStoreOptions                          AndMatcher<T>                       CalendarIntervalTriggerMisfireInstruction
+CalendarNameMatcher                         CalendarQuery                       ClusterNode
+ClusterNodeState                            ClusteringOptions                   CronTriggerMisfireInstruction
+DailyTimeIntervalTriggerMisfireInstruction  DataMapExtensions                   DataSourceOptions
+EverythingMatcher<T>                        ExecutionGroupInFlight              ExecutionGroupLimit
+ExecutionGroupScope                         ExecutionLimitScope                 ExecutionLimitsBuilder
+ExecutionSlots                              FireInstance                        FireInstanceQuery
+FireInstanceState                           GroupMatcher<T>                     IJob<T>
+IJobConfigurator<T>                         IJobExecutionContextAccessor        IJobExecutionMiddleware
+IPersistentStoreBuilder                     IQuartzBuilder                      ISchedulerRegistry
+ITriggerConfigurator<T>                     InMemoryJobStoreOptions             JobBuilder<T>
+JobDetailExtensions                         JobExecutionContextInputExtensions  JobExecutionDelegate
+JobExecutionProcessException                JobGroup                            JobGroupQuery
+JobHeader                                   JobInputBuilderExtensions           JobInstantiationException
+JobQuery                                    JobType                             JsonSerializationException
+Key<T>                                      KeyMatcher<T>                       Matchers
+MonthDay                                    NameMatcher<T>                      NotMatcher<T>
+OneOffJobOptions                            OrMatcher<T>                        PagedQuery
+PagedResult<T>                              PersistentStoreBuilderExtensions    PreferredNode
+QuartzBuilderExtensions                     QuartzHealthCheckExtensions         QuartzHealthCheckOptions
+QuartzHostApplicationBuilderExtensions      QuartzSchedulerBuilder              QuartzSchedulerOptions
+RecurrenceTriggerMisfireInstruction         RetryPolicy                         ScheduleJobOptions
+SchedulerErrorContext                       SchedulerJobExtensions              SchedulerMetadata
+SchedulerOrigin                             SchedulerQueryExtensions            SchedulerRegistration
+SchedulerStatus                             SchedulingDataValidationException   SchemaProvisioning
+ShutdownJobInterruption                     SimpleTriggerMisfireInstruction     StandaloneSchedulerFactory
+StringMatcher<T>                            StringOperator                      SystemTextJsonConfigurationExtensions
+ThreadPoolOptions                           TimeRange                           TimeZones
+TriggerBuilder<T>                           TriggerConfiguratorExtensions       TriggerGroup
+TriggerGroupQuery                           TriggerHeader                       TriggerQuery
+TypeLoaderOptions
 ```
 
 Most of those are unmistakably Quartz's. These are the ones a host application or an integration library

--- a/src/Quartz.Benchmark/JobRunShellBenchmark.cs
+++ b/src/Quartz.Benchmark/JobRunShellBenchmark.cs
@@ -397,7 +397,7 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
-        public ValueTask AddJob(IJobDetail newJob, bool replace, CancellationToken cancellationToken = default)
+        public ValueTask AddJob(IJobDetail newJob, AddJobOptions options = default, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
@@ -407,12 +407,12 @@ public class JobRunShellBenchmark
             throw new NotImplementedException();
         }
 
-        public ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+        public ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public ValueTask AddTrigger(IOperableTrigger newTrigger, bool replace, CancellationToken cancellationToken = default)
+        public ValueTask AddTrigger(IOperableTrigger newTrigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/RAMJobStoreBenchmark.cs
@@ -47,14 +47,14 @@ public class RAMJobStoreBenchmark
         // * no triggers
         _ramJobStore2 = TestJobStores.Ram();
         await _ramJobStore2.Initialize(TestJobStores.Identity());
-        await _ramJobStore2.AddJob(_noOpJob, false);
+        await _ramJobStore2.AddJob(_noOpJob);
 
         // A RAMJobStore with:
         // * a no-op job that disallows concurrent execution
         // * no triggers
         _ramJobStore3 = TestJobStores.Ram();
         await _ramJobStore3.Initialize(TestJobStores.Identity());
-        await _ramJobStore3.AddJob(_noOpJobNoConcurrent1, false);
+        await _ramJobStore3.AddJob(_noOpJobNoConcurrent1);
 
         // A RAMJobStore with:
         // * a no-op job that allows concurrent execution
@@ -63,18 +63,18 @@ public class RAMJobStoreBenchmark
         //   - 1 trigger with the IgnoreMisfirePolicy misfire instructions, and DateTimeOffset.UtcNow plus one day as next fire time
         _ramJobStore4 = TestJobStores.Ram();
         await _ramJobStore4.Initialize(TestJobStores.Identity());
-        await _ramJobStore4.AddJob(_noOpJob, false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("3"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("4"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("5"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("6"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("7"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("8"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("9"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("10"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("11"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy, DateTimeOffset.UtcNow.AddDays(1)), false);
+        await _ramJobStore4.AddJob(_noOpJob);
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("3"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("4"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("5"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("6"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("7"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("8"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("9"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("10"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore4.AddTrigger(CreateTrigger(new TriggerKey("11"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy, DateTimeOffset.UtcNow.AddDays(1)));
 
         // A RAMJobStore with:
         // * a no-op job that allows concurrent execution
@@ -82,8 +82,8 @@ public class RAMJobStoreBenchmark
         //   - 1 trigger with the IgnoreMisfirePolicy misfire instructions, and a computed next fire time
         _ramJobStore5 = TestJobStores.Ram();
         await _ramJobStore5.Initialize(TestJobStores.Identity());
-        await _ramJobStore5.AddJob(_noOpJob, false);
-        await _ramJobStore5.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJob, TimeSpan.FromSeconds(1), MisfireInstruction.IgnoreMisfirePolicy), false);
+        await _ramJobStore5.AddJob(_noOpJob);
+        await _ramJobStore5.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJob, TimeSpan.FromSeconds(1), MisfireInstruction.IgnoreMisfirePolicy));
 
         // A RAMJobStore with:
         // * a no-op job that disallows concurrent execution
@@ -94,14 +94,14 @@ public class RAMJobStoreBenchmark
         //   - 3 triggers with the IgnoreMisfirePolicy misfire instructions, and a computed next fire time
         _ramJobStore6 = TestJobStores.Ram();
         await _ramJobStore6.Initialize(TestJobStores.Identity());
-        await _ramJobStore6.AddJob(_noOpJobNoConcurrent1, false);
-        await _ramJobStore6.AddJob(_noOpJobNoConcurrent2, false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1a"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1b"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1c"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2a"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2b"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2c"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
+        await _ramJobStore6.AddJob(_noOpJobNoConcurrent1);
+        await _ramJobStore6.AddJob(_noOpJobNoConcurrent2);
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1a"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1b"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("1c"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2a"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2b"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore6.AddTrigger(CreateTrigger(new TriggerKey("2c"), _noOpJobNoConcurrent2, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
 
         // A RAMJobStore with:
         // * a no-op job that disallows concurrent execution
@@ -112,10 +112,10 @@ public class RAMJobStoreBenchmark
         //   - 1 trigger with the IgnoreMisfirePolicy misfire instructions, and a computed next fire time
         _ramJobStore7 = TestJobStores.Ram();
         await _ramJobStore7.Initialize(TestJobStores.Identity());
-        await _ramJobStore7.AddJob(_noOpJobNoConcurrent1, false);
-        await _ramJobStore7.AddJob(_noOpJob, false);
-        await _ramJobStore7.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore7.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy), false);
+        await _ramJobStore7.AddJob(_noOpJobNoConcurrent1);
+        await _ramJobStore7.AddJob(_noOpJob);
+        await _ramJobStore7.AddTrigger(CreateTrigger(new TriggerKey("1"), _noOpJobNoConcurrent1, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore7.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1000), MisfireInstruction.IgnoreMisfirePolicy));
 
         // A RAMJobStore with:
         // * a no-op job that allows concurrent execution
@@ -129,15 +129,15 @@ public class RAMJobStoreBenchmark
         _ramJobStore8 = TestJobStores.Ram();
         _ramJobStore8.MisfireThreshold = TimeSpan.FromMilliseconds(1);
         await _ramJobStore8.Initialize(TestJobStores.Identity());
-        await _ramJobStore8.AddJob(_noOpJob, false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("1"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("3"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("4"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("5"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("6"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("7"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue), false);
-        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("8"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.IgnoreMisfirePolicy, DateTimeOffset.MinValue), false);
+        await _ramJobStore8.AddJob(_noOpJob);
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("1"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("2"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("3"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("4"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("5"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("6"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("7"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.SimpleTrigger.FireNow, DateTimeOffset.MinValue));
+        await _ramJobStore8.AddTrigger(CreateTrigger<MisfireTrigger>(new TriggerKey("8"), _noOpJob, TimeSpan.FromTicks(1), MisfireInstruction.IgnoreMisfirePolicy, DateTimeOffset.MinValue));
 
         // A RAMJobStore with:
         // * a no-op job that disallows concurrent execution
@@ -145,11 +145,11 @@ public class RAMJobStoreBenchmark
         //   - 3 triggers with the IgnoreMisfirePolicy misfire instructions, a repeat interval of TimeSpan.MaxValue and a computed next fire time
         _ramJobStore9 = TestJobStores.Ram();
         await _ramJobStore9.Initialize(TestJobStores.Identity());
-        await _ramJobStore9.AddJob(_noOpJobNoConcurrent1, false);
+        await _ramJobStore9.AddJob(_noOpJobNoConcurrent1);
         _triggerForRamJobStore9 = CreateTrigger(new TriggerKey("1"), _noOpJobNoConcurrent1, TimeSpan.MaxValue, MisfireInstruction.IgnoreMisfirePolicy);
-        await _ramJobStore9.AddTrigger(_triggerForRamJobStore9, false);
-        await _ramJobStore9.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJobNoConcurrent1, TimeSpan.MaxValue, MisfireInstruction.IgnoreMisfirePolicy), false);
-        await _ramJobStore9.AddTrigger(CreateTrigger(new TriggerKey("3"), _noOpJobNoConcurrent1, TimeSpan.MaxValue, MisfireInstruction.IgnoreMisfirePolicy), false);
+        await _ramJobStore9.AddTrigger(_triggerForRamJobStore9);
+        await _ramJobStore9.AddTrigger(CreateTrigger(new TriggerKey("2"), _noOpJobNoConcurrent1, TimeSpan.MaxValue, MisfireInstruction.IgnoreMisfirePolicy));
+        await _ramJobStore9.AddTrigger(CreateTrigger(new TriggerKey("3"), _noOpJobNoConcurrent1, TimeSpan.MaxValue, MisfireInstruction.IgnoreMisfirePolicy));
 
         // A RAMJobStore with:
         // * a no-op job that disallows concurrent execution
@@ -157,8 +157,8 @@ public class RAMJobStoreBenchmark
         // * no triggers for either job
         _ramJobStore10 = TestJobStores.Ram();
         await _ramJobStore10.Initialize(TestJobStores.Identity());
-        await _ramJobStore10.AddJob(_noOpJobNoConcurrent1, false);
-        await _ramJobStore10.AddJob(_noOpJob, false);
+        await _ramJobStore10.AddJob(_noOpJobNoConcurrent1);
+        await _ramJobStore10.AddJob(_noOpJob);
     }
 
     [GlobalCleanup]
@@ -179,7 +179,7 @@ public class RAMJobStoreBenchmark
     [Benchmark]
     public async Task StoreTrigger_ReplaceExisting_SingleThreaded()
     {
-       await _ramJobStore2!.AddTrigger(_trigger1!, true);
+       await _ramJobStore2!.AddTrigger(_trigger1!, AddTriggerOptions.Replacing);
     }
 
     [Benchmark(OperationsPerInvoke = 200_000)]
@@ -195,7 +195,7 @@ public class RAMJobStoreBenchmark
 
                 for (var j = 0; j < 10_000; j++)
                 {
-                    await _ramJobStore2!.AddTrigger(_trigger1!, true);
+                    await _ramJobStore2!.AddTrigger(_trigger1!, AddTriggerOptions.Replacing);
                 }
             });
         }).ToArray();
@@ -212,7 +212,7 @@ public class RAMJobStoreBenchmark
 
         for (var i = 0; i < 100_000; i++)
         {
-            await _ramJobStore1!.AddJob(job, true);
+            await _ramJobStore1!.AddJob(job, AddJobOptions.Replacing);
             await _ramJobStore1.DeleteJob(job.Key);
         }
     }
@@ -222,9 +222,9 @@ public class RAMJobStoreBenchmark
     {
         for (var i = 0; i < 100_000; i++)
         {
-            await _ramJobStore1!.AddJob(_noOpJob!, true);
-            await _ramJobStore1.AddTrigger(_trigger1!, true);
-            await _ramJobStore1.AddTrigger(_trigger2!, true);
+            await _ramJobStore1!.AddJob(_noOpJob!, AddJobOptions.Replacing);
+            await _ramJobStore1.AddTrigger(_trigger1!, AddTriggerOptions.Replacing);
+            await _ramJobStore1.AddTrigger(_trigger2!, AddTriggerOptions.Replacing);
             await _ramJobStore1.DeleteJob(_noOpJob!.Key);
         }
     }

--- a/src/Quartz.Benchmark/TracingJobStoreBenchmark.cs
+++ b/src/Quartz.Benchmark/TracingJobStoreBenchmark.cs
@@ -47,8 +47,8 @@ public class TracingJobStoreBenchmark
         await decorated.Initialize(identity);
 
         IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job", "group").Build();
-        await bare.AddJob(job, true);
-        await inner.AddJob(job, true);
+        await bare.AddJob(job, AddJobOptions.Replacing);
+        await inner.AddJob(job, AddJobOptions.Replacing);
 
         trigger = (IOperableTrigger) TriggerBuilder.Create()
             .ForJob(job)
@@ -95,7 +95,7 @@ public class TracingJobStoreBenchmark
     {
         for (int i = 0; i < 10_000; i++)
         {
-            await bare.AddTrigger(trigger, true);
+            await bare.AddTrigger(trigger, AddTriggerOptions.Replacing);
         }
     }
 
@@ -104,7 +104,7 @@ public class TracingJobStoreBenchmark
     {
         for (int i = 0; i < 10_000; i++)
         {
-            await decorated.AddTrigger(trigger, true);
+            await decorated.AddTrigger(trigger, AddTriggerOptions.Replacing);
         }
     }
 

--- a/src/Quartz.Benchmark/TriggerAcquisitionAttemptBenchmark.cs
+++ b/src/Quartz.Benchmark/TriggerAcquisitionAttemptBenchmark.cs
@@ -47,23 +47,23 @@ public class TriggerAcquisitionAttemptBenchmark
         // Nothing due for a day, which is what an idle scheduler's store looks like.
         idleStore = TestJobStores.Ram();
         await idleStore.Initialize(TestJobStores.Identity());
-        await idleStore.AddJob(job, false);
+        await idleStore.AddJob(job);
         for (int i = 0; i < IdleTriggerCount; i++)
         {
-            await idleStore.AddTrigger(Trigger("idle" + i, job, TimeProvider.System.GetUtcNow().AddDays(1)), false);
+            await idleStore.AddTrigger(Trigger("idle" + i, job, TimeProvider.System.GetUtcNow().AddDays(1)));
         }
 
         singleStore = TestJobStores.Ram();
         await singleStore.Initialize(TestJobStores.Identity());
-        await singleStore.AddJob(job, false);
-        await singleStore.AddTrigger(Trigger("due", job, fireTime: null), false);
+        await singleStore.AddJob(job);
+        await singleStore.AddTrigger(Trigger("due", job, fireTime: null));
 
         batchStore = TestJobStores.Ram();
         await batchStore.Initialize(TestJobStores.Identity());
-        await batchStore.AddJob(job, false);
+        await batchStore.AddJob(job);
         for (int i = 0; i < 10; i++)
         {
-            await batchStore.AddTrigger(Trigger("due" + i, job, fireTime: null), false);
+            await batchStore.AddTrigger(Trigger("due" + i, job, fireTime: null));
         }
     }
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ConcurrentMisfireRecoveryTestBase.cs
@@ -86,7 +86,7 @@ public abstract class ConcurrentMisfireRecoveryTestBase : ClusteredJobStoreTestB
             .StoreDurably()
             .Build();
 
-        await nodeA.AddJob(job, replace: true);
+        await nodeA.AddJob(job, AddJobOptions.Replacing);
 
         for (int i = 0; i < TriggerCount; i++)
         {
@@ -94,7 +94,7 @@ public abstract class ConcurrentMisfireRecoveryTestBase : ClusteredJobStoreTestB
             trigger.ComputeFirstFireTimeUtc(null);
             trigger.NextFireTimeUtc = scheduled;
 
-            await nodeA.AddTrigger(trigger, replace: true);
+            await nodeA.AddTrigger(trigger, AddTriggerOptions.Replacing);
         }
 
         (await CountTriggersDueAt(scheduled)).Should().Be(TriggerCount,

--- a/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/JobStoreContractTest.cs
@@ -135,7 +135,7 @@ public abstract class JobStoreContractTest
         IOperableTrigger second = CreateTrigger("second", TriggerGroupB, job.Key);
 
         await Store.ScheduleJob(job, first);
-        await Store.AddTrigger(second, replace: false);
+        await Store.AddTrigger(second);
 
         (await Store.PauseJob(job.Key)).Should().BeTrue();
 
@@ -157,7 +157,7 @@ public abstract class JobStoreContractTest
             .StoreDurably()
             .Build();
 
-        await Store.AddJob(job, replace: false);
+        await Store.AddJob(job);
 
         (await Store.PauseJob(job.Key)).Should().BeTrue(
             "the answer says whether the job was found, not how many triggers it happened to have");
@@ -202,7 +202,7 @@ public abstract class JobStoreContractTest
             .WithIdentity("durable", JobGroupA)
             .StoreDurably()
             .Build();
-        await Store.AddJob(durable, replace: false);
+        await Store.AddJob(durable);
 
         JobKey firstJob = new JobKey("first", JobGroupA);
         JobKey secondJob = new JobKey("second", JobGroupB);
@@ -662,8 +662,8 @@ public abstract class JobStoreContractTest
             .WithIdentity("durable", JobGroupA)
             .StoreDurably()
             .Build();
-        await Store.AddJob(durable, replace: false);
-        await Store.AddTrigger(CreateTrigger("durable", TriggerGroupA, durable.Key), replace: false);
+        await Store.AddJob(durable);
+        await Store.AddTrigger(CreateTrigger("durable", TriggerGroupA, durable.Key));
 
         List<TriggerKey> deleted = await Store.DeleteTriggers(GroupMatcher<TriggerKey>.GroupEquals(TriggerGroupA));
 
@@ -820,18 +820,18 @@ public abstract class JobStoreContractTest
         // ObjectAlreadyExistsException derives from JobPersistenceException, so a store that wraps it
         // still satisfies a catch of the base type — and silently costs the caller the only thing that
         // told "already there" apart from "the store broke".
-        Func<Task> addingTheJobAgain = async () => await Store.AddJob(CreateJob("taken", JobGroupA), replace: false);
+        Func<Task> addingTheJobAgain = async () => await Store.AddJob(CreateJob("taken", JobGroupA));
         await addingTheJobAgain.Should().ThrowAsync<ObjectAlreadyExistsException>(
             "storing over a job without asking to replace it names the mistake");
 
         Func<Task> addingTheTriggerAgain = async () => await Store.AddTrigger(
-            CreateTrigger("taken", TriggerGroupA, job.Key), replace: false);
+            CreateTrigger("taken", TriggerGroupA, job.Key));
         await addingTheTriggerAgain.Should().ThrowAsync<ObjectAlreadyExistsException>();
 
         Func<Task> replacing = async () =>
         {
-            await Store.AddJob(CreateJob("taken", JobGroupA), replace: true);
-            await Store.AddTrigger(CreateTrigger("taken", TriggerGroupA, job.Key), replace: true);
+            await Store.AddJob(CreateJob("taken", JobGroupA), AddJobOptions.Replacing);
+            await Store.AddTrigger(CreateTrigger("taken", TriggerGroupA, job.Key), AddTriggerOptions.Replacing);
         };
 
         await replacing.Should().NotThrowAsync("replacing is what the flag asks for");
@@ -2180,7 +2180,7 @@ public abstract class JobStoreContractTest
             startAt: DateTimeOffset.UtcNow.AddHours(1));
         replacement.PreviousFireTimeUtc.Should().BeNull("the replacement is a new object with no history of its own");
 
-        await Store.AddTrigger(replacement, replace: true);
+        await Store.AddTrigger(replacement, AddTriggerOptions.Replacing);
 
         (await Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc.Should().Be(previous,
             "a job reading context.PreviousFireTimeUtc must not be told the schedule has never fired merely "
@@ -2203,7 +2203,7 @@ public abstract class JobStoreContractTest
             startAt: DateTimeOffset.UtcNow.AddHours(1));
         replacement.PreviousFireTimeUtc = chosen;
 
-        await Store.AddTrigger(replacement, replace: true);
+        await Store.AddTrigger(replacement, AddTriggerOptions.Replacing);
 
         (await Store.GetTrigger(trigger.Key)).PreviousFireTimeUtc.Should().Be(chosen,
             "carrying the old value over is a default for a caller who said nothing, not an override of one who did");
@@ -2218,7 +2218,7 @@ public abstract class JobStoreContractTest
 
         IOperableTrigger replacement = CreateTrigger("replaced", TriggerGroupA, trigger.JobKey,
             startAt: DateTimeOffset.UtcNow.AddHours(1));
-        await Store.AddTrigger(replacement, replace: true);
+        await Store.AddTrigger(replacement, AddTriggerOptions.Replacing);
 
         (await Store.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused,
             "a paused group imposes the pause on what is written into it, whether that is an insert or a replace — "
@@ -2411,7 +2411,7 @@ public abstract class JobStoreContractTest
         blocked.ComputeFirstFireTimeUtc(null);
         blocked.NextFireTimeUtc = overdue;
 
-        await Store.AddTrigger(blocked, replace: false);
+        await Store.AddTrigger(blocked);
 
         List<TriggerFiredResult> fired = await Store.TriggersFired([firing]);
         fired.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull(

--- a/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireThroughAStoreTestBase.cs
@@ -233,7 +233,7 @@ public abstract class MisfireThroughAStoreTestBase
         trigger.ComputeFirstFireTimeUtc(calendar);
         trigger.NextFireTimeUtc = scheduledFireTimeUtc;
 
-        await store.Store.AddTrigger(trigger, replace: false);
+        await store.Store.AddTrigger(trigger);
         return trigger;
     }
 

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationBindingIsSourceGeneratedTest.cs
@@ -69,7 +69,11 @@ public class ConfigurationBindingIsSourceGeneratedTest
     private static readonly Dictionary<string, string> codeOnlyMembers = new(StringComparer.Ordinal)
     {
         ["Quartz.DataSourceOptions.DataSourceFactory"] =
-            "a Func<IServiceProvider, DbDataSource> is a value only code can supply, and the member says so"
+            "a Func<IServiceProvider, DbDataSource> is a value only code can supply, and the member says so",
+        ["Quartz.AdoJobStoreOptions.IsTransient"] =
+            "a Func<Exception, bool> classifies an exception the driver threw, which no configuration "
+            + "file can describe: the answer depends on the exception's type, its error number and its "
+            + "inner exceptions, and the member says so"
     };
 
     [Test]

--- a/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
+++ b/src/Quartz.Tests.Unit/Core/TriggerInErrorNotificationTest.cs
@@ -84,7 +84,7 @@ public class TriggerInErrorNotificationTest
             .StoreDurably()
             .Build();
 
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
 
         IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
             .WithIdentity("trigger1", "errorstate")
@@ -93,7 +93,7 @@ public class TriggerInErrorNotificationTest
             .Build();
 
         trigger.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(trigger, replace: false);
+        await store.AddTrigger(trigger);
 
         await store.TriggeredJobComplete(trigger, job, SchedulerInstruction.SetTriggerError);
 

--- a/src/Quartz.Tests.Unit/Diagnostics/TracingJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/TracingJobStoreTest.cs
@@ -134,7 +134,7 @@ public sealed class TracingJobStoreTest
         IJobStore store = await Decorated(TestJobStores.Ram());
 
         IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job", "jobs").Build();
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
 
         Activity span = SpanFor(OperationName.JobStore.AddJob);
 
@@ -350,9 +350,9 @@ public sealed class TracingJobStoreTest
             .ForJob(jobKey).WithIdentity(triggerKey).StartNow().Build();
 
         await store.ScheduleJob(job, trigger);
-        await store.ScheduleJobs(new Dictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>>(), replace: false);
-        await store.AddJob(job, replace: true);
-        await store.AddTrigger(trigger, replace: true);
+        await store.ScheduleJobs(new Dictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>>());
+        await store.AddJob(job, AddJobOptions.Replacing);
+        await store.AddTrigger(trigger, AddTriggerOptions.Replacing);
         await store.AddCalendar("calendar", new Quartz.Impl.Calendar.BaseCalendar());
         await store.DeleteJob(jobKey);
         await store.DeleteJobs([jobKey]);

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -261,6 +261,79 @@ public class AdoJobStoreBaseTest
         callCount.Should().Be(1);
     }
 
+    /// <summary>
+    /// <see cref="AdoJobStoreOptions.IsTransient" /> is the seam for a driver whose retryable failure
+    /// none of the built-in signals recognise — no <c>DbException.IsTransient</c>, no SQLSTATE 40, not
+    /// one of SQL Server's or SQLite's numbers. Without it such a failure is reported on the first
+    /// attempt, which for a cluster node means a check-in or an acquisition lost to something that
+    /// would have succeeded a second later.
+    /// </summary>
+    [Test]
+    public async Task AConfiguredPredicateMakesAnUnrecognisedFailureRetryable()
+    {
+        int callCount = 0;
+        ConfiguredTransientTestStore store = new ConfiguredTransientTestStore(
+            isTransient: ex => ex.GetBaseException() is TransientTestException);
+
+        string result = await store.CallExecuteInLocalTransactionLock(conn =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                throw new JobPersistenceException("driver said so", new TransientTestException());
+            }
+
+            return new ValueTask<string>("success");
+        }, CancellationToken.None);
+
+        result.Should().Be("success");
+        callCount.Should().Be(2, "the predicate is consulted before the built-in list, so the store retried");
+    }
+
+    [Test]
+    public async Task WithoutAPredicateTheSameFailureIsNotRetried()
+    {
+        int callCount = 0;
+        ConfiguredTransientTestStore store = new ConfiguredTransientTestStore(isTransient: null);
+
+        Func<Task> act = async () => await store.CallExecuteInLocalTransactionLock<string>(conn =>
+        {
+            callCount++;
+            throw new JobPersistenceException("driver said so", new TransientTestException());
+        }, CancellationToken.None);
+
+        await act.Should().ThrowAsync<JobPersistenceException>();
+        callCount.Should().Be(1,
+            "this is the half that proves the test above is measuring the option rather than the "
+            + "built-in classification");
+    }
+
+    /// <summary>
+    /// The predicate can only add. A driver that misreports a failure Quartz already knows to be
+    /// transient is a bug in the built-in list, not something to switch off per application — so
+    /// <see langword="false" /> means "nothing to add", exactly as having no predicate does.
+    /// </summary>
+    [Test]
+    public async Task APredicateThatSaysNoDoesNotStopABuiltInRetry()
+    {
+        int callCount = 0;
+        ConfiguredTransientTestStore store = new ConfiguredTransientTestStore(isTransient: _ => false);
+
+        string result = await store.CallExecuteInLocalTransactionLock(conn =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                throw new JobPersistenceException("timed out", new TimeoutException());
+            }
+
+            return new ValueTask<string>("success");
+        }, CancellationToken.None);
+
+        result.Should().Be("success");
+        callCount.Should().Be(2, "a timeout is transient whatever the application's predicate answers");
+    }
+
     [Test]
     public async Task TestExecuteInLocalTransactionLock_NoRetryWhenMaxTransientRetriesIsZero()
     {
@@ -1207,6 +1280,45 @@ public class AdoJobStoreBaseTest
         {
             // Mark JobPersistenceException wrapping TransientTestException as transient
             return ex is JobPersistenceException { InnerException: TransientTestException };
+        }
+
+        public ValueTask<T> CallExecuteInLocalTransactionLock<T>(
+            Func<ConnectionAndTransactionHolder, ValueTask<T>> txCallback,
+            CancellationToken cancellationToken)
+        {
+            return ExecuteInLocalTransactionLock(null, txCallback, cancellationToken: cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// The same scaffolding as <see cref="RetryTestAdoJobStoreBase"/>, except that it does not override
+    /// <c>IsTransient</c> — so the classification under test is the store's own, consulting
+    /// <see cref="AdoJobStoreOptions.IsTransient"/>.
+    /// </summary>
+    public sealed class ConfiguredTransientTestStore : AdoJobStoreBase
+    {
+        public ConfiguredTransientTestStore(Func<Exception, bool> isTransient)
+            : base(TestJobStores.Dependencies(storeOptions: TestJobStores.StoreOptions(configure: options =>
+            {
+                options.MaxTransientRetries = 3;
+                options.TransientRetryInterval = TimeSpan.Zero;
+                options.IsTransient = isTransient;
+            })))
+        {
+        }
+
+        protected override ValueTask<ConnectionAndTransactionHolder> GetLocalTransactionConnection(CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<ConnectionAndTransactionHolder>(
+                new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null));
+        }
+
+        protected override ValueTask<T> ExecuteInLock<T>(
+            SchedulerLock? lockKind,
+            Func<ConnectionAndTransactionHolder, ValueTask<T>> txCallback,
+            CancellationToken cancellationToken = default)
+        {
+            return ExecuteInLocalTransactionLock(lockKind, txCallback, cancellationToken: cancellationToken);
         }
 
         public ValueTask<T> CallExecuteInLocalTransactionLock<T>(

--- a/src/Quartz.Tests.Unit/Impl/DelegatingJobStoreForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DelegatingJobStoreForwardingTest.cs
@@ -1,0 +1,126 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using FakeItEasy;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Jobs;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// The three storing members of <see cref="DelegatingJobStore" /> hand their options on unchanged.
+/// </summary>
+/// <remarks>
+/// These used to take a <see cref="bool" />, and a decorator forwarding one flag is hard to get wrong.
+/// An options record is not: a wrapper that read <c>options.Replace</c> and rebuilt the record, or that
+/// passed <see langword="default" /> because the parameter has a default, would turn a caller's
+/// "replace what is there" into "throw if it is there" — and it would do so only for the applications
+/// that wrap their store, which is exactly the population no other test covers.
+/// </remarks>
+public sealed class DelegatingJobStoreForwardingTest
+{
+    [Test]
+    public async Task AddJobHandsOnTheOptionsItWasGiven()
+    {
+        IJobStore inner = A.Fake<IJobStore>();
+        DelegatingJobStore store = new DelegatingJobStore(inner);
+        IJobDetail job = Job();
+
+        await store.AddJob(job, AddJobOptions.Replacing);
+
+        A.CallTo(() => inner.AddJob(job, AddJobOptions.Replacing, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task AddJobHandsOnTheDefaultWhenItIsOmitted()
+    {
+        IJobStore inner = A.Fake<IJobStore>();
+        DelegatingJobStore store = new DelegatingJobStore(inner);
+        IJobDetail job = Job();
+
+        await store.AddJob(job);
+
+        A.CallTo(() => inner.AddJob(job, default, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+        A.CallTo(() => inner.AddJob(job, AddJobOptions.Replacing, A<CancellationToken>._)).MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task AddTriggerHandsOnTheOptionsItWasGiven()
+    {
+        IJobStore inner = A.Fake<IJobStore>();
+        DelegatingJobStore store = new DelegatingJobStore(inner);
+        IOperableTrigger trigger = Trigger();
+
+        await store.AddTrigger(trigger, AddTriggerOptions.Replacing);
+
+        A.CallTo(() => inner.AddTrigger(trigger, AddTriggerOptions.Replacing, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task ScheduleJobsHandsOnTheOptionsItWasGiven()
+    {
+        IJobStore inner = A.Fake<IJobStore>();
+        DelegatingJobStore store = new DelegatingJobStore(inner);
+        Dictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> batch = new() { [Job()] = [Trigger()] };
+
+        await store.ScheduleJobs(batch, ScheduleJobOptions.Replacing);
+
+        A.CallTo(() => inner.ScheduleJobs(batch, ScheduleJobOptions.Replacing, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// The token travels too, which a wrapper that wrote <c>default</c> would quietly stop doing.
+    /// </summary>
+    [Test]
+    public async Task TheCancellationTokenTravelsWithTheCall()
+    {
+        using CancellationTokenSource source = new CancellationTokenSource();
+
+        IJobStore inner = A.Fake<IJobStore>();
+        DelegatingJobStore store = new DelegatingJobStore(inner);
+        IOperableTrigger trigger = Trigger();
+
+        await store.AddTrigger(trigger, cancellationToken: source.Token);
+
+        A.CallTo(() => inner.AddTrigger(trigger, default, source.Token)).MustHaveHappenedOnceExactly();
+    }
+
+    private static IJobDetail Job()
+    {
+        return JobBuilder.Create<NoOpJob>().WithIdentity("compaction").StoreDurably().Build();
+    }
+
+    private static IOperableTrigger Trigger()
+    {
+        return (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .ForJob("compaction")
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreNotifiesAfterUnlockTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreNotifiesAfterUnlockTest.cs
@@ -151,7 +151,7 @@ public sealed class RAMJobStoreNotifiesAfterUnlockTest
             "the trigger that does the blocking has to be handed over before it can fire").Subject;
 
         SimpleTriggerImpl blocked = Trigger(OverdueKey.Name, MisfiringJobKey, Now.AddHours(-1), OverdueKey.Group);
-        await store.AddTrigger(blocked, replace: false);
+        await store.AddTrigger(blocked);
 
         await store.TriggersFired([firing]);
 
@@ -278,10 +278,9 @@ public sealed class RAMJobStoreNotifiesAfterUnlockTest
             .StoreDurably()
             .Build();
 
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
         await store.AddTrigger(
-            Trigger(OverdueKey.Name, MisfiringJobKey, Now.AddHours(-1), OverdueKey.Group),
-            replace: false);
+            Trigger(OverdueKey.Name, MisfiringJobKey, Now.AddHours(-1), OverdueKey.Group));
     }
 
     private async Task GivenATriggerToPauseFromTheListener()
@@ -292,10 +291,9 @@ public sealed class RAMJobStoreNotifiesAfterUnlockTest
             .StoreDurably()
             .Build();
 
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
         await store.AddTrigger(
-            Trigger(OtherKey.Name, OtherJobKey, Now.AddHours(1), OtherKey.Group),
-            replace: false);
+            Trigger(OtherKey.Name, OtherJobKey, Now.AddHours(1), OtherKey.Group));
     }
 
     private SimpleTriggerImpl Trigger(string name, JobKey jobKey, DateTimeOffset startAt, string group = "triggers")

--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreQueryTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreQueryTest.cs
@@ -177,7 +177,7 @@ public class RAMJobStoreQueryTest
             .UsingJobData("secret", "value")
             .Build();
 
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
 
         PagedResult<JobHeader> result = await store.QueryJobs(new JobQuery());
         JobHeader header = result.Items.Single();
@@ -236,7 +236,7 @@ public class RAMJobStoreQueryTest
             .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(5)).RepeatForever())
             .Build();
         trigger.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(trigger, replace: false);
+        await store.AddTrigger(trigger);
 
         var acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         acquired.Should().HaveCount(1);
@@ -273,7 +273,7 @@ public class RAMJobStoreQueryTest
             .Build();
 
         trigger.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(trigger, replace: false);
+        await store.AddTrigger(trigger);
 
         PagedResult<TriggerHeader> result = await store.QueryTriggers(new TriggerQuery());
         TriggerHeader header = result.Items.Single();
@@ -310,7 +310,7 @@ public class RAMJobStoreQueryTest
         };
 
         custom.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(custom, replace: false);
+        await store.AddTrigger(custom);
 
         PagedResult<TriggerHeader> result = await store.QueryTriggers(new TriggerQuery());
 
@@ -717,7 +717,7 @@ public class RAMJobStoreQueryTest
             .StoreDurably()
             .Build();
 
-        await store.AddJob(job, replace: false);
+        await store.AddJob(job);
         return job;
     }
 
@@ -743,7 +743,7 @@ public class RAMJobStoreQueryTest
     {
         IOperableTrigger trigger = (IOperableTrigger) builder.Build();
         trigger.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(trigger, replace: false);
+        await store.AddTrigger(trigger);
         return trigger;
     }
 

--- a/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/TriggeredJobCompleteTest.cs
@@ -218,7 +218,7 @@ public sealed class TriggeredJobCompleteTest
         // FireNow on a one-shot: the missed firing is owed, so the policy hands the trigger back due
         // now rather than due in the past.
         IOperableTrigger blocked = CreateOverdueOneShot("blocked", job, clock, SimpleTriggerMisfireInstruction.FireNow);
-        await store.AddTrigger(blocked, replace: false);
+        await store.AddTrigger(blocked);
 
         (await store.GetTriggerState(blocked.Key)).Should().Be(TriggerState.Blocked,
             "a trigger added while the job is already running is blocked as it arrives");
@@ -248,7 +248,7 @@ public sealed class TriggeredJobCompleteTest
         // Reschedule to the next firing after now, of which a one-shot whose only firing was missed
         // has none: the policy writes the missed firing off and leaves the trigger finished.
         IOperableTrigger blocked = CreateOverdueOneShot("blocked", job, clock, SimpleTriggerMisfireInstruction.NextWithRemainingCount);
-        await store.AddTrigger(blocked, replace: false);
+        await store.AddTrigger(blocked);
 
         await store.TriggeredJobComplete(firing, job, SchedulerInstruction.NoInstruction);
 
@@ -718,7 +718,7 @@ public sealed class TriggeredJobCompleteTest
         await store.ScheduleJob(job, triggers[0]);
         for (int i = 1; i < triggers.Length; i++)
         {
-            await store.AddTrigger(triggers[i], replace: false);
+            await store.AddTrigger(triggers[i]);
         }
 
         List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest

--- a/src/Quartz.Tests.Unit/OptionsShorthandTest.cs
+++ b/src/Quartz.Tests.Unit/OptionsShorthandTest.cs
@@ -1,5 +1,7 @@
+using Quartz.Extensibility;
 using Quartz.Impl.Calendar;
 using Quartz.Jobs;
+using Quartz.Tests;
 
 namespace Quartz.Tests.Unit;
 
@@ -15,6 +17,7 @@ public sealed class OptionsShorthandTest
         AddJobOptions.Replacing.Should().Be(new AddJobOptions { Replace = true },
             "the shorthand is the initializer, so it must not quietly set the other flag as well");
         ScheduleJobOptions.Replacing.Should().Be(new ScheduleJobOptions { Replace = true });
+        AddTriggerOptions.Replacing.Should().Be(new AddTriggerOptions { Replace = true });
         AddCalendarOptions.Replacing.Should().Be(new AddCalendarOptions { Replace = true });
         AddCalendarOptions.ReplacingAndUpdatingTriggers.Should().Be(new AddCalendarOptions { Replace = true, UpdateTriggers = true });
     }
@@ -102,6 +105,38 @@ public sealed class OptionsShorthandTest
         {
             await scheduler.Shutdown(waitForJobsToComplete: false);
         }
+    }
+
+    /// <summary>
+    /// <see cref="AddTriggerOptions" /> has no scheduler-level call site — a trigger reaches a scheduler
+    /// through <c>ScheduleJob</c> — so its shorthand is exercised where it is used, on the store.
+    /// </summary>
+    [Test]
+    public async Task AddTriggerReplacing_OverwritesTheStoredTrigger()
+    {
+        IJobStore store = TestJobStores.Ram();
+        await store.Initialize(TestJobStores.Identity());
+        await store.AddJob(Job("owner"));
+
+        await store.AddTrigger(OperableTrigger("first"), AddTriggerOptions.Replacing);
+        await store.AddTrigger(OperableTrigger("second"), AddTriggerOptions.Replacing);
+
+        IOperableTrigger stored = await store.GetTrigger(new TriggerKey("nightly"));
+        stored.Description.Should().Be("second", "AddTriggerOptions.Replacing carries Replace = true to the store");
+
+        Func<Task> withoutTheOption = async () => await store.AddTrigger(OperableTrigger("third"));
+        await withoutTheOption.Should().ThrowAsync<ObjectAlreadyExistsException>(
+            "the default options replace nothing, so the shorthand is what made the two calls above work");
+    }
+
+    private static IOperableTrigger OperableTrigger(string description)
+    {
+        return (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("nightly")
+            .ForJob("compaction")
+            .WithDescription(description)
+            .StartAt(DateTimeOffset.UtcNow.AddHours(1))
+            .Build();
     }
 
     private static IJobDetail Job(string description)

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -54,7 +54,7 @@ public class RAMJobStoreTest
             .StoreDurably(true)
             .Build();
 
-        fJobStore.AddJob(fJobDetail, false);
+        fJobStore.AddJob(fJobDetail);
     }
 
     [Test]
@@ -68,9 +68,9 @@ public class RAMJobStoreTest
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
         trigger3.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
-        await fJobStore.AddTrigger(trigger3, false);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
+        await fJobStore.AddTrigger(trigger3);
 
         DateTimeOffset firstFireTime = trigger1.NextFireTimeUtc.Value;
 
@@ -108,12 +108,12 @@ public class RAMJobStoreTest
         trigger3.ComputeFirstFireTimeUtc(null);
         trigger4.ComputeFirstFireTimeUtc(null);
         trigger10.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(early, false);
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
-        await fJobStore.AddTrigger(trigger3, false);
-        await fJobStore.AddTrigger(trigger4, false);
-        await fJobStore.AddTrigger(trigger10, false);
+        await fJobStore.AddTrigger(early);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
+        await fJobStore.AddTrigger(trigger3);
+        await fJobStore.AddTrigger(trigger4);
+        await fJobStore.AddTrigger(trigger10);
 
         DateTimeOffset firstFireTime = trigger1.NextFireTimeUtc.Value;
 
@@ -200,7 +200,7 @@ public class RAMJobStoreTest
         IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
         Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.None));
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
         Assert.That(await fJobStore.GetTriggerState(trigger.Key), Is.EqualTo(TriggerState.Normal));
 
         await fJobStore.PauseTrigger(trigger.Key);
@@ -228,7 +228,7 @@ public class RAMJobStoreTest
         IOperableTrigger trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.Now.AddSeconds(100), DateTimeOffset.Now.AddSeconds(200), 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
         ICalendar calendar = new MonthlyCalendar();
-        fJobStore.AddTrigger(trigger, false);
+        fJobStore.AddTrigger(trigger);
         fJobStore.AddCalendar("cal", calendar, new AddCalendarOptions { UpdateTriggers = true });
 
         fJobStore.DeleteCalendar("cal");
@@ -242,7 +242,7 @@ public class RAMJobStoreTest
         var detail = JobBuilder.Create<NoOpJob>()
             .WithIdentity(new JobKey(jobName, jobGroup))
             .Build();
-        await fJobStore.AddJob(detail, false);
+        await fJobStore.AddJob(detail);
 
         string trName = "StoreTriggerReplacesTrigger";
         string trGroup = "StoreTriggerReplacesTriggerGroup";
@@ -250,11 +250,11 @@ public class RAMJobStoreTest
         tr.JobKey = new JobKey(jobName, jobGroup);
         tr.CalendarName = null;
 
-        await fJobStore.AddTrigger(tr, false);
+        await fJobStore.AddTrigger(tr);
         Assert.That(await fJobStore.GetTrigger(new TriggerKey(trName, trGroup)), Is.EqualTo(tr));
 
         tr.CalendarName = "NonExistingCalendar";
-        await fJobStore.AddTrigger(tr, true);
+        await fJobStore.AddTrigger(tr, AddTriggerOptions.Replacing);
         Assert.That(await fJobStore.GetTrigger(new TriggerKey(trName, trGroup)), Is.EqualTo(tr));
         var trigger = await fJobStore.GetTrigger(new TriggerKey(trName, trGroup));
         Assert.That(trigger.CalendarName, Is.EqualTo(tr.CalendarName), "AddJob doesn't replace triggers");
@@ -262,7 +262,7 @@ public class RAMJobStoreTest
         bool exceptionRaised = false;
         try
         {
-            await fJobStore.AddTrigger(tr, false);
+            await fJobStore.AddTrigger(tr);
         }
         catch (ObjectAlreadyExistsException)
         {
@@ -282,20 +282,20 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey(jobName1, jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(detail, false);
+        await fJobStore.AddJob(detail);
         await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
 
         detail = JobBuilder.Create<NoOpJob>()
             .WithIdentity(new JobKey(jobName2, jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(detail, false);
+        await fJobStore.AddJob(detail);
 
         string trName = "PauseJobGroupPausesNewJobTrigger";
         string trGroup = "PauseJobGroupPausesNewJobTriggerGroup";
         IOperableTrigger tr = new SimpleTriggerImpl { Key = new TriggerKey(trName, trGroup), StartTimeUtc = DateTimeOffset.UtcNow };
         tr.JobKey = new JobKey(jobName2, jobGroup);
-        await fJobStore.AddTrigger(tr, false);
+        await fJobStore.AddTrigger(tr);
         Assert.That(await fJobStore.GetTriggerState(tr.Key), Is.EqualTo(TriggerState.Paused));
     }
 
@@ -307,14 +307,14 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("job1", jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job, false);
+        await fJobStore.AddJob(job);
 
         await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
         await fJobStore.ResumeJob(job.Key);
 
         IOperableTrigger tr = new SimpleTriggerImpl { Key = new TriggerKey("newTrigger", "triggerGroup"), StartTimeUtc = DateTimeOffset.UtcNow };
         tr.JobKey = job.Key;
-        await fJobStore.AddTrigger(tr, false);
+        await fJobStore.AddTrigger(tr);
 
         Assert.That(await fJobStore.GetTriggerState(tr.Key), Is.EqualTo(TriggerState.Normal));
     }
@@ -331,19 +331,19 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("job2", jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job1, false);
-        await fJobStore.AddJob(job2, false);
+        await fJobStore.AddJob(job1);
+        await fJobStore.AddJob(job2);
 
         await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
         await fJobStore.ResumeJob(job1.Key);
 
         IOperableTrigger tr1 = new SimpleTriggerImpl { Key = new TriggerKey("trigger1", "triggerGroup"), StartTimeUtc = DateTimeOffset.UtcNow };
         tr1.JobKey = job1.Key;
-        await fJobStore.AddTrigger(tr1, false);
+        await fJobStore.AddTrigger(tr1);
 
         IOperableTrigger tr2 = new SimpleTriggerImpl { Key = new TriggerKey("trigger2", "triggerGroup"), StartTimeUtc = DateTimeOffset.UtcNow };
         tr2.JobKey = job2.Key;
-        await fJobStore.AddTrigger(tr2, false);
+        await fJobStore.AddTrigger(tr2);
 
         Assert.That(await fJobStore.GetTriggerState(tr1.Key), Is.EqualTo(TriggerState.Normal));
         Assert.That(await fJobStore.GetTriggerState(tr2.Key), Is.EqualTo(TriggerState.Paused));
@@ -357,7 +357,7 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("job1", jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job, false);
+        await fJobStore.AddJob(job);
 
         await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
         await fJobStore.ResumeJob(job.Key);
@@ -365,7 +365,7 @@ public class RAMJobStoreTest
 
         IOperableTrigger tr = new SimpleTriggerImpl { Key = new TriggerKey("newTrigger", "triggerGroup"), StartTimeUtc = DateTimeOffset.UtcNow };
         tr.JobKey = job.Key;
-        await fJobStore.AddTrigger(tr, false);
+        await fJobStore.AddTrigger(tr);
 
         Assert.That(await fJobStore.GetTriggerState(tr.Key), Is.EqualTo(TriggerState.Paused));
     }
@@ -378,7 +378,7 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("job1", jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job, false);
+        await fJobStore.AddJob(job);
 
         await fJobStore.PauseJobs(GroupMatcher<JobKey>.GroupEquals(jobGroup));
 
@@ -390,11 +390,11 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("nonexistent", jobGroup))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(laterJob, false);
+        await fJobStore.AddJob(laterJob);
 
         IOperableTrigger tr = new SimpleTriggerImpl { Key = new TriggerKey("newTrigger", "triggerGroup"), StartTimeUtc = DateTimeOffset.UtcNow };
         tr.JobKey = laterJob.Key;
-        await fJobStore.AddTrigger(tr, false);
+        await fJobStore.AddTrigger(tr);
 
         Assert.That(await fJobStore.GetTriggerState(tr.Key), Is.EqualTo(TriggerState.Paused));
     }
@@ -424,7 +424,7 @@ public class RAMJobStoreTest
         for (int i = 0; i < 10; i++)
         {
             IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job" + i).Build();
-            await store.AddJob(job, false);
+            await store.AddJob(job);
         }
         // Retrieve jobs.
         for (int i = 0; i < 10; i++)
@@ -444,10 +444,10 @@ public class RAMJobStoreTest
         for (int i = 0; i < 10; i++)
         {
             IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job" + i).Build();
-            await store.AddJob(job, true);
+            await store.AddJob(job, AddJobOptions.Replacing);
             SimpleScheduleBuilder schedule = SimpleScheduleBuilder.Create();
             ITrigger trigger = TriggerBuilder.Create().WithIdentity("job" + i).WithSchedule(schedule).ForJob(job).Build();
-            await store.AddTrigger((IOperableTrigger) trigger, true);
+            await store.AddTrigger((IOperableTrigger) trigger, AddTriggerOptions.Replacing);
         }
         // Retrieve job and trigger.
         for (int i = 0; i < 10; i++)
@@ -559,7 +559,7 @@ public class RAMJobStoreTest
             TimeSpan.FromMilliseconds(2000));
 
         trigger1.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger1, false);
+        await fJobStore.AddTrigger(trigger1);
 
         var firstFireTime = trigger1.NextFireTimeUtc.Value;
 
@@ -591,7 +591,7 @@ public class RAMJobStoreTest
             .Build();
 
         var store = TestJobStores.Ram();
-        await store.AddJob(job, false);
+        await store.AddJob(job);
 
         var deleteSuccess = await store.DeleteJob(new JobKey("job0"));
         Assert.That(deleteSuccess, Is.True, "Expected DeleteJob to return True when deleting an existing job");
@@ -608,7 +608,7 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("blockedJob", "group1"))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job, true);
+        await fJobStore.AddJob(job, AddJobOptions.Replacing);
 
         var d = TestDates.EvenMinuteDateAfterNow();
         var trigger1 = new SimpleTriggerImpl("trigger1", "group1", job.Key.Name, job.Key.Group,
@@ -618,8 +618,8 @@ public class RAMJobStoreTest
 
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
 
         // Acquire and fire one trigger
         var acquiredTriggers = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
@@ -658,7 +658,7 @@ public class RAMJobStoreTest
             .WithIdentity(new JobKey("blockedJob", "group1"))
             .StoreDurably(true)
             .Build();
-        await fJobStore.AddJob(job, true);
+        await fJobStore.AddJob(job, AddJobOptions.Replacing);
 
         var d = TestDates.EvenMinuteDateAfterNow();
         var trigger1 = new SimpleTriggerImpl("trigger1", "group1", job.Key.Name, job.Key.Group,
@@ -668,8 +668,8 @@ public class RAMJobStoreTest
 
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
 
         // Acquire and fire one trigger
         var acquiredTriggers = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
@@ -715,7 +715,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("executingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         acquired.Should().HaveCount(1);
@@ -739,7 +739,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("concurrentTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         // The job allows concurrent execution, so the trigger is re-armed as soon as it fires and can be
         // acquired again while the first execution is still in flight.
@@ -772,7 +772,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("pausedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -794,7 +794,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("removedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -809,7 +809,7 @@ public class RAMJobStoreTest
 
         // Once the execution has been accounted for, a trigger re-stored under the same key is idle.
         var replacement = ExecutingTestTrigger("removedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(replacement, false);
+        await fJobStore.AddTrigger(replacement);
 
         (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal);
     }
@@ -825,7 +825,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("recreatedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -834,7 +834,7 @@ public class RAMJobStoreTest
         (await fJobStore.DeleteTrigger(trigger.Key)).Should().BeTrue();
 
         var replacement = ExecutingTestTrigger("recreatedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(replacement, false);
+        await fJobStore.AddTrigger(replacement);
 
         (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal,
             "the new trigger never fired, so it cannot inherit the deleted trigger's execution");
@@ -847,7 +847,7 @@ public class RAMJobStoreTest
     }
 
     /// <summary>
-    /// ReplaceTrigger deletes rather than updates, so unlike AddTrigger(replace: true) it does
+    /// ReplaceTrigger deletes rather than updates, so unlike AddTrigger(AddTriggerOptions.Replacing) it does
     /// not carry the executions over — matching the ADO store, where ReplaceTrigger removes the
     /// fired-trigger rows and an in-place update leaves them.
     /// </summary>
@@ -856,7 +856,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("replacedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -877,16 +877,16 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("clearedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         (await fJobStore.TriggersFired(acquired)).Should().HaveCount(1);
 
         await fJobStore.Clear();
 
-        await fJobStore.AddJob(fJobDetail, true);
+        await fJobStore.AddJob(fJobDetail, AddJobOptions.Replacing);
         var replacement = ExecutingTestTrigger("clearedWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(replacement, false);
+        await fJobStore.AddTrigger(replacement);
 
         (await fJobStore.GetTriggerState(replacement.Key)).Should().Be(TriggerState.Normal);
     }
@@ -900,10 +900,10 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("mismatchedReplacementTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var otherJob = JobBuilder.Create<NoOpJob>().WithIdentity("otherJob", "jobGroup1").StoreDurably().Build();
-        await fJobStore.AddJob(otherJob, true);
+        await fJobStore.AddJob(otherJob, AddJobOptions.Replacing);
 
         var replacement = new SimpleTriggerImpl("mismatchedReplacementTrigger", "triggerGroup1",
             otherJob.Key.Name, otherJob.Key.Group, d.AddSeconds(1), d.AddSeconds(200), 10, TimeSpan.FromSeconds(5));
@@ -923,7 +923,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("rescheduledWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -933,7 +933,7 @@ public class RAMJobStoreTest
         // has to stay visible, which is also what the ADO store reports since its fired-trigger row
         // survives the update.
         var replacement = ExecutingTestTrigger("rescheduledWhileExecutingTrigger", d);
-        await fJobStore.AddTrigger(replacement, replace: true);
+        await fJobStore.AddTrigger(replacement, AddTriggerOptions.Replacing);
 
         (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing);
 
@@ -953,7 +953,7 @@ public class RAMJobStoreTest
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("missingCalendarTrigger", d);
         trigger.CalendarName = "noSuchCalendar";
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         acquired.Should().HaveCount(1);
@@ -979,7 +979,7 @@ public class RAMJobStoreTest
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("blankCalendarTrigger", d);
         trigger.CalendarName = "";
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         (await fJobStore.GetTrigger(trigger.Key))!.CalendarName.Should().BeNull(
             "a blank name is stored as no calendar, so nothing is ever looked up for it");
@@ -1007,7 +1007,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("releasedAfterFiringTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         var fired = await fJobStore.TriggersFired(acquired);
@@ -1025,7 +1025,7 @@ public class RAMJobStoreTest
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("releasedTrigger", d);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = d.AddSeconds(10), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         acquired.Should().HaveCount(1);
@@ -1052,7 +1052,7 @@ public class RAMJobStoreTest
 
         var job = JobBuilder.Create().OfType<NoOpJob>()
             .WithIdentity("testJob", "testGroup").StoreDurably(true).Build();
-        await store.AddJob(job, false);
+        await store.AddJob(job);
 
         var trigger = new CronTriggerImpl("testTrigger", "testGroup", "0 * * * * ?", fakeTime)
         {
@@ -1061,7 +1061,7 @@ public class RAMJobStoreTest
         };
         trigger.PreviousFireTimeUtc = previousFireTime;
         trigger.NextFireTimeUtc = originalScheduledTime;
-        await store.AddTrigger(trigger, false);
+        await store.AddTrigger(trigger);
 
         var acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = now.AddMinutes(1), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         Assert.That(acquired, Has.Count.EqualTo(1));
@@ -1097,7 +1097,7 @@ public class RAMJobStoreTest
 
         var job = JobBuilder.Create().OfType<NoOpJob>()
             .WithIdentity("testJob", "testGroup").StoreDurably(true).Build();
-        await store.AddJob(job, false);
+        await store.AddJob(job);
 
         var trigger = new SimpleTriggerImpl(fakeTime)
         {
@@ -1109,7 +1109,7 @@ public class RAMJobStoreTest
             MisfireInstructionCode = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount
         };
         trigger.ComputeFirstFireTimeUtc(null);
-        await store.AddTrigger(trigger, false);
+        await store.AddTrigger(trigger);
 
         // Act: acquiring triggers due by 'now' applies the misfire handling
         var acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = now, MaxCount = 1, TimeWindow = TimeSpan.Zero });
@@ -1132,7 +1132,7 @@ public class RAMJobStoreTest
         var trigger = new SimpleTriggerImpl("trigger1", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group,
             scheduledTime, scheduledTime.AddHours(1), 2, TimeSpan.FromMinutes(30));
         trigger.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         var acquired = await fJobStore.AcquireNextTriggers(new TriggerAcquisitionRequest { NoLaterThan = scheduledTime.AddSeconds(1), MaxCount = 1, TimeWindow = TimeSpan.Zero });
         Assert.That(acquired, Has.Count.EqualTo(1));
@@ -1164,9 +1164,9 @@ public class RAMJobStoreTest
         trigger2.ComputeFirstFireTimeUtc(null);
         trigger3.ComputeFirstFireTimeUtc(null);
 
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
-        await fJobStore.AddTrigger(trigger3, false);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
+        await fJobStore.AddTrigger(trigger3);
 
         // Acquire all three triggers
         DateTimeOffset firstFireTime = trigger1.NextFireTimeUtc!.Value;
@@ -1207,8 +1207,8 @@ public class RAMJobStoreTest
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
 
-        await fJobStore.AddTrigger(trigger1, false);
-        await fJobStore.AddTrigger(trigger2, false);
+        await fJobStore.AddTrigger(trigger1);
+        await fJobStore.AddTrigger(trigger2);
 
         // Acquire both triggers
         DateTimeOffset firstFireTime = trigger1.NextFireTimeUtc!.Value;
@@ -1253,7 +1253,7 @@ public class RAMJobStoreTest
             [job] = new IOperableTrigger[] { cronTrigger }
         };
 
-        await fJobStore.ScheduleJobs(triggersAndJobs, replace: true);
+        await fJobStore.ScheduleJobs(triggersAndJobs, ScheduleJobOptions.Replacing);
 
         var updated = await fJobStore.GetTrigger(new TriggerKey("trigger-switch", "group1"));
         Assert.That(updated, Is.InstanceOf<ICronTrigger>(), "Trigger should have been replaced with a CronTrigger");
@@ -1264,7 +1264,7 @@ public class RAMJobStoreTest
     {
         IOperableTrigger trigger = new SimpleTriggerImpl("missing-key-pause", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.UtcNow.AddMinutes(5), null, 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         (await fJobStore.PauseTrigger(new TriggerKey("no-such-trigger"))).Should().BeFalse(
             "pausing a missing trigger is a no-op");
@@ -1279,7 +1279,7 @@ public class RAMJobStoreTest
     {
         IOperableTrigger trigger = new SimpleTriggerImpl("missing-key-resume", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.UtcNow.AddMinutes(5), null, 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         (await fJobStore.ResumeTrigger(new TriggerKey("no-such-trigger"))).Should().BeFalse(
             "resuming a missing trigger is a no-op");
@@ -1311,7 +1311,7 @@ public class RAMJobStoreTest
     {
         IOperableTrigger trigger = new SimpleTriggerImpl("missing-key-reset", "triggerGroup1", fJobDetail.Key.Name, fJobDetail.Key.Group, DateTimeOffset.UtcNow.AddMinutes(5), null, 2, TimeSpan.FromSeconds(2));
         trigger.ComputeFirstFireTimeUtc(null);
-        await fJobStore.AddTrigger(trigger, false);
+        await fJobStore.AddTrigger(trigger);
 
         (await fJobStore.ResetTriggerFromErrorState(new TriggerKey("no-such-trigger"))).Should().BeFalse(
             "resetting a missing trigger is a no-op");

--- a/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
+++ b/src/Quartz.Tests.Unit/UpdateTriggerDetailsTest.cs
@@ -27,7 +27,7 @@ public class UpdateTriggerDetailsTest
             .StoreDurably(true)
             .Build();
 
-        await jobStore.AddJob(jobDetail, false);
+        await jobStore.AddJob(jobDetail);
     }
 
     [Test]
@@ -36,7 +36,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -58,7 +58,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -79,7 +79,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -112,7 +112,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
         await jobStore.PauseTrigger(trigger.Key);
 
         (await jobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Paused);
@@ -133,8 +133,8 @@ public class UpdateTriggerDetailsTest
 
         trigger1.ComputeFirstFireTimeUtc(null);
         trigger2.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger1, false);
-        await jobStore.AddTrigger(trigger2, false);
+        await jobStore.AddTrigger(trigger1);
+        await jobStore.AddTrigger(trigger2);
 
         await jobStore.UpdateTriggerDetails(trigger2.Key, new TriggerDetailsUpdate().WithPriority(10));
 
@@ -152,7 +152,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         Assert.ThrowsAsync<JobPersistenceException>(async () =>
             await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithCalendarName("nonexistent")));
@@ -167,7 +167,7 @@ public class UpdateTriggerDetailsTest
         trigger.ComputeFirstFireTimeUtc(null);
 
         await jobStore.AddCalendar("myCal", new BaseCalendar());
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithCalendarName(null));
 
@@ -184,7 +184,7 @@ public class UpdateTriggerDetailsTest
         trigger.ComputeFirstFireTimeUtc(null);
 
         await jobStore.AddCalendar("myCal", new BaseCalendar());
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         bool result = await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithCalendarName(""));
 
@@ -198,7 +198,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         (await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate())).Should().BeTrue();
     }
@@ -209,7 +209,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -235,7 +235,7 @@ public class UpdateTriggerDetailsTest
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.MisfireInstructionCode = MisfireInstruction.IgnoreMisfirePolicy;
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -253,7 +253,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         TriggerDetailsUpdate update = new TriggerDetailsUpdate()
             .WithMisfireInstructionCode((int) CronTriggerMisfireInstruction.DoNothing);
@@ -271,7 +271,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         // Code 2 is in range for a cron trigger, so TriggerBase's own validation passes it and
         // the trigger silently becomes DoNothing. Only the update object knows a simple trigger's
@@ -325,7 +325,7 @@ public class UpdateTriggerDetailsTest
         trigger.MisfireInstructionCode.Should().Be(MisfireInstruction.SmartPolicy,
             "the fixture needs a trigger whose instruction the update would visibly change");
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
         return trigger;
     }
 
@@ -335,7 +335,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithMisfireInstruction(CronTriggerMisfireInstruction.FireAndProceed));
 
@@ -351,7 +351,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -371,7 +371,7 @@ public class UpdateTriggerDetailsTest
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ExecutionGroup = "heavy";
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         (await jobStore.GetTrigger(trigger.Key))!.ExecutionGroup.Should().Be("heavy");
 
@@ -387,7 +387,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -410,7 +410,7 @@ public class UpdateTriggerDetailsTest
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.RetryPolicy = RetryPolicy.Exponential(4, TimeSpan.FromSeconds(5));
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         (await jobStore.GetTrigger(trigger.Key))!.RetryPolicy.Should().NotBeNull();
 
@@ -428,7 +428,7 @@ public class UpdateTriggerDetailsTest
         trigger.RetryPolicy = RetryPolicy.Fixed(5, TimeSpan.FromSeconds(1));
         trigger.RetryAttempt = 2;
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         await jobStore.UpdateTriggerDetails(
             trigger.Key,
@@ -447,7 +447,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         DateTimeOffset nextFireBefore = trigger.NextFireTimeUtc!.Value;
 
@@ -468,7 +468,7 @@ public class UpdateTriggerDetailsTest
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.PreferredNode = PreferredNode.For("nodeA");
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         (await jobStore.GetTrigger(trigger.Key))!.PreferredNode.Should().Be(PreferredNode.For("nodeA"));
 
@@ -484,7 +484,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         await jobStore.UpdateTriggerDetails(trigger.Key, new TriggerDetailsUpdate().WithPreferredNode(PreferredNode.Auto));
 
@@ -499,7 +499,7 @@ public class UpdateTriggerDetailsTest
         DateTimeOffset start = TestDates.EvenMinuteDateAfterNow();
         IOperableTrigger trigger = CreateCronTrigger("t1", "g1", "0/30 * * * * ?", start);
         trigger.ComputeFirstFireTimeUtc(null);
-        await jobStore.AddTrigger(trigger, false);
+        await jobStore.AddTrigger(trigger);
 
         TriggerDetailsUpdate update = new TriggerDetailsUpdate()
             .WithDescription("pinned")

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -28,6 +28,7 @@ namespace Quartz
         public string DataSource { get; set; }
         public System.TimeSpan DbRetryInterval { get; set; }
         public bool DoubleCheckLockMisfireHandler { get; set; }
+        public System.Func<System.Exception, bool>? IsTransient { get; set; }
         public bool LockOnInsert { get; set; }
         public int MaxMisfiresToHandleAtATime { get; set; }
         public int MaxTransientRetries { get; set; }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -14,6 +14,11 @@ namespace Quartz
         public bool StoreNonDurableWhileAwaitingScheduling { get; init; }
         public static Quartz.AddJobOptions Replacing { get; }
     }
+    public readonly struct AddTriggerOptions : System.IEquatable<Quartz.AddTriggerOptions>
+    {
+        public bool Replace { get; init; }
+        public static Quartz.AddTriggerOptions Replacing { get; }
+    }
     public sealed class AdoJobStoreOptions
     {
         public AdoJobStoreOptions() { }
@@ -2035,8 +2040,8 @@ namespace Quartz.Extensibility
         bool SupportsPersistence { get; }
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> AcquireNextTriggers(Quartz.Extensibility.TriggerAcquisitionRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, bool replace, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, bool replace, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, Quartz.AddTriggerOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
@@ -2083,7 +2088,7 @@ namespace Quartz.Extensibility
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> ResumeTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail job, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, bool replace, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SchedulerPaused(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SchedulerResumed(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default);
@@ -2339,9 +2344,9 @@ namespace Quartz.Impl.AdoJobStore
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> AcquireNextTriggers(Quartz.Extensibility.TriggerAcquisitionRequest request, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask AddCalendar(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask AddJob(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.IJobDetail newJob, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, Quartz.AddTriggerOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask AddTrigger(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, Quartz.Extensibility.IOperableTrigger newTrigger, Quartz.IJobDetail? job, bool replace, Quartz.Extensibility.StoredTriggerState state, bool forceState, bool recovering, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.DateTimeOffset CalcFailedIfAfter(Quartz.Impl.AdoJobStore.SchedulerStateRecord record) { }
         protected System.Threading.Tasks.ValueTask<bool> CalendarExists(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder conn, string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
@@ -2453,7 +2458,7 @@ namespace Quartz.Impl.AdoJobStore
         protected System.Threading.Tasks.ValueTask<T> RetryExecuteInLocalTransactionLock<T>(Quartz.Impl.AdoJobStore.SchedulerLock? lockKind, System.Func<Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder, System.Threading.Tasks.ValueTask<T>> txCallback, System.Guid? requestorId = default, System.Threading.CancellationToken cancellationToken = default) { }
         protected System.Threading.Tasks.ValueTask RollbackConnection(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder? connection, System.Exception cause, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail job, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerPaused(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerResumed(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default) { }
@@ -3387,8 +3392,8 @@ namespace Quartz.Impl
         public virtual bool SupportsPersistence { get; }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> AcquireNextTriggers(Quartz.Extensibility.TriggerAcquisitionRequest request, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, Quartz.AddTriggerOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3435,7 +3440,7 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> ResumeTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail job, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public virtual System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask SchedulerPaused(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask SchedulerResumed(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default) { }
@@ -3584,8 +3589,8 @@ namespace Quartz.Impl
         public bool SupportsPersistence { get; }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Extensibility.IOperableTrigger>> AcquireNextTriggers(Quartz.Extensibility.TriggerAcquisitionRequest request, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask AddCalendar(string calendarName, Quartz.ICalendar calendar, Quartz.AddCalendarOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask AddJob(Quartz.IJobDetail job, Quartz.AddJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask AddTrigger(Quartz.Extensibility.IOperableTrigger trigger, Quartz.AddTriggerOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Clear(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string calendarName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<bool> DeleteJob(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
@@ -3632,7 +3637,7 @@ namespace Quartz.Impl
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> ResumeTriggers(Quartz.GroupMatcher<Quartz.TriggerKey> matcher, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.TriggerKey>> ResumeTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask ScheduleJob(Quartz.IJobDetail job, Quartz.Extensibility.IOperableTrigger trigger, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, bool replace, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ScheduleJobs(System.Collections.Generic.IReadOnlyDictionary<Quartz.IJobDetail, System.Collections.Generic.IReadOnlyCollection<Quartz.Extensibility.IOperableTrigger>> triggersAndJobs, Quartz.ScheduleJobOptions options = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerPaused(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerResumed(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask SchedulerStarted(System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/AddTriggerOptions.cs
+++ b/src/Quartz/AddTriggerOptions.cs
@@ -1,0 +1,55 @@
+#region License
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+#endregion
+
+using Quartz.Extensibility;
+
+namespace Quartz;
+
+/// <summary>
+/// How a trigger is stored on its own, without the job it fires.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Defaults are the conservative ones: nothing is replaced. So <see langword="default"/> — which is
+/// what omitting the argument gives — is "store it, replace nothing", and there is no third state
+/// between "not given" and "all defaults" for an implementer to have to guess about.
+/// </para>
+/// <para>
+/// This is a store-level type. <see cref="IScheduler" /> has no <c>AddTrigger</c>: a trigger reaches a
+/// scheduler through <see cref="IScheduler.ScheduleJob(ITrigger, ScheduleJobOptions, CancellationToken)" />,
+/// which is the same operation named for what it accomplishes. <see cref="IJobStore.AddTrigger" /> is
+/// the storage half of it, and this is the storage half's options.
+/// </para>
+/// </remarks>
+/// <seealso cref="IJobStore.AddTrigger" />
+public readonly record struct AddTriggerOptions
+{
+    /// <summary>
+    /// Over-write an already stored trigger with the same key. The name for
+    /// <c>new AddTriggerOptions { Replace = true }</c>, which is what nearly every call that passes
+    /// these options at all is saying.
+    /// </summary>
+    public static AddTriggerOptions Replacing => new() { Replace = true };
+
+    /// <summary>
+    /// Whether an already stored trigger with the same key is over-written. When false, storing a
+    /// trigger whose key already exists throws <see cref="ObjectAlreadyExistsException" />.
+    /// </summary>
+    public bool Replace { get; init; }
+}

--- a/src/Quartz/Configuration/AdoJobStoreOptions.cs
+++ b/src/Quartz/Configuration/AdoJobStoreOptions.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Data.Common;
 
 using Quartz.Impl.AdoJobStore;
 
@@ -99,6 +100,33 @@ public sealed class AdoJobStoreOptions
     /// How many consecutive failures of a retryable action occur before they are logged as errors.
     /// </summary>
     public int RetryableActionErrorLogThreshold { get; set; } = 4;
+
+    /// <summary>
+    /// An extra answer to "is this failure worth retrying", for a driver that reports a retryable
+    /// condition Quartz does not recognise.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Consulted first, and only additive: returning <see langword="false"/> — which is also what
+    /// leaving this unset means — falls through to the built-in classification, so a predicate cannot
+    /// make Quartz stop retrying something it already retries. That is deliberate. The built-in list is
+    /// <see cref="DbException.IsTransient"/>, a SQLSTATE in class <c>40</c>, SQL Server's transient
+    /// error numbers, SQLite's busy and locked codes and <see cref="TimeoutException"/>, over the whole
+    /// chain of inner exceptions; a driver that misreports one of those is a bug to fix in
+    /// <c>TransientErrorDetector</c> rather than to work around here.
+    /// </para>
+    /// <para>
+    /// The exception handed over is the store's own, so the driver's exception is usually its
+    /// <see cref="Exception.InnerException"/> — <see cref="Exception.GetBaseException"/> is the short
+    /// way to the one your driver threw.
+    /// </para>
+    /// <para>
+    /// It is called on the failure path of a store operation, while a lock may be held, so it must be
+    /// quick and must not throw: a predicate that throws would replace the database failure the store
+    /// was about to report with one from the classification of it.
+    /// </para>
+    /// </remarks>
+    public Func<Exception, bool>? IsTransient { get; set; }
 
     /// <summary>
     /// Whether database row locks are used for synchronization. Required for clustering.

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -730,7 +730,7 @@ internal sealed class QuartzScheduler
             // lock once, so a caller replacing a job and its trigger together cannot be seen half
             // applied and cannot lose a race with another node doing the same thing.
             Dictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> one = new(1) { [jobDetail] = [trig] };
-            await resources.JobStore.ScheduleJobs(one, scheduleOptions.Replace, cancellationToken).ConfigureAwait(false);
+            await resources.JobStore.ScheduleJobs(one, scheduleOptions, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -786,7 +786,7 @@ internal sealed class QuartzScheduler
 
         // Replacing is the store's own operation, taken under the store's lock, so an upsert is one
         // call rather than a CheckExists / UnscheduleJob / ScheduleJob a caller has to serialize itself.
-        await resources.JobStore.AddTrigger(trig, options.Replace, cancellationToken).ConfigureAwait(false);
+        await resources.JobStore.AddTrigger(trig, new AddTriggerOptions { Replace = options.Replace }, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(trigger.NextFireTimeUtc);
         await NotifySchedulerListenersScheduled(trigger, cancellationToken).ConfigureAwait(false);
 
@@ -818,7 +818,7 @@ internal sealed class QuartzScheduler
 
         PrepareJobData(jobDetail.JobDataMap);
 
-        await resources.JobStore.AddJob(jobDetail, options.Replace, cancellationToken).ConfigureAwait(false);
+        await resources.JobStore.AddJob(jobDetail, options, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(null);
         await NotifySchedulerListenersJobAdded(jobDetail, cancellationToken).ConfigureAwait(false);
     }
@@ -968,7 +968,7 @@ internal sealed class QuartzScheduler
             validated.Add(job, operableTriggers);
         }
 
-        await resources.JobStore.ScheduleJobs(validated, options.Replace, cancellationToken).ConfigureAwait(false);
+        await resources.JobStore.ScheduleJobs(validated, options, cancellationToken).ConfigureAwait(false);
         NotifySchedulerThread(null);
         foreach (var pair in validated)
         {
@@ -1395,7 +1395,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await resources.JobStore.AddTrigger(trig, false, cancellationToken).ConfigureAwait(false);
+                await resources.JobStore.AddTrigger(trig, cancellationToken: cancellationToken).ConfigureAwait(false);
                 collision = false;
             }
             catch (ObjectAlreadyExistsException)
@@ -1426,7 +1426,7 @@ internal sealed class QuartzScheduler
         {
             try
             {
-                await resources.JobStore.AddTrigger(trigger, false, cancellationToken).ConfigureAwait(false);
+                await resources.JobStore.AddTrigger(trigger, cancellationToken: cancellationToken).ConfigureAwait(false);
                 collision = false;
             }
             catch (ObjectAlreadyExistsException)

--- a/src/Quartz/Diagnostics/TracingJobStore.cs
+++ b/src/Quartz/Diagnostics/TracingJobStore.cs
@@ -104,43 +104,43 @@ internal sealed class TracingJobStore : DelegatingJobStore
             static s => s.InnerJobStore.ScheduleJob(s.job, s.trigger, s.cancellationToken));
     }
 
-    public override ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default)
+    public override ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
         StoreOperation operation = Begin(OperationName.JobStore.AddJob);
         if (!operation.IsRecording)
         {
-            return InnerJobStore.AddJob(job, replace, cancellationToken);
+            return InnerJobStore.AddJob(job, options, cancellationToken);
         }
 
         operation.Job(job.Key).Start();
-        return Complete(operation, (InnerJobStore, job, replace, cancellationToken),
-            static s => s.InnerJobStore.AddJob(s.job, s.replace, s.cancellationToken));
+        return Complete(operation, (InnerJobStore, job, options, cancellationToken),
+            static s => s.InnerJobStore.AddJob(s.job, s.options, s.cancellationToken));
     }
 
-    public override ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+    public override ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         StoreOperation operation = Begin(OperationName.JobStore.ScheduleJobs);
         if (!operation.IsRecording)
         {
-            return InnerJobStore.ScheduleJobs(triggersAndJobs, replace, cancellationToken);
+            return InnerJobStore.ScheduleJobs(triggersAndJobs, options, cancellationToken);
         }
 
         operation.Start();
-        return Complete(operation, (InnerJobStore, triggersAndJobs, replace, cancellationToken),
-            static s => s.InnerJobStore.ScheduleJobs(s.triggersAndJobs, s.replace, s.cancellationToken));
+        return Complete(operation, (InnerJobStore, triggersAndJobs, options, cancellationToken),
+            static s => s.InnerJobStore.ScheduleJobs(s.triggersAndJobs, s.options, s.cancellationToken));
     }
 
-    public override ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default)
+    public override ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default)
     {
         StoreOperation operation = Begin(OperationName.JobStore.AddTrigger);
         if (!operation.IsRecording)
         {
-            return InnerJobStore.AddTrigger(trigger, replace, cancellationToken);
+            return InnerJobStore.AddTrigger(trigger, options, cancellationToken);
         }
 
         operation.Trigger(trigger.Key).Start();
-        return Complete(operation, (InnerJobStore, trigger, replace, cancellationToken),
-            static s => s.InnerJobStore.AddTrigger(s.trigger, s.replace, s.cancellationToken));
+        return Complete(operation, (InnerJobStore, trigger, options, cancellationToken),
+            static s => s.InnerJobStore.AddTrigger(s.trigger, s.options, s.cancellationToken));
     }
 
     public override ValueTask AddCalendar(string calendarName, ICalendar calendar, AddCalendarOptions options = default, CancellationToken cancellationToken = default)

--- a/src/Quartz/Extensibility/IJobStore.cs
+++ b/src/Quartz/Extensibility/IJobStore.cs
@@ -116,13 +116,16 @@ public interface IJobStore
     /// Store the given <see cref="IJobDetail" />.
     /// </summary>
     /// <param name="job">The <see cref="IJobDetail" /> to be stored.</param>
-    /// <param name="replace">
-    ///     If <see langword="true" />, any <see cref="IJob" /> existing in the
-    ///     <see cref="IJobStore" /> with the same name and group should be
-    ///     over-written.
+    /// <param name="options">
+    ///     How to store it. <see cref="AddJobOptions.Replace" /> over-writes a job already stored
+    ///     under the same key; without it, storing one whose key exists throws
+    ///     <see cref="ObjectAlreadyExistsException" />.
+    ///     <see cref="AddJobOptions.StoreNonDurableWhileAwaitingScheduling" /> is a scheduler-level
+    ///     rule that <see cref="IScheduler" /> has already applied by the time the store is called, so
+    ///     a store neither reads it nor has anything to do about it.
     /// </param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default);
+    ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Store all the given jobs with their related triggers.
@@ -132,13 +135,14 @@ public interface IJobStore
     ///     like the rest of the store contract — the scheduler validates and downcasts the caller's
     ///     triggers before they reach the store.
     /// </param>
-    /// <param name="replace">
-    ///     If <see langword="true" />, any <see cref="IJob" /> or <see cref="ITrigger" /> existing in
-    ///     the <see cref="IJobStore" /> with the same key should be over-written.
+    /// <param name="options">
+    ///     How to store them. <see cref="ScheduleJobOptions.Replace" /> over-writes any job or trigger
+    ///     already stored under one of the same keys; without it, a key that exists throws
+    ///     <see cref="ObjectAlreadyExistsException" /> and none of the batch is stored.
     /// </param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <throws>  ObjectAlreadyExistsException </throws>
-    ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default);
+    ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove (delete) the <see cref="IJob" /> with the given
@@ -209,12 +213,14 @@ public interface IJobStore
     /// Store the given <see cref="ITrigger" />.
     /// </summary>
     /// <param name="trigger">The <see cref="ITrigger" /> to be stored.</param>
-    /// <param name="replace">If <see langword="true" />, any <see cref="ITrigger" /> existing in
-    ///     the <see cref="IJobStore" /> with the same name and group should
-    ///     be over-written.</param>
+    /// <param name="options">
+    ///     How to store it. <see cref="AddTriggerOptions.Replace" /> over-writes a trigger already
+    ///     stored under the same key; without it, storing one whose key exists throws
+    ///     <see cref="ObjectAlreadyExistsException" />.
+    /// </param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <throws>  ObjectAlreadyExistsException </throws>
-    ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default);
+    ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Remove (delete) the <see cref="ITrigger" /> with the given key.

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Execution.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Execution.cs
@@ -372,15 +372,23 @@ public abstract partial class AdoJobStoreBase
     /// is momentarily too busy — as opposed to one that will fail again just as surely the second time.
     /// </summary>
     /// <remarks>
-    /// The seam for a store whose driver reports something Quartz does not know how to read. The
-    /// default answer comes from <see cref="TransientErrorDetector" />: the driver's own
+    /// <para>
+    /// The built-in answer comes from <see cref="TransientErrorDetector" />: the driver's own
     /// <see cref="DbException.IsTransient" />, a SQLSTATE in class <c>40</c> (transaction rollback,
     /// <c>40002</c> excepted), SQL Server's transient error numbers, SQLite's busy and locked codes,
     /// and <see cref="TimeoutException" />, over the whole chain of inner exceptions.
+    /// </para>
+    /// <para>
+    /// <see cref="AdoJobStoreOptions.IsTransient" /> is asked first, for a driver that reports a
+    /// retryable condition none of that recognises. It can only add: its <see langword="false" /> is
+    /// the same as not having one, so a predicate cannot make the store stop retrying what it already
+    /// retries.
+    /// </para>
     /// </remarks>
     /// <param name="ex">The exception to classify.</param>
     /// <returns>If the exception is identified as transient.</returns>
-    protected virtual bool IsTransient(Exception ex) => TransientErrorDetector.IsTransient(ex);
+    protected virtual bool IsTransient(Exception ex)
+        => configuredIsTransient?.Invoke(ex) == true || TransientErrorDetector.IsTransient(ex);
 
     /// <summary>
     /// Whether a failure is the caller having asked the operation to stop, rather than anything the

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
@@ -48,16 +48,13 @@ public abstract partial class AdoJobStoreBase
     /// Stores the given <see cref="IJobDetail" />.
     /// </summary>
     /// <param name="job">The <see cref="IJobDetail" /> to be stored.</param>
-    /// <param name="replace">
-    ///     If <see langword="true" />, any <see cref="IJob" /> existing in the
-    ///     <see cref="IJobStore" /> with the same name &amp; group should be over-written.
-    /// </param>
+    /// <param name="options">How to store it; see <see cref="IJobStore.AddJob" />.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    public async ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
         await ExecuteInLock(
-            LockOnInsert || replace ? SchedulerLock.TriggerAccess : null,
-            conn => AddJob(conn, job, replace, cancellationToken),
+            LockOnInsert || options.Replace ? SchedulerLock.TriggerAccess : null,
+            conn => AddJob(conn, job, options.Replace, cancellationToken),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -104,21 +101,17 @@ public abstract partial class AdoJobStoreBase
     /// Store the given <see cref="ITrigger" />.
     /// </summary>
     /// <param name="trigger">The <see cref="ITrigger" /> to be stored.</param>
-    /// <param name="replace">
-    ///     If <see langword="true" />, any <see cref="ITrigger" /> existing in
-    ///     the <see cref="IJobStore" /> with the same name &amp; group should
-    ///     be over-written.
-    /// </param>
+    /// <param name="options">How to store it; see <see cref="IJobStore.AddTrigger" />.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <exception cref="ObjectAlreadyExistsException">
-    /// if a <see cref="ITrigger" /> with the same name/group already
-    /// exists, and replace is set to false.
+    /// if a <see cref="ITrigger" /> with the same name/group already exists, and
+    /// <see cref="AddTriggerOptions.Replace" /> was not asked for.
     /// </exception>
-    public async ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default)
     {
         await ExecuteInLock(
-            LockOnInsert || replace ? SchedulerLock.TriggerAccess : null,
-            conn => AddTrigger(conn, trigger, null, replace, StoredTriggerState.Waiting, false, false, cancellationToken),
+            LockOnInsert || options.Replace ? SchedulerLock.TriggerAccess : null,
+            conn => AddTrigger(conn, trigger, null, options.Replace, StoredTriggerState.Waiting, false, false, cancellationToken),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -346,10 +339,10 @@ public abstract partial class AdoJobStoreBase
             }, cancellationToken);
     }
 
-    public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         await ExecuteInLock(
-            LockOnInsert || replace ? SchedulerLock.TriggerAccess : null, async conn =>
+            LockOnInsert || options.Replace ? SchedulerLock.TriggerAccess : null, async conn =>
             {
                 // A job and its triggers at a time, on purpose rather than for want of a bulk insert:
                 // AddTrigger is a read-decide-write — does the row exist, is its group paused, is its
@@ -360,10 +353,10 @@ public abstract partial class AdoJobStoreBase
                 {
                     var job = pair.Key;
                     var triggers = pair.Value;
-                    await AddJob(conn, job, replace, cancellationToken).ConfigureAwait(false);
+                    await AddJob(conn, job, options.Replace, cancellationToken).ConfigureAwait(false);
                     foreach (var trigger in triggers)
                     {
-                        await AddTrigger(conn, trigger, job, replace, StoredTriggerState.Waiting, false, false, cancellationToken).ConfigureAwait(false);
+                        await AddTrigger(conn, trigger, job, options.Replace, StoredTriggerState.Waiting, false, false, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }, cancellationToken).ConfigureAwait(false);

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.cs
@@ -40,6 +40,7 @@ public abstract partial class AdoJobStoreBase : IJobStore
     private readonly bool useProperties;
     private readonly Dictionary<string, ICalendar?> calendarCache = [];
     private readonly IDriverDelegate driverDelegate;
+    private readonly Func<Exception, bool>? configuredIsTransient;
     private TimeSpan misfireThreshold = TimeSpan.FromMinutes(1); // one minute
     private readonly TimeSpan? misfirehandlerFrequence;
 
@@ -115,6 +116,7 @@ public abstract partial class AdoJobStoreBase : IJobStore
         MaxTransientRetries = options.MaxTransientRetries;
         TransientRetryInterval = options.TransientRetryInterval;
         RetryableActionErrorLogThreshold = options.RetryableActionErrorLogThreshold;
+        configuredIsTransient = options.IsTransient;
         UseDbLocks = options.UseDbLocks;
         LockOnInsert = options.LockOnInsert;
         AcquireTriggersWithinLock = options.AcquireTriggersWithinLock;

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -89,9 +89,12 @@ public class MySQLDelegate : StdAdoDelegate
             .Replace("{0}TRIGGERS t", "{0}TRIGGERS t FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
     }
 
+    /// <summary>
+    /// The counting form of the misfire scan carries the same FORCE INDEX hint, on the unaliased table.
+    /// </summary>
     protected override string GetCountMisfiredTriggersInStateSql()
     {
-        return StdAdoConstants.SqlCountMisfiredTriggersInStates
+        return base.GetCountMisfiredTriggersInStateSql()
             .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE");
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/TransientErrorDetector.cs
+++ b/src/Quartz/Impl/AdoJobStore/TransientErrorDetector.cs
@@ -33,10 +33,10 @@ namespace Quartz.Impl.AdoJobStore;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="AdoJobStoreBase.IsTransient" /> is the seam a store overrides to add its own driver's
-/// verdict; this is what it answers with by default. Every signal is inclusive: the first one that
-/// says "transient" wins, and the chain of inner exceptions is walked because the store wraps
-/// almost everything it catches in a <see cref="JobPersistenceException" />.
+/// This is the store's built-in verdict, and <see cref="AdoJobStoreOptions.IsTransient" /> is where an
+/// application adds its own driver's. Every signal is inclusive: the first one that says "transient"
+/// wins, and the chain of inner exceptions is walked because the store wraps almost everything it
+/// catches in a <see cref="JobPersistenceException" />.
 /// </para>
 /// <para>
 /// This used to sniff for a property literally named <c>IsTransient</c> on the exception's type.

--- a/src/Quartz/Impl/DelegatingJobStore.cs
+++ b/src/Quartz/Impl/DelegatingJobStore.cs
@@ -96,14 +96,14 @@ public class DelegatingJobStore : IJobStore
         return jobStore.ScheduleJob(job, trigger, cancellationToken);
     }
 
-    public virtual ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default)
+    public virtual ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
-        return jobStore.AddJob(job, replace, cancellationToken);
+        return jobStore.AddJob(job, options, cancellationToken);
     }
 
-    public virtual ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+    public virtual ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
-        return jobStore.ScheduleJobs(triggersAndJobs, replace, cancellationToken);
+        return jobStore.ScheduleJobs(triggersAndJobs, options, cancellationToken);
     }
 
     public virtual ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
@@ -126,9 +126,9 @@ public class DelegatingJobStore : IJobStore
         return jobStore.GetJob(jobKey, cancellationToken);
     }
 
-    public virtual ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default)
+    public virtual ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default)
     {
-        return jobStore.AddTrigger(trigger, replace, cancellationToken);
+        return jobStore.AddTrigger(trigger, options, cancellationToken);
     }
 
     public virtual ValueTask<bool> DeleteTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -282,16 +282,14 @@ public sealed class RAMJobStore : IJobStore
     /// Store the given <see cref="IJob" />.
     /// </summary>
     /// <param name="job">The <see cref="IJob" /> to be stored.</param>
-    /// <param name="replace">If <see langword="true" />, any <see cref="IJob" /> existing in the
-    ///     <see cref="IJobStore" /> with the same name and group should be
-    ///     over-written.</param>
+    /// <param name="options">How to store it; see <see cref="IJobStore.AddJob" />.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    public async ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            AddJobNoLock(job, replace);
+            AddJobNoLock(job, options.Replace);
         }
         finally
         {
@@ -499,7 +497,7 @@ public sealed class RAMJobStore : IJobStore
         return deleted;
     }
 
-    public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<IOperableTrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         PendingSignals pending = default;
 
@@ -507,7 +505,7 @@ public sealed class RAMJobStore : IJobStore
         try
         {
             // make sure there are no collisions...
-            if (!replace)
+            if (!options.Replace)
             {
                 foreach (var triggersByJob in triggersAndJobs)
                 {
@@ -563,18 +561,16 @@ public sealed class RAMJobStore : IJobStore
     /// Store the given <see cref="ITrigger" />.
     /// </summary>
     /// <param name="trigger">The <see cref="ITrigger" /> to be stored.</param>
-    /// <param name="replace">If <see langword="true" />, any <see cref="ITrigger" /> existing in
-    ///     the <see cref="IJobStore" /> with the same name and group should
-    ///     be over-written.</param>
+    /// <param name="options">How to store it; see <see cref="IJobStore.AddTrigger" />.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    public async ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default)
+    public async ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default)
     {
         PendingSignals pending = default;
 
         await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            AddTriggerNoLock(trigger, replace, ref pending);
+            AddTriggerNoLock(trigger, options.Replace, ref pending);
         }
         finally
         {


### PR DESCRIPTION
Part 2 of #3596 — the `IJobStore` options alignment, the `IsTransient` hook the internalization needs, and the last of the design note's small corrections.

Deliberately **not** stacked on #3616: the two touch disjoint files, so each baseline diff reviews on its own and either can merge first.

## `IJobStore`'s three storing members take options (I2)

Four members of `IJobStore` decide whether an existing item is over-written. `AddCalendar` took `AddCalendarOptions`; `AddJob`, `AddTrigger` and `ScheduleJobs` took a bare `bool replace`. One interface, one decision, two spellings — and the three with the primitive are the three every custom store has to implement. After the freeze that is permanent.

```diff
- ValueTask AddJob(IJobDetail job, bool replace, CancellationToken cancellationToken = default);
- ValueTask AddTrigger(IOperableTrigger trigger, bool replace, CancellationToken cancellationToken = default);
- ValueTask ScheduleJobs(IReadOnlyDictionary<…> triggersAndJobs, bool replace, CancellationToken cancellationToken = default);
+ ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default);
+ ValueTask AddTrigger(IOperableTrigger trigger, AddTriggerOptions options = default, CancellationToken cancellationToken = default);
+ ValueTask ScheduleJobs(IReadOnlyDictionary<…> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default);
```

**One deviation from the design note, and it makes the change smaller.** The note specs a new `ScheduleJobsOptions`. `ScheduleJobOptions` already exists — `IScheduler.ScheduleJobs` takes it, with exactly the shape wanted — so inventing a second would have been a near-duplicate type differing by one letter. Only `AddTriggerOptions` is new. That leaves the scheduler forwarding the record it was handed rather than unpacking it into a flag and the store rebuilding it.

`AddJobOptions.StoreNonDurableWhileAwaitingScheduling` stays a scheduler-level rule, applied before the store is called, and `IJobStore.AddJob`'s doc now says so rather than leaving a store author to guess. The default is `default`, not `Replacing` — today's `false` for a caller that omits it, so the source break is confined to callers that passed `true`.

`AddTriggerOptions` has one call site, because `IScheduler` has no `AddTrigger`: a trigger reaches a scheduler through `ScheduleJob`, and `IJobStore.AddTrigger` is the storage half of that. Its remarks say so.

### Coverage

- `DelegatingJobStoreForwardingTest` is new: the three members hand their options on unchanged, the omitted argument arrives as `default` rather than as `Replacing`, and the token travels. Forwarding a `bool` is hard to get wrong; forwarding a record is not — a wrapper that rebuilt it, or that passed `default` because the parameter has one, turns "replace what is there" into "throw if it is there", and only for applications that wrap their store.
- `OptionsShorthandTest` gains `AddTriggerOptions.Replacing`, shape and behaviour, exercised against the store because that is where its only call site is.
- **`DeferredScheduler` and `DelegatingScheduler` need no change and get no new lines**: both already take `AddJobOptions` / `ScheduleJobOptions`, because `IScheduler`'s signatures are untouched. The design note listed them as a coverage risk; there is nothing there to cover.

## `AdoJobStoreOptions.IsTransient` — the seam PR-C removes an override for

`AdoJobStoreBase.IsTransient` is a `protected virtual` that `operations.md` teaches as the seam for a driver whose retryable failure none of the built-in signals recognise. PR-C makes the class internal, so the seam needs a replacement that is not inheritance — and per AGENTS.md a shipped component is configured through its options type and only there.

```csharp
public Func<Exception, bool>? IsTransient { get; set; }
```

Consulted first, and **only additive**: `false` means what having no predicate means, so it cannot make the store stop retrying something it already retries. A driver that misreports a condition the built-in list covers is a bug to fix in `TransientErrorDetector`, not to switch off per application. Three tests, on a store that does *not* override `IsTransient` so the classification under test is the real one: the predicate makes an unrecognised failure retryable, the same failure without it is not retried, and a predicate answering `false` does not stop a timeout being retried.

It is code-only, like `DataSourceOptions.DataSourceFactory` — no configuration source can describe a predicate over an exception's type, error number and inner exceptions — so it joins that list in `ConfigurationBindingIsSourceGeneratedTest`, which is the test that would otherwise, correctly, fail it as a setting that binds from nowhere. `configuration/reference.md` documents it. `operations.md` still teaches the override, and moves in PR-C when the override goes.

## `MySQLDelegate.GetCountMisfiredTriggersInStateSql` calls `base`

Three of its overrides splice the same `FORCE INDEX` hint. Two ask `base` for the statement and transform the string; the third reached `StdAdoConstants` directly, which is **internal** — so a delegate outside this assembly can write the first shape and cannot write the third. Same statement, same hint, no behaviour change, and `MySQLDelegate` is now proof that the public kit is sufficient rather than an example that only compiles inside Quartz.

## Baseline

Reviewed and accepted; three groups, nothing else moved:

- `+ AddTriggerOptions`, two members, in the `Quartz` namespace
- `+ AdoJobStoreOptions.IsTransient`
- the three signatures, on `IJobStore`, `AdoJobStoreBase`, `DelegatingJobStore` and `RAMJobStore`

Migration-guide rows in the same PR: the "same verbs" table rows, a new **The store takes the same options** subsection with the 3.x to 4.x call table, `AddTriggerOptions` added to the shorthand table and to the `Quartz`-namespace collision listing — which is mechanically derived, so it re-flows and its count moves from ninety-three to ninety-four — and the two paragraphs that said the store *keeps* its `bool replace` are now the ones that say it does not.

## For a reviewer to decide

- **`AddTriggerOptions` is a public type for one interface member.** The alternative was leaving `AddTrigger` the odd one out, which is what the issue asked to fix. Reusing `AddJobOptions` was rejected: wrong noun, and it carries a flag with no meaning for a trigger.
- **`AdoJobStoreOptions.IsTransient` is additive-only by design.** If you want a predicate that can *veto* the built-in classification, say so now — it is the one thing about the shape that cannot be changed later without breaking someone.
- The `protected` `AdoJobStoreBase.AddJob(conn, …)` and `AddTrigger(conn, …)` twins keep their `bool`. They are machinery, and PR-C makes them internal.

## Verification

```
dotnet build Quartz.slnx                 → Build succeeded, 0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit        → Passed! Failed: 0, Passed: 4443, Skipped: 0
dotnet test src/Quartz.Tests.AspNetCore  → Passed! Failed: 0, Passed: 548, Skipped: 0
dotnet fallout VerifyDocsSnippets        → Succeeded, 102 markdown files checked
dotnet fallout BenchmarkSmoke            → Succeeded
```

`Quartz.Tests.Integration` compiles — its `replace:` call sites moved with the rest — but was not run: it needs a Docker daemon, which this machine does not have. `npm run docs:check-links` was not run locally, there being no `node_modules` in the worktree, so the one new heading anchor rests on CI.

Rebased onto `577531990` after #3618 merged; the baseline merged cleanly and the build and unit suite above are from there.

Part 2 of #3596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
