### PR TITLE
What the alpha.5 audit examined and kept is written down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,19 @@ pass; do not "finish" any of them.
 - **The `AddQuartz(NameValueCollection, …)` overloads stay beside their dictionary twins.** They look
   like a duplicate pair; they are the 3.x on-ramp, because a `NameValueCollection` is what an
   application migrating from `StdSchedulerFactory` already holds.
+- **Reading has two altitudes, and both stay.** `IScheduler`'s `Query*` members take a query record —
+  filter, page, optional total — and answer with headers; `SchedulerQueryExtensions`' `Get*` conveniences
+  take none of that and answer with bare keys and names. Neither is the other's leftovers, and a
+  shorthand saving only the `new` earns nothing. The pause/resume matcher members are `*Groups` because
+  the group set is what they write and answer with: a paused group survives a restart and binds what is
+  added to it next, which no list of keys can say.
+- **`ISchedulerRepository` and `ISchedulerRegistry` answer different questions.** The repository is the
+  live-instance directory — bind, remove, look up. The registry lists what a container has *registered*,
+  built or not, so an operator can enumerate tenants without starting every one. Both stay.
+- **`NameMatcher` — the arity-free one — sits outside `IMatcher<T>` on purpose.** That interface and the
+  `Matchers.And`/`Or`/`Not` combinators are constrained to `Key<T>`, which is what lets a matcher reach
+  the scheduler members that take one; a calendar's or a group's name is not a key. It was
+  `CalendarNameMatcher`: it took the family's name without taking the family's interface.
 
 ### Overload sets audited and frozen in #3598
 
@@ -134,6 +147,48 @@ members themselves, so read the XML docs before reopening one.
   `TriggerFiredBundle`. Both are `Quartz.Extensibility` types on a mainstream path, and both are the
   only type that says the thing: the trigger builder must write onto what it is handed, and a firing
   before its job exists has no `IJobExecutionContext` yet.
+
+### Examined in the alpha.5 audit and kept (#3603)
+
+The rule above, for the things that are not names. The reason is on the member too.
+
+- **The two day fields follow Vixie, not Cronos.** A field written exactly `*` or `?` restricts nothing
+  and defers to the other; when both name days the expression fires on their *union*, so
+  `0 0 0 13 * FRI` is every Friday **and** the 13th. Cronos ANDs them and would fire only on Friday the
+  13th. The union is `crontab(5)`'s rule and what `cron-expressions.md` has always taught,
+  `UnixCronFormatTest` pins it, and "finishing" the alignment would halve every schedule that names
+  both fields. `*/n` is restricted here, unlike Vixie, whose parser reads the leading `*` first.
+- **`CronFormat` is stated, never sniffed.** A five-field string throws in the default `Quartz` format,
+  and the message names `CronFormat.Unix` and the rewritten expression. Auto-detect was rejected: the
+  suite already uses "five fields" to mean "invalid expression", a dropped middle field would change a
+  schedule in silence, and the same digit is a different day in each dialect. Detection can be added
+  later; removing it could not.
+- **Wrapping ranges and `H` are Quartz supersets over standard cron, and are identity.** A range whose
+  end is below its start wraps instead of sorting its endpoints — `22-2` is five hours, `FRI-MON` a long
+  weekend — and `H` spreads a firing deterministically from the trigger key or an explicit one.
+  `CronExpressionWrappingRangeTest` pins the wrap, and the Unix rewrite carries both into five fields.
+- **Every `ISchedulerListener` member leads with `IScheduler`.** A job or trigger listener reaches its
+  scheduler through the execution context; no scheduler-listener notification has one, so the scheduler
+  is the first argument instead — which is also what lets one instance serve several schedulers and say
+  which of them paused a trigger. `ITriggerListener` leads with the trigger, for the mirror reason.
+- **`SchedulerContext` and `JobDataMap` are not twins to align.** The map is persisted, dirty-tracked
+  and equatable, and its `PutAsString` writers are instance members because they take part in that
+  change tracking. The context is never persisted, is read and written concurrently, and has nothing to
+  track. Only the typed *read* accessors are shared, in `DataMapExtensions`.
+- **`LogProvider.SetLogProvider` is the one static escape hatch, kept knowingly.** Plenty of things that
+  log are never handed a logger by a container: a listener you constructed, a trigger deserialized out of
+  a job store, the static helpers, a standalone `QuartzSchedulerBuilder`. Nor is it seeded from the
+  container: the slot outlives any one container, and a host built, disposed and built again would leave
+  it pointing at a disposed `ILoggerFactory`.
+- **The built-in trigger serializers are public and unsealed, and so are all five `*TriggerImpl` types.**
+  That pairing is the subclassed-trigger seam: derive from the trigger, derive from its serializer, call
+  `base.SerializeFields`/`base.DeserializeFields`. Three of the trigger types were sealed during 4.x's
+  development and reopened for it; `BuiltInTriggerSerializerDerivationTest` fails if either half closes.
+- **A job's timeout is `[JobTimeout]`, not a builder member.** How long the work may take is a property
+  of the code that does it, and an attribute travels with the type through every job store, wire format
+  and way of scheduling — a builder value would have to be persisted, migrated and round-tripped to reach
+  the same places, or squat on a reserved data-map key. As with `[DisallowConcurrentExecution]`. Nothing
+  enforces it until `AddJobTimeout` registers the middleware.
 
 ## Build & Test
 


