### PR TITLE
A macro means the same schedule on the hash path as everywhere else

### DIFF
--- a/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionHashTest.cs
@@ -559,6 +559,105 @@ public class CronExpressionHashTest
                 "and the same holds for a seed");
     }
 
+    // --- Macros on the hash path ---
+
+    /// <summary>
+    /// A macro names a whole schedule rather than a field, so it carries no <c>H</c> token and has
+    /// nothing to resolve - but it still has to survive the hash path. Issue #3626: hash resolution
+    /// counts fields before anything is parsed, and it ran ahead of the constructor's macro expansion,
+    /// so a one-field macro was rejected as malformed before anything looked at what it said.
+    /// </summary>
+    [TestCase("@yearly", "0 0 0 1 1 ?")]
+    [TestCase("@annually", "0 0 0 1 1 ?")]
+    [TestCase("@monthly", "0 0 0 1 * ?")]
+    [TestCase("@weekly", "0 0 0 ? * SUN")]
+    [TestCase("@daily", "0 0 0 * * ?")]
+    [TestCase("@midnight", "0 0 0 * * ?")]
+    [TestCase("@hourly", "0 0 * * * ?")]
+    public void ResolveHash_Macro_ExpandsItRatherThanCountingItsFields(string macro, string expanded)
+    {
+        CronExpression.ResolveHash(macro, "key").Should().Be(expanded,
+            "a macro is expanded wherever an expression string is read, the hash path included");
+
+        CronExpression.ResolveHash(macro, 42).Should().Be(expanded,
+            "and the seeded overload reads the same expression as the keyed one");
+    }
+
+    [TestCase("@daily", "0 0 0 * * ?")]
+    [TestCase("@weekly", "0 0 0 ? * SUN")]
+    public void ParseWithHash_Macro_ParsesToTheScheduleTheMacroNames(string macro, string expanded)
+    {
+        CronExpression.ParseWithHash(macro, "nightly").CronExpressionString.Should().Be(expanded);
+        CronExpression.ParseWithHash(macro, 42).CronExpressionString.Should().Be(expanded);
+    }
+
+    [TestCase("@daily", "0 0 0 * * ?")]
+    [TestCase("@weekly", "0 0 0 ? * SUN")]
+    public void TryParseWithHash_Macro_SucceedsRatherThanReportingItInvalid(string macro, string expanded)
+    {
+        CronExpression.TryParseWithHash(macro, "nightly", out CronExpression result).Should().BeTrue(
+            "a validator that rejects what its own parser accepts sends the caller to fix an expression that was never wrong");
+
+        result.CronExpressionString.Should().Be(expanded);
+    }
+
+    /// <summary>
+    /// The round trip the fix exists for: every door into the parser has to answer the same thing for
+    /// the same string. The constructor expands macros, so the hash path has to agree with it.
+    /// </summary>
+    [TestCase("@yearly")]
+    [TestCase("@annually")]
+    [TestCase("@monthly")]
+    [TestCase("@weekly")]
+    [TestCase("@daily")]
+    [TestCase("@midnight")]
+    [TestCase("@hourly")]
+    public void AMacroMeansTheSameThroughTheHashPathAsThroughTheConstructor(string macro)
+    {
+        string throughTheConstructor = new CronExpression(macro).CronExpressionString;
+
+        CronExpression.ParseWithHash(macro, "nightly").CronExpressionString
+            .Should().Be(throughTheConstructor, "ParseWithHash is a parse, and a parse reads the macro");
+        CronExpression.ParseWithHash(macro, 42).CronExpressionString
+            .Should().Be(throughTheConstructor);
+        CronExpression.ResolveHash(macro, "nightly")
+            .Should().Be(throughTheConstructor, "and the resolved string is what the constructor would have held");
+
+        CronExpression.TryParseWithHash(macro, "nightly", out CronExpression tried).Should().BeTrue();
+        tried.CronExpressionString.Should().Be(throughTheConstructor);
+
+        CronExpression.ParseWithHash(macro, "nightly")
+            .Should().Be(CronExpression.Parse(macro), "the two entry points build equal expressions, not merely equal strings");
+    }
+
+    [Test]
+    public void ResolveHash_UnsupportedMacro_ExplainsTheMacroRatherThanTheFieldCount()
+    {
+        Action reboot = () => CronExpression.ResolveHash("@reboot", "key");
+        reboot.Should().Throw<FormatException>()
+            .WithMessage("*reboot*", "the macro's own rejection is the one that names the fix; a field count teaches nothing here");
+
+        Action unknown = () => CronExpression.ResolveHash("@nightly", "key");
+        unknown.Should().Throw<FormatException>()
+            .WithMessage("*@daily*", "an unknown macro is answered with the set that does exist");
+    }
+
+    [Test]
+    public void TryParseWithHash_UnsupportedMacro_ReturnsFalse()
+    {
+        CronExpression.TryParseWithHash("@reboot", "key", out CronExpression result).Should().BeFalse(
+            "an unsupported macro is an expression the caller has to fix, which is what the attempt reports");
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void ResolveHash_MacroWithSurroundingWhitespace_IsStillAMacro()
+    {
+        CronExpression.ResolveHash("  @daily  ", "key").Should().Be("0 0 0 * * ?",
+            "the constructor trims before it expands, so the hash path has to trim too or the two disagree");
+    }
+
     // --- Fire time validation ---
 
     [Test]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -664,6 +664,11 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// <item><description><c>H/step</c> — hash-derived offset, then every step</description></item>
     /// <item><description><c>H(min-max)/step</c> — hash-derived offset in range, then every step</description></item>
     /// </list>
+    /// <para>
+    /// A leading <c>@</c> macro is expanded first, as the constructor expands it, so a macro means the
+    /// same schedule here as everywhere else. A macro names a whole schedule and so carries no
+    /// <c>H</c> token; it simply passes through with nothing to resolve.
+    /// </para>
     /// </remarks>
     /// <param name="cronExpression">Cron expression that may contain H tokens</param>
     /// <param name="hashKey">A stable string key used to derive hash values (e.g., trigger name)</param>
@@ -681,7 +686,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         }
 
         return ResolveHashTokens(
-            CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression),
+            CronMacros.Expand(CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression).Trim()),
             HashStringToSeed(hashKey));
     }
 
