### PR TITLE
The freeze audit's two blocking findings are fixed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,7 +270,7 @@ Quartz.NET is an enterprise job scheduling library. The core domain model:
 ### Job Stores
 
 - **`RAMJobStore`** (`Quartz.Impl`) — in-memory, volatile. Default.
-- **`AdoJobStoreBase`** → `LocalTransactionJobStore` / `ExternalTransactionJobStore` (`Quartz.Impl.AdoJobStore`) — ADO.NET-based persistence with database-specific delegates (`SqlServerDelegate`, `PostgreSQLDelegate`, `OracleDelegate`, `MySQLDelegate`, `SQLiteDelegate`, `FirebirdDelegate`). On 3.x these are `JobStoreSupport` → `JobStoreTX` / `JobStoreCMT`.
+- **`AdoJobStoreBase`** → `LocalTransactionJobStore` / `ExternalTransactionJobStore` (`Quartz.Impl.AdoJobStore`) — ADO.NET-based persistence with database-specific delegates (`SqlServerDelegate`, `PostgreSQLDelegate`, `OracleDelegate`, `MySQLDelegate`, `SQLiteDelegate`, `FirebirdDelegate`). On 3.x these are `JobStoreSupport` → `JobStoreTX` / `JobStoreCMT`. All three are **internal**: `UsePersistentStore` builds the local one and `UsePersistentStore(s => s.UseAmbientTransactions())` the other, the driver delegate is the seam, and `quartz.jobStore.type` still names either by string.
 
 ### Database scripts
 

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -762,6 +762,7 @@ Two differences are worth knowing:
 | `quartz.jobStore.makeThreadsDaemons` | `JobStore:UseBackgroundThreads` |
 | `quartz.jobStore.clustered` | `JobStore:Clustering:Enabled`, or `UseClustering()` |
 | `quartz.jobStore.acceptEnlistedTransactions` | `JobStore:AcceptEnlistedTransactions` |
+| `quartz.jobStore.openConnection` | `JobStore:OpenConnection`, read only by the ambient-transaction store |
 | `quartz.jobStore.clusterCheckinInterval` | `JobStore:Clustering:CheckinInterval` |
 | `quartz.jobStore.clusterCheckinMisfireThreshold` | `JobStore:Clustering:CheckinMisfireThreshold` |
 | `quartz.jobStore.dataSource` | set for you by the database methods |

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -177,7 +177,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 | `UseBackgroundThreads` | bool | `false` | Runs the misfire handler and cluster manager on background threads, which do not keep the process alive. These two are the only real threads Quartz creates. |
 | `SchemaProvisioning` | `SchemaProvisioning` | `Validate` | What the store does about its schema at startup: `None` does nothing, `Validate` verifies the expected tables exist, `CreateIfMissing` creates whatever is missing and then verifies. |
 | `SelectWithLockSql` | string? | none | Overrides the row-lock statement, defaulted to SQL Server's `WITH (UPDLOCK,ROWLOCK)` form when that is the database. Read only when the store builds a database-locking handler for itself — see [Locking](#locking). |
-| `OpenConnection` | bool | `false` | Whether `ExternalTransactionJobStore` opens the connections it creates; read only by that store. |
+| `OpenConnection` | bool | `false` | Whether `ExternalTransactionJobStore` opens the connections it creates; read only by that store, which is the one `UsePersistentStore(store => store.UseAmbientTransactions())` selects. |
 
 A custom trigger persistence delegate is registered with
 `UsePersistentStore(s => s.UseTriggerPersistenceDelegate<T>())` rather than through an option; the

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -321,8 +321,10 @@ A few rules to be aware of:
 
 - Unconfigured fields default to `*` (every value).
 - Each field can be configured only once; configuring it again throws `InvalidOperationException`.
-- Day-of-month and day-of-week are mutually exclusive per cron syntax - the builder renders
-  the unused one as `?` and throws if you try to configure both.
+- One expression carries one day field: the builder renders the unused one as `?` and throws if
+  you configure both. That is the builder's own rule rather than cron's, because an expression
+  naming both day fields fires on the union of the two (`0 15 10 1,2,3 * MON,FRI`), which
+  `CronExpression.Parse` accepts - so write that one as text.
 - Values are validated eagerly against each field's allowed range, and `Build()` returns a
   fully validated `CronExpression`; use `ToString()` if you only need the expression string.
 - Days of the week are emitted using their textual names (`MON`, `FRI`, ...), so the produced

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -8296,11 +8296,19 @@ The names went with the types. An operation `IQuartzApiClient` forwards to a sch
 | `GetMisfires(DashboardMisfireQuery)` → `PagedResult<DashboardMisfireEntry>?` | `QueryMisfires(…)` → `PagedResult<DashboardMisfireEntry>`, never null |
 | `CountMisfires(name, since)` → `int?` | → `int` |
 | `IDashboardHistoryStore.Add`, `GetPage`, `GetMisfires` | `AddExecution`, `QueryExecutions`, `QueryMisfires`; `AddMisfire` and `CountMisfires` are unchanged |
+| `Interrupt`, `InterruptFireInstance`, `DeleteJob`, `UnscheduleJob`, `DeleteCalendar` → `ValueTask` | → `ValueTask<bool>`, the flag `IScheduler` returns |
 
 `GetSchedulers`, `GetScheduler` and `GetCalendarNames` keep their names: the first two list and read the
 container's registrations, which is not an operation a scheduler has, and `GetCalendarNames` reads *every*
 page of `IScheduler.QueryCalendarNames` rather than one, so naming it `Query*` would promise a paged query
 it does not take.
+
+The five that answered with a bare `ValueTask` now answer with the applied flag their `IScheduler`
+counterparts always returned, so all ten mutations report it and none of them silently drop it: the HTTP
+API has always put it on the wire as `OperationAppliedResponse`, and a client member sharing a scheduler's
+verb has to share its answer or read as the same operation while not being one. An implementation of
+`IQuartzApiClient` returns what the scheduler told it; a page can now tell "deleted" from "was already
+gone" and says which.
 
 The three nullable returns were nullable because the deleted HTTP-backed client turned a 404 into "this
 data source keeps no history". Nothing in this process has that answer: `IDashboardHistoryStore` always

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -6534,7 +6534,9 @@ quartz.jobStore.type = Quartz.Impl.AdoJobStore.LocalTransactionJobStore, Quartz
 ```
 
 Code that names the type — `UsePersistentStore<JobStoreTX>()`, a subclass, a `typeof` — has to be updated.
-`UsePersistentStore()` with no type argument already picks the right store and needs no change.
+`UsePersistentStore()` with no type argument already picks the local-transaction store and needs no change,
+and the other store is chosen by `UsePersistentStore(store => store.UseAmbientTransactions())` — the type
+itself is internal, so it is the member rather than the name that selects it.
 
 ### The vocabulary follows
 
@@ -6554,8 +6556,9 @@ guarantee the write landed before `Initialize` ran:
 
 ```diff
 - ((ExternalTransactionJobStore) store).OpenConnection = true;
