### PR TITLE
The dashboard's client speaks the scheduler's vocabulary, and the trigger serializer seam is settled

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/trigger-persistence-delegate.md
+++ b/docs/documentation/quartz-4.x/how-tos/trigger-persistence-delegate.md
@@ -170,9 +170,10 @@ A persistence delegate is one of four pieces:
 implement `GetScheduleBuilder()`.
 
 ::: tip
-Of the five shipped trigger implementations, only `SimpleTriggerImpl` and `CronTriggerImpl` are
-subclassable — `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and `RecurrenceTriggerImpl`
-are sealed.
+All five shipped trigger implementations are subclassable, so deriving from `SimpleTriggerImpl` or
+`CronTriggerImpl` — or from `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` or
+`RecurrenceTriggerImpl` — is the shortest route to a trigger that is one of those with something added.
+Pair it with a serializer deriving from that trigger's built-in serializer, as below.
 :::
 
 **2. An `IScheduleBuilder`.** The store rebuilds a trigger as

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3939,10 +3939,18 @@ Each of these was a `public class` with `virtual` members in 3.x:
 | Sealed in 4.x | Derive from this instead |
 |---|---|
 | `AnnualCalendar`, `CronCalendar`, `DailyCalendar`, `HolidayCalendar`, `MonthlyCalendar`, `WeeklyCalendar` | `BaseCalendar`, which stays open, or `ICalendar` directly. Every shipped calendar is a short `BaseCalendar` — the `virtual` `IsDayExcluded` / `SetDayExcluded` / `AreAllDaysExcluded` overrides they offered only made sense for that one calendar's day set anyway |
-| `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl`, `RecurrenceTriggerImpl` | `TriggerBase`. `CronTriggerImpl` and `SimpleTriggerImpl` stay open, so a trigger deriving from one of *those* two is still the shortest route to a custom cron or simple trigger. `HasAdditionalProperties` is `virtual` on `TriggerBase`, so it is available either way |
 | `JobExecutionContextImpl`, and its nine `virtual` members with it | `IJobExecutionContext`. A test double implements the interface; a decorator wraps one |
 | `DefaultThreadPool`, `ZeroSizeThreadPool` | `IThreadPool`, or `TaskSchedulingThreadPool`, which stays open — see [The thread pool is asynchronous](#the-thread-pool-is-asynchronous) |
 | `JobChainingJobListener` | The three listener interfaces. Every notification member is a default interface member now, so implementing one directly costs a `Name` at most — see [The three `*Support` base classes are gone](#the-three-support-base-classes-are-gone) |
+
+**The five `*TriggerImpl` types are deliberately not in that list.** A trigger of your own derives from
+`TriggerBase` or from any of the five, `HasAdditionalProperties` is `virtual` on `TriggerBase`, and
+deriving from a built-in trigger pairs with deriving from that trigger's built-in JSON serializer —
+which is why those serializers are public and unsealed in both packages, so a subclass can call
+`base.SerializeFields` / `base.DeserializeFields` and keep the built-in fields' stored shape.
+`CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` and `RecurrenceTriggerImpl` were sealed
+during 4.x's development and were reopened for exactly that pairing — see
+[Other Breaking Changes](#other-breaking-changes).
 
 `JobChainingJobListener` also changed base. It derived from `Quartz.Listener.JobListenerSupport`, which is
 gone, and implements `IJobListener` directly, so its `Name` and `JobWasExecuted` are no longer `override`s.
@@ -5516,7 +5524,7 @@ than with an empty list, so a caller need not branch on whether clustering is on
 | `IScheduler` | `ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)` — implement it if you have an `IScheduler` of your own; `DelegatingScheduler` forwards it for you |
 | `IJobStore` | `ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)` — a plain member, so a store of your own must implement it. A store with no cluster state answers with one node: itself, `Alive`, both times `null` |
 | HTTP API | `GET {ApiPath}/schedulers/{name}/nodes`, unpaged, and `HttpScheduler.QueryClusterNodes` reads it (see [Cluster nodes](packages/http-api.md#cluster-nodes)) |
-| Dashboard | `IQuartzApiClient.GetClusterNodes(name, CancellationToken)`, and a **Cluster** page at `/quartz/cluster` |
+| Dashboard | `IQuartzApiClient.QueryClusterNodes(name, CancellationToken)`, and a **Cluster** page at `/quartz/cluster` |
 
 Neither member touches the schema, and neither writes anything: `QueryClusterNodes` is a read of the
 rows the check-in loop already keeps.
@@ -7897,18 +7905,18 @@ already had `JobKeyDto` and `TriggerKeyDto`. Now it says what Quartz says:
 | `GetTriggerState(…)` → `string` | → `TriggerState` |
 | `TriggerHeaderDto.State` is `string?` | `TriggerState?` |
 | `SchedulerHeaderDto.Status`, `SchedulerDetailDto.Status` are `string` | `SchedulerStatus`, a new public enum in `Quartz` |
-| `GetJobs(name, string? groupFilter, int page, int pageSize)` → `JobPageDto` | `GetJobs(name, DashboardJobQuery)` → `PagedResult<JobKeyDto>` |
-| `GetTriggers(name, string? groupFilter, TriggerState?, int page, int pageSize)` → `TriggerPageDto` | `GetTriggers(name, DashboardTriggerQuery)` → `PagedResult<TriggerHeaderDto>` |
-| `GetHistory(JobHistoryQueryDto)` → `JobHistoryPageDto` (a `JsonElement`) | `GetHistory(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>?` |
-| `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `GetFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
+| `GetJobs(name, string? groupFilter, int page, int pageSize)` → `JobPageDto` | `QueryJobs(name, DashboardJobQuery)` → `PagedResult<JobKeyDto>` |
+| `GetTriggers(name, string? groupFilter, TriggerState?, int page, int pageSize)` → `TriggerPageDto` | `QueryTriggers(name, DashboardTriggerQuery)` → `PagedResult<TriggerHeaderDto>` |
+| `GetHistory(JobHistoryQueryDto)` → `JobHistoryPageDto` (a `JsonElement`) | `QueryExecutions(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
+| `GetCurrentlyExecutingJobs(name)` → `List<CurrentlyExecutingJobDto>` | `QueryFireInstances(name, DashboardFireInstanceQuery)` → `PagedResult<FireInstanceDto>`, following `IScheduler` — see [What is running is a listing, not a list of contexts](#what-is-running-is-a-listing-not-a-list-of-contexts) |
 | `CurrentlyExecutingJobDto` | `FireInstanceDto`: `FireInstanceId` is non-null and leads, `JobKey` is nullable (an acquired firing has no job loaded yet), and `SchedulerInstanceId`, `FireInstanceState State` and `ScheduledFireTimeUtc` are new |
-| — | `GetClusterNodes(name)` → `List<ClusterNodeDto>` (new), behind the **Cluster** page — see [The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing) |
-| `IsJobGroupPaused(name, group)` → `bool` | `GetJobGroups(name, DashboardGroupQuery)` → `PagedResult<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one, and `Take = 0` with `Paused = true` counts the paused ones without listing them |
-| — | `GetTriggerGroups(name, DashboardGroupQuery)` → `PagedResult<TriggerGroupDto>` (new), the trigger-group twin of the above |
-| — | `CountMisfires(name, since)` → `int?` (new), null when the data source keeps no misfire feed — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
+| — | `QueryClusterNodes(name)` → `List<ClusterNodeDto>` (new), behind the **Cluster** page — see [The nodes of a cluster are a listing](#the-nodes-of-a-cluster-are-a-listing) |
+| `IsJobGroupPaused(name, group)` → `bool` | `QueryJobGroups(name, DashboardGroupQuery)` → `PagedResult<JobGroupDto>`, each carrying `Name` and `Paused`; one call answers for every group instead of one, and `Take = 0` with `Paused = true` counts the paused ones without listing them |
+| — | `QueryTriggerGroups(name, DashboardGroupQuery)` → `PagedResult<TriggerGroupDto>` (new), the trigger-group twin of the above |
+| — | `CountMisfires(name, since)` → `int` (new), what the overview's misfire tile reads — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
 | `ExecutionLimitsDto(IReadOnlyDictionary<string, int?> Limits)` | `ExecutionLimitsDto(Dictionary<string, DashboardExecutionLimit> Limits, bool UsesTriggerGroupWhenUnset = false, bool CanReport = true)` — concrete out, as everywhere else; each entry carries the limit's [scope](#an-execution-limit-can-be-cluster-wide) as well as its number, and the keys are the spellings configuration and the HTTP API use (`_` for the ungrouped bucket, `*` for the catch-all) so that a firing can be joined to the limit governing it |
 | `GetExecutionLimits(name)` → `ExecutionLimitsDto?`, null both for "nothing is limited" and for "this scheduler cannot say" | → `ExecutionLimitsDto`, never null: nothing limited is an empty `Limits`, and a scheduler that cannot answer is `ExecutionLimitsDto.CannotReport`, whose `CanReport` is `false` |
-| `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `GetPage(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
+| `IDashboardHistoryStore.GetPage(name, page, pageSize, jobFilter, triggerFilter)` → `DashboardHistoryPage` | `QueryExecutions(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>` |
 | `…Job(name, string group, string jobName)` — eight members | `…Job(name, JobKeyDto)` |
 | `…Trigger(name, string group, string triggerName)` — seven members | `…Trigger(name, TriggerKeyDto)` |
 
@@ -7931,6 +7939,37 @@ The dashboard hub's `SchedulerStateDto` follows: it is
 `SchedulerStarting` pushes nothing, being an event rather than a state. The instance id is new in
 alpha.3 — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from).
 
+### The client speaks the scheduler's verbs
+
+The names went with the types. An operation `IQuartzApiClient` forwards to a scheduler is spelled the way
+`IScheduler` spells it, so a reader who knows one knows the other; only what has no counterpart on
+`IScheduler` — the scheduler listing, the execution history — names itself. The DTO suffixes and the
+`PagedResult<T>` returns are unchanged.
+
+| 4.0 preview | 4.0 |
+|---|---|
+| `StartScheduler`, `StandbyScheduler`, `ShutdownScheduler` | `Start`, `Standby`, `Shutdown` |
+| `InterruptJob(name, JobKeyDto)` | `Interrupt(name, JobKeyDto)`; `InterruptFireInstance` is unchanged |
+| `TriggerJob(name, JobKeyDto)` **and** `TriggerJobWithData(name, JobKeyDto, JobDataMap)` | one `TriggerJob(name, JobKeyDto, JobDataMap? jobDataMap = null)`, as `IScheduler.TriggerJob` is |
+| `GetJobs`, `GetJobGroups`, `GetTriggers`, `GetTriggerGroups`, `GetFireInstances`, `GetClusterNodes` | `QueryJobs`, `QueryJobGroups`, `QueryTriggers`, `QueryTriggerGroups`, `QueryFireInstances`, `QueryClusterNodes` |
+| `GetJob(name, JobKeyDto)` → `JobDetailDto` | `GetJobDetail(name, JobKeyDto)`, the noun `IScheduler` uses |
+| `GetJobTriggers(name, JobKeyDto)` | `GetTriggersOfJob(name, JobKeyDto)` |
+| `GetHistory(DashboardHistoryQuery)` → `PagedResult<DashboardHistoryEntry>?` | `QueryExecutions(…)` → `PagedResult<DashboardHistoryEntry>`, never null |
+| `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` | `QueryMisfires(…)` → `PagedResult<DashboardMisfireEntry>`, never null |
+| `CountMisfires(name, since)` → `int?` | → `int` |
+| `IDashboardHistoryStore.Add`, `GetPage`, `GetMisfires` | `AddExecution`, `QueryExecutions`, `QueryMisfires`; `AddMisfire` and `CountMisfires` are unchanged |
+
+`GetSchedulers`, `GetScheduler` and `GetCalendarNames` keep their names: the first two list and read the
+container's registrations, which is not an operation a scheduler has, and `GetCalendarNames` reads *every*
+page of `IScheduler.QueryCalendarNames` rather than one, so naming it `Query*` would promise a paged query
+it does not take.
+
+The three nullable returns were nullable because the deleted HTTP-backed client turned a 404 into "this
+data source keeps no history". Nothing in this process has that answer: `IDashboardHistoryStore` always
+answers, and a store holding nothing returns an empty page and a count of zero. The History page's
+"execution history is unavailable" state went with the null, and the overview's misfire tile shows a dash
+only while no scheduler has answered yet.
+
 ### A trigger is an `ITrigger`, a calendar is an `ICalendar`
 
 Six members of that contract still spoke `System.Text.Json.JsonElement`. They were placeholders from
@@ -7945,7 +7984,7 @@ something Quartz already has a type for:
 | `RescheduleRequest(JsonElement NewTrigger)` | `RescheduleRequest(ITrigger NewTrigger)` |
 | `AddCalendarRequest(string, JsonElement Calendar, bool, bool)` | `AddCalendarRequest(string, ICalendar Calendar, bool, bool)` |
 | `JobDetailDto.JobDataMap` is a `JsonElement` | a `JobDataMap` |
-| `TriggerJobWithData(…, JsonElement jobDataMap, …)` | `TriggerJobWithData(…, JobDataMap jobDataMap, …)` |
+| `TriggerJobWithData(…, JsonElement jobDataMap, …)` | `TriggerJob(…, JobDataMap? jobDataMap = null, …)` |
 
 `TriggerDetailDto` and `CalendarDetailDto` are gone with them; nothing remains for them to wrap.
 
@@ -8003,8 +8042,8 @@ peer's. Both feeds carry the node now, and the history is bounded by age as well
 | — | `DashboardMisfireEntry(SchedulerName, SchedulerInstanceId, TriggerGroup, TriggerName, JobKeyDto? JobKey, MisfiredAtUtc, DateTimeOffset? ScheduledFireTimeUtc)` (new) |
 | — | `DashboardMisfireQuery : PagedQuery`, with `SchedulerName`, `SchedulerInstanceId` and `TriggerFilter` (new) |
 | `DashboardHistoryQuery` | gained `string? SchedulerInstanceId` — null lists every node's |
-| `IDashboardHistoryStore` | gained `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` |
-| `IQuartzApiClient` | gained `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` and `CountMisfires(name, since)` → `int?`, which is what the overview's misfire tile reads |
+| `IDashboardHistoryStore` | gained `AddMisfire`, `QueryMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` |
+| `IQuartzApiClient` | gained `QueryMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>` and `CountMisfires(name, since)` → `int`, which is what the overview's misfire tile reads |
 | `QuartzDashboardOptions` | gained `TimeSpan HistoryRetention` (24 hours) and `int HistoryMaxEntriesPerScheduler` (2000) |
 | `DashboardHistoryPlugin(IServiceProvider)` | `DashboardHistoryPlugin(IServiceProvider, TimeProvider)`, and it implements `ITriggerListener` as well as `IJobListener` |
 | `SchedulerStateDto(SchedulerName, Status)` | `SchedulerStateDto(SchedulerName, SchedulerInstanceId, Status)` |
@@ -8014,9 +8053,8 @@ peer's. Both feeds carry the node now, and the history is bounded by age as well
 | `IQuartzDashboardHubClient.JobPaused(JobKeyDto)` / `JobResumed` | take `JobLifecycleDto(SchedulerInstanceId, JobKey)` |
 
 **`IDashboardHistoryStore` is public and is the documented persistence seam, so the three new members
-are a breaking change for anyone who implemented it.** A store that only records executions can throw
-`NotSupportedException` from the misfire members; the History page reports a data source that answers
-`null` for misfires by omitting the section rather than by failing.
+are a breaking change for anyone who implemented it.** A store that records no misfires answers with an
+empty page and a count of zero; the History page renders the section saying so.
 
 A pause and a resume get a payload of their own rather than growing `JobKeyDto` / `TriggerKeyDto`:
 those are keys, `IQuartzApiClient` uses them everywhere, and a key does not belong to a node.
@@ -9445,14 +9483,13 @@ readable while you migrate it to JSON — see
 | `BLOB_TRIGGERS.BLOB_DATA` | `TriggerBase`, `SimpleTriggerImpl`, `CronTriggerImpl`, `CalendarIntervalTriggerImpl`, `DailyTimeIntervalTriggerImpl` |
 
 A trigger reaches that third row when no trigger persistence delegate handles it — a type of your own, or one
-deriving from `CronTriggerImpl` or `SimpleTriggerImpl` (the two that are still open) with
-`HasAdditionalProperties` returning `true`. The store writes the whole object into `BLOB_TRIGGERS`, so the
-trigger class hierarchy is part of the blob graph.
+deriving from any of the five shipped implementations with `HasAdditionalProperties` returning `true`. The
+store writes the whole object into `BLOB_TRIGGERS`, so the trigger class hierarchy is part of the blob graph.
 
 `RecurrenceTriggerImpl` is the one trigger implementation *not* on that list: it does not carry
 `[Serializable]`, where `TriggerBase` and the other four do. In practice a recurrence trigger is written to
-`SIMPROP_TRIGGERS` by `RecurrenceTriggerPersistenceDelegate` and never takes the blob path — it is `sealed`,
-so `HasAdditionalProperties` cannot be overridden to `true`. It did carry the attribute on 3.x, though, so a
+`SIMPROP_TRIGGERS` by `RecurrenceTriggerPersistenceDelegate` and never takes the blob path. It did carry the
+attribute on 3.x, though, so a
 3.x database that somehow holds a binary recurrence-trigger blob (which takes a delegate list with that
 delegate removed) should have that row migrated to JSON on 3.x before the upgrade.
 
@@ -9904,9 +9941,9 @@ Parameters and behavior are unchanged:
 | Group matchers translate to SQL correctly | `SelectTriggerGroups`, `DeletePausedTriggerGroup` and both `UpdateTriggerGroupStateFromOtherState(s)` members always built a `LIKE`, even for an equality matcher; they take the `=` path now, which is exact and index-friendly. `LIKE` patterns escape `%`, `_` and the escape character in the matcher's own text with an explicit `ESCAPE` clause, so a group literally named `50%` matches itself. The escape character is `!` rather than a backslash, because MySQL applies C-style escaping inside string literals and `ESCAPE '\'` is a syntax error there |
 | `StdAdoConstants` group and fired-trigger statements were split | `SqlDeletePausedTriggerGroup`, `SqlSelectTriggerGroupsFiltered`, `SqlUpdateTriggerGroupStateFromState` and `SqlUpdateTriggerGroupStateFromStates` are `…Equals` / `…Like` pairs, and the FIRED_TRIGGERS statements are one `SqlSelectFiredTriggers` / `SqlDeleteFiredTriggers` base plus `SqlFiredTrigger*Predicate` fragments. The type is internal |
 | `IDashboardAuthorizationFilter` and `QuartzDashboardOptions.AuthorizationFilter` removed | Nothing ever invoked the filter, so setting it bought a false sense of security. Use `AuthorizationPolicy`, which is enforced |
-| `IDashboardHistoryStore` is asynchronous | `ValueTask Add`, `ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery)`, so a store can talk to a database. `SearchFilter.DebounceMilliseconds` is a `TimeSpan Debounce`, and `InProcessQuartzApiClient` is internal — resolve `IQuartzApiClient` |
-| `IDashboardHistoryStore` carries the misfire feed | `AddMisfire`, `GetMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` are new members on the interface, so **an application with its own store has to implement three more** — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
-| `IQuartzApiClient` speaks Quartz's vocabulary | See [The dashboard's client speaks one currency](#the-dashboard-s-client-speaks-one-currency) |
+| `IDashboardHistoryStore` is asynchronous | `ValueTask AddExecution`, `ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery)`, so a store can talk to a database. `SearchFilter.DebounceMilliseconds` is a `TimeSpan Debounce`, and `InProcessQuartzApiClient` is internal — resolve `IQuartzApiClient` |
+| `IDashboardHistoryStore` carries the misfire feed | `AddMisfire`, `QueryMisfires(DashboardMisfireQuery)` and `CountMisfires(name, since)` are new members on the interface, so **an application with its own store has to implement three more** — see [History and live events say which node they came from](#history-and-live-events-say-which-node-they-came-from) |
+| `IQuartzApiClient` speaks Quartz's vocabulary, with `IScheduler`'s verbs | The renames are a table of their own — see [The client speaks the scheduler's verbs](#the-client-speaks-the-scheduler-s-verbs) |
 | The dashboard's HTTP-backed API client is gone | `QuartzApiClient` was never registered; the dashboard renders the schedulers in its own process, and `QuartzDashboardOptions.BaseUrl` and `.ApiPath` went with it — see [The dashboard reads the schedulers in its own process](#the-dashboard-reads-the-schedulers-in-its-own-process) |
 | Serializers outside a scheduler read a container-wide registry | Because the serializer maps are per-serializer, the HTTP API and `Quartz.HttpClient` read a `SystemTextJsonSerializerRegistry` registered in the container. Register it as a singleton to make a custom serializer visible to them. The dashboard no longer registers one of its own: it passes triggers and calendars through as themselves |
 | `SystemTextJsonSerializerRegistry` gained `AddTypeInfoResolver(IJsonTypeInfoResolver)` | Where reflection-based serialization is off — a `PublishTrimmed` or `PublishAot` application — this is how job-data values of the application's own types are answered for. Hand it a generated `JsonSerializerContext`'s `Default`. Everything Quartz writes, and every custom trigger or calendar registered with the registry, is already covered; with reflection on it changes nothing — see [Trimming annotations](#trimming-annotations) |

--- a/src/Quartz.Dashboard/Components/Pages/Cluster.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Cluster.razor
@@ -199,12 +199,12 @@
                 SchedulerDetailDto scheduler = await Api.GetScheduler(schedulerName);
                 _isClustered = scheduler.Clustered;
 
-                _nodes.AddRange(await Api.GetClusterNodes(schedulerName));
+                _nodes.AddRange(await Api.QueryClusterNodes(schedulerName));
 
                 // Both states, because the two columns are what a node is holding and what it is
                 // running: a reservation left behind by a node that died is exactly the thing an
                 // operator comes to this page to see.
-                PagedResult<FireInstanceDto> firings = await Api.GetFireInstances(
+                PagedResult<FireInstanceDto> firings = await Api.QueryFireInstances(
                     schedulerName,
                     new DashboardFireInstanceQuery { State = null });
 

--- a/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
+++ b/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
@@ -177,7 +177,7 @@
 
             if (!string.IsNullOrWhiteSpace(schedulerName))
             {
-                PagedResult<FireInstanceDto> page = await Api.GetFireInstances(schedulerName, new DashboardFireInstanceQuery());
+                PagedResult<FireInstanceDto> page = await Api.QueryFireInstances(schedulerName, new DashboardFireInstanceQuery());
                 _fireInstances.AddRange(page.Items);
                 _hasMore = page.HasMore;
                 _totalCount = page.TotalCount ?? page.Items.Count;

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -221,8 +221,8 @@
     }
 
     /// <remarks>
-    /// A data source that keeps no misfire feed has not looked, which is a different fact from having
-    /// looked and found none — so it reads as a dash rather than as a clean bill of health.
+    /// Nothing has been counted until a scheduler is selected and answers, which is a different fact from
+    /// having counted and found none — so it reads as a dash rather than as a clean bill of health.
     /// </remarks>
     private string MisfiresStatValue => _misfires?.ToString(CultureInfo.InvariantCulture) ?? "—";
 
@@ -288,14 +288,14 @@
             _storeIsClustered = scheduler.Clustered;
 
             // Counting queries: Take = 0 fetches no items, only the exact totals the tiles show.
-            PagedResult<JobKeyDto> jobs = await Api.GetJobs(schedulerName, new DashboardJobQuery { Take = 0 });
-            PagedResult<TriggerHeaderDto> triggers = await Api.GetTriggers(schedulerName, new DashboardTriggerQuery { Take = 0 });
-            PagedResult<FireInstanceDto> executing = await Api.GetFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
+            PagedResult<JobKeyDto> jobs = await Api.QueryJobs(schedulerName, new DashboardJobQuery { Take = 0 });
+            PagedResult<TriggerHeaderDto> triggers = await Api.QueryTriggers(schedulerName, new DashboardTriggerQuery { Take = 0 });
+            PagedResult<FireInstanceDto> executing = await Api.QueryFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
 
             _triggersByState.Clear();
             foreach (TriggerState state in HistogramStates)
             {
-                PagedResult<TriggerHeaderDto> inState = await Api.GetTriggers(
+                PagedResult<TriggerHeaderDto> inState = await Api.QueryTriggers(
                     schedulerName,
                     new DashboardTriggerQuery { Take = 0, State = state });
                 _triggersByState[state] = inState.TotalCount ?? 0;
@@ -304,10 +304,10 @@
             // The paused groups are counted with the paused filter rather than by listing every group
             // and tallying: a group can be paused while it holds nothing, and an unfiltered listing
             // enumerates the groups that hold something.
-            PagedResult<TriggerGroupDto> pausedTriggerGroups = await Api.GetTriggerGroups(
+            PagedResult<TriggerGroupDto> pausedTriggerGroups = await Api.QueryTriggerGroups(
                 schedulerName,
                 new DashboardGroupQuery { Take = 0, Paused = true });
-            PagedResult<JobGroupDto> pausedJobGroups = await Api.GetJobGroups(
+            PagedResult<JobGroupDto> pausedJobGroups = await Api.QueryJobGroups(
                 schedulerName,
                 new DashboardGroupQuery { Take = 0, Paused = true });
 
@@ -317,7 +317,7 @@
                 schedulerName,
                 DateTimeOffset.UtcNow - Options.Value.HistoryRetention);
 
-            List<ClusterNodeDto> nodes = await Api.GetClusterNodes(schedulerName);
+            List<ClusterNodeDto> nodes = await Api.QueryClusterNodes(schedulerName);
 
             _totalJobs = jobs.TotalCount ?? 0;
             _totalTriggers = triggers.TotalCount ?? 0;
@@ -401,7 +401,7 @@
                 return;
             }
 
-            PagedResult<FireInstanceDto> executing = await Api.GetFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
+            PagedResult<FireInstanceDto> executing = await Api.QueryFireInstances(schedulerName, new DashboardFireInstanceQuery { Take = 0 });
             _currentlyExecuting = executing.TotalCount ?? 0;
         }
         catch (Exception ex)
@@ -417,7 +417,7 @@
     private Task StartSchedulerAsync()
     {
         return ExecuteSchedulerActionAsync(
-            schedulerName => Api.StartScheduler(schedulerName),
+            schedulerName => Api.Start(schedulerName),
             "Started scheduler.",
             actionName: "StartScheduler");
     }
@@ -425,7 +425,7 @@
     private Task StandbySchedulerAsync()
     {
         return ExecuteSchedulerActionAsync(
-            schedulerName => Api.StandbyScheduler(schedulerName),
+            schedulerName => Api.Standby(schedulerName),
             "Scheduler is in standby.",
             actionName: "StandbyScheduler");
     }
@@ -449,7 +449,7 @@
     private Task ShutdownSchedulerAsync()
     {
         return ExecuteSchedulerActionAsync(
-            schedulerName => Api.ShutdownScheduler(schedulerName),
+            schedulerName => Api.Shutdown(schedulerName),
             "Shutdown scheduler.",
             actionName: "ShutdownScheduler",
             preferCurrentScheduler: false);

--- a/src/Quartz.Dashboard/Components/Pages/History.razor
+++ b/src/Quartz.Dashboard/Components/Pages/History.razor
@@ -50,7 +50,7 @@
         </div>
     </div>
 
-    @if (!_isLoading && !_historyUnavailable && string.IsNullOrWhiteSpace(_error))
+    @if (!_isLoading && string.IsNullOrWhiteSpace(_error))
     {
         <p class="qz-muted">Page @_page / @_totalPages · Showing @_entries.Count row(s) · Total @_totalCount row(s)</p>
         <p class="qz-muted">@BuildFilterSummary()</p>
@@ -63,10 +63,6 @@
     else if (!string.IsNullOrWhiteSpace(_error))
     {
         <ErrorAlert Message="@_error" OnRetry="LoadDataAsync" />
-    }
-    else if (_historyUnavailable)
-    {
-        <p class="qz-muted">Execution history is unavailable for the current API backend.</p>
     }
     else if (_totalCount == 0)
     {
@@ -115,7 +111,7 @@
                     OnPageChanged="OnPageChangedAsync" />
     }
 
-    @if (!_isLoading && !_historyUnavailable && string.IsNullOrWhiteSpace(_error) && !_misfiresUnavailable)
+    @if (!_isLoading && string.IsNullOrWhiteSpace(_error) && !_misfiresUnavailable)
     {
         @* The overview's misfire tile links here by fragment, so the id is part of that contract. *@
         <section id="misfires" class="qz-section qz-misfires">
@@ -171,7 +167,6 @@
 @code {
     private readonly List<DashboardHistoryEntry> _entries = [];
     private bool _isLoading = true;
-    private bool _historyUnavailable;
     private string? _error;
     private int _page = 1;
     private readonly int _pageSize = 25;
@@ -309,10 +304,9 @@
 
         _loadingInProgress = true;
         _isLoading = true;
-        _historyUnavailable = false;
         // Nothing has answered yet, so there is no misfire feed to show. Anything short of a page coming
-        // back — no scheduler selected, a data source that keeps no history, a read that threw — leaves
-        // the section out rather than rendering "no misfires" over an answer nobody gave.
+        // back — no scheduler selected, a read that threw — leaves the section out rather than rendering
+        // "no misfires" over an answer nobody gave.
         _misfiresUnavailable = true;
         _error = null;
         _entries.Clear();
@@ -334,12 +328,7 @@
 
             await LoadClusterNodesAsync(schedulerName);
 
-            PagedResult<DashboardHistoryEntry>? page = await Api.GetHistory(HistoryQuery(schedulerName, _page));
-            if (page is null)
-            {
-                _historyUnavailable = true;
-                return;
-            }
+            PagedResult<DashboardHistoryEntry> page = await Api.QueryExecutions(HistoryQuery(schedulerName, _page));
 
             _currentPageSize = _pageSize;
             _totalCount = page.TotalCount ?? page.Items.Count;
@@ -350,17 +339,14 @@
             if (_page > _totalPages)
             {
                 _page = _totalPages;
-                page = await Api.GetHistory(HistoryQuery(schedulerName, _page)) ?? page;
+                page = await Api.QueryExecutions(HistoryQuery(schedulerName, _page));
             }
 
             _entries.AddRange(page.Items);
 
-            PagedResult<DashboardMisfireEntry>? misfires = await Api.GetMisfires(MisfireQuery(schedulerName));
-            _misfiresUnavailable = misfires is null;
-            if (misfires is not null)
-            {
-                _misfires.AddRange(misfires.Items);
-            }
+            PagedResult<DashboardMisfireEntry> misfires = await Api.QueryMisfires(MisfireQuery(schedulerName));
+            _misfiresUnavailable = false;
+            _misfires.AddRange(misfires.Items);
 
             ComputeAnalytics();
         }
@@ -391,7 +377,7 @@
 
         try
         {
-            foreach (ClusterNodeDto node in await Api.GetClusterNodes(schedulerName))
+            foreach (ClusterNodeDto node in await Api.QueryClusterNodes(schedulerName))
             {
                 _clusterNodes.Add(node.InstanceId);
             }

--- a/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
@@ -166,9 +166,9 @@
                 return;
             }
 
-            _job = await Api.GetJob(schedulerName, JobKey);
+            _job = await Api.GetJobDetail(schedulerName, JobKey);
             _triggerDataMap = CloneJobDataMap(JobDataMap);
-            _triggers.AddRange(await Api.GetJobTriggers(schedulerName, JobKey));
+            _triggers.AddRange(await Api.GetTriggersOfJob(schedulerName, JobKey));
         }
         catch (Exception ex)
         {
@@ -223,7 +223,7 @@
     private Task TriggerWithDataAsync()
     {
         return ExecuteMutatingActionAsync(
-            () => Api.TriggerJobWithData(Scheduler.ActiveSchedulerName!, JobKey, _triggerDataMap),
+            () => Api.TriggerJob(Scheduler.ActiveSchedulerName!, JobKey, _triggerDataMap),
             "Triggered job " + DisplayValueHelper.FormatKey(Group, Name) + " with overrides.",
             actionName: "TriggerJobWithData",
             target: DisplayValueHelper.FormatKey(Group, Name));

--- a/src/Quartz.Dashboard/Components/Pages/Jobs.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Jobs.razor
@@ -161,14 +161,14 @@
             }
 
             string? groupFilter = string.IsNullOrWhiteSpace(_filter) ? null : _filter;
-            PagedResult<JobKeyDto> page = await Api.GetJobs(schedulerName, PageQuery(groupFilter, _currentPage));
+            PagedResult<JobKeyDto> page = await Api.QueryJobs(schedulerName, PageQuery(groupFilter, _currentPage));
 
             int totalCount = page.TotalCount ?? page.Items.Count;
             int totalPages = Math.Max(1, (int) Math.Ceiling((double) totalCount / _pageSize));
             if (_currentPage > totalPages)
             {
                 _currentPage = totalPages;
-                page = await Api.GetJobs(schedulerName, PageQuery(groupFilter, _currentPage));
+                page = await Api.QueryJobs(schedulerName, PageQuery(groupFilter, _currentPage));
                 totalCount = page.TotalCount ?? page.Items.Count;
             }
 
@@ -177,7 +177,7 @@
 
             // Every group, because the page labels each of the ones its current page shows, and it
             // cannot know which those are before it has them.
-            PagedResult<JobGroupDto> groups = await Api.GetJobGroups(schedulerName, new DashboardGroupQuery { Take = int.MaxValue });
+            PagedResult<JobGroupDto> groups = await Api.QueryJobGroups(schedulerName, new DashboardGroupQuery { Take = int.MaxValue });
             foreach (JobGroupDto group in groups.Items)
             {
                 _groupStates[group.Name] = group.Paused ? "Paused" : "Normal";
@@ -421,7 +421,7 @@
         try
         {
             // The group filter matches groups that contain it, so the exact group is selected here.
-            PagedResult<JobKeyDto> groupPage = await Api.GetJobs(
+            PagedResult<JobKeyDto> groupPage = await Api.QueryJobs(
                 schedulerName,
                 new DashboardJobQuery { GroupContains = group, Take = int.MaxValue });
             List<JobKeyDto> jobsInGroup = [];

--- a/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Schedulers.razor
@@ -229,7 +229,7 @@
             int? nodeCount = null;
             if (detail.Persistent && detail.Clustered)
             {
-                List<ClusterNodeDto> nodes = await Api.GetClusterNodes(header.SchedulerName);
+                List<ClusterNodeDto> nodes = await Api.QueryClusterNodes(header.SchedulerName);
                 nodeCount = nodes.Count;
             }
 

--- a/src/Quartz.Dashboard/Components/Pages/Triggers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Triggers.razor
@@ -201,14 +201,14 @@
             }
 
             string? groupFilter = string.IsNullOrWhiteSpace(_filter) ? null : _filter;
-            PagedResult<TriggerHeaderDto> page = await Api.GetTriggers(schedulerName, PageQuery(groupFilter, _currentPage));
+            PagedResult<TriggerHeaderDto> page = await Api.QueryTriggers(schedulerName, PageQuery(groupFilter, _currentPage));
 
             int totalCount = page.TotalCount ?? page.Items.Count;
             int totalPages = Math.Max(1, (int) Math.Ceiling((double) totalCount / _pageSize));
             if (_currentPage > totalPages)
             {
                 _currentPage = totalPages;
-                page = await Api.GetTriggers(schedulerName, PageQuery(groupFilter, _currentPage));
+                page = await Api.QueryTriggers(schedulerName, PageQuery(groupFilter, _currentPage));
                 totalCount = page.TotalCount ?? page.Items.Count;
             }
 
@@ -416,7 +416,7 @@
         try
         {
             // The group filter matches groups that contain it, so the exact group is selected here.
-            PagedResult<TriggerHeaderDto> groupPage = await Api.GetTriggers(
+            PagedResult<TriggerHeaderDto> groupPage = await Api.QueryTriggers(
                 schedulerName,
                 new DashboardTriggerQuery { GroupContains = group, Take = int.MaxValue });
             List<TriggerHeaderDto> triggersInGroup = [];

--- a/src/Quartz.Dashboard/Components/Shared/ExecutionGroups.razor
+++ b/src/Quartz.Dashboard/Components/Shared/ExecutionGroups.razor
@@ -241,7 +241,7 @@
             }
 
             // Both states, because a reservation holds a slot as surely as a running execution does.
-            PagedResult<FireInstanceDto> firings = await Api.GetFireInstances(
+            PagedResult<FireInstanceDto> firings = await Api.QueryFireInstances(
                 schedulerName,
                 new DashboardFireInstanceQuery { State = null });
 

--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -90,7 +90,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITr
                 Succeeded: jobException is null,
                 ExceptionMessage: jobException?.Message);
 
-            return store.Add(entry, cancellationToken);
+            return store.AddExecution(entry, cancellationToken);
         }
         catch (ObjectDisposedException)
         {

--- a/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
+++ b/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
@@ -89,22 +89,26 @@ public sealed record DashboardMisfireEntry(
 /// The seam an application replaces to keep history somewhere that survives a restart — the shipped
 /// implementation is per-process and in-memory, so every node of a cluster holds its own. Both feeds
 /// carry the node that produced each row, which is what makes a shared implementation readable.
+/// <para>
+/// Two feeds, one verb each way: an execution and a misfire are both written with <c>Add*</c> and both
+/// read with <c>Query*</c>, and the paged reads are named as <see cref="IQuartzApiClient" />'s are.
+/// </para>
 /// </remarks>
 public interface IDashboardHistoryStore
 {
-    ValueTask Add(DashboardHistoryEntry entry, CancellationToken cancellationToken = default);
+    ValueTask AddExecution(DashboardHistoryEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of the recorded executions, newest first.
     /// </summary>
-    ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
 
     ValueTask AddMisfire(DashboardMisfireEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of the recorded misfires, newest first.
     /// </summary>
-    ValueTask<PagedResult<DashboardMisfireEntry>> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<DashboardMisfireEntry>> QueryMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// How many misfires the scheduler has recorded since <paramref name="since" />.
@@ -150,7 +154,7 @@ internal sealed class DashboardHistoryStore : IDashboardHistoryStore
         retention = options.Value.HistoryRetention;
     }
 
-    public ValueTask Add(DashboardHistoryEntry entry, CancellationToken cancellationToken = default)
+    public ValueTask AddExecution(DashboardHistoryEntry entry, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(entry);
 
@@ -166,7 +170,7 @@ internal sealed class DashboardHistoryStore : IDashboardHistoryStore
         return default;
     }
 
-    public ValueTask<PagedResult<DashboardHistoryEntry>> GetPage(DashboardHistoryQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -192,7 +196,7 @@ internal sealed class DashboardHistoryStore : IDashboardHistoryStore
         return ValueTask.FromResult(Page(filtered.OrderByDescending(static entry => entry.FiredAtUtc).ToList(), query));
     }
 
-    public ValueTask<PagedResult<DashboardMisfireEntry>> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<DashboardMisfireEntry>> QueryMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -34,6 +34,13 @@ namespace Quartz.Dashboard.Services;
 /// <see cref="JobDataMap" /> rather than JSON.
 /// </para>
 /// <para>
+/// The verbs are <see cref="IScheduler" />'s own, spelled the same way: an operation this interface
+/// forwards carries the name the scheduler gives it — <see cref="Start" />, <see cref="Interrupt" />,
+/// one <see cref="TriggerJob" /> with an optional map, and the <c>Query*</c> family for the paged
+/// listings. Only what has no counterpart on <see cref="IScheduler" /> — the scheduler listing, the
+/// execution history — names itself.
+/// </para>
+/// <para>
 /// A trigger and a calendar arrive as themselves because Quartz already owns the polymorphism they
 /// need: the serializer registry maps each kind to its own serializer, custom kinds an application
 /// registered included, and the wire format is that discriminated shape. A DTO family of the
@@ -61,11 +68,11 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default);
 
-    ValueTask StartScheduler(string schedulerName, CancellationToken cancellationToken = default);
+    ValueTask Start(string schedulerName, CancellationToken cancellationToken = default);
 
-    ValueTask StandbyScheduler(string schedulerName, CancellationToken cancellationToken = default);
+    ValueTask Standby(string schedulerName, CancellationToken cancellationToken = default);
 
-    ValueTask ShutdownScheduler(string schedulerName, CancellationToken cancellationToken = default);
+    ValueTask Shutdown(string schedulerName, CancellationToken cancellationToken = default);
 
     ValueTask PauseAll(string schedulerName, CancellationToken cancellationToken = default);
 
@@ -76,21 +83,21 @@ public interface IQuartzApiClient
     /// <see cref="PagedResult{T}.HasMore" /> and, because the dashboard asks for it, a
     /// <see cref="PagedResult{T}.TotalCount" />.
     /// </summary>
-    ValueTask<PagedResult<JobKeyDto>> GetJobs(string schedulerName, DashboardJobQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<JobKeyDto>> QueryJobs(string schedulerName, DashboardJobQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of job groups, ordered by name, each carrying whether it is paused.
     /// </summary>
-    ValueTask<PagedResult<JobGroupDto>> GetJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<JobGroupDto>> QueryJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of trigger groups, ordered by name, each carrying whether it is paused.
     /// </summary>
-    ValueTask<PagedResult<TriggerGroupDto>> GetTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<TriggerGroupDto>> QueryTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
 
-    ValueTask<JobDetailDto> GetJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
+    ValueTask<JobDetailDto> GetJobDetail(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
-    ValueTask<List<TriggerHeaderDto>> GetJobTriggers(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
+    ValueTask<List<TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of firings — by default the ones that are running — ordered by trigger group,
@@ -98,17 +105,17 @@ public interface IQuartzApiClient
     /// cluster, so a firing owned by another node is listed too, marked with that node's
     /// <see cref="FireInstanceDto.SchedulerInstanceId" />.
     /// </summary>
-    ValueTask<PagedResult<FireInstanceDto>> GetFireInstances(string schedulerName, DashboardFireInstanceQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<FireInstanceDto>> QueryFireInstances(string schedulerName, DashboardFireInstanceQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the scheduler's cluster nodes, the node that answered first. A scheduler that is not
     /// clustered answers with the one node it is, with no check-in times.
     /// </summary>
     /// <remarks>
-    /// Joins to <see cref="GetFireInstances" /> on <see cref="FireInstanceDto.SchedulerInstanceId" />,
+    /// Joins to <see cref="QueryFireInstances" /> on <see cref="FireInstanceDto.SchedulerInstanceId" />,
     /// which is how the Cluster page counts what each node is running.
     /// </remarks>
-    ValueTask<List<ClusterNodeDto>> GetClusterNodes(string schedulerName, CancellationToken cancellationToken = default);
+    ValueTask<List<ClusterNodeDto>> QueryClusterNodes(string schedulerName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Pauses the job. Returns <see langword="true" /> when the job existed and was paused,
@@ -122,21 +129,24 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<bool> ResumeJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
-    ValueTask TriggerJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
-
     /// <summary>
     /// Triggers the job once, with <paramref name="jobDataMap" /> merged over the job's own data for
-    /// that one firing.
+    /// that one firing when a map is given.
     /// </summary>
-    ValueTask TriggerJobWithData(string schedulerName, JobKeyDto jobKey, JobDataMap jobDataMap, CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// One method with an optional map, exactly as <see cref="IScheduler.TriggerJob" /> is: firing a job
+    /// with data and firing it without are the same operation, and the pair of methods this replaces made
+    /// them look like two.
+    /// </remarks>
+    ValueTask TriggerJob(string schedulerName, JobKeyDto jobKey, JobDataMap? jobDataMap = null, CancellationToken cancellationToken = default);
 
-    ValueTask InterruptJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
+    ValueTask Interrupt(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Interrupts one execution, named by its fire instance id.
     /// </summary>
     /// <remarks>
-    /// The single-execution form of <see cref="InterruptJob" />, which interrupts every execution of the
+    /// The single-execution form of <see cref="Interrupt" />, which interrupts every execution of the
     /// job. Node-local on the server side: a firing owned by another node is interrupted by asking that
     /// node.
     /// </remarks>
@@ -150,7 +160,7 @@ public interface IQuartzApiClient
     /// Returns one page of triggers, ordered by group and then name, each carrying its state and
     /// execution group.
     /// </summary>
-    ValueTask<PagedResult<TriggerHeaderDto>> GetTriggers(string schedulerName, DashboardTriggerQuery query, CancellationToken cancellationToken = default);
+    ValueTask<PagedResult<TriggerHeaderDto>> QueryTriggers(string schedulerName, DashboardTriggerQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the trigger itself — a <see cref="ICronTrigger" />, <see cref="ISimpleTrigger" /> or
@@ -196,28 +206,32 @@ public interface IQuartzApiClient
     ValueTask DeleteCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns one page of execution history, newest first, or <see langword="null" /> when the data
-    /// source keeps no history.
+    /// Returns one page of execution history, newest first.
     /// </summary>
-    ValueTask<PagedResult<DashboardHistoryEntry>?> GetHistory(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// The history is <see cref="IDashboardHistoryStore" />'s, and that store always answers: a store
+    /// holding nothing returns an empty page, which is what "no executions recorded" is. This used to be
+    /// nullable because the deleted remote client turned a 404 into "no history at all", and nothing
+    /// in this process has ever had that answer to give.
+    /// </remarks>
+    ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Returns one page of the triggers that missed a firing, newest first, or <see langword="null" />
-    /// when the data source keeps no history.
+    /// Returns one page of the triggers that missed a firing, newest first.
     /// </summary>
-    ValueTask<PagedResult<DashboardMisfireEntry>?> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// <inheritdoc cref="QueryExecutions" path="/remarks" />
+    /// </remarks>
+    ValueTask<PagedResult<DashboardMisfireEntry>> QueryMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Counts the misfires the scheduler has recorded since <paramref name="since" />, or
-    /// <see langword="null" /> when the data source keeps no misfire feed.
+    /// Counts the misfires the scheduler has recorded since <paramref name="since" />.
     /// </summary>
     /// <remarks>
     /// A count rather than a page, because the overview's tile asks "how bad is it right now" and a
     /// store keeping its history in a database can answer that without loading rows it would discard.
-    /// Null is not zero: a data source with no feed has not looked, and the tile says so rather than
-    /// reporting a clean bill of health it did not earn.
     /// </remarks>
-    ValueTask<int?> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default);
+    ValueTask<int> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns the execution limits the scheduler is running with, or

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -91,21 +91,21 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             metadata.Version);
     }
 
-    public ValueTask StartScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public ValueTask Start(string schedulerName, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
         return scheduler.Start(cancellationToken);
     }
 
-    public ValueTask StandbyScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public ValueTask Standby(string schedulerName, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
         return scheduler.Standby(cancellationToken);
     }
 
-    public ValueTask ShutdownScheduler(string schedulerName, CancellationToken cancellationToken = default)
+    public ValueTask Shutdown(string schedulerName, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
@@ -126,7 +126,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return scheduler.ResumeAll(cancellationToken);
     }
 
-    public async ValueTask<PagedResult<JobKeyDto>> GetJobs(string schedulerName, DashboardJobQuery query, CancellationToken cancellationToken = default)
+    public async ValueTask<PagedResult<JobKeyDto>> QueryJobs(string schedulerName, DashboardJobQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -150,7 +150,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<JobKeyDto>(items, jobs.HasMore, jobs.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<PagedResult<JobGroupDto>> GetJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
+    public async ValueTask<PagedResult<JobGroupDto>> QueryJobGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -174,7 +174,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<JobGroupDto>(items, groups.HasMore, groups.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<PagedResult<TriggerGroupDto>> GetTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
+    public async ValueTask<PagedResult<TriggerGroupDto>> QueryTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -198,7 +198,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<TriggerGroupDto>(items, groups.HasMore, groups.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<JobDetailDto> GetJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public async ValueTask<JobDetailDto> GetJobDetail(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         JobKey jobKey = AsJobKey(key);
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
@@ -224,7 +224,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
     /// The triggers themselves are needed for the schedule summary, and their states come from a single
     /// query rather than one <see cref="IScheduler.GetTriggerState"/> call per trigger.
     /// </remarks>
-    public async ValueTask<List<TriggerHeaderDto>> GetJobTriggers(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public async ValueTask<List<TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         JobKey jobKey = AsJobKey(key);
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
@@ -263,7 +263,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return result;
     }
 
-    public async ValueTask<PagedResult<FireInstanceDto>> GetFireInstances(string schedulerName, DashboardFireInstanceQuery query, CancellationToken cancellationToken = default)
+    public async ValueTask<PagedResult<FireInstanceDto>> QueryFireInstances(string schedulerName, DashboardFireInstanceQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -296,7 +296,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return new PagedResult<FireInstanceDto>(items, page.HasMore, page.TotalCount ?? items.Count);
     }
 
-    public async ValueTask<List<ClusterNodeDto>> GetClusterNodes(string schedulerName, CancellationToken cancellationToken = default)
+    public async ValueTask<List<ClusterNodeDto>> QueryClusterNodes(string schedulerName, CancellationToken cancellationToken = default)
     {
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
         List<ClusterNode> nodes = await scheduler.QueryClusterNodes(cancellationToken).ConfigureAwait(false);
@@ -329,22 +329,14 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return scheduler.ResumeJob(AsJobKey(key), cancellationToken);
     }
 
-    public ValueTask TriggerJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public ValueTask TriggerJob(string schedulerName, JobKeyDto key, JobDataMap? jobDataMap = null, CancellationToken cancellationToken = default)
     {
-        EnsureWritable();
-        IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        return scheduler.TriggerJob(AsJobKey(key), cancellationToken: cancellationToken);
-    }
-
-    public ValueTask TriggerJobWithData(string schedulerName, JobKeyDto key, JobDataMap jobDataMap, CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(jobDataMap);
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
         return scheduler.TriggerJob(AsJobKey(key), jobDataMap, cancellationToken);
     }
 
-    public async ValueTask InterruptJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public async ValueTask Interrupt(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
@@ -380,7 +372,7 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return scheduler.AddJob(jobDetail, options, cancellationToken);
     }
 
-    public async ValueTask<PagedResult<TriggerHeaderDto>> GetTriggers(
+    public async ValueTask<PagedResult<TriggerHeaderDto>> QueryTriggers(
         string schedulerName,
         DashboardTriggerQuery query,
         CancellationToken cancellationToken = default)
@@ -536,23 +528,23 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         _ = await scheduler.DeleteCalendar(calendarName, cancellationToken).ConfigureAwait(false);
     }
 
-    public async ValueTask<PagedResult<DashboardHistoryEntry>?> GetHistory(DashboardHistoryQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        return await historyStore.GetPage(query, cancellationToken).ConfigureAwait(false);
+        return historyStore.QueryExecutions(query, cancellationToken);
     }
 
-    public async ValueTask<PagedResult<DashboardMisfireEntry>?> GetMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<DashboardMisfireEntry>> QueryMisfires(DashboardMisfireQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        return await historyStore.GetMisfires(query, cancellationToken).ConfigureAwait(false);
+        return historyStore.QueryMisfires(query, cancellationToken);
     }
 
-    public async ValueTask<int?> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default)
+    public ValueTask<int> CountMisfires(string schedulerName, DateTimeOffset since, CancellationToken cancellationToken = default)
     {
-        return await historyStore.CountMisfires(schedulerName, since, cancellationToken).ConfigureAwait(false);
+        return historyStore.CountMisfires(schedulerName, since, cancellationToken);
     }
 
     private static GroupMatcher<TKey>? BuildGroupMatcher<TKey>(string? groupFilter) where TKey : Key<TKey>

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/ClusterPageTest.cs
@@ -174,7 +174,7 @@ public class ClusterPageTest
     [Test]
     public void AFailedReadIsReportedRatherThanLeavingAnEmptyTable()
     {
-        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryClusterNodes(A<string>._, A<CancellationToken>._))
             .Throws(new InvalidOperationException("state table unavailable"));
 
         IRenderedComponent<Cluster> page = context.Render<Cluster>();
@@ -249,13 +249,13 @@ public class ClusterPageTest
 
     private void GivenNodes(params ClusterNodeDto[] nodes)
     {
-        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryClusterNodes(A<string>._, A<CancellationToken>._))
             .Returns(nodes.ToList());
     }
 
     private void GivenFirings(params FireInstanceDto[] firings)
     {
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<FireInstanceDto>(firings));
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardComponentContext.cs
@@ -68,12 +68,16 @@ internal sealed class DashboardComponentContext : BunitContext
         // empty answer rather than whatever a dummy would have invented.
         A.CallTo(() => Api.GetExecutionLimits(A<string>._, A<CancellationToken>._))
             .Returns(new ExecutionLimitsDto([]));
-        A.CallTo(() => Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<FireInstanceDto>([], HasMore: false, TotalCount: 0));
-        A.CallTo(() => Api.GetTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => Api.QueryTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<TriggerGroupDto>([], HasMore: false, TotalCount: 0));
-        A.CallTo(() => Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => Api.QueryJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<JobGroupDto>([], HasMore: false, TotalCount: 0));
+        A.CallTo(() => Api.QueryExecutions(A<DashboardHistoryQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<DashboardHistoryEntry>([], HasMore: false, TotalCount: 0));
+        A.CallTo(() => Api.QueryMisfires(A<DashboardMisfireQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<DashboardMisfireEntry>([], HasMore: false, TotalCount: 0));
         A.CallTo(() => Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._))
             .Returns(0);
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
@@ -60,7 +60,7 @@ public class DashboardPageTest
         page.StatCardValue("Currently Executing").Should().Be("2");
         page.StatCardValue("Error Triggers").Should().Be("3");
 
-        A.CallTo(() => context.Api.GetJobs(
+        A.CallTo(() => context.Api.QueryJobs(
                 TestData.SchedulerName,
                 A<DashboardJobQuery>.That.Matches(query => query.Take == 0),
                 A<CancellationToken>._))
@@ -123,7 +123,7 @@ public class DashboardPageTest
 
         page.FindAll("button").First(button => button.TextContent.Trim() == "Standby").Click();
 
-        A.CallTo(() => context.Api.StandbyScheduler(TestData.SchedulerName, A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() => context.Api.Standby(TestData.SchedulerName, A<CancellationToken>._)).MustHaveHappened();
         context.Toasts.Messages.Should().ContainSingle().Which.Message.Should().Be("Scheduler is in standby.");
         context.ActionLog.GetLatest(1).Should().ContainSingle()
             .Which.Action.Should().Be("StandbyScheduler");
@@ -135,13 +135,13 @@ public class DashboardPageTest
         IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
 
         page.FindAll("button").First(button => button.TextContent.Trim() == "Shutdown").Click();
-        A.CallTo(() => context.Api.ShutdownScheduler(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => context.Api.Shutdown(A<string>._, A<CancellationToken>._)).MustNotHaveHappened();
         page.Markup.Should().Contain("Running jobs may be interrupted",
             "shutting a scheduler down is not undone by clicking Start again");
 
         page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
 
-        A.CallTo(() => context.Api.ShutdownScheduler(TestData.SchedulerName, A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() => context.Api.Shutdown(TestData.SchedulerName, A<CancellationToken>._)).MustHaveHappened();
     }
 
     [Test]
@@ -220,7 +220,7 @@ public class DashboardPageTest
 
         foreach (TriggerState state in new[] { TriggerState.Normal, TriggerState.Paused, TriggerState.Blocked, TriggerState.Error, TriggerState.Complete })
         {
-            A.CallTo(() => context.Api.GetTriggers(
+            A.CallTo(() => context.Api.QueryTriggers(
                     TestData.SchedulerName,
                     A<DashboardTriggerQuery>.That.Matches(query => query.Take == 0 && query.State == state),
                     A<CancellationToken>._))
@@ -256,12 +256,12 @@ public class DashboardPageTest
         page.FindAll(".qz-stat-card-warning").Should().NotBeEmpty(
             "a paused group is why work is not being done, which is not an informational fact");
 
-        A.CallTo(() => context.Api.GetTriggerGroups(
+        A.CallTo(() => context.Api.QueryTriggerGroups(
                 TestData.SchedulerName,
                 A<DashboardGroupQuery>.That.Matches(query => query.Take == 0 && query.Paused == true),
                 A<CancellationToken>._))
             .MustHaveHappened();
-        A.CallTo(() => context.Api.GetJobGroups(
+        A.CallTo(() => context.Api.QueryJobGroups(
                 TestData.SchedulerName,
                 A<DashboardGroupQuery>.That.Matches(query => query.Take == 0 && query.Paused == true),
                 A<CancellationToken>._))
@@ -309,14 +309,13 @@ public class DashboardPageTest
     }
 
     /// <summary>
-    /// A data source with no misfire feed has not looked, which is not the same as having looked and
+    /// Nothing has been counted until a scheduler answers, which is not the same as having counted and
     /// found none.
     /// </summary>
     [Test]
-    public void ADataSourceThatKeepsNoMisfiresSaysSoRatherThanReportingZero()
+    public void ATileOverNoSchedulerSaysSoRatherThanReportingZero()
     {
-        A.CallTo(() => context.Api.CountMisfires(A<string>._, A<DateTimeOffset>._, A<CancellationToken>._))
-            .Returns((int?) null);
+        context.SchedulerState.ActiveSchedulerName = null;
 
         IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
 
@@ -382,7 +381,7 @@ public class DashboardPageTest
             byState[state] = count;
         }
 
-        A.CallTo(() => context.Api.GetTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
             .ReturnsLazily((string _, DashboardTriggerQuery query, CancellationToken _) =>
                 new PagedResult<TriggerHeaderDto>(
                     [],
@@ -392,29 +391,29 @@ public class DashboardPageTest
 
     private void GivenPausedGroups(int triggerGroups, int jobGroups)
     {
-        A.CallTo(() => context.Api.GetTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryTriggerGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<TriggerGroupDto>([], HasMore: false, TotalCount: triggerGroups));
-        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<JobGroupDto>([], HasMore: false, TotalCount: jobGroups));
     }
 
     private void GivenCounts(int jobs, int triggers, int errorTriggers, int executing)
     {
-        A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<JobKeyDto>([], HasMore: false, TotalCount: jobs));
-        A.CallTo(() => context.Api.GetTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
             .ReturnsLazily((string _, DashboardTriggerQuery query, CancellationToken _) =>
                 new PagedResult<TriggerHeaderDto>(
                     [],
                     HasMore: false,
                     TotalCount: query.State == TriggerState.Error ? errorTriggers : triggers));
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<FireInstanceDto>([], HasMore: false, TotalCount: executing));
     }
 
     private void GivenNodes(params ClusterNodeDto[] nodes)
     {
-        A.CallTo(() => context.Api.GetClusterNodes(A<string>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryClusterNodes(A<string>._, A<CancellationToken>._))
             .Returns(nodes.ToList());
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/ExecutionGroupsPanelTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/ExecutionGroupsPanelTest.cs
@@ -275,7 +275,7 @@ public class ExecutionGroupsPanelTest
     public void CountsTakenFromAPartialPageSayThatTheyAre()
     {
         GivenLimits(Limits(("batch", 4, ExecutionLimitScope.Node)));
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(new PagedResult<FireInstanceDto>(
                 [Firing("batch", FireInstanceState.Executing)],
                 HasMore: true,
@@ -314,7 +314,7 @@ public class ExecutionGroupsPanelTest
 
     private void GivenFirings(params FireInstanceDto[] firings)
     {
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<FireInstanceDto>(firings.ToList()));
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/HistoryPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/HistoryPageTest.cs
@@ -116,15 +116,13 @@ public class HistoryPageTest
     }
 
     [Test]
-    public void AStoreThatKeepsNoHistorySaysSoInsteadOfShowingAnEmptyPage()
+    public void AStoreHoldingNothingShowsAnEmptyPageRatherThanAFault()
     {
-        A.CallTo(() => context.Api.GetHistory(A<DashboardHistoryQuery>._, A<CancellationToken>._))
-            .Returns((PagedResult<DashboardHistoryEntry>?) null);
-
         IRenderedComponent<History> page = context.Render<History>();
 
-        page.Markup.Should().Contain("Execution history is unavailable",
-            "a null page means the data source keeps no history, which is not the same as an empty one");
+        page.Markup.Should().Contain("No execution history yet",
+            "a store that has recorded nothing answers with an empty page, which is the only "
+            + "'no history' answer there is now that the client cannot say it keeps none");
         page.Markup.Should().NotContain("qz-stat-card",
             "there is nothing to compute an average over");
     }
@@ -142,7 +140,7 @@ public class HistoryPageTest
             "the summary says what the listing is narrowed to, with the query values trimmed as they "
             + "were applied");
 
-        A.CallTo(() => context.Api.GetHistory(
+        A.CallTo(() => context.Api.QueryExecutions(
                 A<DashboardHistoryQuery>.That.Matches(query =>
                     query.JobFilter == "DummyGroup.DummyJob"
                     && query.TriggerFilter == "CronTriggerGroup"
@@ -161,7 +159,7 @@ public class HistoryPageTest
 
         context.Render<History>();
 
-        A.CallTo(() => context.Api.GetHistory(
+        A.CallTo(() => context.Api.QueryExecutions(
                 A<DashboardHistoryQuery>.That.Matches(query => query.Skip == 50 && query.Take == 25),
                 A<CancellationToken>._))
             .MustHaveHappened();
@@ -178,7 +176,7 @@ public class HistoryPageTest
 
         page.Markup.Should().Contain("Page 2 / 2",
             "asking for page 99 of 2 means the last one, which is what a job or trigger listing does too");
-        A.CallTo(() => context.Api.GetHistory(
+        A.CallTo(() => context.Api.QueryExecutions(
                 A<DashboardHistoryQuery>.That.Matches(query => query.Skip == 25),
                 A<CancellationToken>._))
             .MustHaveHappened();
@@ -207,7 +205,7 @@ public class HistoryPageTest
 
         IRenderedComponent<History> page = context.Render<History>();
 
-        A.CallTo(() => context.Api.GetHistory(
+        A.CallTo(() => context.Api.QueryExecutions(
                 A<DashboardHistoryQuery>.That.Matches(query => query.SchedulerInstanceId == "node-b"),
                 A<CancellationToken>._))
             .MustHaveHappened();
@@ -234,7 +232,7 @@ public class HistoryPageTest
     public void TheNodeFilterOffersTheClusterNodesEvenWhereNoRowNamesThem()
     {
         GivenHistory(Entry(100, node: "node-a"));
-        A.CallTo(() => context.Api.GetClusterNodes(TestData.SchedulerName, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryClusterNodes(TestData.SchedulerName, A<CancellationToken>._))
             .Returns(new List<ClusterNodeDto>
             {
                 new("node-a", null, null, ClusterNodeState.Alive, IsCurrentNode: true),
@@ -324,18 +322,18 @@ public class HistoryPageTest
 
     private void GivenHistory(int totalCount, params DashboardHistoryEntry[] entries)
     {
-        A.CallTo(() => context.Api.GetHistory(A<DashboardHistoryQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryExecutions(A<DashboardHistoryQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<DashboardHistoryEntry>(entries, totalCount));
     }
 
     /// <remarks>
-    /// Left unstubbed the fake answers null, which is the "this data source keeps no history" answer —
-    /// so a test that says nothing about misfires renders no misfire section, and the tests above are
-    /// unaffected by one.
+    /// Left unstubbed the misfire feed answers the empty page <see cref="DashboardComponentContext" />
+    /// sets up, so a test that says nothing about misfires renders the section with nothing in it and
+    /// the tests above are unaffected by one.
     /// </remarks>
     private void GivenMisfires(params DashboardMisfireEntry[] entries)
     {
-        A.CallTo(() => context.Api.GetMisfires(A<DashboardMisfireQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryMisfires(A<DashboardMisfireQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<DashboardMisfireEntry>(entries));
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
@@ -56,7 +56,7 @@ public class JobsPageTest
 
         page.FindAll(".qz-pagination button").First(button => button.TextContent.Trim() == "2").Click();
 
-        A.CallTo(() => context.Api.GetJobs(
+        A.CallTo(() => context.Api.QueryJobs(
                 TestData.SchedulerName,
                 A<DashboardJobQuery>.That.Matches(query => query.Skip == 25 && query.Take == 25),
                 A<CancellationToken>._))
@@ -92,7 +92,7 @@ public class JobsPageTest
 
         // The filter is debounced, so the listing reloads a moment after the last keystroke.
         page.WaitForAssertion(() => page.TextOfAll("h2").Should().Equal(["imports"]));
-        A.CallTo(() => context.Api.GetJobs(
+        A.CallTo(() => context.Api.QueryJobs(
                 TestData.SchedulerName,
                 A<DashboardJobQuery>.That.Matches(query => query.GroupContains == "imp" && query.Skip == 0),
                 A<CancellationToken>._))
@@ -166,7 +166,7 @@ public class JobsPageTest
     [Test]
     public void AnApiThatRefusesIsReportedInsteadOfLeavingAStaleListing()
     {
-        A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
             .Throws(new InvalidOperationException("the scheduler is not answering"));
 
         IRenderedComponent<Jobs> page = context.Render<Jobs>();
@@ -178,7 +178,7 @@ public class JobsPageTest
 
     private void GivenJobs(IReadOnlyList<JobKeyDto> jobs)
     {
-        A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
             .ReturnsLazily((string _, DashboardJobQuery query, CancellationToken _) =>
             {
                 List<JobKeyDto> matched = jobs
@@ -200,7 +200,7 @@ public class JobsPageTest
             dtos.Add(new JobGroupDto(name, paused));
         }
 
-        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<JobGroupDto>(dtos));
     }
 }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -61,7 +61,7 @@ public class RemainingPagesTest
     [Test]
     public void CurrentlyExecutingNamesTheNodeThatOwnsEachFiring()
     {
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<FireInstanceDto>([
                 new FireInstanceDto(
                     "fire-1",
@@ -86,7 +86,7 @@ public class RemainingPagesTest
     [Test]
     public void CurrentlyExecutingSaysSoWhenNothingIsRunning()
     {
-        A.CallTo(() => context.Api.GetFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<FireInstanceDto>([]));
 
         IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
@@ -109,7 +109,7 @@ public class RemainingPagesTest
     [Test]
     public void AJobThatIsGoneSaysSoRatherThanRenderingBlanks()
     {
-        A.CallTo(() => context.Api.GetJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.GetJobDetail(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
             .Throws(new InvalidOperationException("no such job"));
 
         IRenderedComponent<JobDetail> page = RenderJobDetail();
@@ -218,7 +218,7 @@ public class RemainingPagesTest
 
     private void GivenJob()
     {
-        A.CallTo(() => context.Api.GetJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.GetJobDetail(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
             .Returns(new JobDetailDto(
                 "job-1",
                 "reports",
@@ -229,7 +229,7 @@ public class RemainingPagesTest
                 ConcurrentExecutionDisallowed: true,
                 PersistJobDataAfterExecution: false,
                 JobDataMap: new JobDataMap { ["TestKey"] = "TestValue" }));
-        A.CallTo(() => context.Api.GetJobTriggers(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.GetTriggersOfJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.TriggerHeaders("nightly", 1));
     }
 

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulerAuthorizationTest.cs
@@ -124,9 +124,9 @@ public class SchedulerAuthorizationTest
 
         // The frame's own header still lists the schedulers the visitor may see — that listing is the
         // filtered one. What must not have happened is any of the reads the page itself makes.
-        A.CallTo(() => context.Api.GetJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobs(A<string>._, A<DashboardJobQuery>._, A<CancellationToken>._))
             .MustNotHaveHappened();
-        A.CallTo(() => context.Api.GetJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryJobGroups(A<string>._, A<DashboardGroupQuery>._, A<CancellationToken>._))
             .MustNotHaveHappened();
     }
 
@@ -144,7 +144,7 @@ public class SchedulerAuthorizationTest
 
         layout.Markup.Should().NotContain("Not authorized");
         layout.FindAll("h1").Should().Contain(heading => heading.TextContent.Trim() == "Jobs");
-        A.CallTo(() => context.Api.GetJobs("acme", A<DashboardJobQuery>._, A<CancellationToken>._)).MustHaveHappened();
+        A.CallTo(() => context.Api.QueryJobs("acme", A<DashboardJobQuery>._, A<CancellationToken>._)).MustHaveHappened();
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulersPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/SchedulersPageTest.cs
@@ -80,7 +80,7 @@ public class SchedulersPageTest
             TestData.Dashboard.SchedulerHeader("reporting"));
         GivenDetail("core", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "core", clustered: true, persistent: true));
         GivenDetail("reporting", TestData.Dashboard.SchedulerDetail(SchedulerStatus.Running, "reporting"));
-        A.CallTo(() => context.Api.GetClusterNodes("core", A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryClusterNodes("core", A<CancellationToken>._))
             .Returns(new List<ClusterNodeDto> { Node("node-a", isCurrent: true), Node("node-b", isCurrent: false) });
 
         IRenderedComponent<Schedulers> page = context.Render<Schedulers>();
@@ -90,7 +90,7 @@ public class SchedulersPageTest
             "a store with no node table answers with the one node it is, so asking is a round trip per "
             + "scheduler for a number that is always one");
 
-        A.CallTo(() => context.Api.GetClusterNodes("reporting", A<CancellationToken>._)).MustNotHaveHappened();
+        A.CallTo(() => context.Api.QueryClusterNodes("reporting", A<CancellationToken>._)).MustNotHaveHappened();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
@@ -52,7 +52,7 @@ public class TriggersPageTest
 
         page.FindAll(".qz-pagination button").First(button => button.TextContent.Trim() == "2").Click();
 
-        A.CallTo(() => context.Api.GetTriggers(
+        A.CallTo(() => context.Api.QueryTriggers(
                 TestData.SchedulerName,
                 A<DashboardTriggerQuery>.That.Matches(query => query.Skip == 25 && query.Take == 25),
                 A<CancellationToken>._))
@@ -70,7 +70,7 @@ public class TriggersPageTest
 
         errorOnly.Click();
 
-        A.CallTo(() => context.Api.GetTriggers(
+        A.CallTo(() => context.Api.QueryTriggers(
                 TestData.SchedulerName,
                 A<DashboardTriggerQuery>.That.Matches(query => query.State == TriggerState.Error && query.Skip == 0),
                 A<CancellationToken>._))
@@ -90,7 +90,7 @@ public class TriggersPageTest
         page.FindAll("button").First(button => button.TextContent.Trim() == "Executing only").Click();
 
         // A narrowed listing has fewer pages, so the page number the reader was on means nothing.
-        A.CallTo(() => context.Api.GetTriggers(
+        A.CallTo(() => context.Api.QueryTriggers(
                 TestData.SchedulerName,
                 A<DashboardTriggerQuery>.That.Matches(query => query.State == TriggerState.Executing && query.Skip == 0),
                 A<CancellationToken>._))
@@ -158,7 +158,7 @@ public class TriggersPageTest
 
         IRenderedComponent<Triggers> page = context.Render<Triggers>();
 
-        A.CallTo(() => context.Api.GetTriggers(
+        A.CallTo(() => context.Api.QueryTriggers(
                 TestData.SchedulerName,
                 A<DashboardTriggerQuery>.That.Matches(query => query.State == TriggerState.Paused),
                 A<CancellationToken>._))
@@ -177,7 +177,7 @@ public class TriggersPageTest
 
         IRenderedComponent<Triggers> page = context.Render<Triggers>();
 
-        A.CallTo(() => context.Api.GetTriggers(
+        A.CallTo(() => context.Api.QueryTriggers(
                 TestData.SchedulerName,
                 A<DashboardTriggerQuery>.That.Matches(query => query.State == null),
                 A<CancellationToken>._))
@@ -189,7 +189,7 @@ public class TriggersPageTest
 
     private void GivenTriggers(IReadOnlyList<TriggerHeaderDto> triggers)
     {
-        A.CallTo(() => context.Api.GetTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
+        A.CallTo(() => context.Api.QueryTriggers(A<string>._, A<DashboardTriggerQuery>._, A<CancellationToken>._))
             .ReturnsLazily((string _, DashboardTriggerQuery query, CancellationToken _) =>
             {
                 List<TriggerHeaderDto> matched = triggers

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardDurationTest.cs
@@ -42,7 +42,7 @@ public class DashboardDurationTest
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(ExecutionContext(scheduler, SubMillisecond), jobException: null);
 
-        PagedResult<DashboardHistoryEntry> page = await store.GetPage(new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
+        PagedResult<DashboardHistoryEntry> page = await store.QueryExecutions(new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
 
         DashboardHistoryEntry entry = page.Items.Should().ContainSingle().Subject;
         entry.Duration.Should().Be(SubMillisecond,
@@ -64,7 +64,7 @@ public class DashboardDurationTest
             ExecutionContext(scheduler, TimeSpan.FromSeconds(2)),
             new JobExecutionException("the job threw"));
 
-        DashboardHistoryEntry entry = (await store.GetPage(new DashboardHistoryQuery { SchedulerName = "TestScheduler" }))
+        DashboardHistoryEntry entry = (await store.QueryExecutions(new DashboardHistoryQuery { SchedulerName = "TestScheduler" }))
             .Items.Should().ContainSingle().Subject;
 
         entry.Succeeded.Should().BeFalse();
@@ -114,17 +114,17 @@ public class DashboardDurationTest
         DashboardHistoryStore store = StoreAtTestTime();
         for (int i = 0; i < 5; i++)
         {
-            await store.Add(EntryAt(new DateTimeOffset(2025, 1, 1, 0, 0, i, TimeSpan.Zero), "job" + i));
+            await store.AddExecution(EntryAt(new DateTimeOffset(2025, 1, 1, 0, 0, i, TimeSpan.Zero), "job" + i));
         }
 
-        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+        PagedResult<DashboardHistoryEntry> page = await store.QueryExecutions(
             new DashboardHistoryQuery { SchedulerName = "TestScheduler", Take = 2 });
 
         page.Items.Select(x => x.JobName).Should().Equal(["job4", "job3"], "history reads newest first");
         page.HasMore.Should().BeTrue();
         page.TotalCount.Should().Be(5, "the total counts the whole match, not the page");
 
-        PagedResult<DashboardHistoryEntry> filtered = await store.GetPage(
+        PagedResult<DashboardHistoryEntry> filtered = await store.QueryExecutions(
             new DashboardHistoryQuery { SchedulerName = "TestScheduler", JobFilter = "job2" });
 
         filtered.Items.Should().ContainSingle().Which.JobName.Should().Be("job2");

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryPluginTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryPluginTest.cs
@@ -32,7 +32,7 @@ public class DashboardHistoryPluginTest
         await plugin.Initialize("history", scheduler);
         await plugin.JobWasExecuted(ExecutionContext(scheduler), jobException: null);
 
-        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+        PagedResult<DashboardHistoryEntry> page = await store.QueryExecutions(
             new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
 
         page.Items.Should().ContainSingle().Which.SchedulerInstanceId.Should().Be("node-a",
@@ -49,7 +49,7 @@ public class DashboardHistoryPluginTest
         await plugin.Initialize("history", scheduler);
         await plugin.TriggerMisfired(MisfiringTrigger(), scheduler);
 
-        PagedResult<DashboardMisfireEntry> misfires = await store.GetMisfires(
+        PagedResult<DashboardMisfireEntry> misfires = await store.QueryMisfires(
             new DashboardMisfireQuery { SchedulerName = "TestScheduler" });
 
         DashboardMisfireEntry entry = misfires.Items.Should().ContainSingle().Subject;
@@ -74,7 +74,7 @@ public class DashboardHistoryPluginTest
         await plugin.Initialize("history", scheduler);
         await plugin.TriggerMisfired(MisfiringTrigger(), scheduler);
 
-        PagedResult<DashboardHistoryEntry> page = await store.GetPage(
+        PagedResult<DashboardHistoryEntry> page = await store.QueryExecutions(
             new DashboardHistoryQuery { SchedulerName = "TestScheduler" });
 
         page.Items.Should().BeEmpty("nothing ran, so there is no execution to show");

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryStoreTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardHistoryStoreTest.cs
@@ -25,7 +25,7 @@ public class DashboardHistoryStoreTest
         FakeTimeProvider clock = new(Start);
         DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromHours(1));
 
-        await store.Add(Entry(Start, "nightly"));
+        await store.AddExecution(Entry(Start, "nightly"));
 
         clock.Advance(TimeSpan.FromMinutes(59));
         (await Page(store)).Items.Should().ContainSingle(
@@ -42,7 +42,7 @@ public class DashboardHistoryStoreTest
         FakeTimeProvider clock = new(Start);
         DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromHours(1));
 
-        await store.Add(Entry(Start, "nightly"));
+        await store.AddExecution(Entry(Start, "nightly"));
         clock.Advance(TimeSpan.FromHours(2));
 
         // nothing is added in between: this scheduler has gone quiet, which is exactly the case a
@@ -60,7 +60,7 @@ public class DashboardHistoryStoreTest
 
         for (int index = 0; index < 5; index++)
         {
-            await store.Add(Entry(Start.AddSeconds(index), "job" + index));
+            await store.AddExecution(Entry(Start.AddSeconds(index), "job" + index));
         }
 
         PagedResult<DashboardHistoryEntry> page = await Page(store);
@@ -75,8 +75,8 @@ public class DashboardHistoryStoreTest
         FakeTimeProvider clock = new(Start);
         DashboardHistoryStore store = Store(clock, retention: TimeSpan.FromMinutes(10), maxEntriesPerScheduler: 100);
 
-        await store.Add(Entry(Start.AddMinutes(-30), "old"));
-        await store.Add(Entry(Start, "fresh"));
+        await store.AddExecution(Entry(Start.AddMinutes(-30), "old"));
+        await store.AddExecution(Entry(Start, "fresh"));
 
         PagedResult<DashboardHistoryEntry> page = await Page(store);
 
@@ -89,8 +89,8 @@ public class DashboardHistoryStoreTest
     {
         DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
 
-        await store.Add(Entry(Start, "on-a", node: "node-a"));
-        await store.Add(Entry(Start, "on-b", node: "node-b"));
+        await store.AddExecution(Entry(Start, "on-a", node: "node-a"));
+        await store.AddExecution(Entry(Start, "on-b", node: "node-b"));
 
         PagedResult<DashboardHistoryEntry> everywhere = await Page(store);
         everywhere.Items.Should().HaveCount(2, "an unfiltered query is every node's");
@@ -105,13 +105,13 @@ public class DashboardHistoryStoreTest
     {
         DashboardHistoryStore store = Store(new FakeTimeProvider(Start));
 
-        await store.Add(Entry(Start, "ran"));
+        await store.AddExecution(Entry(Start, "ran"));
         await store.AddMisfire(Misfire(Start, "nightly"));
 
         (await Page(store)).Items.Should().ContainSingle(
             "a misfire is not an execution — nothing ran — so it must not appear in the history");
 
-        PagedResult<DashboardMisfireEntry> misfires = await store.GetMisfires(
+        PagedResult<DashboardMisfireEntry> misfires = await store.QueryMisfires(
             new DashboardMisfireQuery { SchedulerName = SchedulerName, IncludeTotalCount = true });
 
         DashboardMisfireEntry misfire = misfires.Items.Should().ContainSingle().Subject;
@@ -131,13 +131,13 @@ public class DashboardHistoryStoreTest
         await store.AddMisfire(Misfire(Start.AddSeconds(1), "two"));
         await store.AddMisfire(Misfire(Start.AddSeconds(2), "three"));
 
-        PagedResult<DashboardMisfireEntry> capped = await store.GetMisfires(
+        PagedResult<DashboardMisfireEntry> capped = await store.QueryMisfires(
             new DashboardMisfireQuery { SchedulerName = SchedulerName });
         capped.Items.Select(entry => entry.TriggerName).Should().Equal(["three", "two"],
             "the cap is per feed, and the misfire feed is not exempt from it");
 
         clock.Advance(TimeSpan.FromHours(2));
-        PagedResult<DashboardMisfireEntry> aged = await store.GetMisfires(
+        PagedResult<DashboardMisfireEntry> aged = await store.QueryMisfires(
             new DashboardMisfireQuery { SchedulerName = SchedulerName });
         aged.Items.Should().BeEmpty("the retention window covers misfires too");
     }
@@ -165,7 +165,7 @@ public class DashboardHistoryStoreTest
         await store.AddMisfire(Misfire(Start, "on-a", node: "node-a"));
         await store.AddMisfire(Misfire(Start, "on-b", node: "node-b"));
 
-        PagedResult<DashboardMisfireEntry> onA = await store.GetMisfires(
+        PagedResult<DashboardMisfireEntry> onA = await store.QueryMisfires(
             new DashboardMisfireQuery { SchedulerName = SchedulerName, SchedulerInstanceId = "node-a" });
 
         onA.Items.Should().ContainSingle().Which.TriggerName.Should().Be("on-a");
@@ -181,7 +181,7 @@ public class DashboardHistoryStoreTest
 
     private static ValueTask<PagedResult<DashboardHistoryEntry>> Page(DashboardHistoryStore store, string? node = null)
     {
-        return store.GetPage(new DashboardHistoryQuery
+        return store.QueryExecutions(new DashboardHistoryQuery
         {
             SchedulerName = SchedulerName,
             SchedulerInstanceId = node,

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardPluginRegistrationTest.cs
@@ -130,7 +130,7 @@ public class DashboardPluginRegistrationTest
         await plugin.Initialize("quartzDashboardHistory", scheduler);
         await plugin.JobWasExecuted(ExecutionContext(scheduler), jobException: null);
 
-        PagedResult<DashboardHistoryEntry> page = await store.GetPage(new DashboardHistoryQuery { SchedulerName = "acme" });
+        PagedResult<DashboardHistoryEntry> page = await store.QueryExecutions(new DashboardHistoryQuery { SchedulerName = "acme" });
         page.Items.Should().ContainSingle("the plugin resolves its store from the container it was built with")
             .Which.JobName.Should().Be("DummyJob");
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -162,7 +162,7 @@ public class InProcessQuartzApiClientTest
             await scheduler.AddJob(job, new AddJobOptions { Replace = true });
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            JobDetailDto dto = await client.GetJob(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
+            JobDetailDto dto = await client.GetJobDetail(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
 
             dto.JobDataMap["Name"].Should().Be("abc");
             dto.JobDataMap["Count"].Should().Be(5);
@@ -228,7 +228,7 @@ public class InProcessQuartzApiClientTest
                     .WithCronSchedule("0 0 1 * * ?").Build());
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            List<TriggerHeaderDto> headers = await client.GetJobTriggers(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
+            List<TriggerHeaderDto> headers = await client.GetTriggersOfJob(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
 
             headers.Should().HaveCount(2);
             TriggerHeaderDto simple = headers.Single(h => h.Name == "simple");
@@ -243,7 +243,7 @@ public class InProcessQuartzApiClientTest
                 "the states come from the single trigger query the associated triggers table used to make one call per trigger for");
 
             await scheduler.PauseTrigger(new TriggerKey("cron", "group1"));
-            headers = await client.GetJobTriggers(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
+            headers = await client.GetTriggersOfJob(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name));
 
             headers.Single(h => h.Name == "cron").State.Should().Be(TriggerState.Paused, "each header carries its own trigger's state");
             headers.Single(h => h.Name == "simple").State.Should().Be(TriggerState.Normal);
@@ -272,20 +272,20 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            PagedResult<JobKeyDto> firstPage = await client.GetJobs(scheduler.SchedulerName, new DashboardJobQuery { Take = 25 });
+            PagedResult<JobKeyDto> firstPage = await client.QueryJobs(scheduler.SchedulerName, new DashboardJobQuery { Take = 25 });
             firstPage.Items.Should().HaveCount(25, "the page size limits what the store returns");
             firstPage.TotalCount.Should().Be(30, "the total is counted regardless of paging");
             firstPage.HasMore.Should().BeTrue("30 jobs do not fit on one page of 25");
             firstPage.Items[0].Name.Should().Be("job01", "results are ordered by group and then name");
 
-            PagedResult<JobKeyDto> secondPage = await client.GetJobs(scheduler.SchedulerName, new DashboardJobQuery { Skip = 25, Take = 25 });
+            PagedResult<JobKeyDto> secondPage = await client.QueryJobs(scheduler.SchedulerName, new DashboardJobQuery { Skip = 25, Take = 25 });
             secondPage.Items.Should().HaveCount(5, "the second page holds the remainder");
             secondPage.Items.Select(x => x.Name).Should().Equal(["job26", "job27", "job28", "job29", "job30"],
                 "page 2 continues where page 1 ended");
             secondPage.HasMore.Should().BeFalse("nothing matches beyond the second page");
             secondPage.TotalCount.Should().Be(30);
 
-            PagedResult<JobKeyDto> countOnly = await client.GetJobs(scheduler.SchedulerName, new DashboardJobQuery { Take = 0 });
+            PagedResult<JobKeyDto> countOnly = await client.QueryJobs(scheduler.SchedulerName, new DashboardJobQuery { Take = 0 });
             countOnly.Items.Should().BeEmpty("a page size of zero fetches no items");
             countOnly.TotalCount.Should().Be(30, "the dashboard total jobs tile is a count query, not a materialized list");
         }
@@ -306,7 +306,7 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            PagedResult<JobKeyDto> filtered = await client.GetJobs(scheduler.SchedulerName, new DashboardJobQuery { GroupContains = "mpor", Take = 25 });
+            PagedResult<JobKeyDto> filtered = await client.QueryJobs(scheduler.SchedulerName, new DashboardJobQuery { GroupContains = "mpor", Take = 25 });
 
             filtered.Items.Should().ContainSingle("the group filter matches groups that contain it")
                 .Which.Group.Should().Be("imports");
@@ -346,24 +346,24 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            PagedResult<TriggerHeaderDto> firstPage = await client.GetTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 25 });
+            PagedResult<TriggerHeaderDto> firstPage = await client.QueryTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 25 });
             firstPage.Items.Should().HaveCount(25);
             firstPage.TotalCount.Should().Be(30);
             firstPage.HasMore.Should().BeTrue("30 triggers do not fit on one page of 25");
             firstPage.Items[0].State.Should().Be(TriggerState.Paused, "the header carries the state the listing used to fetch per trigger");
             firstPage.Items[0].ExecutionGroup.Should().Be("imports", "the header carries the execution group without loading the trigger");
 
-            PagedResult<TriggerHeaderDto> secondPage = await client.GetTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Skip = 25, Take = 25 });
+            PagedResult<TriggerHeaderDto> secondPage = await client.QueryTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Skip = 25, Take = 25 });
             secondPage.Items.Select(x => x.Name).Should().Equal(["trigger26", "trigger27", "trigger28", "trigger29", "trigger30"],
                 "page 2 continues where page 1 ended");
             secondPage.HasMore.Should().BeFalse();
             secondPage.Items[^1].State.Should().Be(TriggerState.Normal, "the last four triggers were never paused");
 
-            PagedResult<TriggerHeaderDto> pausedCount = await client.GetTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Paused });
+            PagedResult<TriggerHeaderDto> pausedCount = await client.QueryTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Paused });
             pausedCount.TotalCount.Should().Be(26,
                 "a state-filtered count is exact, where the dashboard tile used to count states over the first 25 items only");
 
-            PagedResult<TriggerHeaderDto> errorCount = await client.GetTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Error });
+            PagedResult<TriggerHeaderDto> errorCount = await client.QueryTriggers(scheduler.SchedulerName, new DashboardTriggerQuery { Take = 0, State = TriggerState.Error });
             errorCount.Items.Should().BeEmpty();
             errorCount.TotalCount.Should().Be(0, "no trigger has failed, and the error tile reports that exactly");
         }
@@ -458,7 +458,7 @@ public class InProcessQuartzApiClientTest
             // in process there is no serializer between the page and the scheduler, so a value keeps
             // the type it was given rather than the one a JSON reader would have guessed
             JobDataMap overrides = new() { ["Count"] = 5 };
-            await client.TriggerJobWithData(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name), overrides);
+            await client.TriggerJob(scheduler.SchedulerName, new JobKeyDto(jobKey.Group, jobKey.Name), overrides);
 
             PagedResult<TriggerHeader> triggers = await scheduler.QueryTriggers(new TriggerQuery { Job = jobKey });
             triggers.Items.Should().ContainSingle("triggering a job now schedules the one-off trigger that fires it");
@@ -501,7 +501,7 @@ public class InProcessQuartzApiClientTest
             await scheduler.PauseJobs(GroupMatcher<JobKey>.GroupEquals("paused"));
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            PagedResult<JobGroupDto> groups = await client.GetJobGroups(scheduler.SchedulerName, new DashboardGroupQuery());
+            PagedResult<JobGroupDto> groups = await client.QueryJobGroups(scheduler.SchedulerName, new DashboardGroupQuery());
 
             groups.Items.Select(x => x.Name).Should().Contain(["paused", "running"], "every job group is listed");
             groups.Items.Single(x => x.Name == "paused").Paused.Should().BeTrue("the group was paused");
@@ -542,10 +542,10 @@ public class InProcessQuartzApiClientTest
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            PagedResult<TriggerGroupDto> pausedTriggerGroups = await client.GetTriggerGroups(
+            PagedResult<TriggerGroupDto> pausedTriggerGroups = await client.QueryTriggerGroups(
                 scheduler.SchedulerName,
                 new DashboardGroupQuery { Take = 0, Paused = true });
-            PagedResult<JobGroupDto> pausedJobGroups = await client.GetJobGroups(
+            PagedResult<JobGroupDto> pausedJobGroups = await client.QueryJobGroups(
                 scheduler.SchedulerName,
                 new DashboardGroupQuery { Take = 0, Paused = true });
 
@@ -574,7 +574,7 @@ public class InProcessQuartzApiClientTest
             await scheduler.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals("paused"));
 
             InProcessQuartzApiClient client = CreateClient(scheduler);
-            PagedResult<TriggerGroupDto> groups = await client.GetTriggerGroups(scheduler.SchedulerName, new DashboardGroupQuery());
+            PagedResult<TriggerGroupDto> groups = await client.QueryTriggerGroups(scheduler.SchedulerName, new DashboardGroupQuery());
 
             groups.Items.Select(x => x.Name).Should().Contain(["paused", "running"], "every trigger group is listed");
             groups.Items.Single(x => x.Name == "paused").Paused.Should().BeTrue("the group was paused");
@@ -722,7 +722,7 @@ public class InProcessQuartzApiClientTest
         {
             InProcessQuartzApiClient client = CreateClient(scheduler);
 
-            List<ClusterNodeDto> nodes = await client.GetClusterNodes(scheduler.SchedulerName);
+            List<ClusterNodeDto> nodes = await client.QueryClusterNodes(scheduler.SchedulerName);
 
             ClusterNodeDto node = nodes.Should().ContainSingle().Subject;
             node.InstanceId.Should().Be(scheduler.SchedulerInstanceId);
@@ -808,6 +808,54 @@ public class InProcessQuartzApiClientTest
         }
     }
 
+    /// <summary>
+    /// The history feeds answer for themselves. A store holding nothing has an empty page and a count of
+    /// zero, which is the only "no history" answer there is: the nullable returns these replace meant
+    /// "this data source keeps no history", which was the deleted HTTP-backed client's 404 and never a
+    /// thing an in-process store could say.
+    /// </summary>
+    [Test]
+    public async Task TheHistoryFeedsAnswerWithAPageEvenWhenNothingWasRecorded()
+    {
+        IScheduler scheduler = await CreateScheduler(nameof(TheHistoryFeedsAnswerWithAPageEvenWhenNothingWasRecorded));
+        try
+        {
+            DashboardHistoryStore store = TestData.Dashboard.HistoryStore();
+            InProcessQuartzApiClient client = CreateClient(scheduler, store);
+            DashboardHistoryQuery historyQuery = new() { SchedulerName = scheduler.SchedulerName };
+            DashboardMisfireQuery misfireQuery = new() { SchedulerName = scheduler.SchedulerName };
+
+            PagedResult<DashboardHistoryEntry> executions = await client.QueryExecutions(historyQuery);
+            PagedResult<DashboardMisfireEntry> misfires = await client.QueryMisfires(misfireQuery);
+            int misfireCount = await client.CountMisfires(scheduler.SchedulerName, DateTimeOffset.MinValue);
+
+            executions.Items.Should().BeEmpty("nothing has run, which is an empty page rather than no page");
+            misfires.Items.Should().BeEmpty("nothing has misfired, which is an empty page rather than no page");
+            misfireCount.Should().Be(0);
+
+            await store.AddExecution(new DashboardHistoryEntry(
+                SchedulerName: scheduler.SchedulerName,
+                SchedulerInstanceId: scheduler.SchedulerInstanceId,
+                JobGroup: "reports",
+                JobName: "rollup",
+                TriggerGroup: "nightly",
+                TriggerName: "midnight",
+                FiredAtUtc: DateTimeOffset.UtcNow,
+                Duration: TimeSpan.FromSeconds(1),
+                Succeeded: true,
+                ExceptionMessage: null));
+
+            executions = await client.QueryExecutions(historyQuery);
+
+            executions.Items.Should().ContainSingle("the client reads the store it was given, unchanged")
+                .Which.SchedulerName.Should().Be(scheduler.SchedulerName);
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string testName)
     {
         NameValueCollection properties = new()
@@ -821,13 +869,21 @@ public class InProcessQuartzApiClientTest
 
     private static InProcessQuartzApiClient CreateClient(IScheduler scheduler, params string[] registeredButNotCreated)
     {
+        return CreateClient(scheduler, TestData.Dashboard.HistoryStore(), registeredButNotCreated);
+    }
+
+    private static InProcessQuartzApiClient CreateClient(
+        IScheduler scheduler,
+        IDashboardHistoryStore historyStore,
+        params string[] registeredButNotCreated)
+    {
         SchedulerRepository repository = new();
         repository.Bind(scheduler);
         return new InProcessQuartzApiClient(
             repository,
             new StubSchedulerRegistry(repository, registeredButNotCreated),
             Options.Create(new QuartzDashboardOptions()),
-            TestData.Dashboard.HistoryStore());
+            historyStore);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -243,52 +243,51 @@ namespace Quartz.Dashboard.Services
     }
     public interface IDashboardHistoryStore
     {
-        System.Threading.Tasks.ValueTask Add(Quartz.Dashboard.Services.DashboardHistoryEntry entry, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask AddExecution(Quartz.Dashboard.Services.DashboardHistoryEntry entry, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddMisfire(Quartz.Dashboard.Services.DashboardMisfireEntry entry, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>> GetMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>> GetPage(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>> QueryExecutions(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>> QueryMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IQuartzApiClient
     {
         System.Threading.Tasks.ValueTask AddCalendar(string schedulerName, Quartz.Dashboard.Services.AddCalendarRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddJob(string schedulerName, Quartz.Dashboard.Services.AddJobRequest request, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<int?> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<int> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ClusterNodeDto>> GetClusterNodes(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.FireInstanceDto>> GetFireInstances(string schedulerName, Quartz.Dashboard.Services.DashboardFireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>?> GetHistory(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.JobDetailDto> GetJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobGroupDto>> GetJobGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.TriggerHeaderDto>> GetJobTriggers(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobKeyDto>> GetJobs(string schedulerName, Quartz.Dashboard.Services.DashboardJobQuery query, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>?> GetMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.JobDetailDto> GetJobDetail(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.SchedulerDetailDto> GetScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.SchedulerHeaderDto>> GetSchedulers(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ITrigger> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerGroupDto>> GetTriggerGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerHeaderDto>> GetTriggers(string schedulerName, Quartz.Dashboard.Services.DashboardTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask Interrupt(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask InterruptJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask PauseAll(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> PauseJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> PauseTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.ClusterNodeDto>> QueryClusterNodes(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardHistoryEntry>> QueryExecutions(Quartz.Dashboard.Services.DashboardHistoryQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.FireInstanceDto>> QueryFireInstances(string schedulerName, Quartz.Dashboard.Services.DashboardFireInstanceQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobGroupDto>> QueryJobGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.JobKeyDto>> QueryJobs(string schedulerName, Quartz.Dashboard.Services.DashboardJobQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.DashboardMisfireEntry>> QueryMisfires(Quartz.Dashboard.Services.DashboardMisfireQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerGroupDto>> QueryTriggerGroups(string schedulerName, Quartz.Dashboard.Services.DashboardGroupQuery query, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.PagedResult<Quartz.Dashboard.Services.TriggerHeaderDto>> QueryTriggers(string schedulerName, Quartz.Dashboard.Services.DashboardTriggerQuery query, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask RescheduleJob(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, Quartz.Dashboard.Services.RescheduleRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> ResetTriggerFromErrorState(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ResumeAll(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> ResumeJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> ResumeTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask ScheduleJob(string schedulerName, Quartz.Dashboard.Services.ScheduleJobRequest request, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask ShutdownScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask StandbyScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask StartScheduler(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask TriggerJobWithData(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, Quartz.JobDataMap jobDataMap, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask Shutdown(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask Standby(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask Start(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask TriggerJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, Quartz.JobDataMap? jobDataMap = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask UnscheduleJob(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class JobDetailDto : System.IEquatable<Quartz.Dashboard.Services.JobDetailDto>

--- a/src/Quartz.Tests.Unit/Simpl/BuiltInTriggerSerializerDerivationTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/BuiltInTriggerSerializerDerivationTest.cs
@@ -1,0 +1,161 @@
+using System.Text;
+using System.Text.Json;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.Triggers;
+using Quartz.Serialization.Newtonsoft;
+using Quartz.Serialization.SystemTextJson;
+
+using StjJsonSerializerOptions = System.Text.Json.JsonSerializerOptions;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// The built-in trigger serializers are public and unsealed on purpose, in both packages: a trigger
+/// deriving from a built-in trigger pairs with a serializer deriving from that trigger's built-in
+/// serializer, which calls the base for the built-in fields so their stored shape stays the built-in
+/// one rather than a hand-copy that has to be kept in step with it.
+/// </summary>
+/// <remarks>
+/// The ADO smoke tests exercise the same seam, but only where a database is running. This is its guard
+/// at unit speed, so that making a built-in serializer internal — or sealing one — fails here first.
+/// </remarks>
+public class BuiltInTriggerSerializerDerivationTest
+{
+    [Test]
+    public void ANewtonsoftSerializerDerivesFromTheBuiltInOneAndKeepsItsFields()
+    {
+        NewtonsoftJsonSerializerRegistry registry = new NewtonsoftJsonSerializerRegistry()
+            .AddTriggerSerializer<ReportTrigger>(new ReportTriggerNewtonsoftSerializer());
+        NewtonsoftJsonObjectSerializer serializer = new(registry);
+
+        byte[] payload = serializer.Serialize(CreateTrigger());
+
+        Encoding.UTF8.GetString(payload).Should().Contain("CronExpressionString",
+            "the built-in serializer's base call is what writes the cron half of the payload");
+
+        ReportTrigger restored = serializer.Deserialize<ReportTrigger>(payload);
+
+        AssertRoundTripped(restored);
+    }
+
+    [Test]
+    public void ASystemTextJsonSerializerDerivesFromTheBuiltInOneAndKeepsItsFields()
+    {
+        SystemTextJsonSerializerRegistry registry = new SystemTextJsonSerializerRegistry()
+            .AddTriggerSerializer<ReportTrigger>(new ReportTriggerSystemTextJsonSerializer());
+        SystemTextJsonObjectSerializer serializer = new(registry);
+
+        byte[] payload = serializer.Serialize(CreateTrigger());
+
+        Encoding.UTF8.GetString(payload).Should().Contain("CronExpressionString",
+            "the built-in serializer's base call is what writes the cron half of the payload");
+
+        ReportTrigger restored = serializer.Deserialize<ReportTrigger>(payload);
+
+        AssertRoundTripped(restored);
+    }
+
+    private static ReportTrigger CreateTrigger()
+    {
+        return new ReportTrigger
+        {
+            Key = new TriggerKey("nightly", "reports"),
+            JobKey = new JobKey("rollup", "reports"),
+            CronExpressionString = "0 0 3 * * ?",
+            TimeZone = TimeZoneInfo.Utc,
+            Report = "daily-revenue"
+        };
+    }
+
+    private static void AssertRoundTripped(ReportTrigger restored)
+    {
+        restored.Should().NotBeNull();
+        restored.CronExpressionString.Should().Be("0 0 3 * * ?",
+            "the built-in half of the payload is read back by the built-in serializer's own fields");
+        restored.TimeZone.Should().Be(TimeZoneInfo.Utc);
+        restored.Report.Should().Be("daily-revenue",
+            "the derived half is the only part the subclass writes itself");
+        restored.HasAdditionalProperties.Should().BeTrue(
+            "a trigger that adds properties to a built-in one is what this pairing exists for");
+    }
+
+    /// <summary>
+    /// A cron trigger with something added, which is what <c>HasAdditionalProperties</c> announces.
+    /// </summary>
+    private sealed class ReportTrigger : CronTriggerImpl
+    {
+        public override bool HasAdditionalProperties => true;
+
+        public string Report { get; set; } = "";
+    }
+
+    private sealed class ReportTriggerNewtonsoftSerializer : Serialization.Newtonsoft.Triggers.CronTriggerSerializer
+    {
+        public override string TriggerTypeName => "ReportTrigger";
+
+        public override IScheduleBuilder CreateScheduleBuilder(JObject source)
+        {
+            return new ReportTriggerScheduleBuilder(
+                source.Value<string>("CronExpressionString")!,
+                TimeZones.FindById(source.Value<string>("TimeZone")!));
+        }
+
+        protected override void SerializeFields(JsonWriter writer, ICronTrigger trigger)
+        {
+            base.SerializeFields(writer, trigger);
+            writer.WritePropertyName("Report");
+            writer.WriteValue(((ReportTrigger) trigger).Report);
+        }
+
+        protected override void DeserializeFields(ICronTrigger trigger, JObject source)
+        {
+            base.DeserializeFields(trigger, source);
+            ((ReportTrigger) trigger).Report = source.Value<string>("Report")!;
+        }
+    }
+
+    private sealed class ReportTriggerSystemTextJsonSerializer : Serialization.SystemTextJson.Triggers.CronTriggerSerializer
+    {
+        public override string TriggerTypeName => "ReportTrigger";
+
+        public override IScheduleBuilder CreateScheduleBuilder(JsonElement jsonElement, StjJsonSerializerOptions options)
+        {
+            return new ReportTriggerScheduleBuilder(
+                jsonElement.GetProperty("CronExpressionString").GetString()!,
+                TimeZones.FindById(jsonElement.GetProperty("TimeZone").GetString()!));
+        }
+
+        protected override void SerializeFields(Utf8JsonWriter writer, ICronTrigger trigger, StjJsonSerializerOptions options)
+        {
+            base.SerializeFields(writer, trigger, options);
+            writer.WriteString("Report", ((ReportTrigger) trigger).Report);
+        }
+
+        protected override void DeserializeFields(ICronTrigger trigger, JsonElement jsonElement, StjJsonSerializerOptions options)
+        {
+            base.DeserializeFields(trigger, jsonElement, options);
+            ((ReportTrigger) trigger).Report = jsonElement.GetProperty("Report").GetString()!;
+        }
+    }
+
+    /// <summary>
+    /// Builds the subclass rather than the built-in trigger, which is the one thing a derived serializer
+    /// cannot inherit: the built-in schedule builder knows only the built-in type.
+    /// </summary>
+    private sealed class ReportTriggerScheduleBuilder(string cronExpression, TimeZoneInfo timeZone) : IScheduleBuilder
+    {
+        public IMutableTrigger Build()
+        {
+            return new ReportTrigger
+            {
+                CronExpressionString = cronExpression,
+                TimeZone = timeZone
+            };
+        }
+    }
+}


### PR DESCRIPTION
Closes #3600 — the dashboard half of the issue, plus a ratification and a docs correction where the serializer half would have gone.

Rebased onto `bf12a6531` (#3619).

## The dashboard's client speaks the scheduler's vocabulary

`IQuartzApiClient` now spells an operation the way `IScheduler` spells it. DTO suffixes and `PagedResult<T>` returns are unchanged.

| Before | After |
|---|---|
| `StartScheduler`, `StandbyScheduler`, `ShutdownScheduler` | `Start`, `Standby`, `Shutdown` |
| `InterruptJob` | `Interrupt` (`InterruptFireInstance` unchanged) |
| `TriggerJob(name, key)` **and** `TriggerJobWithData(name, key, JobDataMap)` | one `TriggerJob(name, key, JobDataMap? jobDataMap = null)` |
| `GetJobs`, `GetJobGroups`, `GetTriggers`, `GetTriggerGroups`, `GetFireInstances`, `GetClusterNodes` | `QueryJobs`, `QueryJobGroups`, `QueryTriggers`, `QueryTriggerGroups`, `QueryFireInstances`, `QueryClusterNodes` |
| `GetJob` → `JobDetailDto` | `GetJobDetail` |
| `GetJobTriggers` | `GetTriggersOfJob` |
| `GetHistory`, `GetMisfires` | `QueryExecutions`, `QueryMisfires` |
| `IDashboardHistoryStore.Add`, `GetPage`, `GetMisfires` | `AddExecution`, `QueryExecutions`, `QueryMisfires` (`AddMisfire`, `CountMisfires` unchanged) |

Beyond the issue's enumerated list: `GetClusterNodes` → `QueryClusterNodes` (`IScheduler.QueryClusterNodes`, same return shape), `GetJob` → `GetJobDetail` (AGENTS.md: the scheduler's noun is `JobDetail`) and `GetJobTriggers` → `GetTriggersOfJob` (`IScheduler.GetTriggersOfJob`). **Not** renamed: `GetSchedulers` / `GetScheduler`, which read the container's registrations and have no scheduler counterpart, and `GetCalendarNames`, which drains *every* page of `IScheduler.QueryCalendarNames` — naming it `Query*` would promise a paged query it does not take.

### Nullability, unified honestly

`QueryExecutions`, `QueryMisfires` and `CountMisfires` are non-nullable now. The `?` existed because the deleted HTTP-backed client turned a 404 into "this data source keeps no history"; `IDashboardHistoryStore` returns non-nullable pages and an `int`, so in-process that answer never existed. A store holding nothing returns an empty page and a count of zero.

`CountMisfires` was not in the issue's list — it carried the same dead `null` for the same dead reason. Two consequences:

- the History page's "Execution history is unavailable for the current API backend" branch is gone (dead once the return is non-null), replaced by the existing empty-page message. `AStoreThatKeepsNoHistorySaysSoInsteadOfShowingAnEmptyPage` became `AStoreHoldingNothingShowsAnEmptyPageRatherThanAFault`.
- `ADataSourceThatKeepsNoMisfiresSaysSoRatherThanReportingZero` became `ATileOverNoSchedulerSaysSoRatherThanReportingZero`: the overview's dash-not-zero distinction survives, but the state that produces it is "no scheduler has answered yet" rather than "the data source keeps no feed".

`IQuartzDashboardHubClient` is untouched: its `Task` returns and its public visibility are SignalR's requirement, and `QuartzDashboardHubClientProxyTest` guards them.

`DelegatingScheduler`, `DelegatingJobStore` and `HttpScheduler` (the issue's third dashboard clause) stay public — verified, not skipped: the first two are taught as derivation seams in `how-tos/custom-job-store.md` and the migration guide, and `HttpScheduler` is the HTTP client package's product type.

## The trigger serializer seam is settled, and the docs now say what the code does

The issue also asked for the built-in trigger serializers to go internal in both packages. **They stay public and unsealed.** Commit `5f442177d` ratified that seam deliberately three weeks ago, the persistence-delegate how-to teaches it ("the built-in serializers are public and unsealed on purpose"), and the migration guide gives it as the reason `AddTriggerSerializer<TTrigger>` keeps its `ITriggerSerializer` parameter. `Quartz` and `Quartz.Serialization.Newtonsoft` therefore have **no public-API delta in this PR**: `PublicApiTest_Quartz.verified.txt` and `PublicApiTest_Quartz.Serialization.Newtonsoft.verified.txt` are byte-identical to `main`, and `Quartz.Serialization.Newtonsoft` keeps its twelve public types.

Two things go with that ruling:

**A unit-level guard for the seam.** `BuiltInTriggerSerializerDerivationTest` round-trips a `ReportTrigger : CronTriggerImpl` (with `HasAdditionalProperties`) through a serializer deriving from the built-in `CronTriggerSerializer` in *each* package, calling `base.SerializeFields` / `base.DeserializeFields`. Until now the seam was only exercised by the ADO smoke tests, which need a database; making a built-in serializer internal or sealed will now fail a 100 ms unit test instead.

**The stale "sealed" claims are corrected — the docs were wrong, not the types.** All five `*TriggerImpl` types are `public class` on `main` and in the API baseline; three of them were sealed during 4.x's development and were reopened precisely so the serializer pairing works. Three places still said otherwise:

- `migration-guide.md`, "The shipped implementations are sealed" — the trigger row is removed, and a paragraph now states the pairing (derive from a built-in trigger, derive from its built-in serializer) and why the three were reopened.
- `migration-guide.md`, the `BLOB_TRIGGERS` section — "deriving from `CronTriggerImpl` or `SimpleTriggerImpl` (the two that are still open)" is now all five, and `RecurrenceTriggerImpl`'s "it is `sealed`, so `HasAdditionalProperties` cannot be overridden to `true`" is dropped; what is true is that it carries no `[Serializable]` and is written to `SIMPROP_TRIGGERS` by its persistence delegate.
- `how-tos/trigger-persistence-delegate.md` — the tip claiming only `SimpleTriggerImpl` and `CronTriggerImpl` are subclassable now says all five are, and points at the serializer pairing below it.

## Verification

On `55e1b3474`, rebased onto `bf12a6531`:

```
dotnet build Quartz.slnx                        Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit               Passed! Failed: 0, Passed: 4794, Skipped: 36
dotnet test src/Quartz.Tests.AspNetCore         Passed! Failed: 0, Passed: 549
dotnet fallout VerifyDocsSnippets               Documentation snippets are up to date (102 markdown files checked)
npm run docs:check-links                        220 pages, 1070 internal links, 650 fragments - no dead links or anchors
```

Earlier on the pre-rebase head, when this branch still touched the serializer packages: `AdoJobStoreSmokeTest.TestSQLite` passed (6 tests, the container-free half of the ADO suite). Those files are untouched now, so the run no longer covers anything this PR changes. `Quartz.Benchmark` names no serializer or dashboard type; no benchmark-visible type moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