@@ -689,6 +694,10 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// Resolves H (hash) tokens in a cron expression to deterministic numeric values
     /// based on the given integer seed.
     /// </summary>
+    /// <remarks>
+    /// A leading <c>@</c> macro is expanded first, as the constructor expands it, so a macro means the
+    /// same schedule here as everywhere else.
+    /// </remarks>
     /// <param name="cronExpression">Cron expression that may contain H tokens</param>
     /// <param name="hashSeed">An integer seed used to derive hash values</param>
     /// <returns>A standard cron expression string with all H tokens resolved to numeric values</returns>
@@ -700,7 +709,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
         }
 
         return ResolveHashTokens(
-            CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression),
+            CronMacros.Expand(CultureInfo.InvariantCulture.TextInfo.ToUpper(cronExpression).Trim()),
             hashSeed);
     }
 


### PR DESCRIPTION
The `@` macros #3620 added are expanded by the `CronExpression` constructor, and both the docs and the migration guide describe that as universal — *"it works wherever an expression string is read"*, and *"expanded by the `CronExpression` constructor, which is what every entry point goes through"*. Hash resolution was the exception, because it reads the expression string **before** constructing anything and `ResolveHashTokens` counts fields first. A one-field macro was therefore rejected as malformed before anything looked at what it said.

Measured on `main` before this change:

```
ctor                        OK    -> 0 0 0 * * ?
Parse                       OK    -> 0 0 0 * * ?
WithCronSchedule("@daily")  OK    -> 0 0 0 * * ?
ResolveHash("@daily", key)  THROW FormatException: Invalid cron expression (expected 6-7 fields, got 1): @DAILY.
ParseWithHash("@daily", key)  THROW FormatException: ... got 1): @DAILY.
ParseWithHash("@daily", 42)   THROW FormatException: ... got 1): @DAILY.
TryParseWithHash("@daily", …) OK    -> false
```

`TryParseWithHash` is the one that had to be fixed before the freeze: it reported `@daily` as an **invalid expression**, so a validator built on it contradicts the parser it stands in for, and the caller is sent to fix an expression that was never wrong.

## The change

`CronMacros.Expand` at the top of both `ResolveHash` overloads, with the same `.Trim()` the constructor applies so that the two normalise identically. Two lines of behaviour; the rest of the product diff is the XML doc sentence on each overload saying so.

It is **additive in the safe direction**: every string that resolved before resolves to exactly the same value — a macro is the only input whose first character is `@`, and `@` was previously rejected outright — while strings that threw a field count now mean what they say. `@reboot` and an unknown `@name` now reach their own rejections, which name the fix, instead of a field count that teaches nothing about the real problem.

A macro carries no `H` token by construction, so there is nothing to hash and the key goes unused. That is why this is a normalisation fix rather than a feature: it makes one door agree with the others, and adds no capability.

## Not done, deliberately

- **No docs edits.** Both pages already assert the behaviour this restores; the fix makes their existing prose true rather than needing new prose. Checked before starting: `cron-expressions.md:99` ("works wherever an expression string is read") and `migration-guide.md:4797` ("`@daily` and the rest of the macros work everywhere"). Neither page ever claimed macros combine with `H`, so nothing needed correcting, only enabling. I would explicitly *not* weaken either sentence.
- **No footnote** saying `ParseWithHash("@daily", key)` is legal but pointless. It is a sentence explaining why a call nobody writes is harmless.
- **No shared normalisation helper.** The root cause is that "upper, trim, expand" is spelled in more than one place, and a private `Normalize(string)` used by the constructor and both overloads would make the invariant structural rather than repeated. I left it out because it touches the constructor, which is not what this issue is about, and the agreed shape here was fix-only. It is a clean follow-up if you want it — say so and I will do it.

## Verification

- `dotnet test src/Quartz.Tests.Unit` — **4,813 passed, 0 failed, 36 skipped**
- `dotnet test src/Quartz.Tests.AspNetCore` — **548 passed, 0 failed**
- `dotnet fallout BenchmarkSmoke` — Restore / Compile / BenchmarkSmoke all succeeded (`CronExpression` construction is benchmarked, and `CronHashTokenBenchmark` calls `ResolveHash` directly)
- `dotnet fallout VerifyDocsSnippets` — up to date, 102 markdown files
- Public API baseline unchanged, as expected: no member added or removed, only doc comments.

The pins fail without the fix — verified by reverting the product file, rebuilding and re-running: **20 failed, 56 passed** in `CronExpressionHashTest`, the 20 being exactly the new cases and the 56 the pre-existing ones. With the fix, 76 pass.

Closes #3626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
