### PR TITLE
XML scheduling is maintained, not extended

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/json.md
+++ b/docs/documentation/quartz-4.x/configuration/json.md
@@ -223,6 +223,8 @@ All trigger types support these optional fields:
 | `Description` | Trigger description |
 | `Priority` | Trigger priority (integer) |
 | `CalendarName` | Calendar to apply |
+| `ExecutionGroup` | The trigger's [execution group](../tutorial/execution-groups.md) |
+| `RetryPolicy` | The trigger's [retry policy](../how-tos/retrying-failed-jobs.md) in its stored form, for example `fixed;3;00:00:30` |
 | `StartTime` | ISO 8601 start time (e.g., `"2024-01-01T00:00:00Z"`) |
 | `StartTimeSecondsInFuture` | Start time as seconds from now (mutually exclusive with StartTime) |
 | `EndTime` | ISO 8601 end time |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3875,6 +3875,17 @@ A schema violation still throws `SchedulingDataValidationException` carrying eve
 `XmlSchedulingDataProcessorPlugin` still wraps whatever surfaces in a `SchedulerException`, so a
 plugin-based setup sees no change at all.
 
+**Nor will it change.** The schema is frozen at what it already says: `simple`, `cron` and
+`calendar-interval` triggers, and none of the trigger kinds or trigger settings written since. A
+daily time interval trigger, a [retry policy](#a-trigger-can-carry-a-retry-policy) and an execution
+group are expressible in the JSON format and are not expressible in XML, now or later — two file
+formats that both grow is two parsers and two schemas for one feature, and the XML one is the one that
+has to keep loading files written twenty years ago. It does: **XML scheduling is not deprecated and is
+not going away in 4.x**, and a schedule that only needs the three trigger kinds above never has to
+move. Write a new schedule as JSON, and move an XML one when it needs something the schema cannot
+spell. `UseJsonSchedulingConfiguration` takes the same `FileSchedulingOptions` as its XML twin, so the
+registration is one word different.
+
 ### The shipped plugins are sealed
 
 `LoggingJobHistoryPlugin`, `LoggingTriggerHistoryPlugin`, `StructuredLoggingJobHistoryPlugin`,

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -670,7 +670,7 @@ assignable on a live instance with nothing saying which wins or when. The compon
 | `RedisLockHandler.RedisConfiguration`, `.KeyPrefix`, `.LockTimeToLive`, `.LockRetryInterval` | `UseRedisLockHandler(o => …)` |
 | The history plugins' message templates | `UseJobHistoryLogging(o => …)`, `UseTriggerHistoryLogging(o => …)`, and now `UseStructuredJobLogging(o => …)` / `UseStructuredTriggerLogging(o => …)` |
 | `JobInterruptMonitorPlugin.DefaultMaxRunTime` | `UseJobAutoInterrupt(o => …)` |
-| The scheduling-data plugins' `FileNames`, `ScanInterval`, `FailOn*` | `UseXmlSchedulingConfiguration(o => …)` / `UseJsonSchedulingConfiguration(o => …)` |
+| The scheduling-data plugins' `FileNames`, `ScanInterval`, `FailOn*` (internal outright — see [one surface](#the-two-scheduling-data-plugins-have-one-surface)) | `UseXmlSchedulingConfiguration(o => …)` / `UseJsonSchedulingConfiguration(o => …)` |
 | `ShutdownHookPlugin.CleanShutdown` | `UseShutdownHook(o => o.CleanShutdown = …)` |
 
 The two shipped row-lock handlers keep their retry knobs, but as `init`-only properties rather than
@@ -2355,10 +2355,35 @@ to write two empty members to say so:
 ```
 
 Nothing about the lifecycle changes: the scheduler still calls both, through the interface, at the same
-two moments. An existing plugin that declares them keeps working and needs no change. Seven of the
-plugins shipped here dropped eleven such members between them, which is the only visible effect in the
-public API — a member that did nothing is no longer on the concrete type. Call the plugin through
+two moments. An existing plugin that declares them keeps working and needs no change. The plugins
+shipped here dropped every such member they had, which is the only visible effect in the public API —
+a member that did nothing is no longer on the concrete type. Call the plugin through
 `ISchedulerPlugin` if you were invoking one of those directly.
+
+### The two scheduling-data plugins have one surface
+
+`XmlSchedulingDataProcessorPlugin` and `JsonSchedulingDataProcessorPlugin` read one schedule out of two
+file formats, and had drifted into two different types: one published `ProcessFile` and no `Shutdown`,
+the other a do-nothing `Shutdown` and no `ProcessFile`, and both published the settings that configure
+them as get-only properties. Their surface is now the same, and it is the two constructors plus what
+`ISchedulerPlugin` and `IFileScanListener` ask for:
+
+| Member | Was | Now |
+|---|---|---|
+| `XmlSchedulingDataProcessorPlugin.ProcessFile(string, CancellationToken)` | public on the XML plugin, private on the JSON one | private on both. `IFileScanListener.FileUpdated(fileName)` says a file changed, and it is what `FileScanJob` calls — reading a file on demand is that call, made yourself |
+| `JsonSchedulingDataProcessorPlugin.Shutdown(CancellationToken)` | public on the JSON plugin, absent on the XML one | absent on both: `ISchedulerPlugin.Shutdown` does nothing by default, and neither plugin has anything to release |
+| `FileNames`, `ScanInterval`, `FailOnFileNotFound`, `FailOnSchedulingError` | public get-only on both, with internal setters | internal, like every other shipped component's settings. `FileSchedulingOptions` is what says them, and `quartz.plugin.<name>.fileNames` and friends still write them |
+| `Name`, `Scheduler` | public get-only on both | internal. They are what `Initialize` was handed, and the scheduler that handed them over is the one asking |
+
+Nothing here was writable from outside, so nothing that *configured* a plugin stops compiling. Code
+that *read* one of these properties is what changes, and the answer is the options rather than the
+plugin: `IOptionsFactory<FileSchedulingOptions>.Create(schedulerName)` is the same value from the
+place that decided it.
+
+The `FileNames`/`Files` split stays, on purpose: `FileSchedulingOptions.Files` is a `List<string>`
+because that is what code and a configuration binder say naturally, and the plugin keeps a delimited
+`FileNames` string because `quartz.plugin.<name>.fileNames` is one. The join happens in
+`UseXmlSchedulingConfiguration` / `UseJsonSchedulingConfiguration`, and both plugins now agree about it.
 
 ### The container is not in the scheduler context
 
@@ -7935,7 +7960,8 @@ called out.
 | `RedisSemaphore.LockTtlMilliseconds`, `.LockRetryIntervalMilliseconds` | `RedisLockHandler.LockTimeToLive`, `.LockRetryInterval`, both `TimeSpan` — **also the config keys `lockTtlMilliseconds` → `lockTimeToLive` and `lockRetryIntervalMilliseconds` → `lockRetryInterval`** |
 | `IObjectSerializer.DeSerialize` | `Deserialize`. `IObjectSerializer.Initialize()` went at the same time: a serializer builds whatever it needs on first use, and nothing was left for a separate initialization call to do |
 | `TriggerFiredBundle.PrevFireTimeUtc` | `PreviousFireTimeUtc`, matching the spelling used everywhere else. The type is a required-init record now: the eight-positional constructor ended in three interchangeable `DateTimeOffset?` values, so transposing `scheduledFireTimeUtc` and `previousFireTimeUtc` compiled cleanly and reported wrong fire times to every listener. A custom job store's `TriggerFired` writes `new TriggerFiredBundle { JobDetail = …, Trigger = …, Recovering = …, FireTimeUtc = …, ScheduledFireTimeUtc = …, PreviousFireTimeUtc = …, NextFireTimeUtc = … }`; only `Calendar` is optional |
-| `Quartz.Plugin.Xml.XMLSchedulingDataProcessorPlugin` | `Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin` — the namespace moved and the casing follows .NET rules. A `quartz.plugin.<name>.type` naming either old spelling still resolves, with a warning. Its nested `JobFile` class and its `JobFiles` property are internal now: they are how the plugin tracks what it has read, not something to call |
+| `Quartz.Plugin.Xml.XMLSchedulingDataProcessorPlugin` | `Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin` — the namespace moved and the casing follows .NET rules. A `quartz.plugin.<name>.type` naming either old spelling still resolves, with a warning. Its nested `JobFile` class and its `JobFiles` property are internal now: they are how the plugin tracks what it has read, not something to call. So are `FileNames`, `ScanInterval`, `FailOnFileNotFound`, `FailOnSchedulingError`, `Name` and `Scheduler`, and `ProcessFile` is private — see [The two scheduling-data plugins have one surface](#the-two-scheduling-data-plugins-have-one-surface) |
+| `XMLSchedulingDataProcessorPlugin.ProcessFile(fileName)` | `FileUpdated(fileName)`, the `IFileScanListener` member the file-scan job calls. The plugin-typed one is private |
 | `Quartz.Xml.ValidationException` | `Quartz.SchedulingDataValidationException`. The old name collided with `System.ComponentModel.DataAnnotations.ValidationException` in any file that used both, and it was never XML-specific — the JSON processor throws it too. Its `ValidationExceptions` is an `IReadOnlyList<Exception>`; it was a `List<Exception>` a caller could add to |
 
 ### One spelling per constant

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -259,14 +259,14 @@ Two things worth knowing before reaching for it:
 ### Plugins named by properties
 
 A `quartz.plugin.<name>.*` entry is read from the property bag of the scheduler it was configured on,
-so two tenants each configuring an XML plugin get two instances with their own files:
+so two tenants each configuring a scheduling-data plugin get two instances with their own files:
 
 <!-- snippet: sample_tenancy_plugin_by_properties -->
 ```csharp
 builder.Services.AddQuartz("acme", new NameValueCollection
 {
-    ["quartz.plugin.xml.type"] = typeof(XmlSchedulingDataProcessorPlugin).AssemblyQualifiedName,
-    ["quartz.plugin.xml.fileNames"] = "acme-jobs.xml",
+    ["quartz.plugin.json.type"] = typeof(JsonSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+    ["quartz.plugin.json.fileNames"] = "acme-jobs.json",
 });
 ```
 <!-- endSnippet -->

--- a/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
+++ b/docs/documentation/quartz-4.x/packages/microsoft-di-integration.md
@@ -315,9 +315,9 @@ q.AddCalendar("businessDays", serviceProvider =>
 
 <!-- snippet: sample_di_plugins -->
 ```csharp
-q.UseXmlSchedulingConfiguration(x =>
+q.UseJsonSchedulingConfiguration(x =>
 {
-    x.Files.Add("~/quartz_jobs.config");
+    x.Files.Add("~/quartz_jobs.json");
     x.ScanInterval = TimeSpan.FromSeconds(2);
     x.FailOnFileNotFound = true;
     x.FailOnSchedulingError = true;

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -35,8 +35,8 @@ spelling of the same thing and still work.
 | `StructuredLoggingJobHistoryPlugin` | `UseStructuredJobLogging(…)` | `JobHistoryLoggingOptions` |
 | `StructuredLoggingTriggerHistoryPlugin` | `UseStructuredTriggerLogging(…)` | `TriggerHistoryLoggingOptions` |
 | `ShutdownHookPlugin` | `UseShutdownHook(…)` | `ShutdownHookOptions` |
-| `XmlSchedulingDataProcessorPlugin` | `UseXmlSchedulingConfiguration(…)` | `FileSchedulingOptions` |
 | `JsonSchedulingDataProcessorPlugin` | `UseJsonSchedulingConfiguration(…)` | `FileSchedulingOptions` |
+| `XmlSchedulingDataProcessorPlugin` | `UseXmlSchedulingConfiguration(…)` | `FileSchedulingOptions` |
 | `JobInterruptMonitorPlugin` | `UseJobAutoInterrupt(…)` | `JobAutoInterruptOptions` |
 
 They hang off `IQuartzBuilder`, so they work the same under `AddQuartz` and on a standalone
@@ -52,9 +52,9 @@ plugin:
 ```csharp
 // A plugin's options are the scheduler's own named options, so a configuration section binds
 // onto them like any other. The callback below is applied over whatever the section said.
-services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Xml"));
+services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Json"));
 
-services.AddQuartz(q => q.UseXmlSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
+services.AddQuartz(q => q.UseJsonSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
 ```
 <!-- endSnippet -->
 
@@ -172,9 +172,36 @@ services.AddQuartz(q => q.UseShutdownHook(options => options.CleanShutdown = tru
 [the hosted service](hosted-services-integration.md) already stops the scheduler with the application, so
 this plugin is for a scheduler that has no host to stop it.
 
+### JsonSchedulingDataProcessorPlugin
+
+This plugin loads JSON file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes. JSON is the maintained scheduling-file format: everything a trigger can carry is expressible in it, and [the XML format is frozen](#the-xml-format-is-frozen).
+
+::: warning
+The periodically scanning of files for changes is not currently supported in a clustered environment.
+:::
+
+**DI configuration:**
+
+<!-- snippet: sample_plugins_json_scheduling -->
+```csharp
+services.AddQuartz(q =>
+{
+    q.UseJsonSchedulingConfiguration(x =>
+    {
+        x.Files.Add("quartz_jobs.json");
+        x.ScanInterval = TimeSpan.FromMinutes(1);
+        x.FailOnFileNotFound = true;
+        x.FailOnSchedulingError = true;
+    });
+});
+```
+<!-- endSnippet -->
+
+See [JSON Configuration](../configuration/json.md) for the full JSON file format and trigger type reference.
+
 ### XmlSchedulingDataProcessorPlugin
 
-This plugin loads XML file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes.
+This plugin loads XML file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes. It is the XML twin of `JsonSchedulingDataProcessorPlugin` — same surface, same settings, and a format that is frozen.
 
 <!-- snippet: sample_plugins_xml_scheduling -->
 ```csharp
@@ -201,32 +228,28 @@ the file relates to the scheduler, and neither can say anything about how the fi
 The [ProcessingDirectives](../configuration/json.md#processingdirectives) section has the details; they
 apply to both formats.
 
-### JsonSchedulingDataProcessorPlugin
+#### The XML format is frozen
 
-This plugin loads JSON file(s) to add jobs and schedule them with triggers as the scheduler is initialized, and can optionally periodically scan the file for changes. It is the JSON analog of `XmlSchedulingDataProcessorPlugin`.
+`job_scheduling_data_2_0.xsd`, the schema every XML scheduling file is validated against, is what the
+XML format will be for the life of 4.x. It declares three trigger kinds — `simple`, `cron` and
+`calendar-interval` — and it will not gain a fourth, nor the trigger settings written since:
 
-::: warning
-The periodically scanning of files for changes is not currently supported in a clustered environment.
-:::
+| To schedule | XML | JSON |
+|---|---|---|
+| a simple, cron or calendar-interval trigger | `<simple>`, `<cron>`, `<calendar-interval>` | `Simple`, `Cron`, `CalendarInterval` |
+| a daily time interval trigger | not expressible, and will not be | `DailyTimeInterval` |
+| a trigger with a [retry policy](../how-tos/retrying-failed-jobs.md) | not expressible, and will not be | `RetryPolicy` |
+| a trigger in an [execution group](../tutorial/execution-groups.md) | not expressible, and will not be | `ExecutionGroup` |
 
-**DI configuration:**
+[Recurrence triggers](../tutorial/recurrencetrigger.md) are in neither format; a recurrence rule is
+scheduled in code.
 
-<!-- snippet: sample_plugins_json_scheduling -->
-```csharp
-services.AddQuartz(q =>
-{
-    q.UseJsonSchedulingConfiguration(x =>
-    {
-        x.Files.Add("quartz_jobs.json");
-        x.ScanInterval = TimeSpan.FromMinutes(1);
-        x.FailOnFileNotFound = true;
-        x.FailOnSchedulingError = true;
-    });
-});
-```
-<!-- endSnippet -->
-
-See [JSON Configuration](../configuration/json.md) for the full JSON file format and trigger type reference.
+This is a decision, not a backlog. Two file formats that both grow means two parsers, two schemas and
+two sets of documentation for one feature, and the XML one is the one carrying twenty years of files
+that must keep loading unchanged. So it keeps loading them: **XML scheduling is not deprecated and is
+not going away in 4.x**. A `quartz_jobs.xml` that worked on 3.x works here, and a schedule that only
+needs the three trigger kinds above can stay in XML indefinitely. Write a new schedule as JSON, and
+move an XML one when it needs something the schema above cannot spell.
 
 ### JobInterruptMonitorPlugin
 

--- a/docs/documentation/quartz-4.x/quick-start.md
+++ b/docs/documentation/quartz-4.x/quick-start.md
@@ -26,7 +26,7 @@ The optional packages, added the same way when you want them:
 |---|---|
 | [Quartz.Serialization.Newtonsoft](packages/json-serialization.md) | persisting with Newtonsoft.Json instead of System.Text.Json |
 | [Quartz.Jobs](packages/quartz-jobs.md) | the ready-made jobs — file scanning, sending mail, running a process |
-| [Quartz.Plugins](packages/quartz-plugins.md) | history logging, XML/JSON schedule files, the interrupt monitor |
+| [Quartz.Plugins](packages/quartz-plugins.md) | history logging, JSON (and XML) schedule files, the interrupt monitor |
 | [Quartz.AspNetCore](packages/aspnet-core-integration.md) | the HTTP API |
 | [Quartz.Dashboard](packages/dashboard.md) | the web dashboard |
 
@@ -65,10 +65,10 @@ builder.AddQuartz(q =>
         });
     });
 
-    // reads jobs and triggers from XML; requires the Quartz.Plugins package
-    q.UseXmlSchedulingConfiguration(x =>
+    // reads jobs and triggers from JSON; requires the Quartz.Plugins package
+    q.UseJsonSchedulingConfiguration(x =>
     {
-        x.Files.Add("~/quartz_jobs.xml");
+        x.Files.Add("~/quartz_jobs.json");
         x.FailOnFileNotFound = true;
         x.FailOnSchedulingError = true;
     });
@@ -79,6 +79,39 @@ builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 <!-- endSnippet -->
 
 The hosted service starts the scheduler with the application and shuts it down with it.
+
+The file that last call reads declares the jobs and the triggers that fire them, so a schedule can
+change without a rebuild. `quartz_jobs.json`, scheduling one job every ten seconds:
+
+```json
+{
+  "Schedule": {
+    "Jobs": [
+      {
+        "Name": "helloJob",
+        "JobType": "MyApp.HelloJob, MyApp",
+        "Durable": true
+      }
+    ],
+    "Triggers": [
+      {
+        "Name": "helloTrigger",
+        "JobName": "helloJob",
+        "Simple": {
+          "RepeatCount": -1,
+          "Interval": "00:00:10"
+        }
+      }
+    ]
+  }
+}
+```
+
+[JSON Configuration](configuration/json.md) has the whole format — every trigger kind, the
+pre-processing commands and the processing directives. XML files are read too, by
+`UseXmlSchedulingConfiguration`, and keep working; the XML schema is
+[frozen](packages/quartz-plugins.md#xmlschedulingdataprocessorplugin) at what it can already express,
+so JSON is the format to write a new schedule in.
 
 ### Without a host
 

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using Quartz.Extensibility;
-using Quartz.Plugins.Xml;
+using Quartz.Plugins.Json;
 
 namespace Quartz.Documentation.Samples.Tenancy;
 
@@ -142,8 +142,8 @@ public static class MultiTenancySamples
 
         builder.Services.AddQuartz("acme", new NameValueCollection
         {
-            ["quartz.plugin.xml.type"] = typeof(XmlSchedulingDataProcessorPlugin).AssemblyQualifiedName,
-            ["quartz.plugin.xml.fileNames"] = "acme-jobs.xml",
+            ["quartz.plugin.json.type"] = typeof(JsonSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+            ["quartz.plugin.json.fileNames"] = "acme-jobs.json",
         });
 
         #endregion

--- a/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MicrosoftDiIntegrationSamples.cs
@@ -218,9 +218,9 @@ public static class MicrosoftDiIntegrationSamples
 
             #region sample_di_plugins
 
-            q.UseXmlSchedulingConfiguration(x =>
+            q.UseJsonSchedulingConfiguration(x =>
             {
-                x.Files.Add("~/quartz_jobs.config");
+                x.Files.Add("~/quartz_jobs.json");
                 x.ScanInterval = TimeSpan.FromSeconds(2);
                 x.FailOnFileNotFound = true;
                 x.FailOnSchedulingError = true;

--- a/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/QuartzPluginsSamples.cs
@@ -76,9 +76,9 @@ public static class QuartzPluginsSamples
 
         // A plugin's options are the scheduler's own named options, so a configuration section binds
         // onto them like any other. The callback below is applied over whatever the section said.
-        services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Xml"));
+        services.Configure<FileSchedulingOptions>(configuration.GetSection("Quartz:Json"));
 
-        services.AddQuartz(q => q.UseXmlSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
+        services.AddQuartz(q => q.UseJsonSchedulingConfiguration(x => x.ScanInterval = TimeSpan.FromMinutes(1)));
 
         #endregion
     }

--- a/src/Quartz.Documentation.Samples/QuickStartSamples.cs
+++ b/src/Quartz.Documentation.Samples/QuickStartSamples.cs
@@ -41,10 +41,10 @@ public static class QuickStartSamples
                 });
             });
 
-            // reads jobs and triggers from XML; requires the Quartz.Plugins package
-            q.UseXmlSchedulingConfiguration(x =>
+            // reads jobs and triggers from JSON; requires the Quartz.Plugins package
+            q.UseJsonSchedulingConfiguration(x =>
             {
-                x.Files.Add("~/quartz_jobs.xml");
+                x.Files.Add("~/quartz_jobs.json");
                 x.FailOnFileNotFound = true;
                 x.FailOnSchedulingError = true;
             });

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
@@ -35,9 +35,17 @@ namespace Quartz.Plugins.Json;
 /// file for changes.
 /// </summary>
 /// <remarks>
-/// This is the JSON analog of <see cref="Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin"/>.
+/// <para>
+/// This is the JSON analog of <see cref="Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin"/>, and
+/// the maintained one: JSON is where a scheduling file gains what the schedule gains — daily time
+/// interval triggers, retry policies and execution groups are readable here and are not in the frozen
+/// XML schema. The two plugins have one surface deliberately, so a file format is the only thing that
+/// differs between them.
+/// </para>
+/// <para>
 /// The periodically scanning of files for changes is not currently supported in a
 /// clustered environment.
+/// </para>
 /// </remarks>
 public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileScanListener
 {
@@ -66,21 +74,42 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         TypeLoader = typeLoader;
     }
 
-    public string Name { get; private set; } = null!;
-    public IScheduler Scheduler { get; private set; } = null!;
+    internal string Name { get; private set; } = null!;
+    internal IScheduler Scheduler { get; private set; } = null!;
     private ITypeLoader TypeLoader { get; }
 
-    public string FileNames { get; internal set; } = JsonSchedulingDataProcessor.QuartzJsonFileName;
+    /// <summary>
+    /// Comma separated list of file names (with paths) to the JSON files that should be read.
+    /// </summary>
+    /// <inheritdoc cref="Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin.FileNames" path="/remarks" />
+    internal string FileNames { get; set; } = JsonSchedulingDataProcessor.QuartzJsonFileName;
 
+    /// <summary>
+    /// The interval at which to scan for changes to the file. Zero, the default, disables scanning.
+    /// </summary>
     [TimeSpanParseRule(TimeSpanParseRule.Seconds)]
-    public TimeSpan ScanInterval { get; internal set; } = TimeSpan.Zero;
+    internal TimeSpan ScanInterval { get; set; } = TimeSpan.Zero;
 
-    public bool FailOnFileNotFound { get; internal set; } = true;
-    public bool FailOnSchedulingError { get; internal set; }
+    /// <summary>
+    /// Whether initialization of the plugin fails when a file cannot be found.
+    /// </summary>
+    internal bool FailOnFileNotFound { get; set; } = true;
+
+    /// <summary>
+    /// Whether starting of the plugin fails when a file cannot be handled.
+    /// </summary>
+    internal bool FailOnSchedulingError { get; set; }
+
+    internal IReadOnlyCollection<KeyValuePair<string, JobFile>> JobFiles => jobFiles;
 
     public ValueTask FileUpdated(string fileName, CancellationToken cancellationToken = default)
     {
-        return started ? new ValueTask(ProcessFile(fileName, cancellationToken)) : ValueTask.CompletedTask;
+        if (started)
+        {
+            return ProcessFile(fileName, cancellationToken);
+        }
+
+        return default;
     }
 
     public async ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
@@ -156,8 +185,6 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         }
     }
 
-    public ValueTask Shutdown(CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
-
     private string BuildJobTriggerName(string fileBasename)
     {
         var jobTriggerName = PluginName + '_' + Name + '_' + fileBasename.Replace('.', '_');
@@ -188,7 +215,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         return jobTriggerName;
     }
 
-    private async Task ProcessFile(JobFile? jobFile, CancellationToken cancellationToken = default)
+    private async ValueTask ProcessFile(JobFile? jobFile, CancellationToken cancellationToken = default)
     {
         if (jobFile is null || !jobFile.FileFound) return;
 
@@ -237,13 +264,16 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         }
     }
 
-    private Task ProcessFile(string filePath, CancellationToken cancellationToken = default)
+    private ValueTask ProcessFile(string filePath, CancellationToken cancellationToken = default)
     {
         var idx = jobFiles.FindIndex(pair => pair.Key == filePath);
         return ProcessFile(idx >= 0 ? jobFiles[idx].Value : null, cancellationToken);
     }
 
-    private sealed class JobFile
+    /// <summary>
+    /// Information about a file that should be processed by <see cref="JsonSchedulingDataProcessor" />.
+    /// </summary>
+    internal sealed class JobFile
     {
         private readonly JsonSchedulingDataProcessorPlugin plugin;
 
@@ -258,7 +288,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         public string FilePath { get; private set; } = null!;
         public string FileBasename { get; private set; } = null!;
 
-        public Task Initialize(CancellationToken cancellationToken = default)
+        public async ValueTask Initialize(CancellationToken cancellationToken = default)
         {
             Stream? f = null;
             try
@@ -287,11 +317,15 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
             }
             finally
             {
-                try { f?.Dispose(); }
+                try
+                {
+                    if (f is not null)
+                    {
+                        await f.DisposeAsync().ConfigureAwait(false);
+                    }
+                }
                 catch (IOException ioe) { plugin.logger.FileCloseFailed(FileName, ioe); }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
@@ -36,8 +36,18 @@ namespace Quartz.Plugins.Xml;
 /// file for changes.
 ///</summary>
 /// <remarks>
+/// <para>
+/// The XML format is frozen at <c>job_scheduling_data_2_0.xsd</c>: it declares <c>simple</c>,
+/// <c>cron</c> and <c>calendar-interval</c> triggers and nothing else, and it will not gain the
+/// trigger kinds or the trigger settings added since. Files that exist keep working for the life of
+/// 4.x; a schedule that needs anything the schema cannot spell is written as JSON and read by
+/// <see cref="Quartz.Plugins.Json.JsonSchedulingDataProcessorPlugin" />, which is the maintained
+/// format.
+/// </para>
+/// <para>
 /// The periodically scanning of files for changes is not currently supported in a
 /// clustered environment.
+/// </para>
 /// </remarks>
 /// <author>James House</author>
 /// <author>Pierre Awaragi</author>
@@ -77,16 +87,21 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
         TypeLoader = typeLoader;
     }
 
-    public string Name { get; private set; } = null!;
+    internal string Name { get; private set; } = null!;
 
-    public IScheduler Scheduler { get; private set; } = null!;
+    internal IScheduler Scheduler { get; private set; } = null!;
 
     private ITypeLoader TypeLoader { get; }
 
     /// <summary>
     /// Comma separated list of file names (with paths) to the XML files that should be read.
     /// </summary>
-    public string FileNames { get; internal set; } = XmlSchedulingDataProcessor.QuartzXmlFileName;
+    /// <remarks>
+    /// Delimited rather than a collection because <c>quartz.plugin.&lt;name&gt;.fileNames</c> writes
+    /// it as one string. <see cref="FileSchedulingOptions.Files" /> is what a caller says it in code,
+    /// and this is what that option is joined into.
+    /// </remarks>
+    internal string FileNames { get; set; } = XmlSchedulingDataProcessor.QuartzXmlFileName;
 
     /// <summary>
     /// The interval at which to scan for changes to the file.
@@ -94,19 +109,19 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
     /// value for the interval is 0, which disables scanning.
     /// </summary>
     [TimeSpanParseRule(TimeSpanParseRule.Seconds)]
-    public TimeSpan ScanInterval { get; internal set; } = TimeSpan.Zero;
+    internal TimeSpan ScanInterval { get; set; } = TimeSpan.Zero;
 
     /// <summary>
     /// Whether or not initialization of the plugin should fail (throw an
     /// exception) if the file cannot be found. Default is <see langword="true" />.
     /// </summary>
-    public bool FailOnFileNotFound { get; internal set; } = true;
+    internal bool FailOnFileNotFound { get; set; } = true;
 
     /// <summary>
     /// Whether or not starting of the plugin should fail (throw an
     /// exception) if the file cannot be handled. Default is <see langword="false" />.
     /// </summary>
-    public bool FailOnSchedulingError { get; internal set; }
+    internal bool FailOnSchedulingError { get; set; }
 
     internal IReadOnlyCollection<KeyValuePair<string, JobFile>> JobFiles => jobFiles;
 
@@ -335,7 +350,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
         }
     }
 
-    public ValueTask ProcessFile(string filePath, CancellationToken cancellationToken = default)
+    private ValueTask ProcessFile(string filePath, CancellationToken cancellationToken = default)
     {
         JobFile? file = null;
         int idx = jobFiles.FindIndex(pair => pair.Key == filePath);

--- a/src/Quartz.Plugins/README.md
+++ b/src/Quartz.Plugins/README.md
@@ -9,7 +9,7 @@ cleanly when the process exits.
 |---|---|
 | `StructuredLoggingJobHistoryPlugin` / `StructuredLoggingTriggerHistoryPlugin` | `UseStructuredJobLogging(…)` / `UseStructuredTriggerLogging(…)` |
 | `LoggingJobHistoryPlugin` / `LoggingTriggerHistoryPlugin` | `UseJobHistoryLogging(…)` / `UseTriggerHistoryLogging(…)` |
-| `XmlSchedulingDataProcessorPlugin` / `JsonSchedulingDataProcessorPlugin` | `UseXmlSchedulingConfiguration(…)` / `UseJsonSchedulingConfiguration(…)` |
+| `JsonSchedulingDataProcessorPlugin` / `XmlSchedulingDataProcessorPlugin` | `UseJsonSchedulingConfiguration(…)` / `UseXmlSchedulingConfiguration(…)` |
 | `JobInterruptMonitorPlugin` | `UseJobAutoInterrupt(…)` |
 | `ShutdownHookPlugin` | `UseShutdownHook(…)` |
 
@@ -40,6 +40,11 @@ The flat `quartz.plugin.{name}.{property}` keys Quartz 3 used still work and mea
 
 These plugins live in the `Quartz.Plugins.*` namespaces. In Quartz 3 they were the singular
 `Quartz.Plugin.*`; a `quartz.plugin.<name>.type` naming the old spelling still resolves, with a warning.
+
+JSON is the maintained format for a schedule kept in a file. The XML format is frozen at
+`job_scheduling_data_2_0.xsd` — simple, cron and calendar-interval triggers — and will not gain the
+trigger kinds or trigger settings added since. Existing files keep working; write a new schedule as
+JSON.
 
 ## Documentation
 

--- a/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorPluginTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorPluginTest.cs
@@ -1,0 +1,153 @@
+using FakeItEasy;
+
+using Quartz.Plugins.Json;
+
+namespace Quartz.Tests.Unit.Plugin.Json;
+
+/// <summary>
+/// The JSON scheduling plugin, tested the way its XML twin is: the two have one surface, and what
+/// holds for one of them is asked of the other here.
+/// </summary>
+public class JsonSchedulingDataProcessorPluginTest
+{
+    [Test]
+    public async Task WhenFullPathFilesAreSeparatedByCommaSpaceThenPurgeSpaces()
+    {
+        DirectoryInfo tempDir = Directory.CreateTempSubdirectory("quartz-json-plugin-test-");
+        try
+        {
+            string fp1 = Path.Combine(tempDir.FullName, "job-data-1.json");
+            string fp2 = Path.Combine(tempDir.FullName, "job-data-2.json");
+            File.WriteAllText(fp1, "");
+            File.WriteAllText(fp2, "");
+
+            JsonSchedulingDataProcessorPlugin plugin = new()
+            {
+                FileNames = fp1 + ", " + fp2
+            };
+
+            await plugin.Initialize("something", A.Fake<IScheduler>());
+
+            plugin.JobFiles.Should().HaveCount(2);
+            plugin.JobFiles.Select(x => x.Key).Should().Equal(fp1, fp2);
+        }
+        finally
+        {
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task StartSchedulesWhatTheFileDeclares()
+    {
+        DirectoryInfo tempDir = Directory.CreateTempSubdirectory("quartz-json-plugin-test-");
+        IScheduler scheduler = await CreateScheduler();
+        try
+        {
+            string file = Path.Combine(tempDir.FullName, "quartz_jobs.json");
+            await File.WriteAllTextAsync(file, JobsNamed("firstJob"));
+
+            JsonSchedulingDataProcessorPlugin plugin = new()
+            {
+                FileNames = file,
+                FailOnSchedulingError = true
+            };
+
+            await plugin.Initialize("json", scheduler);
+            await plugin.Start();
+
+            (await scheduler.Exists(new JobKey("firstJob"))).Should().BeTrue(
+                "starting the plugin reads every file it was given");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task AFileChangedAfterStartIsReadAgain()
+    {
+        DirectoryInfo tempDir = Directory.CreateTempSubdirectory("quartz-json-plugin-test-");
+        IScheduler scheduler = await CreateScheduler();
+        try
+        {
+            string file = Path.Combine(tempDir.FullName, "quartz_jobs.json");
+            await File.WriteAllTextAsync(file, JobsNamed("firstJob"));
+
+            JsonSchedulingDataProcessorPlugin plugin = new()
+            {
+                FileNames = file,
+                FailOnSchedulingError = true
+            };
+
+            await plugin.Initialize("json", scheduler);
+            await plugin.Start();
+
+            await File.WriteAllTextAsync(file, JobsNamed("firstJob", "secondJob"));
+            await plugin.FileUpdated(file);
+
+            (await scheduler.Exists(new JobKey("secondJob"))).Should().BeTrue(
+                "the file scan job reports a change through IFileScanListener.FileUpdated, which is the "
+                + "whole of what ScanInterval buys");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task AFileChangedBeforeStartIsLeftToStart()
+    {
+        DirectoryInfo tempDir = Directory.CreateTempSubdirectory("quartz-json-plugin-test-");
+        IScheduler scheduler = await CreateScheduler();
+        try
+        {
+            string file = Path.Combine(tempDir.FullName, "quartz_jobs.json");
+            await File.WriteAllTextAsync(file, JobsNamed("firstJob"));
+
+            JsonSchedulingDataProcessorPlugin plugin = new()
+            {
+                FileNames = file,
+                FailOnSchedulingError = true
+            };
+
+            await plugin.Initialize("json", scheduler);
+            await plugin.FileUpdated(file);
+
+            (await scheduler.Exists(new JobKey("firstJob"))).Should().BeFalse(
+                "an update before the scheduler started is not read twice: Start reads every file, and "
+                + "reading one of them ahead of it would schedule against a scheduler that is not ready");
+        }
+        finally
+        {
+            await scheduler.Shutdown();
+            tempDir.Delete(recursive: true);
+        }
+    }
+
+    private static ValueTask<IScheduler> CreateScheduler()
+    {
+        return QuartzSchedulerBuilder.Create()
+            .ConfigureScheduler(options => options.InstanceName = "json-plugin-test-" + Guid.NewGuid().ToString("N"))
+            .UseInMemoryStore()
+            .BuildScheduler();
+    }
+
+    private static string JobsNamed(params string[] names)
+    {
+        IEnumerable<string> jobs = names.Select(name =>
+            $$"""{ "Name": "{{name}}", "JobType": "Quartz.Jobs.NativeJob, Quartz.Jobs", "Durable": true }""");
+
+        return $$"""
+        {
+            "Schedule": {
+                "Jobs": [{{string.Join(", ", jobs)}}]
+            }
+        }
+        """;
+    }
+}

--- a/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
@@ -345,6 +345,49 @@ public class JsonSchedulingDataProcessorTest
             "the trigger has to survive the comments and the trailing commas around it, not merely the job");
     }
 
+    /// <summary>
+    /// The <c>quartz_jobs.json</c> the quick start prints, read by the reader that reads it. The only
+    /// substitution is the job type, which the page names as the reader's own <c>MyApp.HelloJob</c>.
+    /// </summary>
+    [Test]
+    public void TheQuickStartFileIsReadable()
+    {
+        var json = """
+        {
+          "Schedule": {
+            "Jobs": [
+              {
+                "Name": "helloJob",
+                "JobType": "Quartz.Jobs.NativeJob, Quartz.Jobs",
+                "Durable": true
+              }
+            ],
+            "Triggers": [
+              {
+                "Name": "helloTrigger",
+                "JobName": "helloJob",
+                "Simple": {
+                  "RepeatCount": -1,
+                  "Interval": "00:00:10"
+                }
+              }
+            ]
+          }
+        }
+        """;
+
+        var processor = CreateProcessor();
+        processor.ProcessJsonContent(json);
+
+        processor.ParsedJobs.Should().ContainSingle()
+            .Which.Key.Name.Should().Be("helloJob", "a documented file that does not parse is worse than none");
+
+        var trigger = (ISimpleTrigger) processor.ParsedTriggers.Should().ContainSingle().Which;
+        trigger.RepeatInterval.Should().Be(TimeSpan.FromSeconds(10));
+        trigger.RepeatCount.Should().Be(-1);
+        trigger.JobKey.Name.Should().Be("helloJob");
+    }
+
     [Test]
     public async Task DeleteInAllGroups_SkipsProtectedGroups()
     {

--- a/src/Quartz.Tests.Unit/Plugins/SchedulingDataPluginTwinsTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/SchedulingDataPluginTwinsTest.cs
@@ -1,0 +1,127 @@
+#nullable enable
+
+using System.Collections.Specialized;
+using System.Reflection;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+using Quartz.Plugins.Json;
+using Quartz.Plugins.Xml;
+
+namespace Quartz.Tests.Unit.Plugin;
+
+/// <summary>
+/// The XML and JSON scheduling-data plugins do the same thing to two file formats, so they have one
+/// surface: the same members, and the same settings reachable the same way.
+/// </summary>
+/// <remarks>
+/// They had drifted apart. The XML one published <c>ProcessFile</c> and no <c>Shutdown</c>, the JSON
+/// one a do-nothing <c>Shutdown</c> and no <c>ProcessFile</c>, and both published the settings the
+/// <c>quartz.plugin.&lt;name&gt;.*</c> keys write as public get-only properties — readable by an
+/// application that could do nothing with them, and different from the options type that configures
+/// them in code. The settings are internal now, which is what the second test here is about: the
+/// flat keys write non-public setters through reflection, so closing the public surface must not
+/// close the configuration path.
+/// </remarks>
+public sealed class SchedulingDataPluginTwinsTest
+{
+    [Test]
+    public void TheTwinsPublishTheSameMembers()
+    {
+        List<string> xml = PublicSurface(typeof(XmlSchedulingDataProcessorPlugin));
+        List<string> json = PublicSurface(typeof(JsonSchedulingDataProcessorPlugin));
+
+        xml.Should().Equal(json,
+            "the two plugins differ in the format they read and in nothing else, so a member on one of "
+            + "them is a member on the other or it is on neither");
+
+        xml.Should().Equal(
+            [
+                ".ctor()",
+                ".ctor(ILogger`1, ITypeLoader, TimeProvider)",
+                "FileUpdated(String, CancellationToken)",
+                "Initialize(String, IScheduler, CancellationToken)",
+                "Start(CancellationToken)",
+            ],
+            "the surface is the two constructors and what ISchedulerPlugin and IFileScanListener ask "
+            + "for; everything else is either configuration, which belongs to FileSchedulingOptions, "
+            + "or the plugin's own bookkeeping");
+    }
+
+    [Test]
+    public void FlatKeysStillConfigureBothTwins()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(new NameValueCollection
+        {
+            ["quartz.plugin.xml.type"] = typeof(XmlSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+            ["quartz.plugin.xml.fileNames"] = "first.xml, second.xml",
+            ["quartz.plugin.xml.scanInterval"] = "30",
+            ["quartz.plugin.xml.failOnFileNotFound"] = "false",
+            ["quartz.plugin.xml.failOnSchedulingError"] = "true",
+
+            ["quartz.plugin.json.type"] = typeof(JsonSchedulingDataProcessorPlugin).AssemblyQualifiedName,
+            ["quartz.plugin.json.fileNames"] = "first.json, second.json",
+            ["quartz.plugin.json.scanInterval"] = "45",
+            ["quartz.plugin.json.failOnFileNotFound"] = "false",
+            ["quartz.plugin.json.failOnSchedulingError"] = "true",
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        XmlSchedulingDataProcessorPlugin xml = Plugin<XmlSchedulingDataProcessorPlugin>(provider);
+        xml.FileNames.Should().Be("first.xml, second.xml",
+            "the settings are internal now, and the property binder reaches a non-public setter — so a "
+            + "quartz.plugin.<name>.* key that worked before still writes the plugin");
+        xml.ScanInterval.Should().Be(TimeSpan.FromSeconds(30),
+            "the scan interval is read in seconds, which is what [TimeSpanParseRule] on the internal "
+            + "property says");
+        xml.FailOnFileNotFound.Should().BeFalse();
+        xml.FailOnSchedulingError.Should().BeTrue();
+
+        JsonSchedulingDataProcessorPlugin json = Plugin<JsonSchedulingDataProcessorPlugin>(provider);
+        json.FileNames.Should().Be("first.json, second.json");
+        json.ScanInterval.Should().Be(TimeSpan.FromSeconds(45));
+        json.FailOnFileNotFound.Should().BeFalse();
+        json.FailOnSchedulingError.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// The members a consumer of the package can see, formatted so that the two plugins' constructors
+    /// compare equal — <c>ILogger&lt;T&gt;</c> is the one place the twins are each named after themselves.
+    /// </summary>
+    private static List<string> PublicSurface(Type type)
+    {
+        List<string> members = [];
+
+        foreach (MemberInfo member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            members.Add(member switch
+            {
+                MethodBase method => $"{method.Name}({string.Join(", ", method.GetParameters().Select(x => x.ParameterType.Name))})",
+                _ => $"{member.MemberType} {member.Name}",
+            });
+        }
+
+        members.Sort(StringComparer.Ordinal);
+        return members;
+    }
+
+    /// <summary>
+    /// The plugin of the given type a scheduler ends up with, built the way the scheduler builds it.
+    /// </summary>
+    private static T Plugin<T>(IServiceProvider provider) where T : ISchedulerPlugin
+    {
+        SchedulerKey key = new(Key: null);
+        return SchedulerPluginFactory.Create(
+                provider,
+                provider.GetSchedulerServices<ISchedulerPlugin>(key.Key),
+                provider.GetSchedulerProperties(key.OptionsName),
+                key)
+            .Select(x => x.Plugin)
+            .OfType<T>()
+            .Single();
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Plugins.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.Plugins.verified.txt
@@ -127,16 +127,8 @@ namespace Quartz.Plugins.Json
     {
         public JsonSchedulingDataProcessorPlugin() { }
         public JsonSchedulingDataProcessorPlugin(Microsoft.Extensions.Logging.ILogger<Quartz.Plugins.Json.JsonSchedulingDataProcessorPlugin> logger, Quartz.Extensibility.ITypeLoader typeLoader, System.TimeProvider timeProvider) { }
-        public bool FailOnFileNotFound { get; }
-        public bool FailOnSchedulingError { get; }
-        public string FileNames { get; }
-        public string Name { get; }
-        [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Seconds)]
-        public System.TimeSpan ScanInterval { get; }
-        public Quartz.IScheduler Scheduler { get; }
         public System.Threading.Tasks.ValueTask FileUpdated(string fileName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask Shutdown(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
@@ -155,16 +147,8 @@ namespace Quartz.Plugins.Xml
     {
         public XmlSchedulingDataProcessorPlugin() { }
         public XmlSchedulingDataProcessorPlugin(Microsoft.Extensions.Logging.ILogger<Quartz.Plugins.Xml.XmlSchedulingDataProcessorPlugin> logger, Quartz.Extensibility.ITypeLoader typeLoader, System.TimeProvider timeProvider) { }
-        public bool FailOnFileNotFound { get; }
-        public bool FailOnSchedulingError { get; }
-        public string FileNames { get; }
-        public string Name { get; }
-        [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Seconds)]
-        public System.TimeSpan ScanInterval { get; }
-        public Quartz.IScheduler Scheduler { get; }
         public System.Threading.Tasks.ValueTask FileUpdated(string fileName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Initialize(string pluginName, Quartz.IScheduler scheduler, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.ValueTask ProcessFile(string filePath, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask Start(System.Threading.CancellationToken cancellationToken = default) { }
     }
 }


### PR DESCRIPTION
`quick-start.md` taught `UseXmlSchedulingConfiguration` as the first thing a new user configures,
while the XML format it points at understands three trigger kinds and the JSON one understands four
plus retry policies and execution groups. This makes the demotion deliberate, in three parts.

## The XSD is frozen, and says so

The schema is untouched — this half is prose. `job_scheduling_data_2_0.xsd` declares `simple`, `cron`
and `calendar-interval` and will not gain a fourth kind or the trigger settings written since, and the
plugin's documentation page, the package readme and the migration guide now say that, with a table of
what each format can express. The list was checked against `JsonSchedulingDataProcessor`, which is why
it names **daily time interval, retry policy and execution group** and not "recurrence": recurrence
triggers are in neither format, and the page says so rather than implying JSON has them.

Not in scope, and stated in each place: XML scheduling is not deprecated and is not going away in 4.x.

## The quick start teaches JSON

`sample_quick_start_host` registers `UseJsonSchedulingConfiguration`, and the page prints the
`quartz_jobs.json` it reads — a job and a ten-second simple trigger, mirroring what the XML line
scheduled. `JsonSchedulingDataProcessorTest.TheQuickStartFileIsReadable` parses that exact file, with
the job type as the only substitution, so a documented file that does not parse fails the build.

The other pages the issue names follow: `packages/quartz-plugins.md` leads with the JSON plugin and
binds `Quartz:Json` in its options example, `packages/microsoft-di-integration.md` and
`multi-tenancy.md` name the JSON plugin — what those two demonstrate is a plugin and a property bag,
not a file format. `quartz-3.x/` is untouched.

## The plugin twins have one surface (breaking)

Both plugins now publish the two constructors and what `ISchedulerPlugin` and `IFileScanListener` ask
for, and nothing else:

| Member | Was | Now |
|---|---|---|
| `XmlSchedulingDataProcessorPlugin.ProcessFile(string, CancellationToken)` | public on XML, private on JSON | private on both |
| `JsonSchedulingDataProcessorPlugin.Shutdown(CancellationToken)` | public on JSON, absent on XML | absent on both — the interface default does nothing, which is what it did |
| `FileNames`, `ScanInterval`, `FailOnFileNotFound`, `FailOnSchedulingError` | public get-only, internal setters | internal |
| `Name`, `Scheduler` | public get-only | internal |

Fifteen lines leave the `Quartz.Plugins` baseline and none arrive; the migration guide carries a row
for each, in a new section and in the appendix.

**`quartz.plugin.<name>.*` still works, and is tested.** `PropertyBinder` binds
`Public | NonPublic` and calls `GetSetMethod(nonPublic: true)`, so an internal property is still
written by a flat key — `SchedulingDataPluginTwinsTest.FlatKeysStillConfigureBothTwins` drives all
four settings through `AddQuartz(NameValueCollection)` and `SchedulerPluginFactory` for both plugins.
`TheTwinsPublishTheSameMembers` pins the aligned surface so it cannot drift again.

`FileNames` versus `Files` is settled the way the spec asks and both twins now agree: the plugins keep
a delimited `FileNames` string because `quartz.plugin.<name>.fileNames` is one string, and
`FileSchedulingOptions.Files` stays the `List<string>` code and configuration binders say. The join is
in `PluginConfigurationExtensions`, unchanged.

## For the reviewer to decide

- The JSON section now sits **above** the XML one on the plugins page. That is an editorial signal, not
  a technical need; the anchors are unchanged either way.
- `JsonSchedulingDataProcessorPlugin`'s internals were `Task`-returning; they are `ValueTask` now, and
  `JobFile.Initialize` disposes asynchronously as the XML twin's does. Behaviour-neutral, and it is
  what makes "one surface" true below the surface too.
- Left alone deliberately: the twins still split `FileNames` differently — XML with `Split(',')` and
  `TrimStart`, JSON with `RemoveEmptyEntries` and `Trim`, so a trailing comma throws on XML and is
  ignored on JSON. It is a pre-existing difference in behaviour rather than surface, and fixing it
  belongs in its own change.
- `src/Quartz.Examples/12_ConfigureJobSchedulingByUsingXmlConfigurations` and
  `Quartz.Examples.AspNetCore` still demonstrate XML, which is correct: the format is supported, and
  the example is what a reader with an existing `quartz_jobs.xml` looks for.

## Verification

- `dotnet build src/Quartz.Plugins` — succeeded, 0 warnings (trim/AOT analyzers included).
- `dotnet test src/Quartz.Tests.Unit` — **4436 passed, 0 failed**.
- `dotnet fallout VerifyDocsSnippets` — succeeded, 102 markdown files up to date.
- The `Quartz.Plugins` baseline was regenerated by the test and accepted from `.received.txt`; the diff
  is 15 deletions and no additions.
- Not run, and why: the solution-wide build and the other test projects, on the disk budget this
  worktree was given — no project outside `Quartz.Plugins`, `Quartz.Tests.Unit` and
  `Quartz.Documentation.Samples` (all three built clean) names either plugin type, and
  `Quartz.Tests.AspNetCore` neither references `Quartz.Plugins` nor snapshots it. `BenchmarkSmoke` is
  untouched territory — no trigger, `TriggerHeader`, scheduler internal or serialization shape changed.
  `npm run docs:check-links` needs a `node_modules` this worktree has no room for; every new link was
  resolved by hand against the site's slugger (`@mdit-vue/shared`, which maps `.` and spaces to `-`).

Closes #3601

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX