### PR TITLE
The side packages keep their promises

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -731,6 +731,16 @@ IScheduler scheduler = await QuartzSchedulerBuilder.Create()
 than silently ignored; set `quartz.checkConfiguration` to `false` to allow keys of your own.
 Configuration written in code wins over the properties whichever order the two are applied in.
 
+**The check applies to a property bag you wrote, not to `appsettings.json`.** It runs for
+`UseProperties` and the `AddQuartz(services, properties, …)` overloads — the shape a 3.x application
+migrates in, and the one the removed-key advice is written for. Keys that came out of an
+`IConfiguration` section are deliberately not checked, because there every key under `Quartz:` becomes
+a `quartz.*` key whether Quartz reads it or not, so a section holding your own settings would be
+rejected. A misspelled key in `appsettings.json` is therefore read by nobody and reported by nothing —
+`Quartz:JobStore:TabelPrefix` configures no table prefix and says so nowhere — so check a key you have
+just typed against the tables above. Casing is not the risk: configuration keys are matched
+case-insensitively, so `Quartz:Jobstore:TablePrefix` is the same key as `Quartz:JobStore:TablePrefix`.
+
 ## Legacy property keys
 
 Earlier versions configured Quartz with flat `quartz.*` string keys. They still work, and mean exactly
@@ -766,12 +776,31 @@ Two differences are worth knowing:
 | `quartz.jobStore.openConnection` | `JobStore:OpenConnection`, read only by the ambient-transaction store |
 | `quartz.jobStore.clusterCheckinInterval` | `JobStore:Clustering:CheckinInterval` |
 | `quartz.jobStore.clusterCheckinMisfireThreshold` | `JobStore:Clustering:CheckinMisfireThreshold` |
+| `quartz.jobStore.clustering.enabled` | `JobStore:Clustering:Enabled` — the hierarchical spelling of `quartz.jobStore.clustered` |
+| `quartz.jobStore.clustering.checkinInterval` | `JobStore:Clustering:CheckinInterval` |
+| `quartz.jobStore.clustering.checkinMisfireThreshold` | `JobStore:Clustering:CheckinMisfireThreshold` |
+| `quartz.jobStore.driverDelegateType` | `JobStore:DriverDelegateType`; the `UseSqlServer()` family sets it for you |
+| `quartz.jobStore.schemaProvisioning` | `JobStore:SchemaProvisioning` — `None`, `Validate` or `Create` |
+| `quartz.jobStore.performSchemaValidation` | `JobStore:SchemaProvisioning` — `true` means `Validate`, `false` means `None`; the key above says all three |
+| `quartz.jobStore.useDBLocks` | `JobStore:UseDbLocks` |
+| `quartz.jobStore.lockOnInsert` | `JobStore:LockOnInsert` |
+| `quartz.jobStore.acquireTriggersWithinLock` | `JobStore:AcquireTriggersWithinLock` |
+| `quartz.jobStore.selectWithLockSQL` | `JobStore:SelectWithLockSql` |
+| `quartz.jobStore.txIsolationLevelSerializable` | `JobStore:TransactionIsolationLevel` — `true` means `Serializable`; unset says nothing rather than `ReadCommitted` |
+| `quartz.jobStore.misfireHandlerFrequency` | `JobStore:MisfireHandlerFrequency` |
+| `quartz.jobStore.maxMisfiresToHandleAtATime` | `JobStore:MaxMisfiresToHandleAtATime` |
+| `quartz.jobStore.doubleCheckLockMisfireHandler` | `JobStore:DoubleCheckLockMisfireHandler` |
+| `quartz.jobStore.maxTransientRetries` | `JobStore:MaxTransientRetries` |
+| `quartz.jobStore.transientRetryInterval` | `JobStore:TransientRetryInterval` |
+| `quartz.jobStore.dbRetryInterval` | `JobStore:DbRetryInterval` |
+| `quartz.jobStore.retryableActionErrorLogThreshold` | `JobStore:RetryableActionErrorLogThreshold` |
 | `quartz.jobStore.dataSource` | set for you by the database methods |
 | `quartz.dataSource.NAME.provider` | `DataSource:NAME:Provider` |
 | `quartz.dataSource.NAME.connectionString` | `DataSource:NAME:ConnectionString` |
 | `quartz.dataSource.NAME.connectionStringName` | `DataSource:NAME:ConnectionStringName` |
 | `quartz.dbprovider.NAME.*` | the metadata factory on `UseGenericDatabase`; the keys still work |
 | `quartz.serializer.type` | `UseSystemTextJsonSerializer()` / `UseNewtonsoftJsonSerializer()` |
+| `quartz.serializer.PROPERTY` | any other key under this prefix sets that property on the serializer — `quartz.serializer.RegisterTriggerConverters = true`, for instance |
 | `quartz.plugin.NAME.type` | `AddPlugin<T>()` or the plugin's own `Use*` method |
 | `quartz.jobStore.lockHandler.type` | `UseLockHandler<T>()` |
 | `quartz.scheduler.jobFactory.type` | `UseJobFactory<T>()` |
@@ -779,7 +808,9 @@ Two differences are worth knowing:
 | `quartz.scheduler.instanceIdGenerator.type` | `UseInstanceIdGenerator<T>()`; other `quartz.scheduler.instanceIdGenerator.*` keys configure it |
 | `quartz.timeProvider.type` | `UseTimeProvider(timeProvider)` |
 
-Four keys are rejected rather than ignored, because they no longer configure anything.
+Nine key prefixes are rejected rather than ignored, because they no longer configure anything. Each is
+reported by name, with the replacement, instead of as an unknown property — a configuration still
+carrying one of these was configuring something real, and "unknown property" reads like a typo.
 
 `quartz.scheduler.threadName` and `quartz.scheduler.makeSchedulerThreadDaemon`: the scheduling loop is
 a `Task` rather than a `Thread`, so it has no name to set and never held a process open. Remove them;
@@ -791,6 +822,15 @@ could carry no matchers, so it heard everything, and the type it named had to be
 `AddJobListener<T>(matchers)` and `AddTriggerListener<T>(matchers)` take the matchers *and* build the
 listener through the container. Registration is where a listener's matchers belong, so there is nothing
 the keys said that the registration cannot.