-+ services.AddQuartz(q => q.UsePersistentStore<ExternalTransactionJobStore>(store =>
-+     store.ConfigureStore(options => options.OpenConnection = true)));
++ services.AddQuartz(q => q.UsePersistentStore(store => store
++     .UseAmbientTransactions()
++     .ConfigureStore(options => options.OpenConnection = true)));
 ```
 
 ## Nine `Execute…Lock` overloads became four members
@@ -10525,7 +10528,7 @@ namespace, and `Type.Member` for the second one.
 | `Quartz.Listener.BroadcastTriggerListener` | Removed | As above |
 | `Quartz.CalendarIntervalTriggerBuilderExtensions` | Removed | `TriggerConfiguratorExtensions` — see [One family of `WithXSchedule` extensions](#one-family-of-withxschedule-extensions) |
 | `Quartz.SchedulerBuilder.ClusterOptions` | Removed | `ClusteringOptions` — see [Clustering is configured in one place](#clustering-is-configured-in-one-place) |
-| `Quartz.Impl.AdoJobStore.ExternalTransactionJobStore` (3.x `JobStoreCMT`) | Internal | Unchanged as a configuration string; `quartz.jobStore.type` still names it — see [The ADO.NET store is a store, not a base class](#the-ado-net-store-is-a-store-not-a-base-class) |
+| `Quartz.Impl.AdoJobStore.ExternalTransactionJobStore` (3.x `JobStoreCMT`) | Internal | `UsePersistentStore(store => store.UseAmbientTransactions())` selects it in code, and `quartz.jobStore.type` still names it as a configuration string — see [The ADO.NET store is a store, not a base class](#the-ado-net-store-is-a-store-not-a-base-class) |
 | `Quartz.Impl.AdoJobStore.LocalTransactionJobStore` (3.x `JobStoreTX`) | Internal | As above |
 | `Quartz.Impl.AdoJobStore.RecoverMisfiredJobsResult` | Internal | Nothing; it was a `protected` method's return type |
 | `Quartz.Impl.AdoJobStore.Common.ConfigurationBasedDbMetadataFactory` | Internal | The metadata factory on `UseGenericDatabase` |

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -61,7 +61,8 @@ for multiple scheduler instances, within the same database.
 what `UsePersistentStore` registers. If you need scheduling to commit together with your application's own
 database work, it can also be told to use a connection you own; see
 [Joining an existing transaction](#joining-an-existing-transaction) below. `ExternalTransactionJobStore` is the
-other one, for a container that manages the ambient transaction itself.
+other one, for a container that manages the ambient transaction itself; it is selected with
+`UsePersistentStore(store => store.UseAmbientTransactions())`, and it neither commits nor rolls back.
 
 ### Configuring a persistent store
 

--- a/src/Quartz.Dashboard/Components/Pages/CalendarDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/CalendarDetail.razor
@@ -143,11 +143,18 @@
 
         try
         {
-            await Api.DeleteCalendar(schedulerName, CalendarName);
-            ActionLog.Record(schedulerName, "DeleteCalendar", CalendarName, succeeded: true);
-            Toasts.Success("Deleted calendar " + CalendarName + ".");
+            bool deleted = await Api.DeleteCalendar(schedulerName, CalendarName);
+            ActionLog.Record(schedulerName, "DeleteCalendar", CalendarName, succeeded: deleted);
             _showDeleteConfirm = false;
-            Navigation.NavigateTo(DashboardLink.To(Options.Value, "calendars"));
+            if (deleted)
+            {
+                Toasts.Success("Deleted calendar " + CalendarName + ".");
+                Navigation.NavigateTo(DashboardLink.To(Options.Value, "calendars"));
+            }
+            else
+            {
+                Toasts.Info("Calendar " + CalendarName + " was not deleted - it no longer exists.");
+            }
         }
         catch (Exception ex)
         {

--- a/src/Quartz.Dashboard/Components/Pages/Calendars.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Calendars.razor
@@ -221,9 +221,17 @@
 
         try
         {
-            await Api.DeleteCalendar(schedulerName, _pendingCalendarName);
-            ActionLog.Record(schedulerName, "DeleteCalendar", _pendingCalendarName, succeeded: true);
-            Toasts.Success("Deleted calendar " + _pendingCalendarName + ".");
+            bool deleted = await Api.DeleteCalendar(schedulerName, _pendingCalendarName);
+            ActionLog.Record(schedulerName, "DeleteCalendar", _pendingCalendarName, succeeded: deleted);
+            if (deleted)
+            {
+                Toasts.Success("Deleted calendar " + _pendingCalendarName + ".");
+            }
+            else
+            {
+                Toasts.Info("Calendar " + _pendingCalendarName + " was not deleted - it no longer exists.");
+            }
+
             _showDeleteConfirm = false;
             await LoadDataAsync();
         }

--- a/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
+++ b/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
@@ -6,6 +6,7 @@
 @implements IDisposable
 @inject IQuartzApiClient Api
 @inject SchedulerState Scheduler
+@inject ToastService Toasts
 @inject IOptions<QuartzDashboardOptions> Options
 
 <div class="qz-page">
@@ -206,7 +207,15 @@
         {
             // The one execution the row shows, not every execution of its job: the fire instance id is
             // what tells them apart.
-            await Api.InterruptFireInstance(Scheduler.ActiveSchedulerName, fireInstanceId);
+            bool interrupted = await Api.InterruptFireInstance(Scheduler.ActiveSchedulerName, fireInstanceId);
+            if (!interrupted)
+            {
+                // The row is a snapshot of a list that moves: by the time the button is pressed the
+                // firing may have finished, and a page that said nothing would look as though the
+                // interrupt had been delivered.
+                Toasts.Info("Execution " + fireInstanceId + " was not interrupted - it is no longer running on this node.");
+            }
+
             await LoadDataAsync();
         }
         catch (Exception ex)

--- a/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/JobDetail.razor
@@ -242,13 +242,14 @@
 
     private async Task DeleteAsync()
     {
-        bool succeeded = await ExecuteMutatingActionAsync(
+        bool deleted = await ExecuteMutatingActionAsync(
             () => Api.DeleteJob(Scheduler.ActiveSchedulerName!, JobKey),
             "Deleted job " + DisplayValueHelper.FormatKey(Group, Name) + ".",
+            "Job " + DisplayValueHelper.FormatKey(Group, Name) + " was not deleted - it no longer exists.",
             actionName: "DeleteJob",
             target: DisplayValueHelper.FormatKey(Group, Name));
         _showDeleteConfirm = false;
-        if (succeeded)
+        if (deleted)
         {
             Navigation.NavigateTo(DashboardLink.To(Options.Value, "jobs"));
         }

--- a/src/Quartz.Dashboard/Components/Pages/Jobs.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Jobs.razor
@@ -319,6 +319,7 @@
         await ExecuteMutatingActionAsync(
             () => Api.DeleteJob(Scheduler.ActiveSchedulerName!, new JobKeyDto(_pendingDeleteGroup, _pendingDeleteName)),
             "Deleted job " + DisplayValueHelper.FormatKey(_pendingDeleteGroup, _pendingDeleteName) + ".",
+            "Job " + DisplayValueHelper.FormatKey(_pendingDeleteGroup, _pendingDeleteName) + " was not deleted - it no longer exists.",
             actionName: "DeleteJob",
             target: DisplayValueHelper.FormatKey(_pendingDeleteGroup, _pendingDeleteName));
         _showDeleteConfirm = false;

--- a/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
+++ b/src/Quartz.Dashboard/Components/Pages/TriggerDetail.razor
@@ -250,13 +250,14 @@
 
     private async Task UnscheduleAsync()
     {
-        bool succeeded = await ExecuteMutatingActionAsync(
+        bool unscheduled = await ExecuteMutatingActionAsync(
             () => Api.UnscheduleJob(Scheduler.ActiveSchedulerName!, TriggerKey),
             "Unscheduled trigger " + DisplayValueHelper.FormatKey(Group, Name) + ".",
+            "Trigger " + DisplayValueHelper.FormatKey(Group, Name) + " was not unscheduled - it no longer exists.",
             actionName: "UnscheduleTrigger",
             target: DisplayValueHelper.FormatKey(Group, Name));
         _showUnscheduleConfirm = false;
-        if (succeeded)
+        if (unscheduled)
         {
             Navigation.NavigateTo(DashboardLink.To(Options.Value, "triggers"));
         }

--- a/src/Quartz.Dashboard/Components/Pages/Triggers.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Triggers.razor
@@ -331,6 +331,7 @@
         await ExecuteMutatingActionAsync(
             () => Api.UnscheduleJob(Scheduler.ActiveSchedulerName!, new TriggerKeyDto(_pendingGroup, _pendingName)),
             "Unscheduled trigger " + DisplayValueHelper.FormatKey(_pendingGroup, _pendingName) + ".",
+            "Trigger " + DisplayValueHelper.FormatKey(_pendingGroup, _pendingName) + " was not unscheduled - it no longer exists.",
             actionName: "UnscheduleTrigger",
             target: DisplayValueHelper.FormatKey(_pendingGroup, _pendingName));
         _showUnscheduleConfirm = false;

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -41,6 +41,12 @@ namespace Quartz.Dashboard.Services;
 /// execution history — names itself.
 /// </para>
 /// <para>
+/// A mutation that can find nothing to act on answers with the scheduler's own <see cref="bool" />:
+/// whether it applied. Every such member reports it, because a name shared with
+/// <see cref="IScheduler" /> that dropped the answer would read as the same operation and quietly not
+/// be one — and a page cannot tell "deleted" from "was already gone" without it.
+/// </para>
+/// <para>
 /// A trigger and a calendar arrive as themselves because Quartz already owns the polymorphism they
 /// need: the serializer registry maps each kind to its own serializer, custom kinds an application
 /// registered included, and the wire format is that discriminated shape. A DTO family of the
@@ -140,19 +146,34 @@ public interface IQuartzApiClient
     /// </remarks>
     ValueTask TriggerJob(string schedulerName, JobKeyDto jobKey, JobDataMap? jobDataMap = null, CancellationToken cancellationToken = default);
 
-    ValueTask Interrupt(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Interrupts every execution of the job on this node. Returns <see langword="true" /> when at
+    /// least one execution was asked to stop, <see langword="false" /> when the job was not running
+    /// here.
+    /// </summary>
+    /// <remarks>
+    /// A job that does not watch its cancellation token runs to completion regardless, so the flag says
+    /// the interrupt was delivered rather than that the work stopped.
+    /// </remarks>
+    ValueTask<bool> Interrupt(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Interrupts one execution, named by its fire instance id.
+    /// Interrupts one execution, named by its fire instance id. Returns <see langword="true" /> when
+    /// that execution was found and asked to stop, <see langword="false" /> when it had already
+    /// finished or belongs to another node.
     /// </summary>
     /// <remarks>
     /// The single-execution form of <see cref="Interrupt" />, which interrupts every execution of the
     /// job. Node-local on the server side: a firing owned by another node is interrupted by asking that
     /// node.
     /// </remarks>
-    ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, CancellationToken cancellationToken = default);
+    ValueTask<bool> InterruptFireInstance(string schedulerName, string fireInstanceId, CancellationToken cancellationToken = default);
 
-    ValueTask DeleteJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Deletes the job and every trigger that fires it. Returns <see langword="true" /> when the job
+    /// existed and was deleted, <see langword="false" /> when there was nothing to delete.
+    /// </summary>
+    ValueTask<bool> DeleteJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     ValueTask AddJob(string schedulerName, AddJobRequest request, CancellationToken cancellationToken = default);
 
@@ -190,7 +211,12 @@ public interface IQuartzApiClient
 
     ValueTask ScheduleJob(string schedulerName, ScheduleJobRequest request, CancellationToken cancellationToken = default);
 
-    ValueTask UnscheduleJob(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Removes the trigger, and the job it fired if that job is not durable and has no triggers left.
+    /// Returns <see langword="true" /> when the trigger existed and was removed,
+    /// <see langword="false" /> when there was nothing to remove.
+    /// </summary>
+    ValueTask<bool> UnscheduleJob(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
     ValueTask RescheduleJob(string schedulerName, TriggerKeyDto triggerKey, RescheduleRequest request, CancellationToken cancellationToken = default);
 
@@ -203,7 +229,11 @@ public interface IQuartzApiClient
 
     ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default);
 
-    ValueTask DeleteCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Deletes the calendar. Returns <see langword="true" /> when it existed and was deleted,
+    /// <see langword="false" /> when there was nothing to delete.
+    /// </summary>
+    ValueTask<bool> DeleteCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns one page of execution history, newest first.

--- a/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/InProcessQuartzApiClient.cs
@@ -336,25 +336,25 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return scheduler.TriggerJob(AsJobKey(key), jobDataMap, cancellationToken);
     }
 
-    public async ValueTask Interrupt(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public ValueTask<bool> Interrupt(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        _ = await scheduler.Interrupt(AsJobKey(key), cancellationToken).ConfigureAwait(false);
+        return scheduler.Interrupt(AsJobKey(key), cancellationToken);
     }
 
-    public async ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, CancellationToken cancellationToken = default)
+    public ValueTask<bool> InterruptFireInstance(string schedulerName, string fireInstanceId, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        _ = await scheduler.InterruptFireInstance(fireInstanceId, cancellationToken).ConfigureAwait(false);
+        return scheduler.InterruptFireInstance(fireInstanceId, cancellationToken);
     }
 
-    public async ValueTask DeleteJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
+    public ValueTask<bool> DeleteJob(string schedulerName, JobKeyDto key, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        _ = await scheduler.DeleteJob(AsJobKey(key), cancellationToken).ConfigureAwait(false);
+        return scheduler.DeleteJob(AsJobKey(key), cancellationToken);
     }
 
     public ValueTask AddJob(string schedulerName, AddJobRequest request, CancellationToken cancellationToken = default)
@@ -463,11 +463,11 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
         return ScheduleJobWithTrigger(scheduler, jobDetail, request.Trigger, cancellationToken);
     }
 
-    public async ValueTask UnscheduleJob(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
+    public ValueTask<bool> UnscheduleJob(string schedulerName, TriggerKeyDto key, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        _ = await scheduler.UnscheduleJob(AsTriggerKey(key), cancellationToken).ConfigureAwait(false);
+        return scheduler.UnscheduleJob(AsTriggerKey(key), cancellationToken);
     }
 
     public ValueTask RescheduleJob(string schedulerName, TriggerKeyDto key, RescheduleRequest request, CancellationToken cancellationToken = default)
@@ -521,11 +521,11 @@ internal sealed class InProcessQuartzApiClient : IQuartzApiClient
             cancellationToken);
     }
 
-    public async ValueTask DeleteCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
+    public ValueTask<bool> DeleteCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default)
     {
         EnsureWritable();
         IScheduler scheduler = GetSchedulerOrThrow(schedulerName);
-        _ = await scheduler.DeleteCalendar(calendarName, cancellationToken).ConfigureAwait(false);
+        return scheduler.DeleteCalendar(calendarName, cancellationToken);
     }
 
     public ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/JobsPageTest.cs
@@ -146,6 +146,7 @@ public class JobsPageTest
     public void DeletingAJobAsksFirstAndRecordsTheAction()
     {
         GivenJobs(TestData.Dashboard.JobKeys("reports", 1));
+        A.CallTo(() => context.Api.DeleteJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._)).Returns(true);
         IRenderedComponent<Jobs> page = context.Render<Jobs>();
 
         page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
@@ -161,6 +162,26 @@ public class JobsPageTest
             .MustHaveHappened();
         context.ActionLog.GetLatest(1).Should().ContainSingle()
             .Which.Target.Should().Be("reports.job-1");
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Deleted job reports.job-1.");
+    }
+
+    [Test]
+    public void DeletingAJobThatIsAlreadyGoneSaysSoRatherThanClaimingItDeletedOne()
+    {
+        GivenJobs(TestData.Dashboard.JobKeys("reports", 1));
+        A.CallTo(() => context.Api.DeleteJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._)).Returns(false);
+        IRenderedComponent<Jobs> page = context.Render<Jobs>();
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Job reports.job-1 was not deleted - it no longer exists.",
+                "the scheduler says whether it found the job, and a listing that is one refresh out of "
+                + "date is exactly when it matters");
+        context.ActionLog.GetLatest(1).Should().ContainSingle()
+            .Which.Succeeded.Should().BeFalse();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -4,6 +4,9 @@ using Bunit;
 
 using FakeItEasy;
 
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+
 using Quartz.Dashboard.Components.Layout;
 using Quartz.Dashboard.Components.Pages;
 using Quartz.Dashboard.Services;
@@ -95,6 +98,61 @@ public class RemainingPagesTest
     }
 
     [Test]
+    public void InterruptingAFiringThatHasFinishedSaysSoRatherThanLookingLikeItWorked()
+    {
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<FireInstanceDto>([
+                new FireInstanceDto(
+                    "fire-1",
+                    new TriggerKeyDto("nightly", "trigger-1"),
+                    new JobKeyDto("reports", "job-1"),
+                    "node-a",
+                    FireInstanceState.Executing,
+                    TestData.Dashboard.FiredAt,
+                    TestData.Dashboard.FiredAt,
+                    "batch")
+            ]));
+        A.CallTo(() => context.Api.InterruptFireInstance(A<string>._, "fire-1", A<CancellationToken>._))
+            .Returns(false);
+
+        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be(
+                "Execution fire-1 was not interrupted - it is no longer running on this node.",
+                "the listing refreshes every second, so the firing behind the button is routinely gone "
+                + "by the time it is pressed");
+    }
+
+    [Test]
+    public void InterruptingARunningFiringSaysNothingBeyondRefreshingTheListing()
+    {
+        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.Page<FireInstanceDto>([
+                new FireInstanceDto(
+                    "fire-1",
+                    new TriggerKeyDto("nightly", "trigger-1"),
+                    new JobKeyDto("reports", "job-1"),
+                    "node-a",
+                    FireInstanceState.Executing,
+                    TestData.Dashboard.FiredAt,
+                    TestData.Dashboard.FiredAt,
+                    "batch")
+            ]));
+        A.CallTo(() => context.Api.InterruptFireInstance(A<string>._, "fire-1", A<CancellationToken>._))
+            .Returns(true);
+
+        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
+
+        A.CallTo(() => context.Api.InterruptFireInstance(TestData.SchedulerName, "fire-1", A<CancellationToken>._))
+            .MustHaveHappened();
+        context.Toasts.Messages.Should().BeEmpty(
+            "the interrupt was delivered, and the row leaving the listing is the whole of the news");
+    }
+
+    [Test]
     public void TheJobDetailPageShowsTheJobAndItsTriggers()
     {
         GivenJob();
@@ -168,6 +226,76 @@ public class RemainingPagesTest
         page.Markup.Should().Contain("holidays");
         page.Markup.Should().Contain("Test HolidayCalendar",
             "the calendar arrives as itself, so its description is readable without parsing JSON");
+    }
+
+    [Test]
+    public void DeletingAJobFromItsPageReturnsToTheListingOnlyWhenItWasThere()
+    {
+        GivenJob();
+        A.CallTo(() => context.Api.DeleteJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._)).Returns(false);
+
+        IRenderedComponent<JobDetail> page = RenderJobDetail();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Job reports.job-1 was not deleted - it no longer exists.");
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().NotEndWith("/quartz/jobs",
+            "the page navigates away because the job is gone, and nothing went anywhere here");
+
+        A.CallTo(() => context.Api.DeleteJob(A<string>._, A<JobKeyDto>._, A<CancellationToken>._)).Returns(true);
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/quartz/jobs",
+            "the job the page was showing is gone, so staying on it would show a not-found page");
+    }
+
+    [Test]
+    public void DeletingACalendarSaysWhetherThereWasOneToDelete()
+    {
+        A.CallTo(() => context.Api.GetCalendarNames(A<string>._, A<CancellationToken>._))
+            .Returns(new List<string> { "holidays" });
+        A.CallTo(() => context.Api.DeleteCalendar(A<string>._, "holidays", A<CancellationToken>._)).Returns(true);
+
+        IRenderedComponent<Calendars> page = context.Render<Calendars>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Deleted calendar holidays.");
+
+        A.CallTo(() => context.Api.DeleteCalendar(A<string>._, "holidays", A<CancellationToken>._)).Returns(false);
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages[^1].Message.Should().Be(
+            "Calendar holidays was not deleted - it no longer exists.",
+            "a calendar another node removed is the case the flag exists for");
+    }
+
+    [Test]
+    public void ACalendarDetailPageReturnsToTheListingOnlyWhenItDeletedSomething()
+    {
+        A.CallTo(() => context.Api.GetCalendar(A<string>._, "holidays", A<CancellationToken>._))
+            .Returns(TestData.HolidayCalendar);
+        A.CallTo(() => context.Api.DeleteCalendar(A<string>._, "holidays", A<CancellationToken>._)).Returns(false);
+
+        IRenderedComponent<CalendarDetail> page = context.Render<CalendarDetail>(parameters => parameters
+            .Add(x => x.CalendarName, "holidays"));
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete calendar").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Calendar holidays was not deleted - it no longer exists.");
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().NotEndWith("/quartz/calendars");
+
+        A.CallTo(() => context.Api.DeleteCalendar(A<string>._, "holidays", A<CancellationToken>._)).Returns(true);
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Delete calendar").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().EndWith("/quartz/calendars",
+            "the calendar the page was showing is gone");
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggerDetailPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggerDetailPageTest.cs
@@ -148,6 +148,8 @@ public class TriggerDetailPageTest
     public void UnschedulingAsksFirstAndThenReturnsToTheListing()
     {
         GivenTrigger(CronTrigger("0/25 * * * * ?"));
+        A.CallTo(() => context.Api.UnscheduleJob(A<string>._, A<TriggerKeyDto>._, A<CancellationToken>._))
+            .Returns(true);
         IRenderedComponent<TriggerDetail> page = Render();
 
         page.FindAll("button").First(button => button.TextContent.Trim() == "Unschedule").Click();
@@ -169,6 +171,29 @@ public class TriggerDetailPageTest
         context.ActionLog.GetLatest(1).Should().ContainSingle()
             .Which.Action.Should().Be("UnscheduleTrigger",
                 "an action taken from the dashboard is recorded whether or not anyone was watching");
+    }
+
+    [Test]
+    public void UnschedulingATriggerSomebodyElseAlreadyRemovedSaysSoAndStays()
+    {
+        GivenTrigger(CronTrigger("0/25 * * * * ?"));
+        A.CallTo(() => context.Api.UnscheduleJob(A<string>._, A<TriggerKeyDto>._, A<CancellationToken>._))
+            .Returns(false);
+        IRenderedComponent<TriggerDetail> page = Render();
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Unschedule").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be(
+                "Trigger CronTriggerGroup.CronTriggerKey was not unscheduled - it no longer exists.",
+                "the scheduler answers whether the trigger was there, and a page that reported success "
+                + "either way would tell an operator a cluster peer's removal was their own");
+        context.Services.GetRequiredService<NavigationManager>().Uri.Should().NotEndWith("/quartz/triggers",
+            "nothing was removed, so there is nothing to return from");
+        context.ActionLog.GetLatest(1).Should().ContainSingle()
+            .Which.Succeeded.Should().BeFalse(
+                "the action log records what happened, and nothing happened");
     }
 
     private static ITrigger CronTrigger(string cronExpression)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/TriggersPageTest.cs
@@ -133,6 +133,32 @@ public class TriggersPageTest
     }
 
     [Test]
+    public void UnschedulingFromTheListingSaysWhetherTheTriggerWasStillThere()
+    {
+        GivenTriggers(TestData.Dashboard.TriggerHeaders("nightly", 1));
+        A.CallTo(() => context.Api.UnscheduleJob(A<string>._, A<TriggerKeyDto>._, A<CancellationToken>._))
+            .Returns(true);
+        IRenderedComponent<Triggers> page = context.Render<Triggers>();
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Unschedule").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages.Should().ContainSingle()
+            .Which.Message.Should().Be("Unscheduled trigger nightly.trigger-1.");
+
+        A.CallTo(() => context.Api.UnscheduleJob(A<string>._, A<TriggerKeyDto>._, A<CancellationToken>._))
+            .Returns(false);
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Unschedule").Click();
+        page.Find(".qz-confirm-dialog button.qz-button-danger").Click();
+
+        context.Toasts.Messages[^1].Message.Should().Be(
+            "Trigger nightly.trigger-1 was not unscheduled - it no longer exists.",
+            "a listing is a snapshot, so the answer to 'was it still there' is the one thing the page "
+            + "cannot work out for itself");
+    }
+
+    [Test]
     public void ATriggerWithNoExecutionGroupSaysSoRatherThanShowingNothing()
     {
         GivenTriggers([new TriggerHeaderDto("nightly", "trigger-1", "Cron", "0/5 * * * * ?", TriggerState.Normal, null)]);

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -856,6 +856,53 @@ public class InProcessQuartzApiClientTest
         }
     }
 
+    /// <summary>
+    /// Every mutation that can find nothing to act on hands back the scheduler's own answer.
+    /// </summary>
+    /// <remarks>
+    /// Five of these ten used to discard it with a literal <c>_ =</c>, so a dashboard could not tell a
+    /// deletion from a job a cluster peer had already removed. The pairs are asserted together because
+    /// the flag is only worth anything if both answers reach the caller.
+    /// </remarks>
+    [Test]
+    public async Task EveryMutationSaysWhetherItFoundAnythingToActOn()
+    {
+        IScheduler scheduler = await CreateScheduler("AppliedFlagTest");
+        try
+        {
+            JobKey jobKey = new("job1", "group1");
+            TriggerKey triggerKey = new("trigger1", "group1");
+            await scheduler.ScheduleJob(
+                JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).Build(),
+                TriggerBuilder.Create().WithIdentity(triggerKey).ForJob(jobKey).WithCronSchedule("0 0 1 * * ?").Build());
+            await scheduler.AddCalendar("holidays", new HolidayCalendar(), new AddCalendarOptions());
+
+            InProcessQuartzApiClient client = CreateClient(scheduler);
+            string name = scheduler.SchedulerName;
+            JobKeyDto job = new(jobKey.Group, jobKey.Name);
+            TriggerKeyDto trigger = new(triggerKey.Group, triggerKey.Name);
+
+            (await client.Interrupt(name, job)).Should().BeFalse(
+                "the job is scheduled but not running, so there is no execution to interrupt");
+            (await client.InterruptFireInstance(name, "no-such-fire-instance")).Should().BeFalse();
+
+            (await client.UnscheduleJob(name, trigger)).Should().BeTrue("the trigger was there");
+            (await client.UnscheduleJob(name, trigger)).Should().BeFalse(
+                "the second call finds nothing, which is what a second operator clicking the same button does");
+
+            (await client.DeleteCalendar(name, "holidays")).Should().BeTrue();
+            (await client.DeleteCalendar(name, "holidays")).Should().BeFalse();
+
+            (await client.DeleteJob(name, job)).Should().BeFalse(
+                "unscheduling the only trigger of a non-durable job took the job with it");
+            (await client.DeleteJob(name, new JobKeyDto("group1", "never-existed"))).Should().BeFalse();
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
     private static async Task<IScheduler> CreateScheduler(string testName)
     {
         NameValueCollection properties = new()

--- a/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/PublicApiTest_Quartz.Dashboard.verified.txt
@@ -254,8 +254,8 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask AddCalendar(string schedulerName, Quartz.Dashboard.Services.AddCalendarRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask AddJob(string schedulerName, Quartz.Dashboard.Services.AddJobRequest request, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<int> CountMisfires(string schedulerName, System.DateTimeOffset since, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask DeleteCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> DeleteCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> DeleteJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.ICalendar> GetCalendar(string schedulerName, string calendarName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<string>> GetCalendarNames(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.Dashboard.Services.ExecutionLimitsDto> GetExecutionLimits(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
@@ -265,8 +265,8 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask<Quartz.ITrigger> GetTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.Dashboard.Services.TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask Interrupt(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask InterruptFireInstance(string schedulerName, string fireInstanceId, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> Interrupt(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> InterruptFireInstance(string schedulerName, string fireInstanceId, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask PauseAll(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> PauseJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> PauseTrigger(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
@@ -288,7 +288,7 @@ namespace Quartz.Dashboard.Services
         System.Threading.Tasks.ValueTask Standby(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask Start(string schedulerName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask TriggerJob(string schedulerName, Quartz.Dashboard.Services.JobKeyDto jobKey, Quartz.JobDataMap? jobDataMap = null, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.ValueTask UnscheduleJob(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> UnscheduleJob(string schedulerName, Quartz.Dashboard.Services.TriggerKeyDto triggerKey, System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class JobDetailDto : System.IEquatable<Quartz.Dashboard.Services.JobDetailDto>
     {

--- a/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/PersistentStoreBuilderTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Quartz.Configuration;
+using Quartz.Extensibility;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
 
@@ -182,6 +183,71 @@ public sealed class PersistentStoreBuilderTest
             .Should().Be(SchemaProvisioning.Validate,
                 "a named scheduler's options are keyed by its name, so one scheduler granted DDL does "
                 + "not hand it to every other scheduler in the container");
+    }
+
+    [Test]
+    public void UseAmbientTransactions_BuildsTheStoreThatRunsInSomebodyElsesTransaction()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ConnectionString);
+            store.UseAmbientTransactions();
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IJobStore>().Should().BeOfType<ExternalTransactionJobStore>(
+            "the store that neither commits nor rolls back is one of the two Quartz ships, and this is "
+            + "the only way to choose it in code now that the type itself is internal");
+    }
+
+    [Test]
+    public void UsePersistentStore_WithoutIt_StillBuildsTheStoreThatManagesItsOwnTransaction()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IJobStore>().Should().BeOfType<LocalTransactionJobStore>(
+            "a store that commits its own work is what nearly everybody wants, so adding a way to ask "
+            + "for the other one must not change what asking for nothing means");
+    }
+
+    [Test]
+    public void UseAmbientTransactions_AppliesToTheSchedulerThatAskedForIt()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store => store.UseSqlServer(ConnectionString)));
+        services.AddQuartz("reporting", q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlServer(ReportingConnectionString);
+            store.UseAmbientTransactions();
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredKeyedService<IJobStore>("reporting").Should().BeOfType<ExternalTransactionJobStore>();
+        provider.GetRequiredService<IJobStore>().Should().BeOfType<LocalTransactionJobStore>(
+            "the store is registered under the scheduler's own key, so one scheduler handing its "
+            + "transactions to a container does not hand every scheduler's over");
+    }
+
+    [Test]
+    public void UseAmbientTransactions_InsideAStoreNamedByItsType_SaysSo()
+    {
+        var services = new ServiceCollection();
+        var act = () => services.AddQuartz(q => q.UsePersistentStore<LocalTransactionJobStore>(store =>
+        {
+            store.UseSqlServer(ConnectionString);
+            store.UseAmbientTransactions();
+        }));
+
+        act.Should().Throw<SchedulerConfigException>().WithMessage("*UseAmbientTransactions*",
+            "the type argument and the selector name different stores, and keeping the type argument "
+            + "silently would leave a scheduler committing transactions its caller believed somebody "
+            + "else owned");
     }
 
     private sealed class CountingDriverDelegate : StdAdoDelegate

--- a/src/Quartz.Tests.Unit/Configuration/QuartzPropertyBridgeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/QuartzPropertyBridgeTest.cs
@@ -208,6 +208,41 @@ public class QuartzPropertyBridgeTest
         clustering.CheckinInterval.Should().Be(TimeSpan.FromSeconds(10));
     }
 
+    /// <summary>
+    /// The one ambient-transaction store setting a 3.x file could carry reaches its option.
+    /// </summary>
+    /// <remarks>
+    /// 3.x wrote <c>quartz.jobStore.*</c> onto the store object by property name, and
+    /// <c>JobStoreCMT.OpenConnection</c> was one of them. Nothing read the key here until it was
+    /// mapped, and because it sits under a prefix the unknown-key guard accepts, a file carrying it
+    /// was accepted and then ignored — the failure mode the guard exists to prevent, one level down.
+    /// </remarks>
+    [Test]
+    public void TheOpenConnectionFlagReachesTheStoreThatReadsIt()
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+            ["quartz.jobStore.openConnection"] = "true",
+        });
+
+        Options<AdoJobStoreOptions>(provider).OpenConnection.Should().BeTrue(
+            "the key is 3.x's spelling of AdoJobStoreOptions.OpenConnection, and the ambient-transaction "
+            + "store it configures is reachable from a configuration file");
+    }
+
+    [Test]
+    public void TheOpenConnectionFlagIsOffWhenNobodyAsked()
+    {
+        using var provider = Bridge(new NameValueCollection
+        {
+            ["quartz.jobStore.dataSource"] = "primary",
+        });
+
+        Options<AdoJobStoreOptions>(provider).OpenConnection.Should().BeFalse(
+            "opening the connection is the externally managed transaction's job unless the file says otherwise");
+    }
+
     [Test]
     public void TheSerializableIsolationFlagBecomesTheIsolationLevel()
     {

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -267,12 +267,27 @@ public class CronExpressionBuilderTest
             "the hour was rejected before the second and minute were written, so nothing was left half-applied");
     }
 
+    /// <summary>
+    /// The builder writes one day field per expression, and says that is its own rule.
+    /// </summary>
+    /// <remarks>
+    /// The message used to blame cron syntax, which does allow both: an expression naming both day
+    /// fields fires on their union, and <c>CronExpression.Parse</c> reads it that way. A refusal that
+    /// misstates why sends a reader looking for a parser bug, so the wording is pinned here.
+    /// </remarks>
     [Test]
     public void TestDayOfMonthAndDayOfWeekAreMutuallyExclusive()
     {
-        Invoking(x => x.WithDayOfMonth(10).WithDaysOfWeek(DayOfWeek.Monday)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
-        Invoking(x => x.WithDaysOfWeek(DayOfWeek.Monday).WithDayOfMonth(10)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
-        Invoking(x => x.OnLastDayOfMonth().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3)).Should().Throw<InvalidOperationException>().WithMessage("*both day-of-month and day-of-week*");
+        Invoking(x => x.WithDayOfMonth(10).WithDaysOfWeek(DayOfWeek.Monday)).Should().Throw<InvalidOperationException>().WithMessage("*one day field per expression*");
+        Invoking(x => x.WithDaysOfWeek(DayOfWeek.Monday).WithDayOfMonth(10)).Should().Throw<InvalidOperationException>().WithMessage("*one day field per expression*");
+        Invoking(x => x.OnLastDayOfMonth().OnNthDayOfWeekOfMonth(DayOfWeek.Friday, 3)).Should().Throw<InvalidOperationException>().WithMessage("*one day field per expression*");
+        Invoking(x => x.WithDayOfMonth(13).WithDaysOfWeek(DayOfWeek.Friday)).Should().Throw<InvalidOperationException>().WithMessage("*fires on the union*",
+            "cron does allow both fields, so the refusal names the builder's constraint rather than a rule cron does not have");
+
+        CronExpression.Parse("0 0 0 13 * FRI").WithTimeZone(TimeZoneInfo.Utc)
+            .IsSatisfiedBy(new DateTimeOffset(2026, 5, 13, 0, 0, 0, TimeSpan.Zero)).Should().BeTrue(
+            "a Wednesday the 13th satisfies an expression naming both day fields, so the one the builder "
+            + "declines to compose is valid and fires on the union");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConfiguredTypeNamesResolveTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConfiguredTypeNamesResolveTest.cs
@@ -200,6 +200,46 @@ public sealed class ConfiguredTypeNamesResolveTest
     }
 
     /// <summary>
+    /// The container-managed store, chosen by the string a configuration file carries and by the
+    /// builder member, is one store either way.
+    /// </summary>
+    /// <remarks>
+    /// <c>quartz.jobStore.type</c> was the only route to it while the type was internal and nothing on
+    /// <c>IPersistentStoreBuilder</c> selected a store, so <c>UseAmbientTransactions</c> is measured
+    /// against it rather than against a name typed here: a selector that reached a different store than
+    /// the string always has would split one setting into two that disagree.
+    /// </remarks>
+    [Test]
+    public void TheAmbientTransactionStoreIsOneStoreWhicheverWayItIsChosen()
+    {
+        NameValueCollection properties = StoreAndDelegateByName(
+            nameof(TheAmbientTransactionStoreIsOneStoreWhicheverWayItIsChosen),
+            typeof(SQLiteDelegate).AssemblyQualifiedName!);
+        properties["quartz.jobStore.type"] = ExternalTransactionJobStoreName;
+
+        ServiceCollection namedByString = new();
+        namedByString.AddQuartz(properties);
+        using ServiceProvider fromString = namedByString.BuildServiceProvider();
+
+        ServiceCollection chosenInCode = new();
+        chosenInCode.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.UseSqlite(connectionString);
+            store.UseAmbientTransactions();
+        }));
+        using ServiceProvider fromCode = chosenInCode.BuildServiceProvider();
+
+        Type stringStore = fromString.GetRequiredService<IJobStore>().GetType();
+
+        stringStore.FullName.Should().Be("Quartz.Impl.AdoJobStore.ExternalTransactionJobStore",
+            "the legacy key is what every deployment on this store spells today, and it has to go on "
+            + "naming it");
+        fromCode.GetRequiredService<IJobStore>().Should().BeOfType(stringStore,
+            "the typed selector exists because the string was the only way to reach this store; the two "
+            + "have to arrive at the same one");
+    }
+
+    /// <summary>
     /// A whole persistent store spelled the way a configuration file spells it: two type names, a data
     /// source, and nothing in code. Naming the store in code would register a driver delegate of its
     /// own, and registration is <c>TryAdd</c>, so the assertions would be measuring the wrong one.

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -533,6 +533,7 @@ namespace Quartz
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
         Quartz.IPersistentStoreBuilder ConfigureStore(System.Action<Quartz.AdoJobStoreOptions> configure);
         Quartz.IPersistentStoreBuilder ProvisionSchema();
+        Quartz.IPersistentStoreBuilder UseAmbientTransactions();
         Quartz.IPersistentStoreBuilder UseClustering(System.Action<Quartz.ClusteringOptions>? configure = null);
         Quartz.IPersistentStoreBuilder UseConnectionProvider(System.Func<System.IServiceProvider, Quartz.Impl.AdoJobStore.Common.IDbProvider> factory);
         Quartz.IPersistentStoreBuilder UseConnectionProvider<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods)]  T>()

--- a/src/Quartz/Configuration/AdoJobStoreOptions.cs
+++ b/src/Quartz/Configuration/AdoJobStoreOptions.cs
@@ -242,7 +242,13 @@ public sealed class AdoJobStoreOptions
     /// <summary>
     /// Whether <see cref="Impl.AdoJobStore.ExternalTransactionJobStore" /> opens the connections it
     /// creates before handing them to an operation. Defaults to <see langword="false" />, leaving the
-    /// opening to the externally managed transaction. Read only by that store.
+    /// opening to the externally managed transaction.
     /// </summary>
+    /// <remarks>
+    /// Read only by that store, which is the one
+    /// <see cref="IPersistentStoreBuilder.UseAmbientTransactions" /> selects — or
+    /// <c>quartz.jobStore.type = Quartz.Impl.AdoJobStore.ExternalTransactionJobStore, Quartz</c>. It
+    /// says nothing on the default local-transaction store.
+    /// </remarks>
     public bool OpenConnection { get; set; }
 }

--- a/src/Quartz/Configuration/IPersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/IPersistentStoreBuilder.cs
@@ -152,6 +152,34 @@ public interface IPersistentStoreBuilder
     IPersistentStoreBuilder UseClustering(Action<ClusteringOptions>? configure = null);
 
     /// <summary>
+    /// Runs the schedule inside a transaction somebody else owns — an application server or another
+    /// framework that manages transactions — instead of one the store begins and commits itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is how the second of the two shipped ADO.NET stores is chosen. Left uncalled,
+    /// <c>UsePersistentStore</c> builds the local-transaction store, which begins the transaction each
+    /// operation runs in and commits or rolls it back; the ambient store does neither, because the
+    /// connections it creates enlist in the <see cref="System.Transactions.Transaction"/> already in
+    /// progress and its owner is what decides whether the scheduler's work is kept. It is
+    /// <c>quartz.jobStore.type = Quartz.Impl.AdoJobStore.ExternalTransactionJobStore, Quartz</c>
+    /// spelled in code — 3.x's <c>JobStoreCMT</c>.
+    /// </para>
+    /// <para>
+    /// Not the same thing as <see cref="AdoJobStoreOptions.AcceptEnlistedTransactions"/>, which leaves
+    /// the local store in charge and only lets an operation join a transaction the application enlisted
+    /// for that flow, managing its own whenever nothing is enlisted. This hands the whole store over.
+    /// </para>
+    /// <para>
+    /// The store requires database locking — an in-process lock would be released before its owner
+    /// commits — and turns it on for itself unless <see cref="UseLockHandler{T}"/> supplied one.
+    /// <see cref="AdoJobStoreOptions.OpenConnection"/>, which nothing else reads, says whether the
+    /// store opens the connections it creates or leaves that to the transaction's owner.
+    /// </para>
+    /// </remarks>
+    IPersistentStoreBuilder UseAmbientTransactions();
+
+    /// <summary>
     /// Creates whatever this store's schema is missing when the scheduler starts, instead of
     /// requiring it to be there already.
     /// </summary>

--- a/src/Quartz/Configuration/IQuartzBuilder.cs
+++ b/src/Quartz/Configuration/IQuartzBuilder.cs
@@ -149,12 +149,31 @@ public interface IQuartzBuilder
     /// <summary>
     /// Uses a database-backed job store, so jobs and triggers survive restarts and can be clustered.
     /// </summary>
-    /// <inheritdoc cref="UseInMemoryStore" path="/remarks" />
+    /// <remarks>
+    /// <para>
+    /// Takes a sub-builder rather than an options object, unlike <see cref="UseInMemoryStore"/>: a
+    /// database-backed store is a composite that also has a data source, a driver delegate, a
+    /// serializer and a lock handler to choose.
+    /// </para>
+    /// <para>
+    /// Both stores Quartz ships are reached from here. The default begins the transaction each
+    /// operation runs in and commits or rolls it back;
+    /// <see cref="IPersistentStoreBuilder.UseAmbientTransactions"/> inside the callback selects the one
+    /// that runs inside a transaction somebody else owns. <see cref="UsePersistentStore{T}"/> is for a
+    /// store neither of those describes.
+    /// </para>
+    /// </remarks>
     IQuartzBuilder UsePersistentStore(Action<IPersistentStoreBuilder> configure);
 
     /// <summary>
     /// Uses a specific database-backed job store implementation.
     /// </summary>
+    /// <remarks>
+    /// For a persistent store of your own. The two Quartz ships are both selected by
+    /// <see cref="UsePersistentStore(Action{IPersistentStoreBuilder})"/>, which is why naming one of
+    /// them here and also calling <see cref="IPersistentStoreBuilder.UseAmbientTransactions"/> is
+    /// reported as the contradiction it is rather than silently resolved.
+    /// </remarks>
     IQuartzBuilder UsePersistentStore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
         Action<IPersistentStoreBuilder> configure) where T : class, IJobStore;
 

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -250,6 +250,23 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
         return ConfigureStore(options => options.UseDbLocks = true);
     }
 
+    /// <summary>
+    /// Whether this callback asked for the store that runs inside a transaction somebody else owns.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than registered, because the store registration is first-wins and the choice is
+    /// made inside the callback: <see cref="QuartzBuilder"/> reads this once the callback has run and
+    /// registers the store it names. Nothing else can decide it — both stores are constructed from the
+    /// same <c>AdoJobStoreDependencies</c>, so which one is built is the whole of the difference.
+    /// </remarks>
+    internal bool AmbientTransactions { get; private set; }
+
+    public IPersistentStoreBuilder UseAmbientTransactions()
+    {
+        AmbientTransactions = true;
+        return this;
+    }
+
     public IPersistentStoreBuilder ProvisionSchema()
     {
         return ConfigureStore(options => options.SchemaProvisioning = SchemaProvisioning.CreateIfMissing);

--- a/src/Quartz/Configuration/QuartzBuilder.cs
+++ b/src/Quartz/Configuration/QuartzBuilder.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl;
 using Quartz.Extensibility;
+using Quartz.Util;
 
 namespace Quartz.Configuration;
 
@@ -136,7 +137,25 @@ internal sealed class QuartzBuilder : IQuartzBuilder
 
     public IQuartzBuilder UsePersistentStore(Action<IPersistentStoreBuilder> configure)
     {
-        return UsePersistentStore<LocalTransactionJobStore>(configure);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        // Which of the two shipped stores this is decided inside the callback, so the registration
+        // waits for it: registration is first-wins, and registering the local store before running the
+        // callback would make UseAmbientTransactions a call that quietly did nothing.
+        PersistentStoreBuilder store = ConfigurePersistentStore(configure);
+
+        if (store.AmbientTransactions)
+        {
+            RegisterConfigured<IJobStore>((provider, key) =>
+                ActivatorUtilities.CreateInstance<ExternalTransactionJobStore>(SchedulerScopedServiceProvider.For(provider, key)));
+        }
+        else
+        {
+            RegisterConfigured<IJobStore>((provider, key) =>
+                ActivatorUtilities.CreateInstance<LocalTransactionJobStore>(SchedulerScopedServiceProvider.For(provider, key)));
+        }
+
+        return this;
     }
 
     public IQuartzBuilder UsePersistentStore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>(
@@ -147,15 +166,37 @@ internal sealed class QuartzBuilder : IQuartzBuilder
         RegisterConfigured<IJobStore>((provider, key) =>
             ActivatorUtilities.CreateInstance<T>(SchedulerScopedServiceProvider.For(provider, key)));
 
-        var store = new PersistentStoreBuilder(Services, schedulerKey);
-        configure(store);
+        PersistentStoreBuilder store = ConfigurePersistentStore(configure);
 
-        // The serializer, driver delegate and lock handler fallbacks are not registered here. A
-        // serializer named in a configuration file is applied after this callback, so a fallback
-        // registered inside it would win the first-wins race and silently replace the caller's choice.
-        // They go in with the rest of the defaults instead, after everything explicit — and the lock
-        // handler has no fallback at all, so the store can choose one once it knows its database.
+        if (store.AmbientTransactions)
+        {
+            // The type argument already named the store, and UseAmbientTransactions names a different
+            // one. Silently keeping T would leave a scheduler committing transactions the caller
+            // believed somebody else owned.
+            Throw.SchedulerConfigException(
+                "UseAmbientTransactions() selects the store that runs inside a transaction somebody else owns, "
+                + $"but this store was already named as '{typeof(T).Name}'. Call UsePersistentStore(...) without a "
+                + "type argument to use it, or drop the UseAmbientTransactions() call.");
+        }
+
         return this;
+    }
+
+    /// <summary>
+    /// Runs a persistent store's configuration callback and hands back what it decided.
+    /// </summary>
+    /// <remarks>
+    /// The serializer, driver delegate and lock handler fallbacks are deliberately not registered here.
+    /// A serializer named in a configuration file is applied after this callback, so a fallback
+    /// registered inside it would win the first-wins race and silently replace the caller's choice.
+    /// They go in with the rest of the defaults instead, after everything explicit — and the lock
+    /// handler has no fallback at all, so the store can choose one once it knows its database.
+    /// </remarks>
+    private PersistentStoreBuilder ConfigurePersistentStore(Action<IPersistentStoreBuilder> configure)
+    {
+        PersistentStoreBuilder store = new(Services, schedulerKey);
+        configure(store);
+        return store;
     }
 
     public IQuartzBuilder UseJobFactory<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods)] T>()

--- a/src/Quartz/Configuration/QuartzPropertyBridge.cs
+++ b/src/Quartz/Configuration/QuartzPropertyBridge.cs
@@ -663,6 +663,11 @@ internal static class QuartzPropertyBridge
         parser.Bool("quartz.jobStore.lockOnInsert", value => options.LockOnInsert = value);
         parser.Bool("quartz.jobStore.acquireTriggersWithinLock", value => options.AcquireTriggersWithinLock = value);
         parser.Bool("quartz.jobStore.acceptEnlistedTransactions", value => options.AcceptEnlistedTransactions = value);
+        // Read by the ambient-transaction store alone, and settable on 3.x because the store was
+        // constructed and had its properties written by name. A file carrying it configured nothing
+        // here until this line, silently: the key is under a supported prefix, so it was accepted
+        // and dropped.
+        parser.Bool("quartz.jobStore.openConnection", value => options.OpenConnection = value);
         // The legacy key is a flag with two meanings: serializable, or say nothing. "Say nothing" has to
         // stay null rather than becoming ReadCommitted, because the SQLite defaulting reads it.
         parser.Bool(

--- a/src/Quartz/CronExpressionBuilder.cs
+++ b/src/Quartz/CronExpressionBuilder.cs
@@ -30,9 +30,12 @@ namespace Quartz;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Unconfigured fields default to every value ('*'). The day-of-month and
-/// day-of-week fields are mutually exclusive per cron syntax; the unused one
-/// renders as '?'. Each field can be configured only once. Day-of-week values
+/// Unconfigured fields default to every value ('*'). One expression carries one
+/// day field here: configuring day-of-month and day-of-week both is refused, and
+/// the unused one renders as '?'. That is this builder's constraint rather than
+/// cron's — an expression naming both days fires on the union of the two, which
+/// <see cref="CronExpression.Parse(string)" /> accepts and reads that way.
+/// Each field can be configured only once. Day-of-week values
 /// are emitted using their textual names (SUN-SAT) so that the produced
 /// expressions stay unambiguous across cron dialects that use different
 /// day-of-week numbering.
@@ -628,7 +631,7 @@ public sealed class CronExpressionBuilder
     {
         if (dayOfWeek is not null)
         {
-            throw new InvalidOperationException("Day-of-month cannot be configured because day-of-week has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
+            throw new InvalidOperationException("Day-of-month cannot be configured because day-of-week has already been configured. This builder writes one day field per expression; an expression that names both fires on the union of the two, so write that one as text and parse it.");
         }
 
         return SetField(ref dayOfMonth, "Day-of-month", value);
@@ -640,7 +643,7 @@ public sealed class CronExpressionBuilder
     {
         if (dayOfMonth is not null)
         {
-            throw new InvalidOperationException("Day-of-week cannot be configured because day-of-month has already been configured. Cron expressions do not support specifying both day-of-month and day-of-week.");
+            throw new InvalidOperationException("Day-of-week cannot be configured because day-of-month has already been configured. This builder writes one day field per expression; an expression that names both fires on the union of the two, so write that one as text and parse it.");
         }
 
         return SetField(ref dayOfWeek, "Day-of-week", value);


### PR DESCRIPTION
The freeze audit's two blocking items, plus the three addenda the docs sweep (#3640) turned up in the same files.

Closes #3636

## B1 — the ambient-transaction store can be chosen from code

`ExternalTransactionJobStore` was documented as one of the two shipped stores and reachable only through the `quartz.jobStore.type` string: internalizing the ADO hierarchy left `UsePersistentStore<T>` needing a nameable `T`, while `AdoJobStoreOptions.OpenConnection` stayed public with a doc naming a store nothing typed could select.

`IPersistentStoreBuilder.UseAmbientTransactions()` selects it. It is parameterless — both stores are constructed from the same `AdoJobStoreDependencies`, so *which type is built* is the whole of the difference, and the one setting that distinguishes them (`OpenConnection`) already lives on `AdoJobStoreOptions` and is reachable through `ConfigureStore`.

Because registration is first-wins and the choice is made inside the callback, `UsePersistentStore(configure)` now registers the store **after** running the callback. `UsePersistentStore<T>(configure)` still registers `T` first, and reports the contradiction if the callback also calls the selector rather than silently keeping `T` — a scheduler that commits transactions its caller believed somebody else owned is not something to resolve quietly.

- The legacy string path is untouched and is now *measured against* the new member: `ConfiguredTypeNamesResolveTest.TheAmbientTransactionStoreIsOneStoreWhicheverWayItIsChosen` builds the store from `quartz.jobStore.type` and from `UseAmbientTransactions()` and asserts both arrive at the same type.
- `AdoJobStoreOptions.OpenConnection`'s doc now names the typed route, as do `configuration/reference.md` and `tutorial/job-stores.md`.
- Migration guide: the `UsePersistentStore<ExternalTransactionJobStore>(…)` sample (which did not compile) becomes the new member, the "code that names the type has to be updated" line says what to update it *to*, and the appendix row for the type names the selector.
- Baseline: `PublicApiTest_Quartz` moves by exactly one added member, reviewed and accepted.

**Reviewer note — overlap with #3640.** The surrounding section (guide ~:6502-6558) is being rewritten by the docs sweep; my edit is confined to the prescription lines (the diff sample, the "updated to what" sentence, the appendix row) so that the two can be sequenced with this one first.

## R1 — the dashboard client reports the applied flag for all ten mutations

`IScheduler` answers `bool` for each of its ten "did this find anything to act on" mutations and the HTTP API puts all ten on the wire as `OperationAppliedResponse`, but `IQuartzApiClient` returned it for five and discarded it for five with a literal `_ =`. `Interrupt` was renamed to the scheduler's verb in this delta, which is what turns the asymmetry into two members that read as the same operation and are not.

`Interrupt`, `InterruptFireInstance`, `DeleteJob`, `UnscheduleJob` and `DeleteCalendar` return `ValueTask<bool>`, in the shape the five siblings already use, and gain the XML doc the siblings have. Widening a public interface's return type after the tag would be a binary and source break for any implementer, which is why it happens now.

The pages use the answer rather than discarding it one level up:

- deleting a job, unscheduling a trigger or deleting a calendar that a cluster peer already removed reports "was not deleted — it no longer exists" instead of claiming success, and the two detail pages navigate away only when something was actually removed;
- **Currently Executing** now injects `ToastService` and says when the firing behind the button had already finished — the case its one-second refresh makes routine.

**No wire change.** The endpoints call `IScheduler` directly and already answered with `OperationAppliedResponse`; only the dashboard's own client interface moved. Baseline `PublicApiTest_Quartz.Dashboard` moves by the five signatures, reviewed and accepted, with a migration row and a paragraph in "The client speaks the scheduler's verbs".

## Addenda from the #3640 sweep

1. **`CronExpressionBuilder` blamed cron for its own rule.** The refusal said "Cron expressions do not support specifying both day-of-month and day-of-week", which is false since the union rule was ratified: `0 0 0 13 * FRI` parses and fires on every Friday *and* the 13th. The builder's one-day-field constraint stays; the message, the class remark and `cron-expressions.md` now say whose rule it is and what to write instead. The test pins the new reason and asserts the expression the builder declines to compose is a valid one.
2. **`quartz.jobStore.openConnection` had no reader.** 3.x set it by writing the property onto the store object; here the key sits under a supported prefix, so a migrated file was accepted and silently ignored. **Deviation from the brief:** the brief asked for a targeted *rejection* on the grounds that "OpenConnection is a delegate no string can express". It is a `bool` (`AdoJobStoreOptions.OpenConnection`), 3.x's `JobStoreCMT.OpenConnection` was a settable `bool` property, and rejecting the key would break a 3.x file that meant something by it — so it is bridged onto the option instead, with two pin tests and a row in the reference's flat-key table. (`AdoJobStoreOptions.IsTransient` is the setting that genuinely cannot come from a string.)
3. **AGENTS.md** — the job-store paragraph now says the three ADO types are internal and names the two ways to select them. One sentence; the file is 31,072 bytes against the 32,768 cap.

## Verification

```
dotnet build Quartz.slnx                              0 warnings, 0 errors
dotnet test src/Quartz.Tests.Unit                     4839 passed, 36 skipped, 0 failed
dotnet test src/Quartz.Tests.AspNetCore                559 passed, 0 failed
dotnet fallout VerifyDocsSnippets                     up to date (102 markdown files)
dotnet test src/Quartz.Tests.Integration
  --filter ExternalTransactionJobStoreContractTest      93 passed (SQLite file, no container)
```

The rest of the integration suite was not run: it wants a container per dialect and this worktree is disk-constrained. Nothing here touches store internals only an integration test reaches — the ADO change is which type the builder registers, and the contract test above covers that store's behaviour. `Quartz.Benchmark` names none of the types touched, so `BenchmarkSmoke` is not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWqvU1BUkFdU7kRQ7oCQwX