### PR DESCRIPTION
Closes #3603

The alpha.5 audit examined the whole public surface. What it changed has landed; what it
**kept** was argued in PR bodies and design notes and then left there, which is exactly how a
ruling gets re-audited by the next contributor. Eleven of them are now in `AGENTS.md`, each with
its reason.

## Where they went, and why not all in one list

Three are naming decisions and join **"Naming decisions that are settled"**:

- **Reading has two altitudes, and both stay** — `IScheduler`'s `Query*` (record, page, headers)
  and `SchedulerQueryExtensions`' `Get*` (no record, no page, bare keys and names). Neither is the
  other's leftovers; a shorthand saving only the `new` earns nothing. Includes the `*Groups`
  naming of the pause/resume matcher members: the group set is what they write *and* answer with,
  and a paused group binds what is added to it next (#3599 / #3634).
- **`ISchedulerRepository` vs `ISchedulerRegistry`** — live-instance directory vs the container's
  registrations, built or not (#3600-adjacent D6).
- **`NameMatcher` sits outside `IMatcher<T>`** — the interface and the `Matchers` combinators are
  constrained to `Key<T>`; a calendar's or a group's name is not a key (#3634).

The other eight are not names, and the heading above would be a lie for "the day fields follow
Vixie". They get a sibling section, **"Examined in the alpha.5 audit and kept (#3603)"**, placed
after the #3598 overload-set section so the file reads names → overload sets → everything else:

- **The two day fields follow Vixie, not Cronos** — `*`/`?` restrict nothing, both restricted is a
  union, Cronos always ANDs. Named as a divergence so nobody finishes the alignment and halves
  every schedule that uses both fields. The row also names the *second* divergence #3610 found:
  `*/n` is restricted here, where Vixie's parser reads the leading `*` first (#3589 / #3610).
- **`CronFormat` is stated, never sniffed** — a five-field string throws in the default format by
  design, with the reasons auto-detect was rejected (#1253).
- **Wrapping ranges and `H` are Quartz supersets** over standard cron, and are identity.
- **Every `ISchedulerListener` member leads with `IScheduler`** — job and trigger listeners reach
  the scheduler through the execution context; scheduler listeners have no other channel. #3618
  wrote the reason into the migration guide and explicitly left this row for #3603.
- **`SchedulerContext` and `JobDataMap` are not twins to align** — `PutAsString` and equality take
  part in the map's change tracking; the context is never persisted and has nothing to track (I14).
- **`LogProvider.SetLogProvider` is the one static escape hatch, kept knowingly** — including why
  it is deliberately *not* seeded from the container (I15).
- **The built-in trigger serializers are public and unsealed, and so are all five `*TriggerImpl`
  types** — the subclassed-trigger seam, guarded by `BuiltInTriggerSerializerDerivationTest`
  (#3627).
- **A job's timeout is `[JobTimeout]`, not a builder member** — a builder value would need store
  persistence or a reserved data-map key (#3588).

## Deviations from the brief, for a reviewer to accept or reject

1. **Two sections, not one.** The issue says the "Naming decisions that are settled" section
   "gains a row for each". Six of the eleven are not naming decisions, and filing "the day fields
   follow Vixie" under a naming heading makes the heading wrong. Alternatives were renaming the
   existing heading (churns a section this PR otherwise does not touch) or one 20-bullet list
   (unnavigable). Say the word and I will collapse them.
2. **"Three fixtures use 5-fields-means-invalid" is in the row without the count.** The count comes
   from the #1253 ratification comment, written *before* `CronFormat` shipped; the surviving
   fixtures are `CronExpressionTest` and `UnixCronFormatTest`, so the row says "the suite already
   uses 'five fields' to mean 'invalid expression'" rather than asserting a number that has since
   moved.
3. **"Quartz's since 1.0" was cut from the Vixie row.** #3610 shows the `*`-restricts-nothing half
   is new in alpha.5 — 4.0's alphas took the union branch for `*` too. What is long-standing is the
   both-restricted union, which `cron-expressions.md` has always taught, so that is what the row
   claims.
4. **The registry row says "the container's registrations", not "persisted-registration query".**
   `ISchedulerRegistry.QuerySchedulers` reads what a container registered; nothing is persisted.
5. **`cron-expressions.md` is not cited for wrapping ranges** — it documents `H` but never `22-2`;
   the wrap is spelled in `CronExpression`'s XML docs and pinned by
   `CronExpressionWrappingRangeTest`, so those are what the row names.

## Already covered, so not duplicated

Verified present before writing: the four history-logging plugins and the `Use*` verb row (#3632),
the corrected `QuartzSchedulerBuilder` description (#3631), and the whole "Overload sets audited
and frozen in #3598" section — which already carries **I10** (the `Create()` companion split) and
**I9/I16** (`IScheduleBuilder.Build()` returning `IMutableTrigger`, `ConfigureJobScope` taking
`TriggerFiredBundle`). The `AddQuartz(NameValueCollection, …)` twin was already there too.

I swept the merged bodies of #3606–#3634 for other explicit "left for #3603" deferrals. There are
exactly three, and all three are in this PR: #3618 (scheduler listener), #3633 (I9), #3634 (two
altitudes). Other rulings in those PRs — `FireInstanceQuery`'s `TriggerGroup`/`TriggerName`
prefixes, the `Matchers`-vs-per-type-factory split, `OneOffJobOptions`' loose `Name`/`Group`,
`ITrigger.GetTriggerBuilder` staying an interface member, `TriggerDetailsUpdate`'s six misfire
spellings — are written on the members and in the migration guide and were not asked for here;
they are the obvious candidates if the settled list should grow again.

## Budget

`AgentInstructionsTest` caps every instruction file at 32,768 bytes (Codex's
`project_doc_max_bytes`, a running budget). `AGENTS.md` went from **25,788 to 30,843 bytes —
1,925 left**. The first draft was 31,440; the rows were compressed to two or three sentences each
to buy back 597 bytes. No pointer file changed, so the chain total moved by the same 5,055 bytes.

## Verification

On `e0ce6c71`:

```
dotnet build Quartz.slnx                                       Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit --filter AgentInstructionsTest   Passed!  Failed: 0, Passed: 12
dotnet test src/Quartz.Tests.Unit                              Passed!  Failed: 0, Passed: 4832, Skipped: 36
```

The 12 `AgentInstructionsTest` cases are the three size-capped instruction files, the four pointers
checked for naming `AGENTS.md`, the same four checked for still being pointers, and the discovery
test — so "the four pointer files still name `AGENTS.md`" is verified by a run, not by reading.
`AGENTS.md` was edited in place: still UTF-8 with no BOM, still CRLF, and `git diff` reports 55
insertions and 0 deletions, so no existing line was rewritten. No C#, no docs page and no snippet
marker is touched, so `VerifyDocsSnippets`, the AspNetCore suite and `BenchmarkSmoke` have nothing
to cover here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