+
+`quartz.jobStore.lockHandler.tablePrefix`, `quartz.jobStore.lockHandler.schedName` and
+`quartz.jobStore.lockHandler.schedulerName`: a lock handler is told its table prefix and its scheduler's
+name by the job store, through `ILockHandler.Initialize`. Set `quartz.jobStore.tablePrefix` and
+`quartz.scheduler.instanceName` and remove these — a 3.x configuration that sets them meets a startup
+exception rather than being ignored.
+
+`quartz.scheduler.proxy*` and `quartz.scheduler.exporter*` are the remaining two, described at the end
+of this section.
 
 Every key has both spellings. `quartz.jobStore.tablePrefix` and `JobStore:TablePrefix` are the same
 setting said two ways, and so are the ones that select an implementation rather than set a value —

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -136,6 +136,24 @@ dashboard — with the authentication forwarding, execution limits and history s
 is designed in [#3387](https://github.com/quartznet/quartznet/issues/3387).
 :::
 
+### Writing your own `IQuartzApiClient`
+
+Two things the interface promises, so an implementation of your own renders the way the shipped one does:
+
+- **A missing thing is a `KeyNotFoundException`.** Every member taking a `schedulerName` raises it when
+  no scheduler goes by that name, and `GetScheduler`, `GetJobDetail`, `GetTrigger` and `GetCalendar`
+  raise it again when the thing itself is gone. Their return types are not nullable, so there is no
+  other answer they could give, and the dashboard's error boundary turns that exception into the
+  not-found page. Returning `null!` faults the page instead.
+- **Something you cannot report is a value, not a refusal.** `GetExecutionLimits` answers
+  `ExecutionLimitsDto.CannotReport` when the source cannot say — the overview draws that differently
+  from a scheduler that limits nothing.
+
+**The interface is additive from 4.0.0-beta.1 on: a member added to it during 4.x arrives as a default
+interface member**, so your implementation keeps compiling across a minor release. The default body
+reports the datum as unavailable rather than inventing one, the way `CannotReport` does — override it
+when your source can answer.
+
 ## The pages
 
 Ten of them, all served under `{DashboardPath}` — `/quartz` unless you said otherwise. Every one of

--- a/docs/documentation/quartz-4.x/packages/http-client.md
+++ b/docs/documentation/quartz-4.x/packages/http-client.md
@@ -281,8 +281,29 @@ The endpoint accepts **at most 1000 keys per call**; page the keys if you have m
 
 ## Errors
 
-Anything the server rejects arrives as an `HttpClientException`, which derives from
-`SchedulerException`, with the RFC 7807 problem details in the message. Turning on
+**What the server rejects arrives as the exception it named.** The API's problem details carry the type
+the failure came from, and the client rebuilds it — so a `catch` written against a local scheduler fires
+the same way against a remote one. Eight names are mapped back:
+
+| The server raised | The client rethrows |
+|---|---|
+| `SchedulerException` | `SchedulerException` |
+| `InvalidConfigurationException` | `InvalidConfigurationException` |
+| `JobExecutionException` | `JobExecutionException` |
+| `JobPersistenceException` | `JobPersistenceException` |
+| `SchedulerConfigException` | `SchedulerConfigException` |
+| `LockException` | `LockException` |
+| `NoSuchDelegateException` | `NoSuchDelegateException` |
+| `ObjectAlreadyExistsException` | `ObjectAlreadyExistsException` |
+| anything else | `HttpClientException` |
+
+`ObjectAlreadyExistsException` is the one most code depends on: it is what `ScheduleJob` and `AddJob`
+raise for a duplicate, and catching it works over HTTP exactly as it does in process.
+
+Everything else is an `HttpClientException` — a request the endpoint rejected before it reached a
+scheduler, a scheduler name the server does not hold, a response carrying no problem details, a body
+that could not be read. It derives from `SchedulerException`, so a single `catch (SchedulerException)`
+covers both halves, and it carries the RFC 7807 problem details in its message. Turning on
 `QuartzHttpApiOptions.IncludeStackTraceInProblemDetails` on the server puts the server's stack trace in
 there too — useful in development, and not something to ship.
 

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Endpoints/SchedulerEndpoints.cs
@@ -270,10 +270,14 @@ internal static class SchedulerEndpoints
         return EndpointHelper.ExecuteWithOkResponse(schedulerName, schedulerRepository, async scheduler =>
         {
             ExecutionLimits? limits = null;
-            if (request.Limits is { Count: > 0 })
+
+            // A request that names no group and asks for no derivation is the one that clears the limits.
+            // Asking for the derivation alone still configures something - every trigger is then limited
+            // as though its trigger group were its execution group - so it is built rather than dropped.
+            if (request.Limits is { Count: > 0 } || request.UseTriggerGroupWhenUnset)
             {
                 ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
-                foreach (KeyValuePair<string, ExecutionLimitDto> kvp in request.Limits)
+                foreach (KeyValuePair<string, ExecutionLimitDto> kvp in request.Limits ?? [])
                 {
                     string key = kvp.Key.Trim();
                     int? maxConcurrent = kvp.Value.MaxConcurrent;

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -5,11 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <Authors>Lewis Zou, Marko Lahma, Quartz.NET</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--

--- a/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
@@ -14,6 +14,9 @@ using Quartz.Serialization.SystemTextJson;
 
 namespace Quartz;
 
+/// <summary>
+/// Registers and maps the Quartz HTTP API — the server half of <c>Quartz.HttpClient</c>.
+/// </summary>
 public static class QuartzAspNetCoreConfigurationExtensions
 {
     /// <summary>

--- a/src/Quartz.Aspire/Quartz.Aspire.csproj
+++ b/src/Quartz.Aspire/Quartz.Aspire.csproj
@@ -7,11 +7,6 @@
     <Description>Quartz.NET Aspire client integration - wires a persistent job store, its telemetry and its health check from an Aspire connection name; $(Description)</Description>
     <PackageTags>$(PackageTags);aspire;aspire-integration</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Binding is the compiler's job here, not the reflection binder's, for the same reason it is in

--- a/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
+++ b/src/Quartz.Dashboard/Hubs/IQuartzDashboardHubClient.cs
@@ -46,29 +46,70 @@ namespace Quartz.Dashboard.Hubs;
 /// </remarks>
 public interface IQuartzDashboardHubClient
 {
+    /// <summary>
+    /// A job has begun running.
+    /// </summary>
     Task JobExecuting(JobEventDto jobEvent);
 
+    /// <summary>
+    /// A job has finished, successfully, with an exception, or vetoed before it started.
+    /// </summary>
     Task JobExecuted(JobExecutionResultDto result);
 
+    /// <summary>
+    /// A trigger has fired.
+    /// </summary>
     Task TriggerFired(TriggerEventDto triggerEvent);
 
+    /// <summary>
+    /// A trigger will not fire again: its schedule has run out.
+    /// </summary>
     Task TriggerCompleted(TriggerEventDto triggerEvent);
 
+    /// <summary>
+    /// A trigger missed a firing and its misfire instruction has been applied.
+    /// </summary>
     Task TriggerMisfired(TriggerEventDto triggerEvent);
 
+    /// <summary>
+    /// A trigger has been paused.
+    /// </summary>
     Task TriggerPaused(TriggerLifecycleDto triggerEvent);
 
+    /// <summary>
+    /// A trigger has been resumed.
+    /// </summary>
     Task TriggerResumed(TriggerLifecycleDto triggerEvent);
 
+    /// <summary>
+    /// A job has been paused, and with it every trigger that fires it.
+    /// </summary>
     Task JobPaused(JobLifecycleDto jobEvent);
 
+    /// <summary>
+    /// A job has been resumed.
+    /// </summary>
     Task JobResumed(JobLifecycleDto jobEvent);
 
+    /// <summary>
+    /// One node's scheduler has entered a new lifecycle state.
+    /// </summary>
     Task SchedulerStateChanged(SchedulerStateDto state);
 
+    /// <summary>
+    /// A scheduler reported an error it handled itself, such as a store operation it is retrying.
+    /// </summary>
     Task SchedulerError(SchedulerErrorDto schedulerError);
 }
 
+/// <summary>
+/// A job that has begun running, and the node running it.
+/// </summary>
+/// <param name="SchedulerInstanceId">The node that raised the event.</param>
+/// <param name="JobKey">The job that is running.</param>
+/// <param name="TriggerKey">The trigger that fired it.</param>
+/// <param name="FireTimeUtc">When it fired.</param>
+/// <param name="FireInstanceId">This firing's id, which is what an interrupt names.</param>
 public sealed record JobEventDto(
     string SchedulerInstanceId,
     JobKeyDto JobKey,
@@ -76,6 +117,16 @@ public sealed record JobEventDto(
     DateTimeOffset FireTimeUtc,
     string? FireInstanceId);
 
+/// <summary>
+/// How a job execution ended, and the node it ran on.
+/// </summary>
+/// <param name="SchedulerInstanceId">The node that raised the event.</param>
+/// <param name="JobKey">The job that ran.</param>
+/// <param name="TriggerKey">The trigger that fired it.</param>
+/// <param name="FireTimeUtc">When it fired.</param>
+/// <param name="RunTime">How long it ran.</param>
+/// <param name="Vetoed">Whether a listener vetoed it, in which case it never ran at all.</param>
+/// <param name="ExceptionMessage">What it faulted with, or null when it succeeded.</param>
 /// <remarks>
 /// <see cref="RunTime" /> is a <see cref="TimeSpan" />, as every other duration on the wire is — it
 /// carries <see cref="IJobExecutionContext.JobRunTime" /> unrounded, where the milliseconds it used to
@@ -90,6 +141,13 @@ public sealed record JobExecutionResultDto(
     bool Vetoed,
     string? ExceptionMessage);
 
+/// <summary>
+/// A trigger that fired, completed or misfired, and the node it happened on.
+/// </summary>
+/// <param name="SchedulerInstanceId">The node that raised the event.</param>
+/// <param name="TriggerKey">The trigger the event is about.</param>
+/// <param name="JobKey">The job it fires, where the event knows it.</param>
+/// <param name="FireTimeUtc">When it fired, where the event has a time to give.</param>
 public sealed record TriggerEventDto(
     string SchedulerInstanceId,
     TriggerKeyDto TriggerKey,
@@ -121,6 +179,15 @@ public sealed record JobLifecycleDto(string SchedulerInstanceId, JobKeyDto JobKe
 /// </remarks>
 public sealed record SchedulerStateDto(string SchedulerName, string SchedulerInstanceId, SchedulerStatus Status);
 
+/// <summary>
+/// An error a scheduler reported, and the node that reported it.
+/// </summary>
+/// <param name="SchedulerName">The scheduler the error belongs to.</param>
+/// <param name="SchedulerInstanceId">The node that raised the event.</param>
+/// <param name="Message">What went wrong.</param>
+/// <param name="Cause">The underlying failure, where there was one.</param>
+/// <param name="TriggerKey">The trigger the error was about, where the scheduler could say.</param>
+/// <param name="JobKey">The job the error was about, where the scheduler could say.</param>
 /// <remarks>
 /// <see cref="TriggerKey" /> and <see cref="JobKey" /> are null when the scheduler could not say what
 /// the error was about — a store retrying a failed operation names neither.

--- a/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardHistoryPlugin.cs
@@ -24,6 +24,17 @@ using Quartz.Extensibility;
 
 namespace Quartz.Dashboard.Plugins;
 
+/// <summary>
+/// Records what a scheduler has run and what it has missed, so the history and misfire pages have
+/// something to show.
+/// </summary>
+/// <remarks>
+/// The rows go to the <see cref="IDashboardHistoryStore" /> in the container, which by default keeps
+/// them in memory for <c>HistoryRetention</c> — a dashboard's history is an operator's recent view
+/// rather than an audit log. Registered by <c>AddQuartzDashboard</c> against every scheduler in the
+/// container, and told its own scheduler's name when it is initialized, which is what its rows are
+/// keyed by.
+/// </remarks>
 public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITriggerListener
 {
     private readonly IServiceProvider serviceProvider;
@@ -50,8 +61,10 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITr
         this.timeProvider = timeProvider ?? TimeProvider.System;
     }
 
+    /// <inheritdoc />
     public string Name { get; private set; } = "QuartzDashboardHistory";
 
+    /// <inheritdoc />
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
@@ -60,14 +73,19 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITr
         return default;
     }
 
+    /// <inheritdoc />
     public ValueTask Start(CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
     {
         try
@@ -98,8 +116,10 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITr
         }
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         return ValueTask.FromResult(false);
@@ -141,6 +161,7 @@ public sealed class DashboardHistoryPlugin : ISchedulerPlugin, IJobListener, ITr
         }
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerComplete(
         ITrigger trigger,
         IJobExecutionContext context,

--- a/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
+++ b/src/Quartz.Dashboard/Plugins/DashboardLiveEventsPlugin.cs
@@ -26,6 +26,17 @@ using Quartz.Extensibility;
 
 namespace Quartz.Dashboard.Plugins;
 
+/// <summary>
+/// Pushes a scheduler's events to the browsers watching it, which is what makes the dashboard's live
+/// view live.
+/// </summary>
+/// <remarks>
+/// It is all three listener kinds at once because the live view draws all three: a job starting and
+/// finishing, a trigger firing and misfiring, and the scheduler's own lifecycle. Registered by
+/// <c>AddQuartzDashboard</c> against every scheduler in the container rather than named by a
+/// <c>quartz.plugin.*.type</c> key, and told its own scheduler's name when it is initialized — which is
+/// the SignalR group it broadcasts to.
+/// </remarks>
 public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, ITriggerListener, ISchedulerListener
 {
     private readonly IServiceProvider serviceProvider;
@@ -42,8 +53,10 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         this.serviceProvider = serviceProvider;
     }
 
+    /// <inheritdoc />
     public string Name { get; private set; } = "QuartzDashboardLiveEvents";
 
+    /// <inheritdoc />
     public ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
@@ -55,10 +68,13 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return default;
     }
 
+    /// <inheritdoc />
     public ValueTask Start(CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask Shutdown(CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         JobEventDto payload = new(
@@ -71,6 +87,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.JobExecuting(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         JobExecutionResultDto payload = new(
@@ -85,6 +102,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.JobExecuted(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException? jobException, CancellationToken cancellationToken = default)
     {
         JobExecutionResultDto payload = new(
@@ -99,6 +117,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.JobExecuted(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerFired(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
@@ -110,11 +129,13 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.TriggerFired(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask<bool> VetoJobExecution(ITrigger trigger, IJobExecutionContext context, CancellationToken cancellationToken = default)
     {
         return ValueTask.FromResult(false);
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerMisfired(ITrigger trigger, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         TriggerEventDto payload = new(
@@ -126,6 +147,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerMisfired(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerComplete(
         ITrigger trigger,
         IJobExecutionContext context,
@@ -141,50 +163,65 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(context.Scheduler.SchedulerName, client => client.TriggerCompleted(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask JobScheduled(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobUnscheduled(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask TriggerFinalized(IScheduler scheduler, ITrigger trigger, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask TriggerPaused(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         TriggerLifecycleDto payload = new(scheduler.SchedulerInstanceId, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerPaused(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask TriggersPaused(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask TriggerResumed(IScheduler scheduler, TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         TriggerLifecycleDto payload = new(scheduler.SchedulerInstanceId, new TriggerKeyDto(triggerKey.Group, triggerKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.TriggerResumed(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask TriggersResumed(IScheduler scheduler, string? triggerGroup, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobAdded(IScheduler scheduler, IJobDetail jobDetail, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobDeleted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobPaused(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
         JobLifecycleDto payload = new(scheduler.SchedulerInstanceId, new JobKeyDto(jobKey.Group, jobKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobPaused(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask JobInterrupted(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobsPaused(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask JobResumed(IScheduler scheduler, JobKey jobKey, CancellationToken cancellationToken = default)
     {
         JobLifecycleDto payload = new(scheduler.SchedulerInstanceId, new JobKeyDto(jobKey.Group, jobKey.Name));
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.JobResumed(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask JobsResumed(IScheduler scheduler, string? jobGroup, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
     {
         SchedulerErrorDto payload = new(
@@ -198,11 +235,13 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.SchedulerError(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask SchedulerInStandbyMode(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         return BroadcastState(scheduler, SchedulerStatus.Standby);
     }
 
+    /// <inheritdoc />
     public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         return BroadcastState(scheduler, SchedulerStatus.Running);
@@ -218,11 +257,13 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
     /// </remarks>
     public ValueTask SchedulerStarting(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
+    /// <inheritdoc />
     public ValueTask SchedulerShutdown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         return BroadcastState(scheduler, SchedulerStatus.Shutdown);
     }
 
+    /// <inheritdoc />
     public ValueTask SchedulerShuttingDown(IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         return BroadcastState(scheduler, SchedulerStatus.ShuttingDown);
@@ -237,6 +278,7 @@ public sealed class DashboardLiveEventsPlugin : ISchedulerPlugin, IJobListener, 
         return BroadcastToScheduler(scheduler.SchedulerName, client => client.SchedulerStateChanged(payload));
     }
 
+    /// <inheritdoc />
     public ValueTask SchedulingDataCleared(IScheduler scheduler, CancellationToken cancellationToken = default) => default;
 
     private async ValueTask BroadcastToScheduler(string schedulerName, Func<IQuartzDashboardHubClient, Task> send)

--- a/src/Quartz.Dashboard/Quartz.Dashboard.csproj
+++ b/src/Quartz.Dashboard/Quartz.Dashboard.csproj
@@ -5,11 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz.Dashboard</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Not trimmable, said out loud rather than left to the default (issue #3431). Blazor Server is a

--- a/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardEndpointRouteBuilderExtensions.cs
@@ -41,6 +41,9 @@ using Quartz.Dashboard.Hubs;
 
 namespace Quartz;
 
+/// <summary>
+/// Maps the Quartz.NET Dashboard's pages, hub and assets into an application's routes.
+/// </summary>
 public static class QuartzDashboardEndpointRouteBuilderExtensions
 {
     /// <summary>

--- a/src/Quartz.Dashboard/QuartzDashboardOptions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardOptions.cs
@@ -42,6 +42,11 @@ public sealed class QuartzDashboardOptions
     /// </remarks>
     public string DashboardPath { get; set; } = DefaultDashboardPath;
 
+    /// <summary>
+    /// The authorization policy the dashboard's pages, hub, circuit and assets are held to. Null — the
+    /// default — applies none of its own, so what guards the dashboard is whatever the application's
+    /// pipeline already does.
+    /// </summary>
     public string? AuthorizationPolicy { get; set; }
 
     /// <summary>
@@ -66,6 +71,14 @@ public sealed class QuartzDashboardOptions
     /// </remarks>
     public string? SchedulerAuthorizationPolicy { get; set; }
 
+    /// <summary>
+    /// Hides every mutating action — pause, resume, trigger now, reschedule, unschedule, delete — so the
+    /// dashboard is a view of the schedulers rather than a way to drive them.
+    /// </summary>
+    /// <remarks>
+    /// Enforced by the client rather than by the pages alone: a mutation refused here is refused
+    /// wherever it is called from, so hiding a button is not what makes it safe.
+    /// </remarks>
     public bool ReadOnly { get; set; }
 
     /// <summary>

--- a/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
+++ b/src/Quartz.Dashboard/QuartzDashboardServiceCollectionExtensions.cs
@@ -31,8 +31,26 @@ using Quartz.Extensibility;
 
 namespace Quartz;
 
+/// <summary>
+/// Registers the Quartz.NET Dashboard's services.
+/// </summary>
 public static class QuartzDashboardServiceCollectionExtensions
 {
+    /// <summary>
+    /// Registers everything the dashboard renders with — its Blazor components, its SignalR hub, the
+    /// history store and the <see cref="IQuartzApiClient" /> the pages read — and adds its two plugins
+    /// to every scheduler in the container.
+    /// </summary>
+    /// <remarks>
+    /// No option points the dashboard at a scheduler: it renders the schedulers this application
+    /// registered. The client is registered with <c>TryAdd</c>, so an application that registers its own
+    /// <see cref="IQuartzApiClient" /> first is the one the pages read. Call
+    /// <c>MapQuartzDashboard()</c> on the built application to map the endpoints.
+    /// </remarks>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Configures the dashboard, including the path it is served under.</param>
+    /// <returns>The same collection, so calls can be chained.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> is null.</exception>
     public static IServiceCollection AddQuartzDashboard(
         this IServiceCollection services,
         Action<QuartzDashboardOptions>? configure = null)

--- a/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
+++ b/src/Quartz.Dashboard/Services/DashboardHistoryStore.cs
@@ -96,6 +96,9 @@ public sealed record DashboardMisfireEntry(
 /// </remarks>
 public interface IDashboardHistoryStore
 {
+    /// <summary>
+    /// Records one execution, which the history page then reads back.
+    /// </summary>
     ValueTask AddExecution(DashboardHistoryEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -103,6 +106,9 @@ public interface IDashboardHistoryStore
     /// </summary>
     ValueTask<PagedResult<DashboardHistoryEntry>> QueryExecutions(DashboardHistoryQuery query, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Records one misfire, which the misfires page and the overview's tile then read back.
+    /// </summary>
     ValueTask AddMisfire(DashboardMisfireEntry entry, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -53,6 +53,29 @@ namespace Quartz.Dashboard.Services;
 /// dashboard's own would have to be extended for every trigger kind and would still not describe a
 /// kind it had never heard of.
 /// </para>
+/// <para>
+/// <b>Missing things.</b> Every member that takes a <c>schedulerName</c> raises
+/// <see cref="KeyNotFoundException" /> when no scheduler goes by that name, and the four members that
+/// return the thing itself rather than a listing — <see cref="GetScheduler" />,
+/// <see cref="GetJobDetail" />, <see cref="GetTrigger" /> and <see cref="GetCalendar" /> — raise it
+/// again when the thing is gone. Their return types are non-nullable, so there is no other answer
+/// available to them, and the dashboard's error boundary renders that exception as the "not found"
+/// page. A replacement that answered <c>null!</c> instead would fault the page with a
+/// <see cref="NullReferenceException" /> somewhere further in.
+/// </para>
+/// <para>
+/// <b>Things this data source cannot report.</b> A capability the source does not have is a value,
+/// not an exception: <see cref="GetExecutionLimits" /> answers
+/// <see cref="ExecutionLimitsDto.CannotReport" /> where the underlying scheduler refuses with
+/// <see cref="NotSupportedException" />, because "this source cannot say" and "nothing is limited"
+/// are different facts and the overview draws them differently.
+/// </para>
+/// <para>
+/// <b>Additivity.</b> This interface is frozen from 4.0.0-beta.1 in the sense the release promises:
+/// a member added to it in 4.x arrives as a default interface member, so an implementation of an
+/// application's own keeps compiling. Its default body reports the datum as unavailable the way
+/// <see cref="ExecutionLimitsDto.CannotReport" /> does, rather than inventing one.
+/// </para>
 /// </remarks>
 public interface IQuartzApiClient
 {
@@ -72,6 +95,7 @@ public interface IQuartzApiClient
     /// answer; a registration nothing has built is reported by <see cref="GetSchedulers" /> and has no
     /// detail to read.
     /// </summary>
+    /// <exception cref="KeyNotFoundException">No scheduler goes by <paramref name="schedulerName" />.</exception>
     ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default);
 
     ValueTask Start(string schedulerName, CancellationToken cancellationToken = default);
@@ -101,6 +125,13 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<PagedResult<TriggerGroupDto>> QueryTriggerGroups(string schedulerName, DashboardGroupQuery query, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns the job's definition — its type, its durability and its data map.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// No scheduler goes by <paramref name="schedulerName" />, or it holds no job under
+    /// <paramref name="jobKey" />.
+    /// </exception>
     ValueTask<JobDetailDto> GetJobDetail(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     ValueTask<List<TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
@@ -187,6 +218,10 @@ public interface IQuartzApiClient
     /// Returns the trigger itself — a <see cref="ICronTrigger" />, <see cref="ISimpleTrigger" /> or
     /// whichever kind it is, including one an application registered its own serializer for.
     /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// No scheduler goes by <paramref name="schedulerName" />, or it holds no trigger under
+    /// <paramref name="triggerKey" />.
+    /// </exception>
     ValueTask<ITrigger> GetTrigger(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
     ValueTask<TriggerState> GetTriggerState(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
@@ -225,6 +260,10 @@ public interface IQuartzApiClient
     /// <summary>
     /// Returns the calendar itself, of whichever kind it is.
     /// </summary>
+    /// <exception cref="KeyNotFoundException">
+    /// No scheduler goes by <paramref name="schedulerName" />, or it holds no calendar named
+    /// <paramref name="calendarName" />.
+    /// </exception>
     ValueTask<ICalendar> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
 
     ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default);

--- a/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
+++ b/src/Quartz.Dashboard/Services/IQuartzApiClient.cs
@@ -98,14 +98,30 @@ public interface IQuartzApiClient
     /// <exception cref="KeyNotFoundException">No scheduler goes by <paramref name="schedulerName" />.</exception>
     ValueTask<SchedulerDetailDto> GetScheduler(string schedulerName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Starts the scheduler, so its triggers begin firing.
+    /// </summary>
     ValueTask Start(string schedulerName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Puts the scheduler in standby: it keeps its state and stops firing until it is started again.
+    /// </summary>
     ValueTask Standby(string schedulerName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Shuts the scheduler down, waiting for the jobs in flight. A scheduler that has shut down cannot
+    /// be started again.
+    /// </summary>
     ValueTask Shutdown(string schedulerName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Pauses every trigger group, so nothing fires until <see cref="ResumeAll" />.
+    /// </summary>
     ValueTask PauseAll(string schedulerName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Resumes every trigger group, applying each trigger's misfire instruction to what it missed.
+    /// </summary>
     ValueTask ResumeAll(string schedulerName, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -134,6 +150,10 @@ public interface IQuartzApiClient
     /// </exception>
     ValueTask<JobDetailDto> GetJobDetail(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns every trigger scheduled against the job, which is a short list rather than a page: a job
+    /// has as many triggers as somebody wrote for it.
+    /// </summary>
     ValueTask<List<TriggerHeaderDto>> GetTriggersOfJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -206,6 +226,9 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<bool> DeleteJob(string schedulerName, JobKeyDto jobKey, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Stores a job with no trigger, for one that is triggered by hand or scheduled later.
+    /// </summary>
     ValueTask AddJob(string schedulerName, AddJobRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -224,6 +247,10 @@ public interface IQuartzApiClient
     /// </exception>
     ValueTask<ITrigger> GetTrigger(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns the trigger's state, which is <see cref="TriggerState.None" /> when there is no such
+    /// trigger — the one read here that answers rather than raising.
+    /// </summary>
     ValueTask<TriggerState> GetTriggerState(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -244,6 +271,9 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<bool> ResetTriggerFromErrorState(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Schedules a trigger, together with the job it fires when the request carries one.
+    /// </summary>
     ValueTask ScheduleJob(string schedulerName, ScheduleJobRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -253,8 +283,14 @@ public interface IQuartzApiClient
     /// </summary>
     ValueTask<bool> UnscheduleJob(string schedulerName, TriggerKeyDto triggerKey, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Replaces the trigger with the one in the request, keeping the job it fires.
+    /// </summary>
     ValueTask RescheduleJob(string schedulerName, TriggerKeyDto triggerKey, RescheduleRequest request, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Returns the names of every calendar the scheduler holds — a short list rather than a page.
+    /// </summary>
     ValueTask<List<string>> GetCalendarNames(string schedulerName, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -266,6 +302,9 @@ public interface IQuartzApiClient
     /// </exception>
     ValueTask<ICalendar> GetCalendar(string schedulerName, string calendarName, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Stores a calendar under a name, which triggers refer to in order to exclude times from firing.
+    /// </summary>
     ValueTask AddCalendar(string schedulerName, AddCalendarRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -338,6 +377,9 @@ public sealed record DashboardGroupQuery : PagedQuery
 /// </summary>
 public sealed record DashboardJobQuery : PagedQuery
 {
+    /// <summary>
+    /// Lists only the jobs whose group name contains this, or every job when null.
+    /// </summary>
     public string? GroupContains { get; init; }
 }
 
@@ -346,8 +388,14 @@ public sealed record DashboardJobQuery : PagedQuery
 /// </summary>
 public sealed record DashboardTriggerQuery : PagedQuery
 {
+    /// <summary>
+    /// Lists only the triggers whose group name contains this, or every trigger when null.
+    /// </summary>
     public string? GroupContains { get; init; }
 
+    /// <summary>
+    /// Lists only the triggers in this state, or every state when null.
+    /// </summary>
     public TriggerState? State { get; init; }
 }
 
@@ -356,6 +404,9 @@ public sealed record DashboardTriggerQuery : PagedQuery
 /// </summary>
 public sealed record DashboardFireInstanceQuery : PagedQuery
 {
+    /// <summary>
+    /// Lists only the firings whose trigger group name contains this, or every firing when null.
+    /// </summary>
     public string? GroupContains { get; init; }
 
     /// <summary>
@@ -373,6 +424,9 @@ public sealed record DashboardFireInstanceQuery : PagedQuery
 /// </remarks>
 public sealed record DashboardHistoryQuery : PagedQuery
 {
+    /// <summary>
+    /// The scheduler whose history to list. Required: the store keeps every scheduler's rows together.
+    /// </summary>
     public required string SchedulerName { get; init; }
 
     /// <summary>
@@ -380,8 +434,14 @@ public sealed record DashboardHistoryQuery : PagedQuery
     /// </summary>
     public string? SchedulerInstanceId { get; init; }
 
+    /// <summary>
+    /// Lists only the executions whose job key matches this, or every job's when null.
+    /// </summary>
     public string? JobFilter { get; init; }
 
+    /// <summary>
+    /// Lists only the executions whose trigger key matches this, or every trigger's when null.
+    /// </summary>
     public string? TriggerFilter { get; init; }
 }
 
@@ -393,6 +453,9 @@ public sealed record DashboardHistoryQuery : PagedQuery
 /// </remarks>
 public sealed record DashboardMisfireQuery : PagedQuery
 {
+    /// <summary>
+    /// The scheduler whose misfires to list. Required: the store keeps every scheduler's rows together.
+    /// </summary>
     public required string SchedulerName { get; init; }
 
     /// <summary>
@@ -400,6 +463,9 @@ public sealed record DashboardMisfireQuery : PagedQuery
     /// </summary>
     public string? SchedulerInstanceId { get; init; }
 
+    /// <summary>
+    /// Lists only the misfires whose trigger key matches this, or every trigger's when null.
+    /// </summary>
     public string? TriggerFilter { get; init; }
 }
 
@@ -472,12 +538,32 @@ public sealed record SchedulerDetailDto(
     int JobsExecuted,
     string Version);
 
+/// <summary>
+/// A job's identity, as the pages carry it.
+/// </summary>
+/// <param name="Group">The job's group.</param>
+/// <param name="Name">The job's name, unique within the group.</param>
 public sealed record JobKeyDto(string Group, string Name);
 
+/// <summary>
+/// One job group, and whether it is paused.
+/// </summary>
+/// <param name="Name">The group's name.</param>
+/// <param name="Paused">Whether the group is paused, so what is added to it starts paused too.</param>
 public sealed record JobGroupDto(string Name, bool Paused);
 
+/// <summary>
+/// One trigger group, and whether it is paused.
+/// </summary>
+/// <param name="Name">The group's name.</param>
+/// <param name="Paused">Whether the group is paused, so what is added to it starts paused too.</param>
 public sealed record TriggerGroupDto(string Name, bool Paused);
 
+/// <summary>
+/// A trigger's identity, as the pages carry it.
+/// </summary>
+/// <param name="Group">The trigger's group.</param>
+/// <param name="Name">The trigger's name, unique within the group.</param>
 public sealed record TriggerKeyDto(string Group, string Name);
 
 /// <summary>
@@ -553,8 +639,27 @@ public sealed record ScheduleJobRequest(ITrigger Trigger, JobDetailDto? Job);
 /// </summary>
 public sealed record RescheduleRequest(ITrigger NewTrigger);
 
+/// <summary>
+/// The calendar to store, and what to do about what is already there.
+/// </summary>
+/// <param name="CalendarName">The name to store it under.</param>
+/// <param name="Calendar">The calendar itself, of whichever kind it is.</param>
+/// <param name="Replace">Whether a calendar already under that name may be overwritten.</param>
+/// <param name="UpdateTriggers">
+/// Whether the triggers referring to that name are recomputed against the new calendar. Off, they keep
+/// firing on the schedule the old one produced.
+/// </param>
 public sealed record AddCalendarRequest(string CalendarName, ICalendar Calendar, bool Replace, bool UpdateTriggers);
 
+/// <summary>
+/// The job to store, and what to do about what is already there.
+/// </summary>
+/// <param name="Job">The job's definition.</param>
+/// <param name="Replace">Whether a job already under that key may be overwritten.</param>
+/// <param name="StoreNonDurableWhileAwaitingScheduling">
+/// Whether a non-durable job may be stored with no trigger yet, or <see langword="null" /> to leave the
+/// scheduler's own default. A non-durable job stored this way is removed again if nothing schedules it.
+/// </param>
 public sealed record AddJobRequest(JobDetailDto Job, bool Replace, bool? StoreNonDurableWhileAwaitingScheduling);
 
 /// <summary>

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -6,11 +6,6 @@
     <Title>Quartz.NET Redis Integration</Title>
     <Description>Quartz.NET Redis integration - distributed lock handler for clustered scheduling; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).

--- a/src/Quartz.HttpClient/HttpClientException.cs
+++ b/src/Quartz.HttpClient/HttpClientException.cs
@@ -21,12 +21,34 @@
 
 namespace Quartz;
 
+/// <summary>
+/// A failure <see cref="HttpScheduler" /> could not attribute to a Quartz exception the server named.
+/// </summary>
+/// <remarks>
+/// The API answers an error with problem details naming the exception type it came from, and the client
+/// rebuilds that type where it recognises the name — a <see cref="SchedulerException" />,
+/// <see cref="ObjectAlreadyExistsException" /> or any of the other six reach the caller as themselves.
+/// This is what everything else becomes: a request the endpoint rejected before it reached a scheduler,
+/// a scheduler name the server does not hold, a response that carried no problem details, or a body that
+/// could not be deserialized. It derives from <see cref="SchedulerException" /> so that one
+/// <c>catch</c> covers both halves.
+/// </remarks>
 public sealed class HttpClientException : SchedulerException
 {
+    /// <summary>
+    /// Creates the exception with the message a caller sees, which carries the server's problem detail
+    /// where there was one.
+    /// </summary>
+    /// <param name="message">What went wrong.</param>
     public HttpClientException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Creates the exception over the one that caused it.
+    /// </summary>
+    /// <param name="message">What went wrong.</param>
+    /// <param name="innerException">The failure underneath, if there was one.</param>
     public HttpClientException(string message, Exception? innerException) : base(message, innerException)
     {
     }

--- a/src/Quartz.HttpClient/HttpClientOptions.cs
+++ b/src/Quartz.HttpClient/HttpClientOptions.cs
@@ -25,6 +25,15 @@ using Microsoft.Extensions.Options;
 
 namespace Quartz;
 
+/// <summary>
+/// What <c>AddQuartzHttpClient</c> needs to build an <see cref="HttpScheduler" />: which remote
+/// scheduler to address, and which <see cref="System.Net.Http.HttpClient" /> to reach it with.
+/// </summary>
+/// <remarks>
+/// The client is named or built, never held: exactly one of <see cref="HttpClientName" /> and
+/// <see cref="CreateHttpClient" /> is given, and the options are validated when the scheduler is first
+/// resolved rather than when they are bound.
+/// </remarks>
 public sealed class HttpClientOptions
 {
     /// <summary>

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -28,6 +28,29 @@ using Quartz.Util;
 
 namespace Quartz;
 
+/// <summary>
+/// An <see cref="IScheduler" /> that reaches a scheduler in another process through the Quartz HTTP API.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Everything is a round trip: this type holds no scheduler state of its own, and every member calls
+/// the endpoint that answers it. Construct one with the remote scheduler's name and an
+/// <see cref="HttpClient" /> whose <see cref="HttpClient.BaseAddress" /> is where
+/// <c>MapQuartzHttpApi</c> is mapped, or register it with <c>AddQuartzHttpClient</c>.
+/// </para>
+/// <para>
+/// What the server rejects arrives as the exception it named: <see cref="SchedulerException" /> and its
+/// subclasses come back as themselves, and anything else — a request the endpoint refused before it
+/// reached a scheduler, or a server that is not this API — as <see cref="HttpClientException" />, which
+/// derives from <see cref="SchedulerException" /> so one <c>catch</c> covers both.
+/// </para>
+/// <para>
+/// Three members cannot be honoured over a wire and raise <see cref="NotSupportedException" /> rather
+/// than pretending: <see cref="Context" />, <see cref="ListenerManager" /> and
+/// <see cref="UpdateTriggerDetails" />, each of which explains itself. <see cref="DisposeAsync" />
+/// pointedly does not shut the remote scheduler down — see its own remarks.
+/// </para>
+/// </remarks>
 public sealed class HttpScheduler : IScheduler
 {
     private readonly HttpClient httpClient;
@@ -73,8 +96,20 @@ public sealed class HttpScheduler : IScheduler
         this.jsonSerializerOptions.ConfigureWireFormat(serializerRegistry ?? new SystemTextJsonSerializerRegistry());
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// The name this client was constructed with, which every request is addressed to. It is not read
+    /// back from the server, so a name no scheduler goes by is reported when a member is called rather
+    /// than here.
+    /// </remarks>
     public string SchedulerName { get; }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// One round trip, and a blocking one: <see cref="IScheduler" /> declares this a property, and a
+    /// property cannot be awaited. Prefer <see cref="GetMetadata" /> where the calling code can await —
+    /// it answers this and the rest of the scheduler's details in the same request.
+    /// </remarks>
     public string SchedulerInstanceId => GetSchedulerDetailsSync().SchedulerInstanceId;
 
     /// <summary>
@@ -150,6 +185,7 @@ public sealed class HttpScheduler : IScheduler
         return result;
     }
 
+    /// <inheritdoc />
     public async ValueTask<SchedulerMetadata> GetMetadata(CancellationToken cancellationToken = default)
     {
         var schedulerDto = await GetSchedulerDetails(cancellationToken).ConfigureAwait(false);
@@ -174,6 +210,7 @@ public sealed class HttpScheduler : IScheduler
         };
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<FireInstance>> QueryFireInstances(FireInstanceQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -205,6 +242,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<FireInstance>(result.Items.Select(x => x.AsFireInstance()).ToList(), result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<ClusterNode>> QueryClusterNodes(CancellationToken cancellationToken = default)
     {
         ClusterNodeDto[] result = await httpClient
@@ -222,22 +260,26 @@ public sealed class HttpScheduler : IScheduler
         return nodes;
     }
 
+    /// <inheritdoc />
     public ValueTask Start(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/start", jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask StartDelayed(TimeSpan delay, CancellationToken cancellationToken = default)
     {
         // "c" is the invariant round-trip form, which is what the endpoint parses the parameter with.
         return httpClient.Post($"{SchedulerEndpointUrl()}/start?delay={delay.ToString("c")}", jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask Standby(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/standby", jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask Shutdown(bool waitForJobsToComplete = false, CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/shutdown?waitForJobsToComplete={waitForJobsToComplete}", jsonSerializerOptions, cancellationToken);
@@ -266,6 +308,7 @@ public sealed class HttpScheduler : IScheduler
         return default;
     }
 
+    /// <inheritdoc />
     public ValueTask<DateTimeOffset> ScheduleJob(IJobDetail jobDetail, ITrigger trigger, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobDetail);
@@ -273,6 +316,7 @@ public sealed class HttpScheduler : IScheduler
         return DoScheduleJob(jobDetail, trigger, options.Replace, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask<DateTimeOffset> ScheduleJob(ITrigger trigger, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         return DoScheduleJob(null, trigger, options.Replace, cancellationToken);
@@ -293,6 +337,7 @@ public sealed class HttpScheduler : IScheduler
         return result.FirstFireTimeUtc;
     }
 
+    /// <inheritdoc />
     public ValueTask ScheduleJobs(IReadOnlyDictionary<IJobDetail, IReadOnlyCollection<ITrigger>> triggersAndJobs, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggersAndJobs);
@@ -309,6 +354,7 @@ public sealed class HttpScheduler : IScheduler
         }
     }
 
+    /// <inheritdoc />
     public ValueTask ScheduleJob(IJobDetail jobDetail, IReadOnlyCollection<ITrigger> triggersForJob, ScheduleJobOptions options = default, CancellationToken cancellationToken = default)
     {
         var triggersAndJobs = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>
@@ -319,6 +365,7 @@ public sealed class HttpScheduler : IScheduler
         return ScheduleJobs(triggersAndJobs, options, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> UnscheduleJob(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>(
@@ -330,6 +377,7 @@ public sealed class HttpScheduler : IScheduler
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<TriggerKey>> UnscheduleJobs(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
@@ -344,6 +392,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<TriggerKey>> UnscheduleJobs(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(matcher);
@@ -358,6 +407,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<DateTimeOffset?> RescheduleJob(TriggerKey triggerKey, ITrigger newTrigger, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(newTrigger);
@@ -381,6 +431,7 @@ public sealed class HttpScheduler : IScheduler
         throw NotSupportedRemotely(nameof(UpdateTriggerDetails), "the HTTP API has no endpoint for it");
     }
 
+    /// <inheritdoc />
     public async ValueTask SetExecutionLimits(ExecutionLimits? limits, CancellationToken cancellationToken = default)
     {
         if (limits is null)
@@ -402,6 +453,7 @@ public sealed class HttpScheduler : IScheduler
         }
     }
 
+    /// <inheritdoc />
     public async ValueTask<ExecutionLimits?> GetExecutionLimits(CancellationToken cancellationToken = default)
     {
         ExecutionLimitsResponse response = await httpClient.Get<ExecutionLimitsResponse>($"{SchedulerEndpointUrl()}/execution-limits", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
@@ -444,6 +496,7 @@ public sealed class HttpScheduler : IScheduler
         return builder.Build();
     }
 
+    /// <inheritdoc />
     public ValueTask AddJob(IJobDetail jobDetail, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
         var request = new AddJobRequest(
@@ -455,12 +508,14 @@ public sealed class HttpScheduler : IScheduler
         return httpClient.Post(JobEndpointUrl(), request, jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> DeleteJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.DeleteWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<JobKey>> DeleteJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
@@ -475,6 +530,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Jobs.Select(x => x.AsJobKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<JobKey>> DeleteJobs(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(matcher);
@@ -489,6 +545,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Jobs.Select(x => x.AsJobKey())];
     }
 
+    /// <inheritdoc />
     public ValueTask TriggerJob(JobKey jobKey, JobDataMap? data = null, CancellationToken cancellationToken = default)
     {
         if (data is null)
@@ -500,12 +557,14 @@ public sealed class HttpScheduler : IScheduler
         return httpClient.Post($"{JobEndpointUrl(jobKey)}/trigger", request, jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> PauseJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}/pause", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<string>> PauseJobGroups(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
     {
         var urlParams = matcher.ToUrlParameters();
@@ -513,6 +572,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Groups];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<JobKey>> PauseJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
@@ -522,12 +582,14 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Jobs.Select(x => x.AsJobKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>($"{TriggerEndpointUrl(triggerKey)}/pause", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<string>> PauseTriggerGroups(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
     {
         var urlParams = matcher.ToUrlParameters();
@@ -535,6 +597,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Groups];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<TriggerKey>> PauseTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
@@ -544,12 +607,14 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> ResumeJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}/resume", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<string>> ResumeJobGroups(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
     {
         var urlParams = matcher.ToUrlParameters();
@@ -557,6 +622,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Groups];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<JobKey>> ResumeJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
@@ -566,12 +632,14 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Jobs.Select(x => x.AsJobKey())];
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> ResumeTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>($"{TriggerEndpointUrl(triggerKey)}/resume", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<string>> ResumeTriggerGroups(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
     {
         var urlParams = matcher.ToUrlParameters();
@@ -579,6 +647,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Groups];
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<TriggerKey>> ResumeTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
@@ -588,16 +657,19 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    /// <inheritdoc />
     public ValueTask PauseAll(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/pause-all", jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public ValueTask ResumeAll(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/resume-all", jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<JobHeader>> QueryJobs(JobQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -614,6 +686,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<JobHeader>(result.Items.Select(x => x.AsJobHeader()).ToList(), result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<TriggerHeader>> QueryTriggers(TriggerQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -646,6 +719,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<TriggerHeader>(result.Items.Select(x => x.AsTriggerHeader()).ToList(), result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<JobGroup>> QueryJobGroups(JobGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -666,6 +740,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<JobGroup>(result.Items.Select(x => x.AsJobGroup()).ToList(), result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<TriggerGroup>> QueryTriggerGroups(TriggerGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -686,6 +761,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<TriggerGroup>(result.Items.Select(x => x.AsTriggerGroup()).ToList(), result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<PagedResult<string>> QueryCalendarNames(CalendarQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -701,6 +777,7 @@ public sealed class HttpScheduler : IScheduler
         return WholeAnswer(query, new PagedResult<string>([..result.Items], result.HasMore, result.TotalCount));
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<IJobDetail>> GetJobDetails(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
@@ -732,6 +809,7 @@ public sealed class HttpScheduler : IScheduler
         return result;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<ITrigger>> GetTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
@@ -749,6 +827,7 @@ public sealed class HttpScheduler : IScheduler
         ).ConfigureAwait(false);
     }
 
+    /// <inheritdoc />
     public async ValueTask<IJobDetail?> GetJobDetail(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetWithNullForNotFound<JobDetailDto>($"{JobEndpointUrl(jobKey)}", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
@@ -766,24 +845,28 @@ public sealed class HttpScheduler : IScheduler
         return jobDetail;
     }
 
+    /// <inheritdoc />
     public async ValueTask<ITrigger?> GetTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetWithNullForNotFound<ITrigger>(TriggerEndpointUrl(triggerKey), jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result;
     }
 
+    /// <inheritdoc />
     public async ValueTask<TriggerState> GetTriggerState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.Get<TriggerStateDto>($"{TriggerEndpointUrl(triggerKey)}/state", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.State;
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.PostWithResponse<OperationAppliedResponse>($"{TriggerEndpointUrl(triggerKey)}/reset-from-error-state", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<List<TriggerKey>> ResetTriggersFromErrorState(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
@@ -793,6 +876,7 @@ public sealed class HttpScheduler : IScheduler
         return [.. result.Triggers.Select(x => x.AsTriggerKey())];
     }
 
+    /// <inheritdoc />
     public ValueTask AddCalendar(string calendarName, ICalendar calendar, AddCalendarOptions options = default, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(calendarName))
@@ -806,23 +890,27 @@ public sealed class HttpScheduler : IScheduler
         return httpClient.Post(CalendarEndpointUrl(), requestContent, jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> DeleteCalendar(string calendarName, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.DeleteWithResponse<OperationAppliedResponse>(CalendarEndpointUrl(calendarName), jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Applied;
     }
 
+    /// <inheritdoc />
     public ValueTask<ICalendar?> GetCalendar(string calendarName, CancellationToken cancellationToken = default)
     {
         return httpClient.GetWithNullForNotFound<ICalendar>(CalendarEndpointUrl(calendarName), jsonSerializerOptions, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> Interrupt(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var response = await httpClient.PostWithResponse<OperationAppliedResponse>($"{JobEndpointUrl(jobKey)}/interrupt", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return response.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> InterruptFireInstance(string fireInstanceId, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(fireInstanceId))
@@ -839,24 +927,28 @@ public sealed class HttpScheduler : IScheduler
         return response.Applied;
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> Exists(JobKey jobKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.Get<ExistsResponse>($"{JobEndpointUrl(jobKey)}/exists", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Exists;
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> Exists(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.Get<ExistsResponse>($"{TriggerEndpointUrl(triggerKey)}/exists", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Exists;
     }
 
+    /// <inheritdoc />
     public async ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.Get<ExistsResponse>($"{CalendarEndpointUrl(calendarName)}/exists", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         return result.Exists;
     }
 
+    /// <inheritdoc />
     public ValueTask Clear(CancellationToken cancellationToken = default)
     {
         return httpClient.Post($"{SchedulerEndpointUrl()}/clear", jsonSerializerOptions, cancellationToken);

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -385,8 +385,7 @@ public sealed class HttpScheduler : IScheduler
     {
         if (limits is null)
         {
-            using HttpResponseMessage response = await httpClient.DeleteAsync($"{SchedulerEndpointUrl()}/execution-limits", cancellationToken).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+            await httpClient.Delete($"{SchedulerEndpointUrl()}/execution-limits", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
         }
         else
         {
@@ -406,13 +405,17 @@ public sealed class HttpScheduler : IScheduler
     public async ValueTask<ExecutionLimits?> GetExecutionLimits(CancellationToken cancellationToken = default)
     {
         ExecutionLimitsResponse response = await httpClient.Get<ExecutionLimitsResponse>($"{SchedulerEndpointUrl()}/execution-limits", jsonSerializerOptions, cancellationToken).ConfigureAwait(false);
-        if (response.Limits is null || response.Limits.Count == 0)
+
+        // No groups and no derivation is the one answer that means "nothing is configured". A scheduler
+        // that limits nothing but asked for the trigger group to stand in for an unset execution group
+        // has said something, and saying it back as null would lose it.
+        if (response.Limits is not { Count: > 0 } && !response.UseTriggerGroupWhenUnset)
         {
             return null;
         }
 
         ExecutionLimitsBuilder builder = ExecutionLimitsBuilder.Create();
-        foreach (KeyValuePair<string, ExecutionLimitDto> kvp in response.Limits)
+        foreach (KeyValuePair<string, ExecutionLimitDto> kvp in response.Limits ?? [])
         {
             int? maxConcurrent = kvp.Value.MaxConcurrent;
             ExecutionLimitScope scope = kvp.Value.Scope;

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -5,11 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -5,11 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -6,11 +6,6 @@
     <Title>Quartz.NET TimeZoneConverter integration</Title>
     <Description>Quartz.NET TimeZoneConverter integration https://github.com/mj1856/TimeZoneConverter; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <Authors>Sean Farrow, Quartz.NET</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--

--- a/src/Quartz.Plugins/Plugins/History/LoggingJobHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/LoggingJobHistoryPlugin.cs
@@ -256,10 +256,20 @@ public sealed class LoggingJobHistoryPlugin : ISchedulerPlugin, IJobListener
     private readonly ILogger<LoggingJobHistoryPlugin> logger;
     private readonly TimeProvider timeProvider;
 
+    /// <summary>
+    /// Creates the plugin with the static logger and the system clock, for a plugin the loader built
+    /// from a <c>quartz.plugin.&lt;name&gt;.type</c> key and so had nothing to inject into.
+    /// </summary>
     public LoggingJobHistoryPlugin() : this(LogProvider.CreateLogger<LoggingJobHistoryPlugin>(), TimeProvider.System)
     {
     }
 
+    /// <summary>
+    /// Creates the plugin with the logger and clock a container resolved, which is what
+    /// <c>UseJobHistoryLogging</c> uses.
+    /// </summary>
+    /// <param name="logger">Where the history lines go.</param>
+    /// <param name="timeProvider">The clock the lines are stamped with.</param>
     public LoggingJobHistoryPlugin(
         ILogger<LoggingJobHistoryPlugin> logger,
         TimeProvider timeProvider)

--- a/src/Quartz.Plugins/Plugins/History/StructuredLoggingJobHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/StructuredLoggingJobHistoryPlugin.cs
@@ -59,11 +59,21 @@ public sealed class StructuredLoggingJobHistoryPlugin : ISchedulerPlugin, IJobLi
     private readonly ILogger<StructuredLoggingJobHistoryPlugin> logger;
     private readonly TimeProvider timeProvider;
 
+    /// <summary>
+    /// Creates the plugin with the static logger and the system clock, for a plugin the loader built
+    /// from a <c>quartz.plugin.&lt;name&gt;.type</c> key and so had nothing to inject into.
+    /// </summary>
     public StructuredLoggingJobHistoryPlugin()
         : this(LogProvider.CreateLogger<StructuredLoggingJobHistoryPlugin>(), TimeProvider.System)
     {
     }
 
+    /// <summary>
+    /// Creates the plugin with the logger and clock a container resolved, which is what
+    /// <c>UseStructuredJobLogging</c> uses.
+    /// </summary>
+    /// <param name="logger">Where the history events go.</param>
+    /// <param name="timeProvider">The clock the events are stamped with.</param>
     public StructuredLoggingJobHistoryPlugin(
         ILogger<StructuredLoggingJobHistoryPlugin> logger,
         TimeProvider timeProvider)

--- a/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/History/StructuredLoggingTriggerHistoryPlugin.cs
@@ -56,11 +56,21 @@ public sealed class StructuredLoggingTriggerHistoryPlugin : ISchedulerPlugin, IT
     private readonly ILogger<StructuredLoggingTriggerHistoryPlugin> logger;
     private readonly TimeProvider timeProvider;
 
+    /// <summary>
+    /// Creates the plugin with the static logger and the system clock, for a plugin the loader built
+    /// from a <c>quartz.plugin.&lt;name&gt;.type</c> key and so had nothing to inject into.
+    /// </summary>
     public StructuredLoggingTriggerHistoryPlugin()
         : this(LogProvider.CreateLogger<StructuredLoggingTriggerHistoryPlugin>(), TimeProvider.System)
     {
     }
 
+    /// <summary>
+    /// Creates the plugin with the logger and clock a container resolved, which is what
+    /// <c>UseStructuredTriggerLogging</c> uses.
+    /// </summary>
+    /// <param name="logger">Where the history events go.</param>
+    /// <param name="timeProvider">The clock the events are stamped with.</param>
     public StructuredLoggingTriggerHistoryPlugin(
         ILogger<StructuredLoggingTriggerHistoryPlugin> logger,
         TimeProvider timeProvider)

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessorPlugin.cs
@@ -59,11 +59,23 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
     private readonly TimeProvider timeProvider;
     private bool started;
 
+    /// <summary>
+    /// Creates the plugin with the static logger, a reflecting type loader and the system clock, for a
+    /// plugin the loader built from a <c>quartz.plugin.&lt;name&gt;.type</c> key and so had nothing to
+    /// inject into.
+    /// </summary>
     public JsonSchedulingDataProcessorPlugin()
         : this(LogProvider.CreateLogger<JsonSchedulingDataProcessorPlugin>(), new SimpleTypeLoader(), TimeProvider.System)
     {
     }
 
+    /// <summary>
+    /// Creates the plugin with what a container resolved, which is what
+    /// <c>UseJsonSchedulingConfiguration</c> uses.
+    /// </summary>
+    /// <param name="logger">Where the plugin reports what it loaded and what it could not.</param>
+    /// <param name="typeLoader">Resolves the job types the file names as strings.</param>
+    /// <param name="timeProvider">The clock the scanned files' timestamps are compared against.</param>
     public JsonSchedulingDataProcessorPlugin(
         ILogger<JsonSchedulingDataProcessorPlugin> logger,
         ITypeLoader typeLoader,
@@ -102,6 +114,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
 
     internal IReadOnlyCollection<KeyValuePair<string, JobFile>> JobFiles => jobFiles;
 
+    /// <inheritdoc />
     public ValueTask FileUpdated(string fileName, CancellationToken cancellationToken = default)
     {
         if (started)
@@ -112,6 +125,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         return default;
     }
 
+    /// <inheritdoc />
     public async ValueTask Initialize(string pluginName, IScheduler scheduler, CancellationToken cancellationToken = default)
     {
         Name = pluginName;
@@ -132,6 +146,7 @@ public sealed class JsonSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileS
         }
     }
 
+    /// <inheritdoc />
     public async ValueTask Start(CancellationToken cancellationToken = default)
     {
         try

--- a/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
+++ b/src/Quartz.Plugins/Plugins/Xml/XmlSchedulingDataProcessorPlugin.cs
@@ -125,6 +125,7 @@ public sealed class XmlSchedulingDataProcessorPlugin : ISchedulerPlugin, IFileSc
 
     internal IReadOnlyCollection<KeyValuePair<string, JobFile>> JobFiles => jobFiles;
 
+    /// <inheritdoc />
     public ValueTask FileUpdated(
         string fileName,
         CancellationToken cancellationToken = default)

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -5,11 +5,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).

--- a/src/Quartz.Serialization.Newtonsoft/Calendars/CalendarSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Calendars/CalendarSerializer.cs
@@ -3,10 +3,36 @@ using Newtonsoft.Json.Linq;
 
 namespace Quartz.Serialization.Newtonsoft.Calendars;
 
+/// <summary>
+/// Reads and writes one kind of calendar's own fields, beside the ones every calendar has.
+/// </summary>
+/// <remarks>
+/// Register an implementation with <c>NewtonsoftJsonSerializerRegistry.AddCalendarSerializer</c>, or
+/// derive from <see cref="CalendarSerializer{TCalendar}" /> to be handed the calendar already typed.
+/// A calendar with no registered serializer cannot be stored: the first store write fails.
+/// </remarks>
 public interface ICalendarSerializer
 {
+    /// <summary>
+    /// Builds the calendar instance the stored fields are then read into.
+    /// </summary>
+    /// <param name="source">The stored JSON for one calendar.</param>
     ICalendar Create(JObject source);
+
+    /// <summary>
+    /// Writes this kind of calendar's own fields. The description, time zone and chained base calendar
+    /// are written around this call rather than by it.
+    /// </summary>
+    /// <param name="writer">The writer positioned inside the calendar's JSON object.</param>
+    /// <param name="value">The calendar being stored.</param>
     void SerializeFields(JsonWriter writer, ICalendar value);
+
+    /// <summary>
+    /// Reads back what <see cref="SerializeFields" /> wrote, onto the instance
+    /// <see cref="Create" /> returned.
+    /// </summary>
+    /// <param name="value">The calendar being rebuilt.</param>
+    /// <param name="source">The stored JSON for that calendar.</param>
     void DeserializeFields(ICalendar value, JObject source);
 
     /// <summary>
@@ -22,7 +48,7 @@ public interface ICalendarSerializer
 /// <summary>
 /// Convenience base class to strongly type a calendar serializer.
 /// </summary>
-/// <typeparam name="TCalendar"></typeparam>
+/// <typeparam name="TCalendar">The calendar type this serializer reads and writes.</typeparam>
 public abstract class CalendarSerializer<TCalendar> : ICalendarSerializer where TCalendar : ICalendar
 {
     /// <inheritdoc cref="ICalendarSerializer.CalendarTypeName" />
@@ -43,9 +69,23 @@ public abstract class CalendarSerializer<TCalendar> : ICalendarSerializer where 
         DeserializeFields((TCalendar) value, source);
     }
 
+    /// <summary>
+    /// Writes this kind of calendar's own fields, with the calendar already typed.
+    /// </summary>
+    /// <param name="writer">The writer positioned inside the calendar's JSON object.</param>
+    /// <param name="calendar">The calendar being stored.</param>
     protected abstract void SerializeFields(JsonWriter writer, TCalendar calendar);
 
+    /// <summary>
+    /// Reads back what <see cref="SerializeFields(JsonWriter, TCalendar)" /> wrote.
+    /// </summary>
+    /// <param name="calendar">The calendar being rebuilt.</param>
+    /// <param name="source">The stored JSON for that calendar.</param>
     protected abstract void DeserializeFields(TCalendar calendar, JObject source);
 
+    /// <summary>
+    /// Builds the calendar instance the stored fields are then read into.
+    /// </summary>
+    /// <param name="source">The stored JSON for one calendar.</param>
     protected abstract TCalendar Create(JObject source);
 }

--- a/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Impl/NewtonsoftJsonObjectSerializer.cs
@@ -82,6 +82,15 @@ public class NewtonsoftJsonObjectSerializer : IObjectSerializer
         }
     }
 
+    /// <summary>
+    /// Builds the settings every serialization goes through — the converters for Quartz's own types,
+    /// and the type handling a stored blob is read back with.
+    /// </summary>
+    /// <remarks>
+    /// Override to add a converter of your own, calling base and adding to what it returns rather than
+    /// replacing it: a setting dropped here changes the shape of every blob this scheduler writes.
+    /// The result is cached until <see cref="RegisterTriggerConverters" /> changes.
+    /// </remarks>
     protected virtual JsonSerializerSettings CreateSerializerSettings()
     {
         var settings = new JsonSerializerSettings

--- a/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonConfigurationExtensions.cs
+++ b/src/Quartz.Serialization.Newtonsoft/NewtonsoftJsonConfigurationExtensions.cs
@@ -7,6 +7,9 @@ using Quartz.Impl;
 
 namespace Quartz;
 
+/// <summary>
+/// Selects Newtonsoft.Json as a persistent store's serializer.
+/// </summary>
 public static class NewtonsoftJsonConfigurationExtensions
 {
     /// <summary>

--- a/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
+++ b/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
@@ -6,11 +6,6 @@
     <Title>Quartz.NET JSON Serialization</Title>
     <Description>Quartz.NET JSON Serialization Support; $(Description)</Description>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <!--
-      Undocumented public members. P5 (#3646) is the sweep that turns this on for the side packages;
-      Quartz itself is clean and enforces it. Delete the line when this package is documented.
-    -->
-    <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Not trimmable, said out loud rather than left to the default (issue #3431). Json.NET's contract is

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CalendarIntervalTriggerSerializer.cs
@@ -5,10 +5,19 @@ using Quartz.Impl.Triggers;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Stores an <see cref="ICalendarIntervalTrigger" /> as its interval, unit, time zone and the two
+/// daylight-saving choices.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="SimpleTriggerSerializer" path="/remarks" />
+/// </remarks>
 public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarIntervalTriggerImpl>
 {
+    /// <inheritdoc />
     public override string TriggerTypeName => "CalendarIntervalTrigger";
 
+    /// <inheritdoc />
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var repeatIntervalUnit = source["RepeatIntervalUnit"]!.ToObject<IntervalUnit>();
@@ -24,6 +33,7 @@ public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarInter
             .SkipDayIfHourDoesNotExist(skipDayIfHourDoesNotExist);
     }
 
+    /// <inheritdoc />
     protected override void SerializeFields(JsonWriter writer, CalendarIntervalTriggerImpl trigger)
     {
         writer.WritePropertyName("RepeatInterval");
@@ -45,6 +55,7 @@ public class CalendarIntervalTriggerSerializer : TriggerSerializer<CalendarInter
         writer.WriteValue(trigger.TimesTriggered);
     }
 
+    /// <inheritdoc />
     protected override void DeserializeFields(CalendarIntervalTriggerImpl trigger, JObject source)
     {
         // This properties might not exist in the JSON if trigger was serialized with older version

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/CronTriggerSerializer.cs
@@ -3,10 +3,18 @@ using Newtonsoft.Json.Linq;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Stores an <see cref="ICronTrigger" /> as its cron expression and time zone.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="SimpleTriggerSerializer" path="/remarks" />
+/// </remarks>
 public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
 {
+    /// <inheritdoc />
     public override string TriggerTypeName => "CronTrigger";
 
+    /// <inheritdoc />
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var cronExpressionString = source.Value<string>("CronExpressionString")!;
@@ -16,6 +24,7 @@ public class CronTriggerSerializer : TriggerSerializer<ICronTrigger>
             .InTimeZone(timeZone);
     }
 
+    /// <inheritdoc />
     protected override void SerializeFields(JsonWriter writer, ICronTrigger trigger)
     {
         writer.WritePropertyName("CronExpressionString");

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/DailyTimeIntervalTriggerSerializer.cs
@@ -6,10 +6,19 @@ using Quartz.Util;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Stores an <see cref="IDailyTimeIntervalTrigger" /> as its daily window, interval, days of the week
+/// and repeat count.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="SimpleTriggerSerializer" path="/remarks" />
+/// </remarks>
 public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeIntervalTriggerImpl>
 {
+    /// <inheritdoc />
     public override string TriggerTypeName => "DailyTimeIntervalTrigger";
 
+    /// <inheritdoc />
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var repeatCount = source.Value<int>("RepeatCount");
@@ -29,6 +38,7 @@ public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeInt
             .InTimeZone(timeZone);
     }
 
+    /// <inheritdoc />
     protected override void SerializeFields(JsonWriter writer, DailyTimeIntervalTriggerImpl trigger)
     {
         writer.WritePropertyName("RepeatCount");
@@ -51,6 +61,7 @@ public class DailyTimeIntervalTriggerSerializer : TriggerSerializer<DailyTimeInt
         writer.WriteValue(trigger.TimesTriggered);
     }
 
+    /// <inheritdoc />
     protected override void DeserializeFields(DailyTimeIntervalTriggerImpl trigger, JObject source)
     {
         // This properties might not exist in the JSON if trigger was serialized with older version

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/RecurrenceTriggerSerializer.cs
@@ -5,10 +5,18 @@ using Quartz.Impl.Triggers;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Stores an <see cref="IRecurrenceTrigger" /> as its RFC 5545 recurrence rule and time zone.
+/// </summary>
+/// <remarks>
+/// <inheritdoc cref="SimpleTriggerSerializer" path="/remarks" />
+/// </remarks>
 public class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTriggerImpl>
 {
+    /// <inheritdoc />
     public override string TriggerTypeName => "RecurrenceTrigger";
 
+    /// <inheritdoc />
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var recurrenceRule = source.Value<string>("RecurrenceRule")!;
@@ -18,6 +26,7 @@ public class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTriggerIm
             .InTimeZone(timeZone);
     }
 
+    /// <inheritdoc />
     protected override void SerializeFields(JsonWriter writer, RecurrenceTriggerImpl trigger)
     {
         writer.WritePropertyName("RecurrenceRule");
@@ -30,6 +39,7 @@ public class RecurrenceTriggerSerializer : TriggerSerializer<RecurrenceTriggerIm
         writer.WriteValue(trigger.TimesTriggered);
     }
 
+    /// <inheritdoc />
     protected override void DeserializeFields(RecurrenceTriggerImpl trigger, JObject source)
     {
         var timesTriggered = source.Value<int?>("TimesTriggered");

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/SimpleTriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/SimpleTriggerSerializer.cs
@@ -7,10 +7,21 @@ using Quartz.Impl.Triggers;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Stores an <see cref="ISimpleTrigger" /> as its repeat count and interval.
+/// </summary>
+/// <remarks>
+/// Public and unsealed on purpose: a trigger deriving from <see cref="SimpleTriggerImpl" /> pairs with
+/// a serializer deriving from this one, calling base from
+/// <see cref="TriggerSerializer{TTrigger}.SerializeFields" /> so the built-in fields keep their stored
+/// shape.
+/// </remarks>
 public class SimpleTriggerSerializer : TriggerSerializer<SimpleTriggerImpl>
 {
+    /// <inheritdoc />
     public override string TriggerTypeName => "SimpleTrigger";
 
+    /// <inheritdoc />
     public override IScheduleBuilder CreateScheduleBuilder(JObject source)
     {
         var repeatInterval = TimeSpan.ParseExact(source.Value<string>("RepeatIntervalTimeSpan")!, "c", CultureInfo.InvariantCulture);
@@ -21,6 +32,7 @@ public class SimpleTriggerSerializer : TriggerSerializer<SimpleTriggerImpl>
             .WithRepeatCount(repeatCount);
     }
 
+    /// <inheritdoc />
     protected override void SerializeFields(JsonWriter writer, SimpleTriggerImpl trigger)
     {
         writer.WritePropertyName("RepeatCount");
@@ -33,6 +45,7 @@ public class SimpleTriggerSerializer : TriggerSerializer<SimpleTriggerImpl>
         writer.WriteValue(trigger.TimesTriggered);
     }
 
+    /// <inheritdoc />
     protected override void DeserializeFields(SimpleTriggerImpl trigger, JObject source)
     {
         // This properties might not exist in the JSON if trigger was serialized with older version

--- a/src/Quartz.Serialization.Newtonsoft/Triggers/TriggerSerializer.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Triggers/TriggerSerializer.cs
@@ -3,14 +3,44 @@ using Newtonsoft.Json.Linq;
 
 namespace Quartz.Serialization.Newtonsoft.Triggers;
 
+/// <summary>
+/// Reads and writes one kind of trigger's own fields, beside the ones every trigger has.
+/// </summary>
+/// <remarks>
+/// The registry keys serializers by <see cref="TriggerTypeName" />, and that name is written into the
+/// stored JSON as its discriminator — so it is the name a blob is read back by, and changing it makes
+/// every trigger already stored under the old one unreadable. Register an implementation with
+/// <c>NewtonsoftJsonSerializerRegistry.AddTriggerSerializer</c>, or derive from
+/// <see cref="TriggerSerializer{TTrigger}" /> to be handed the trigger already typed.
+/// </remarks>
 public interface ITriggerSerializer
 {
+    /// <summary>
+    /// The discriminator this kind of trigger is stored under, shared with the System.Text.Json
+    /// package so a blob either wrote is readable by both.
+    /// </summary>
     string TriggerTypeName { get; }
 
+    /// <summary>
+    /// Rebuilds the schedule from the stored fields, as the builder the trigger is reconstructed from.
+    /// </summary>
+    /// <param name="source">The stored JSON for one trigger.</param>
     IScheduleBuilder CreateScheduleBuilder(JObject source);
 
+    /// <summary>
+    /// Writes this kind of trigger's own fields. The fields every trigger has are written around this
+    /// call rather than by it.
+    /// </summary>
+    /// <param name="writer">The writer positioned inside the trigger's JSON object.</param>
+    /// <param name="trigger">The trigger being stored.</param>
     void SerializeFields(JsonWriter writer, ITrigger trigger);
 
+    /// <summary>
+    /// Reads back whatever <see cref="SerializeFields" /> wrote that the schedule builder did not
+    /// already restore.
+    /// </summary>
+    /// <param name="trigger">The trigger being rebuilt.</param>
+    /// <param name="source">The stored JSON for that trigger.</param>
     void DeserializeFields(ITrigger trigger, JObject source);
 }
 
@@ -27,12 +57,19 @@ public interface ITriggerSerializer
 /// </remarks>
 public abstract class TriggerSerializer<TTrigger> : ITriggerSerializer where TTrigger : ITrigger
 {
+    /// <inheritdoc />
     public abstract string TriggerTypeName { get; }
 
+    /// <inheritdoc />
     public abstract IScheduleBuilder CreateScheduleBuilder(JObject source);
 
     void ITriggerSerializer.SerializeFields(JsonWriter writer, ITrigger trigger) => SerializeFields(writer, (TTrigger) trigger);
 
+    /// <summary>
+    /// Writes this kind of trigger's own fields, with the trigger already typed.
+    /// </summary>
+    /// <param name="writer">The writer positioned inside the trigger's JSON object.</param>
+    /// <param name="trigger">The trigger being stored.</param>
     protected abstract void SerializeFields(JsonWriter writer, TTrigger trigger);
 
     void ITriggerSerializer.DeserializeFields(ITrigger trigger, JObject source)
@@ -40,6 +77,12 @@ public abstract class TriggerSerializer<TTrigger> : ITriggerSerializer where TTr
         DeserializeFields((TTrigger) trigger, source);
     }
 
+    /// <summary>
+    /// Reads back whatever the schedule builder did not already restore. Does nothing unless
+    /// overridden, which is right for a trigger whose every field is part of its schedule.
+    /// </summary>
+    /// <param name="trigger">The trigger being rebuilt.</param>
+    /// <param name="source">The stored JSON for that trigger.</param>
     protected virtual void DeserializeFields(TTrigger trigger, JObject source)
     {
     }

--- a/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientContractTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/QuartzApiClientContractTest.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Dashboard.Services;
+
+namespace Quartz.Tests.AspNetCore.Dashboard;
+
+/// <summary>
+/// The exception contract <see cref="IQuartzApiClient" /> states, held against whichever implementation
+/// the container answers with.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface is public so that an application can replace it, and its four "return the thing itself"
+/// members have non-nullable return types — so what they do when the thing is gone is contract, not an
+/// implementation detail of the one client Quartz ships. The dashboard's error boundary renders a
+/// <see cref="KeyNotFoundException" /> as the not-found page; a replacement answering <c>null!</c>
+/// instead would fault the page with a <see cref="NullReferenceException" /> raised somewhere further in,
+/// and nothing said so until this test did.
+/// </para>
+/// <para>
+/// It resolves the client out of a container rather than constructing <c>InProcessQuartzApiClient</c>,
+/// because the promise is about whatever <c>AddQuartzDashboard</c> left registered — the registration is
+/// <c>TryAdd</c>, so an application that registers its own client first is the one the pages read, and it
+/// is the one this contract binds.
+/// </para>
+/// </remarks>
+public class QuartzApiClientContractTest
+{
+    private ServiceProvider provider = null!;
+    private IServiceScope scope = null!;
+    private IScheduler scheduler = null!;
+    private IQuartzApiClient client = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        string schedulerName = $"api-client-contract-{Guid.NewGuid():N}";
+
+        ServiceCollection services = new();
+        services.AddQuartzDashboard();
+        services.AddQuartz(quartz => quartz.ConfigureScheduler(options => options.InstanceName = schedulerName));
+
+        provider = services.BuildServiceProvider();
+
+        // Resolving the scheduler is what binds it into the repository the client looks names up in.
+        scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        // Scoped, because that is the lifetime the pages resolve it with.
+        scope = provider.CreateScope();
+        client = scope.ServiceProvider.GetRequiredService<IQuartzApiClient>();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        scope?.Dispose();
+
+        if (scheduler is not null)
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+
+        if (provider is not null)
+        {
+            await provider.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task AnUnknownSchedulerNameIsReportedAsAMissingKey()
+    {
+        Func<Task> act = () => client.GetScheduler("no-such-scheduler").AsTask();
+
+        (await act.Should().ThrowAsync<KeyNotFoundException>(
+            "GetScheduler returns a non-nullable detail, so a name nothing goes by has no other answer"))
+            .Which.Message.Should().Contain("no-such-scheduler", "the page shows the name that was not found");
+    }
+
+    [Test]
+    public async Task AMissingJobIsReportedAsAMissingKey()
+    {
+        Func<Task> act = () => client.GetJobDetail(scheduler.SchedulerName, new JobKeyDto("ghosts", "no-such-job")).AsTask();
+
+        (await act.Should().ThrowAsync<KeyNotFoundException>(
+            "the scheduler exists and holds no such job, which is the case the non-nullable JobDetailDto cannot express"))
+            .Which.Message.Should().Contain("no-such-job");
+    }
+
+    [Test]
+    public async Task AMissingTriggerIsReportedAsAMissingKey()
+    {
+        Func<Task> act = () => client.GetTrigger(scheduler.SchedulerName, new TriggerKeyDto("ghosts", "no-such-trigger")).AsTask();
+
+        (await act.Should().ThrowAsync<KeyNotFoundException>())
+            .Which.Message.Should().Contain("no-such-trigger");
+    }
+
+    [Test]
+    public async Task AMissingCalendarIsReportedAsAMissingKey()
+    {
+        Func<Task> act = () => client.GetCalendar(scheduler.SchedulerName, "no-such-calendar").AsTask();
+
+        (await act.Should().ThrowAsync<KeyNotFoundException>())
+            .Which.Message.Should().Contain("no-such-calendar");
+    }
+
+    /// <summary>
+    /// The other half of the contract: a capability the source does not have is a value rather than an
+    /// exception, so the overview can draw "cannot say" differently from "nothing is limited".
+    /// </summary>
+    [Test]
+    public async Task ASchedulerThatLimitsNothingReportsNoLimitsRatherThanRefusing()
+    {
+        ExecutionLimitsDto limits = await client.GetExecutionLimits(scheduler.SchedulerName);
+
+        limits.Should().NotBeNull("the member never answers null");
+        limits.CanReport.Should().BeTrue("a scheduler Quartz ships can always say what its limits are");
+        limits.Limits.Should().BeEmpty("nothing was limited, which is a different fact from being unable to report");
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/CommonEndpointTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/CommonEndpointTest.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 using FakeItEasy;
 
-
+using Quartz.Impl.AdoJobStore;
 using Quartz.Tests.AspNetCore.Support;
 
 namespace Quartz.Tests.AspNetCore.HttpApi;
@@ -18,6 +18,69 @@ public class CommonEndpointTest : WebApiTest
 
         // Getting non existing job returns null, but should throw if scheduler is not found
         Assert.ThrowsAsync<HttpClientException>(() => nonExistingHttpScheduler.GetJobDetail(new JobKey("non", "existing")).AsTask())!.Message.Should().ContainEquivalentOf("Scheduler not found");
+    }
+
+    /// <summary>
+    /// Clearing the execution limits reports an unknown scheduler name the way every other member does.
+    /// </summary>
+    /// <remarks>
+    /// It is the one member whose request carries a body in neither direction, which is how it came to
+    /// call <c>HttpClient.DeleteAsync</c> raw: <c>EnsureSuccessStatusCode</c> raises
+    /// <see cref="HttpRequestException" /> without reading the problem details, so the 404 that says
+    /// which scheduler was not found arrived as a bare "404 (Not Found)".
+    /// </remarks>
+    [Test]
+    public async Task ClearingExecutionLimitsReportsAnUnknownSchedulerLikeEveryOtherMember()
+    {
+        HttpScheduler nonExistingHttpScheduler = new HttpScheduler(TestData.SchedulerName + "_non_existing", WebApplicationFactory.CreateClient());
+
+        Func<Task> act = () => nonExistingHttpScheduler.SetExecutionLimits(null).AsTask();
+
+        (await act.Should().ThrowAsync<HttpClientException>(
+            "clearing the limits goes through the same checked call as every other member, so a name the repository does not hold is the wrong-name mistake it is"))
+            .Which.Message.Should().ContainEquivalentOf("Scheduler not found");
+    }
+
+    /// <summary>
+    /// The client turns the exception name the server sent back into that exception, for all eight names
+    /// it knows.
+    /// </summary>
+    /// <remarks>
+    /// The mapping is by type <em>name</em>, so nothing but this test relates the two lists: renaming one
+    /// of these exceptions, or teaching the server to raise one the client cannot name, silently
+    /// downgrades a caller's <c>catch</c> to <see cref="HttpClientException" /> — and a remote
+    /// <c>ScheduleJob</c> that used to report a duplicate as
+    /// <see cref="ObjectAlreadyExistsException" /> would stop doing so with nothing failing.
+    /// </remarks>
+    [TestCaseSource(nameof(TheExceptionsTheClientNames))]
+    public async Task TheClientRethrowsEveryExceptionTheServerNames(Func<SchedulerException> create)
+    {
+        SchedulerException expected = create();
+        A.CallTo(() => FakeScheduler.Start(A<CancellationToken>._)).Throws(_ => create());
+
+        Func<Task> act = () => HttpScheduler.Start().AsTask();
+
+        Exception thrown = (await act.Should().ThrowAsync<SchedulerException>()).Which;
+        thrown.Should().BeOfType(expected.GetType(), "the client maps the exception name the server sent back to the type a caller catches");
+        thrown.Message.Should().ContainEquivalentOf(expected.Message);
+    }
+
+    private static IEnumerable<TestCaseData> TheExceptionsTheClientNames()
+    {
+        yield return Case(() => new SchedulerException("the scheduler refused"));
+        yield return Case(() => new InvalidConfigurationException("the configuration is invalid"));
+        yield return Case(() => new JobExecutionException("the job faulted"));
+        yield return Case(() => new JobPersistenceException("the store refused"));
+        yield return Case(() => new SchedulerConfigException("the scheduler is misconfigured"));
+        yield return Case(() => new LockException("the lock was not taken"));
+        yield return Case(() => new NoSuchDelegateException("there is no such delegate"));
+        yield return Case(() => new ObjectAlreadyExistsException("that one exists already"));
+
+        static TestCaseData Case<TException>(Func<TException> create) where TException : SchedulerException
+        {
+            Func<SchedulerException> asBase = create;
+            return new TestCaseData(asBase).SetArgDisplayNames(typeof(TException).Name);
+        }
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/SchedulerEndpointsTest.cs
@@ -77,9 +77,11 @@ public class SchedulerEndpointsTest : WebApiTest
             .ForGroup("tenant", 8, ExecutionLimitScope.Cluster)
             .ForOtherGroups(1, ExecutionLimitScope.Cluster)
             .ForDefaultGroup(3)
+            .UseTriggerGroupWhenUnset()
             .Build());
 
         captured.Should().NotBeNull("the server builds the limits it was sent before anything can be read back");
+        captured.UsesTriggerGroupWhenUnset.Should().BeTrue("the derivation decides which bucket an ungrouped trigger is counted in, so the server has to be told");
 
         ExecutionLimits? readBack = await HttpScheduler.GetExecutionLimits();
 
@@ -91,6 +93,58 @@ public class SchedulerEndpointsTest : WebApiTest
             new ExecutionGroupLimit(ExecutionGroupScope.OtherGroups, 1, ExecutionLimitScope.Cluster),
             new ExecutionGroupLimit(ExecutionGroupScope.Default, 3),
         });
+        readBack.UsesTriggerGroupWhenUnset.Should().BeTrue("the flag comes back with the limits it was set beside");
+    }
+
+    /// <summary>
+    /// The trigger-group derivation survives the round trip on its own, with no group limit beside it.
+    /// </summary>
+    /// <remarks>
+    /// It is the case both ends used to drop. The server built limits only when the request named a
+    /// group, so a request carrying the flag alone <em>cleared</em> the limits; the client answered null
+    /// whenever the limits map was empty, discarding a flag the server had sent. Nothing was limited
+    /// either way, so nothing went wrong loudly — but <c>GetExecutionLimits</c> answered null where the
+    /// scheduler held limits, and setting them through the client threw the configuration away.
+    /// </remarks>
+    [Test]
+    public async Task ExecutionLimitsRoundTripKeepsTheTriggerGroupDerivationWithNoGroupLimits()
+    {
+        ExecutionLimits? captured = null;
+        A.CallTo(() => FakeScheduler.SetExecutionLimits(A<ExecutionLimits>._, A<CancellationToken>._))
+            .Invokes((ExecutionLimits limits, CancellationToken _) => captured = limits);
+        A.CallTo(() => FakeScheduler.GetExecutionLimits(A<CancellationToken>._))
+            .ReturnsLazily(() => new ValueTask<ExecutionLimits?>(captured));
+
+        await HttpScheduler.SetExecutionLimits(ExecutionLimitsBuilder.Create().UseTriggerGroupWhenUnset().Build());
+
+        captured.Should().NotBeNull("asking for the derivation is configuration, not the absence of it");
+        captured.IsEmpty.Should().BeTrue("no group was named");
+        captured.UsesTriggerGroupWhenUnset.Should().BeTrue();
+
+        ExecutionLimits? readBack = await HttpScheduler.GetExecutionLimits();
+
+        readBack.Should().NotBeNull("the server said the derivation is on, and an empty group map is not the same answer as none");
+        readBack.IsEmpty.Should().BeTrue();
+        readBack.UsesTriggerGroupWhenUnset.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Passing null still clears the limits, which is the answer that has to stay distinguishable from
+    /// the empty-but-configured one above.
+    /// </summary>
+    [Test]
+    public async Task ClearingExecutionLimitsLeavesTheSchedulerWithNone()
+    {
+        ExecutionLimits? captured = ExecutionLimitsBuilder.Create().ForGroup("batch", 2).Build();
+        A.CallTo(() => FakeScheduler.SetExecutionLimits(A<ExecutionLimits>._, A<CancellationToken>._))
+            .Invokes((ExecutionLimits limits, CancellationToken _) => captured = limits);
+        A.CallTo(() => FakeScheduler.GetExecutionLimits(A<CancellationToken>._))
+            .ReturnsLazily(() => new ValueTask<ExecutionLimits?>(captured));
+
+        await HttpScheduler.SetExecutionLimits(null);
+
+        captured.Should().BeNull();
+        (await HttpScheduler.GetExecutionLimits()).Should().BeNull();
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/WireFormatSnapshotTest.cs
@@ -56,6 +56,18 @@ public class WireFormatSnapshotTest : WebApiTest
     [Test]
     public async Task RecurrenceTriggerBody() => await VerifyTriggerBody(TestData.Wire.RecurrenceTrigger);
 
+    /// <summary>
+    /// The trigger whose execution group, retry policy, retry attempt and node pin are all set, which
+    /// every other trigger body shows only at its default.
+    /// </summary>
+    /// <remarks>
+    /// These four are what a non-.NET client reads to know which limit bucket a trigger counts against,
+    /// how it retries and which node holds it. Their default shape is pinned five times over; the shape
+    /// they take when used was pinned nowhere, which made renaming or re-casing any of them free.
+    /// </remarks>
+    [Test]
+    public async Task AnnotatedTriggerBody() => await VerifyTriggerBody(TestData.Wire.AnnotatedTrigger);
+
     [Test]
     public async Task CalendarBody()
     {

--- a/src/Quartz.Tests.AspNetCore/Support/TestData.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/TestData.cs
@@ -486,6 +486,17 @@ public static class TestData
         public static readonly ITrigger DailyTimeIntervalTrigger;
         public static readonly ITrigger RecurrenceTrigger;
 
+        /// <summary>
+        /// The one fixture whose execution group and node pin are set, so the wire shape of a trigger
+        /// that uses every optional field is pinned rather than only the default it shares with the rest.
+        /// </summary>
+        /// <remarks>
+        /// The pin is a claimed one because <c>preferredNode</c> and <c>preferredNodeAuto</c> are two
+        /// fields on the wire, and "auto, already claimed" is the combination that needs both. A
+        /// non-.NET client reads these four the way this snapshot spells them.
+        /// </remarks>
+        public static readonly ITrigger AnnotatedTrigger;
+
         static Wire()
         {
             Metadata = new SchedulerMetadata
@@ -596,6 +607,22 @@ public static class TestData
                 .StartAt(StartTime)
                 .EndAt(EndTime)
                 .WithPriority(5)
+                .Build());
+
+            AnnotatedTrigger = WithFireTimes(TriggerBuilder.Create()
+                .WithSimpleSchedule(builder => builder
+                    .WithInterval(TimeSpan.FromMinutes(15))
+                    .WithRepeatCount(5)
+                )
+                .WithIdentity("AnnotatedTriggerKey", "AnnotatedTriggerGroup")
+                .ForJob("AnnotatedJobKey", "AnnotatedJobGroup")
+                .WithDescription("A trigger that retries, is grouped and is pinned")
+                .WithCalendarName(null)
+                .StartAt(StartTime)
+                .EndAt(EndTime)
+                .WithExecutionGroup("reporting")
+                .WithRetryPolicy(RetryPolicy.Exponential(4, TimeSpan.FromSeconds(30), 3, TimeSpan.FromMinutes(10)))
+                .WithPreferredNode(PreferredNode.ClaimedBy("node-b"))
                 .Build());
         }
 

--- a/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_AnnotatedTriggerBody.verified.json
+++ b/src/Quartz.Tests.AspNetCore/Verify/WireFormatSnapshotTest_AnnotatedTriggerBody.verified.json
@@ -1,0 +1,28 @@
+﻿{
+  "triggerType": "SimpleTrigger",
+  "key": {
+    "name": "AnnotatedTriggerKey",
+    "group": "AnnotatedTriggerGroup"
+  },
+  "jobKey": {
+    "name": "AnnotatedJobKey",
+    "group": "AnnotatedJobGroup"
+  },
+  "description": "A trigger that retries, is grouped and is pinned",
+  "calendarName": null,
+  "jobDataMap": {},
+  "misfireInstruction": 0,
+  "startTimeUtc": "2024-07-01T12:00:00+00:00",
+  "endTimeUtc": "2025-07-01T12:00:00+00:00",
+  "priority": 5,
+  "nextFireTimeUtc": "2024-08-01T12:30:00+00:00",
+  "previousFireTimeUtc": "2024-08-01T06:30:00+00:00",
+  "executionGroup": "reporting",
+  "retryPolicy": "exp;4;00:00:30;3;00:10:00",
+  "retryAttempt": 2,
+  "preferredNode": "node-b",
+  "preferredNodeAuto": true,
+  "repeatCount": 5,
+  "repeatIntervalTimeSpan": "00:15:00",
+  "timesTriggered": 0
+}

--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Specialized;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 using Quartz.Configuration;
 
@@ -86,16 +87,34 @@ public class LegacyPropertyKeyExhaustivenessTest
         "quartz.dataSource.myDs.connectionProvider.type",
         "quartz.dbprovider.MyDatabase.productName",
         "quartz.jobStore.acceptEnlistedTransactions",
+        "quartz.jobStore.acquireTriggersWithinLock",
         "quartz.jobStore.clusterCheckinInterval",
         "quartz.jobStore.clusterCheckinMisfireThreshold",
         "quartz.jobStore.clustered",
+        "quartz.jobStore.clustering.checkinInterval",
+        "quartz.jobStore.clustering.checkinMisfireThreshold",
+        "quartz.jobStore.clustering.enabled",
         "quartz.jobStore.dataSource",
+        "quartz.jobStore.dbRetryInterval",
+        "quartz.jobStore.doubleCheckLockMisfireHandler",
         "quartz.jobStore.driverDelegateInitString",
+        "quartz.jobStore.driverDelegateType",
         "quartz.jobStore.lockHandler.type",
+        "quartz.jobStore.lockOnInsert",
         "quartz.jobStore.makeThreadsDaemons",
+        "quartz.jobStore.maxMisfiresToHandleAtATime",
+        "quartz.jobStore.maxTransientRetries",
+        "quartz.jobStore.misfireHandlerFrequency",
         "quartz.jobStore.misfireThreshold",
+        "quartz.jobStore.performSchemaValidation",
+        "quartz.jobStore.retryableActionErrorLogThreshold",
+        "quartz.jobStore.schemaProvisioning",
+        "quartz.jobStore.selectWithLockSQL",
         "quartz.jobStore.tablePrefix",
+        "quartz.jobStore.transientRetryInterval",
+        "quartz.jobStore.txIsolationLevelSerializable",
         "quartz.jobStore.type",
+        "quartz.jobStore.useDBLocks",
         "quartz.jobStore.useProperties",
         "quartz.plugin.myPlugin.type",
         "quartz.scheduler.batchTriggerAcquisitionFireAheadTimeWindow",
@@ -107,24 +126,18 @@ public class LegacyPropertyKeyExhaustivenessTest
         "quartz.scheduler.interruptJobsOnShutdownWithWait",
         "quartz.scheduler.jobFactory.type",
         "quartz.scheduler.typeLoadHelper.type",
+        "quartz.serializer",
         "quartz.serializer.type",
         "quartz.threadExecutor",
         "quartz.threadPool.maxConcurrency",
+        "quartz.threadPool.threadCount",
         "quartz.threadPool.type",
-
-        // tutorial/job-stores.md
-        "quartz.jobStore.driverDelegateType",
 
         // tutorial/execution-groups.md
         "quartz.executionLimit.batch-jobs",
 
         // migration-guide.md
-        "quartz.timeProvider.type",
-
-        // migration-guide.md, the SchemaProvisioning row: the key that replaced
-        // performSchemaValidation, and the one it replaced, which still bridges
-        "quartz.jobStore.schemaProvisioning",
-        "quartz.jobStore.performSchemaValidation"
+        "quartz.timeProvider.type"
     ];
 
     /// <summary>
@@ -267,6 +280,96 @@ public class LegacyPropertyKeyExhaustivenessTest
             "the validator only ever looks at keys under the quartz. prefix, so an entry outside it can never match");
         supported.Should().OnlyContain(key => !key.StartsWith("quartz.server", StringComparison.Ordinal),
             "quartz.server.* belonged to 3.x's Quartz.Server host and is skipped before this list is consulted");
+    }
+
+    /// <summary>
+    /// Every key a reader consults is named somewhere in the 4.x documentation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the assertion that was missing, and the reason nineteen honoured keys — the whole
+    /// ADO.NET locking, retry and schema-provisioning set among them — reached beta.1 documented
+    /// nowhere. Every other test here compares the readers with the <em>validator</em>, so a key that
+    /// worked perfectly and was written down on no page passed all of them:
+    /// <see cref="documentedKeys" /> is a hand transcription, and nothing compared it with the
+    /// markdown it was transcribed from.
+    /// </para>
+    /// <para>
+    /// It asks only whether the key is named, and it looks across the whole 4.x tree rather than one
+    /// page — including the migration guide, because a key documented only there is documented. Which
+    /// page ought to carry a given key is an editorial judgement a test should not make; "no page at
+    /// all mentions it" is not.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void EveryKeyTheReadersConsultIsNamedInTheDocumentation()
+    {
+        string documentation = ReadAllFourXDocumentation();
+
+        List<string> undocumented = keysTheReadersConsult
+            .Where(key => !documentation.Contains(key, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        undocumented.Should().BeEmpty(
+            "a key Quartz honours and no page names is a setting only the source says exists, which is "
+            + "how a reader ends up configuring a scheduler by reading its implementation");
+    }
+
+    /// <summary>
+    /// The mirror: every key this test class calls documented really is written down.
+    /// </summary>
+    /// <remarks>
+    /// Keeps the curated list honest in the other direction, so an entry cannot be added here to quiet
+    /// a failure without the page it claims to quote actually saying it.
+    /// </remarks>
+    [Test]
+    public void EveryKeyThisTestCallsDocumentedIsNamedInTheDocumentation()
+    {
+        string documentation = ReadAllFourXDocumentation();
+
+        List<string> missing = documentedKeys.Concat(documentedRemovals)
+            .Where(key => !Regex.IsMatch(documentation, DocumentationPattern(key), RegexOptions.IgnoreCase))
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "these lists are transcribed from the pages, so an entry the pages do not carry is a "
+            + "transcription that has drifted from what a reader is actually told");
+    }
+
+    /// <summary>
+    /// The names filled into a placeholder segment above, so the search can put the placeholder back.
+    /// </summary>
+    /// <remarks>
+    /// A key matched by prefix is spelled with a stand-in name here — <c>myDs</c>, <c>myPlugin</c> —
+    /// and the pages spell it with one of their own: <c>NAME</c>, <c>myDs</c>, <c>&lt;name&gt;</c>.
+    /// Comparing the two literally would report a documented key as missing, which is why the segment
+    /// is matched as any name rather than as the one this file happens to use.
+    /// </remarks>
+    private static readonly string[] placeholderNames =
+    [
+        "myDs", "MyDatabase", "myPlugin", "myListener", "audit", "environment", "batch-jobs"
+    ];
+
+    private static string DocumentationPattern(string key)
+    {
+        string[] segments = key.Split('.');
+        IEnumerable<string> parts = segments.Select(segment =>
+            placeholderNames.Contains(segment, StringComparer.Ordinal)
+                ? "[^.\\s\"]+"
+                : Regex.Escape(segment));
+
+        return string.Join("\\.", parts);
+    }
+
+    private static string ReadAllFourXDocumentation()
+    {
+        string root = Path.Combine(RepositoryRoot.Find().FullName, "docs", "documentation", "quartz-4.x");
+        Directory.Exists(root).Should().BeTrue($"the 4.x documentation is what this test reads, and '{root}' is where it lives");
+
+        string[] pages = Directory.GetFiles(root, "*.md", SearchOption.AllDirectories);
+        pages.Should().NotBeEmpty("a scan that found no pages would make every assertion over it vacuous");
+
+        return string.Join('\n', pages.Select(File.ReadAllText));
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JsonObjectSerializerTest.cs
@@ -549,6 +549,64 @@ public class JsonObjectSerializerTest
         await VerifyCreatedJson(trigger);
     }
 
+    /// <summary>
+    /// A trigger whose retry policy, retry attempt, execution group and node pin are all something
+    /// other than their default, in the blob both serializers write.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every other snapshot in this file shows those five fields at their defaults, so the blob a
+    /// trigger that actually uses them produces was described nowhere. The ADO store keeps the policy
+    /// and the group in columns, which leaves the shape a third-party <see cref="IObjectSerializer" />
+    /// store writes as the thing nothing pinned — and the shared snapshot is what makes the two
+    /// serializers emit it byte for byte alike.
+    /// </para>
+    /// <para>
+    /// The pin is a claimed one because that is the shape a single node-name field could not express:
+    /// <c>PreferredNode</c> and <c>PreferredNodeAuto</c> are two fields, and "auto, claimed by node-b"
+    /// is the combination that needs both. This test has its own verified file so that adding it
+    /// churns none of the five that were already here.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task SerializeTriggerWithRetryPolicyGroupAndPin()
+    {
+        FakeTimeProvider timeProvider = CreateFakeTimeProvider();
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create(timeProvider)
+            .WithSimpleSchedule(builder => builder
+                .WithInterval(TimeSpan.FromMinutes(15))
+                .WithRepeatCount(5)
+            )
+            .WithIdentity("RetryingTriggerKey", "RetryingTriggerGroup")
+            .ForJob("RetryingJobKey", "RetryingJobGroup")
+            .WithDescription("A trigger that retries, is grouped and is pinned")
+            .WithExecutionGroup("reporting")
+            .WithRetryPolicy(RetryPolicy.Exponential(4, TimeSpan.FromSeconds(30), factor: 3, maxDelay: TimeSpan.FromMinutes(10)))
+            .WithPreferredNode(PreferredNode.ClaimedBy("node-b"))
+            .StartAt(timeProvider.GetUtcNow())
+            .Build();
+
+        SetTimeProvider(timeProvider, trigger);
+        trigger.RetryAttempt = 2;
+
+        CompareSerialization<IOperableTrigger>(
+            trigger,
+            (deserialized, original) =>
+            {
+                using (new AssertionScope())
+                {
+                    deserialized.RetryPolicy.Should().Be(original.RetryPolicy, "a policy that came back different would retry on a different schedule");
+                    deserialized.RetryAttempt.Should().Be(original.RetryAttempt, "an attempt count that reset would retry a trigger that had run out of attempts");
+                    deserialized.ExecutionGroup.Should().Be(original.ExecutionGroup, "the group is what an execution limit counts against");
+                    deserialized.PreferredNode.Should().Be(original.PreferredNode, "the claim is half the pin, and losing it re-opens a trigger another node holds");
+                }
+            }
+        );
+
+        await VerifyCreatedJson(trigger);
+    }
+
     [Test]
     public void PinnedTriggerKeepsItsPin()
     {

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeTriggerWithRetryPolicyGroupAndPin.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeTriggerWithRetryPolicyGroupAndPin.verified.txt
@@ -1,0 +1,28 @@
+﻿{
+  "TriggerType": "SimpleTrigger",
+  "Key": {
+    "Name": "RetryingTriggerKey",
+    "Group": "RetryingTriggerGroup"
+  },
+  "JobKey": {
+    "Name": "RetryingJobKey",
+    "Group": "RetryingJobGroup"
+  },
+  "Description": "A trigger that retries, is grouped and is pinned",
+  "CalendarName": null,
+  "JobDataMap": {},
+  "MisfireInstruction": 0,
+  "StartTimeUtc": "2024-07-01T00:00:00.5+00:00",
+  "EndTimeUtc": null,
+  "Priority": 5,
+  "NextFireTimeUtc": null,
+  "PreviousFireTimeUtc": null,
+  "ExecutionGroup": "reporting",
+  "RetryPolicy": "exp;4;00:00:30;3;00:10:00",
+  "RetryAttempt": 2,
+  "PreferredNode": "node-b",
+  "PreferredNodeAuto": true,
+  "RepeatCount": 5,
+  "RepeatIntervalTimeSpan": "00:15:00",
+  "TimesTriggered": 0
+}


### PR DESCRIPTION
Closes #3646.

N1b found the nine side packages sound in shape and found ten promises they did not keep. This keeps them.

## Behaviour

**`SetExecutionLimits(null)` was the one `HttpScheduler` member outside the client's error mapping** (N1b-1). It called `HttpClient.DeleteAsync` and `EnsureSuccessStatusCode` directly, so it never read the problem details: against a scheduler name the repository does not hold the caller got a bare `HttpRequestException` where every other member reports `HttpClientException` naming the scheduler, and a `SchedulerException` from the scheduler arrived unmapped. It now goes through `HttpClientExtensions.Delete` — the checked equivalent that until now had no callers.

**`ExecutionLimits.UsesTriggerGroupWhenUnset` was dropped in both directions when no group limit was set** (N1b-3). The endpoint built limits only when the request named a group, so a request carrying the flag alone *cleared* them; the client answered `null` whenever the limits map came back empty, discarding a flag the server had sent. Asking for the derivation is configuration rather than the absence of it, so both ends now keep it — and clearing, which is what `null` means, stays distinguishable from it.

Both are shown failing first: `HttpRequestException: Response status code does not indicate success: 404 (Not Found)` for the first, `Expected captured not to be <null>` for the second.

## Pins

- **All eight typed-exception mappings** (N1b-2). The client maps eight exception *names* back to typed exceptions and two were covered end to end. Nothing related the two lists, so renaming one — or teaching the server to raise one the client cannot name — would have downgraded a remote caller's `catch` to `HttpClientException` in silence. A `TestCaseSource` now drives all eight. `ObjectAlreadyExistsException` is the one that matters: it is what a caller catches around `ScheduleJob`.
- **A trigger that uses its optional fields, in the blob and on the wire** (N1b-4). Every trigger snapshot in either project showed `ExecutionGroup`, `RetryPolicy`, `RetryAttempt` and `PreferredNode` at their defaults. Each side gets one new case with its **own** verified file, so none of the ten existing snapshots churns. The pin is a *claimed* one in both, because that is the shape a single node-name field could not express.
- **`IQuartzApiClient`'s not-found contract** (N1b-7), run through whatever client the container holds rather than through `InProcessQuartzApiClient` — the registration is `TryAdd`, so an application's own client is the one the pages read and the one this binds.
- **Every key a reader consults is named in the 4.x documentation.** See below.

## Documentation

- **`http-client.md` told a reader to catch the wrong thing** (N1b-5): its errors section said everything the server rejects arrives as `HttpClientException`, while `http-api.md` said the client maps the names back. The second was right. The section now names all eight and the fallback, so the two pages agree.
- **`HttpScheduler` documented 7 of ~61 public members and used no `<inheritdoc />`** (N1b-6). C# does not inherit interface docs, so IntelliSense on the type a consumer names was blank.
- **`IQuartzApiClient` stated no exception contract** (N1b-7) on an interface that is public *only* so an application can replace it. Four members return non-nullable references whose implementation raises `KeyNotFoundException`; the interface now says so, along with the `NotSupportedException` → `CannotReport` convention. `dashboard.md` gains the same two rules and the **D11 additivity promise**: a member added to this interface during 4.x arrives as a default interface member.
- **`configuration/reference.md` gains the 19 undocumented keys** (N1b-8), the corrected count of **nine** removed prefixes with the three lock-handler spellings, and the `IConfiguration` exemption (N1b-9).

## CS1591

One commit per package, `1591` out of each `NoWarn` as that package becomes clean. Every shipped package now enforces it; nothing in the repository suppresses `1591` any more.

| Package | Sites documented |
|---|---|
| `Quartz.Dashboard` | 123 |
| `Quartz.HttpClient` | 64 |
| `Quartz.Serialization.Newtonsoft` | 42 |
| `Quartz.Plugins` | 12 |
| `Quartz.AspNetCore` | 1 |
| `Quartz.Jobs`, `Quartz.Plugins.TimeZoneConverter`, `Quartz.Extensions.Redis`, `Quartz.Aspire` | 0 — already clean |

## For the reviewer to decide

1. **The mechanical documentation guard, and the drift it found.** Every assertion in `LegacyPropertyKeyExhaustivenessTest` compared the readers with the *validator*; `documentedKeys` was a hand transcription nothing compared with the markdown. That is why 19 honoured keys reached beta.1 documented nowhere (N1b-12). Two tests close it: every key a reader consults must be named somewhere in the 4.x tree, and every key the list calls documented must really be written down. It is scoped to "is the key named at all, anywhere in `quartz-4.x/`" — including the migration guide, because a key documented only there is documented — rather than to a particular page, since which page ought to carry a key is an editorial judgement a test should not make. **The first test fails on `origin/main`'s `reference.md`, naming `quartz.jobStore.acquireTriggersWithinLock`.**
2. **The issue asked to extend `ExecutionLimitsRoundTripKeepsEachLimitsScope` with both cases.** Case (a) — group limits plus the flag — is folded into that test; case (b) — the flag alone — is a test of its own, because it is the case that was broken and a separate name says so on failure. A third test pins that `null` still clears.
3. **No non-packable project re-adds `1591`.** The issue expected it to be re-added in tests, examples, benchmark, samples and the canary. `GenerateDocumentationFile` is set only in the ten shipped packages, and CS1591 is emitted only when a documentation file is produced, so those suppressions would be dead configuration. Verified by building the whole solution warning-free.

## Verification

```
dotnet build Quartz.slnx            Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit         Passed! Failed: 0, Passed: 5173, Skipped: 36, Total: 5209
dotnet test src/Quartz.Tests.AspNetCore   Passed! Failed: 0, Passed: 605, Skipped: 0, Total: 605
dotnet fallout VerifyDocsSnippets   Succeeded (104 markdown files checked)
npm run docs:check-links            221 pages, 1166 internal links, 714 fragments — no dead links or anchors
```

Each swept package additionally rebuilt with `-t:Rebuild` under `TreatWarningsAsErrors`, proving CS1591 is enforced rather than merely unreported.

No public-API baseline moved: doc comments are not in the snapshots. The only `.verified.*` changes are the two new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqrmFVgN97Z6aRpjBU3LRQ
