### PR TITLE
Two file formats gain what the code already had, and an enlistment that cannot happen says so

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/json.md
+++ b/docs/documentation/quartz-4.x/configuration/json.md
@@ -143,7 +143,8 @@ Jobs and triggers can be defined declaratively in `appsettings.json` under a `Sc
 
 ### Trigger Types
 
-Exactly one schedule type must be specified per trigger. The trigger type is determined by which nested object is present.
+Exactly one schedule type must be specified per trigger — `Simple`, `Cron`, `CalendarInterval`,
+`DailyTimeInterval` or `Recurrence`. The trigger type is determined by which nested object is present.
 
 #### Simple Trigger
 
@@ -209,6 +210,37 @@ Exactly one schedule type must be specified per trigger. The trigger type is det
   }
 }
 ```
+
+#### Recurrence Trigger
+
+```json
+{
+  "Name": "recurrenceTrigger",
+  "JobName": "myJob",
+  "StartTime": "2026-01-05T09:00:00Z",
+  "Recurrence": {
+    "Rule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO",
+    "TimeZone": "America/New_York",
+    "MisfireInstruction": "DoNothing"
+  }
+}
+```
+
+- `Rule`: the RFC 5545 recurrence rule, required. See [Recurrence Triggers](../tutorial/recurrencetrigger.md) for what a rule can say.
+- `TimeZone`: the zone the rule's days and times are read in. Defaults to the machine's local zone, so name it if the schedule has to mean the same thing wherever it runs.
+- `MisfireInstruction`: `SmartPolicy` (the default), `FireOnceNow`, `DoNothing` or `IgnoreMisfirePolicy`.
+
+The rule says how the firings repeat; the trigger's own `StartTime` says what they repeat **from**, the
+way `DTSTART` anchors an iCalendar rule. `FREQ=WEEKLY;INTERVAL=2` therefore means "every second week
+counted from the start time", and a trigger given no `StartTime` is anchored to the moment its
+scheduler read the declaration. A rule that cannot be parsed is refused as the file is read, naming
+the rule, rather than at the first firing.
+
+::: tip
+This trigger kind is JSON only. The XML format is [frozen](../packages/quartz-plugins.md#the-xml-format-is-frozen)
+at the three kinds its schema already declares and will not gain a `<recurrence>` element, so a
+recurrence rule is declared in JSON or written in code.
+:::
 
 ### Common Trigger Fields
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -4168,8 +4168,8 @@ plugin-based setup sees no change at all.
 
 **Nor will it change.** The schema is frozen at what it already says: `simple`, `cron` and
 `calendar-interval` triggers, and none of the trigger kinds or trigger settings written since. A
-daily time interval trigger, a [retry policy](#a-trigger-can-carry-a-retry-policy) and an execution
-group are expressible in the JSON format and are not expressible in XML, now or later — two file
+daily time interval trigger, a recurrence rule, a [retry policy](#a-trigger-can-carry-a-retry-policy)
+and an execution group are expressible in the JSON format and are not expressible in XML, now or later — two file
 formats that both grow is two parsers and two schemas for one feature, and the XML one is the one that
 has to keep loading files written twenty years ago. It does: **XML scheduling is not deprecated and is
 not going away in 4.x**, and a schedule that only needs the three trigger kinds above never has to

--- a/docs/documentation/quartz-4.x/packages/quartz-plugins.md
+++ b/docs/documentation/quartz-4.x/packages/quartz-plugins.md
@@ -230,11 +230,9 @@ XML format will be for the life of 4.x. It declares three trigger kinds — `sim
 |---|---|---|
 | a simple, cron or calendar-interval trigger | `<simple>`, `<cron>`, `<calendar-interval>` | `Simple`, `Cron`, `CalendarInterval` |
 | a daily time interval trigger | not expressible, and will not be | `DailyTimeInterval` |
+| a [recurrence trigger](../tutorial/recurrencetrigger.md) | not expressible, and will not be | [`Recurrence`](../configuration/json.md#recurrence-trigger) |
 | a trigger with a [retry policy](../how-tos/retrying-failed-jobs.md) | not expressible, and will not be | `RetryPolicy` |
 | a trigger in an [execution group](../tutorial/execution-groups.md) | not expressible, and will not be | `ExecutionGroup` |
-
-[Recurrence triggers](../tutorial/recurrencetrigger.md) are in neither format; a recurrence rule is
-scheduled in code.
 
 This is a decision, not a backlog. Two file formats that both grow means two parsers, two schemas and
 two sets of documentation for one feature, and the XML one is the one carrying twenty years of files

--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -357,11 +357,21 @@ Things worth knowing before you enable this:
   process, so a concurrent scheduler operation there can fail with "database is locked" until your transaction
   completes. Quartz logs a warning about it at startup.
 * On SQLite, enlist a `DbTransaction` and not a `TransactionScope`. `Microsoft.Data.Sqlite` implements no
-  `DbConnection.EnlistTransaction`, so a connection opened inside a scope never joins it: `EnlistConnection` then hands
-  the store a connection whose writes commit on the spot, and rolling the scope back leaves the schedule behind.
+  `DbConnection.EnlistTransaction`, so a connection opened inside a scope never joins it. `EnlistConnection` refuses
+  such a connection rather than handing it to the store, with a `SchedulerException` that names the driver:
+
+  ```text
+  Scheduler 'MyScheduler' cannot take part in the ambient transaction through a Microsoft.Data.Sqlite.SqliteConnection
+  (Microsoft.Data.Sqlite): the driver implements no DbConnection.EnlistTransaction, so the connection never joined the
+  TransactionScope and every statement the job store issued on it would commit on the spot - a scope that rolled back
+  would leave the schedule behind. Begin a transaction on the connection and enlist that instead:
+  scheduler.EnlistTransaction(connection.BeginTransaction()).
+  ```
+
   `EnlistTransaction(connection.BeginTransaction())` is unaffected, because there the transaction is the connection's
-  own and Quartz uses it directly. This is a property of the driver rather than of Quartz, and it is the reason
-  `EnlistedTransactionTest` runs only the `DbTransaction` cases for SQLite.
+  own and Quartz uses it directly. Which drivers can join an ambient transaction is a property of the driver rather
+  than of Quartz — the other five all can — and the connection is asked to join whichever driver it comes from, so a
+  provider Quartz has never heard of is held to the same answer.
 * An operation that fails halfway leaves its statements in your transaction; there is no savepoint to roll back to.
 * Work the scheduler does on its own - acquiring triggers, handling misfires, cluster check-in - always uses its own
   connections and is unaffected.

--- a/src/Quartz.Plugins/Plugins/Json/JsonJobSchedulingData.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonJobSchedulingData.cs
@@ -123,6 +123,7 @@ internal sealed class JsonFileTriggerDefinition
     public JsonFileCronSchedule? Cron { get; set; }
     public JsonFileCalendarIntervalSchedule? CalendarInterval { get; set; }
     public JsonFileDailyTimeIntervalSchedule? DailyTimeInterval { get; set; }
+    public JsonFileRecurrenceSchedule? Recurrence { get; set; }
 }
 
 internal sealed class JsonFileSimpleSchedule
@@ -143,6 +144,26 @@ internal sealed class JsonFileCalendarIntervalSchedule
 {
     public int RepeatInterval { get; set; }
     public string RepeatIntervalUnit { get; set; } = "Day";
+    public string? MisfireInstruction { get; set; }
+}
+
+/// <summary>
+/// A schedule stated as an RFC 5545 recurrence rule.
+/// </summary>
+/// <remarks>
+/// The rule says how the firings repeat and the trigger's own <c>StartTime</c> says what they repeat
+/// from — a rule is anchored to a moment, exactly as <c>DTSTART</c> anchors an iCalendar one, so
+/// <c>FREQ=WEEKLY;INTERVAL=2</c> means "every second week counted from the start time" and a trigger
+/// given no start time is anchored to the moment the file was read.
+/// </remarks>
+internal sealed class JsonFileRecurrenceSchedule
+{
+    /// <summary>
+    /// The RFC 5545 rule, for example <c>FREQ=WEEKLY;INTERVAL=2;BYDAY=MO</c>.
+    /// </summary>
+    public string Rule { get; set; } = "";
+
+    public string? TimeZone { get; set; }
     public string? MisfireInstruction { get; set; }
 }
 

--- a/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
+++ b/src/Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs
@@ -349,14 +349,16 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
     private IScheduleBuilder BuildSchedule(JsonFileTriggerDefinition def, string triggerName)
     {
         var count = (def.Simple is not null ? 1 : 0) + (def.Cron is not null ? 1 : 0) +
-                    (def.CalendarInterval is not null ? 1 : 0) + (def.DailyTimeInterval is not null ? 1 : 0);
+                    (def.CalendarInterval is not null ? 1 : 0) + (def.DailyTimeInterval is not null ? 1 : 0) +
+                    (def.Recurrence is not null ? 1 : 0);
 
-        if (count == 0) throw new SchedulerConfigException($"JSON trigger '{triggerName}' must specify exactly one schedule type: Simple, Cron, CalendarInterval, or DailyTimeInterval.");
+        if (count == 0) throw new SchedulerConfigException($"JSON trigger '{triggerName}' must specify exactly one schedule type: Simple, Cron, CalendarInterval, DailyTimeInterval, or Recurrence.");
         if (count > 1) throw new SchedulerConfigException($"JSON trigger '{triggerName}' has multiple schedule types. Specify exactly one.");
 
         if (def.Simple is not null) return BuildSimpleSchedule(def.Simple);
         if (def.Cron is not null) return BuildCronSchedule(def.Cron, triggerName);
         if (def.CalendarInterval is not null) return BuildCalendarIntervalSchedule(def.CalendarInterval);
+        if (def.Recurrence is not null) return BuildRecurrenceSchedule(def.Recurrence, triggerName);
         return BuildDailyTimeIntervalSchedule(def.DailyTimeInterval!);
     }
 
@@ -385,6 +387,35 @@ internal sealed class JsonSchedulingDataProcessor : XmlSchedulingDataProcessor
 
         if (cron.TimeZone is not null) builder.InTimeZone(TimeZones.FindById(cron.TimeZone));
         if (cron.MisfireInstruction is not null) builder.WithMisfireInstruction((CronTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Cron, cron.MisfireInstruction, logger));
+        return builder;
+    }
+
+    /// <summary>
+    /// Reads a recurrence schedule, whose rule is the whole of the repetition and whose anchor is the
+    /// trigger's own start time.
+    /// </summary>
+    /// <remarks>
+    /// The rule is validated here rather than at the first firing, for the reason a cron expression is:
+    /// a schedule file that names a rule nobody can parse is a mistake to report while the application
+    /// is still starting.
+    /// </remarks>
+    private RecurrenceScheduleBuilder BuildRecurrenceSchedule(JsonFileRecurrenceSchedule recurrence, string triggerName)
+    {
+        if (string.IsNullOrWhiteSpace(recurrence.Rule))
+            throw new SchedulerConfigException($"JSON trigger '{triggerName}': Recurrence schedule is missing required 'Rule' property.");
+
+        RecurrenceScheduleBuilder builder;
+        try
+        {
+            builder = RecurrenceScheduleBuilder.Create(recurrence.Rule);
+        }
+        catch (Exception ex)
+        {
+            throw new SchedulerConfigException($"JSON trigger '{triggerName}': invalid recurrence rule '{recurrence.Rule}'. {ex.Message}", ex);
+        }
+
+        if (recurrence.TimeZone is not null) builder.InTimeZone(TimeZones.FindById(recurrence.TimeZone));
+        if (recurrence.MisfireInstruction is not null) builder.WithMisfireInstruction((RecurrenceTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Recurrence, recurrence.MisfireInstruction, logger));
         return builder;
     }
 

--- a/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/StringKeyDirtyFlagMapConverter.cs
@@ -14,17 +14,7 @@ internal sealed class StringKeyDirtyFlagMapConverter(NewtonsoftJsonSerializerReg
             JobDataValues.Refuse(jobDataMap, registry);
         }
 
-        // Written entry by entry rather than by handing Json.NET a Dictionary<string, object>, because
-        // the slot a value sits in is what decides whether a $type goes beside it - and a string map
-        // has to go out as the plain object the built-in serializer writes.
-        writer.WriteStartObject();
-        foreach (KeyValuePair<string, object?> pair in (IDictionary<string, object?>) value!)
-        {
-            writer.WritePropertyName(pair.Key);
-            JobDataValues.Write(writer, pair.Value, serializer);
-        }
-
-        writer.WriteEndObject();
+        JobDataValues.WriteMap(writer, (IDictionary<string, object?>) value!, serializer);
     }
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)

--- a/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Converters/TriggerConverter.cs
@@ -35,7 +35,7 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             writer.WriteValue(trigger.CalendarName);
 
             writer.WritePropertyName("JobDataMap");
-            writer.WriteJobDataMapValue(trigger.JobDataMap);
+            JobDataValues.WriteMap(writer, trigger.JobDataMap, serializer);
 
             writer.WritePropertyName("MisfireInstruction");
             writer.WriteValue(trigger.MisfireInstructionCode);
@@ -102,7 +102,7 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
     {
         try
         {
-            var source = JObject.Load(reader);
+            (JObject source, JobDataMap jobDataMap) = ReadTrigger(reader, serializer);
             var type = source["TriggerType"]!.Value<string>()!;
 
             var triggerSerializer = registry.GetTriggerSerializer(type);
@@ -112,7 +112,6 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             var jobKey = source.GetJobKey("JobKey");
             var description = source.Value<string>("Description");
             var calendarName = source.Value<string>("CalendarName");
-            var jobDataMap = source.Value<JObject>("JobDataMap").GetJobDataMap() ?? new JobDataMap();
             var misfireInstruction = source.Value<int>("MisfireInstruction");
             var endTimeUtc = source.Value<DateTimeOffset?>("EndTimeUtc");
             var startTimeUtc = source.Value<DateTimeOffset>("StartTimeUtc");
@@ -176,6 +175,58 @@ internal sealed class TriggerConverter(NewtonsoftJsonSerializerRegistry registry
             // Quartz's exception, deliberately - see the note on the serialize side above.
             throw new Quartz.JsonSerializationException("Failed to parse ITrigger from json", e);
         }
+    }
+
+    /// <summary>
+    /// Reads the stored trigger, taking its job data map off the reader as the map is reached rather
+    /// than out of a token tree the whole trigger was parsed into first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="JobDataValues.ReadMap" /> is the half the default path reads a map with, and it can
+    /// only do its work while the reader is still on the map: whether text that looks like a timestamp
+    /// becomes one is a reader setting, so a map that arrives inside a
+    /// <see cref="JObject.Load(JsonReader)" /> over the whole trigger has already had every such string
+    /// turned into a date — nested ones included, which is what made a stored string map come back with
+    /// values the application never put in it. Turning date parsing off for the whole trigger instead
+    /// would change what <c>StartTimeUtc</c> and its siblings read back as, and those are in databases
+    /// already.
+    /// </para>
+    /// <para>
+    /// The map is therefore the one property not among the returned object's. Nothing reads it from
+    /// there — the trigger a serializer's <c>DeserializeFields</c> is handed already carries the map —
+    /// and putting it back would mean parsing it a second time.
+    /// </para>
+    /// </remarks>
+    private static (JObject Source, JobDataMap JobDataMap) ReadTrigger(JsonReader reader, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new Quartz.JsonSerializationException(
+                $"A trigger is stored as a JSON object, and this payload holds {reader.TokenType} where the trigger should be.");
+        }
+
+        JObject source = new();
+        JobDataMap jobDataMap = new();
+
+        while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
+        {
+            string name = (string) reader.Value!;
+            reader.Read();
+
+            // A payload written before triggers carried a map has no such property at all, which is an
+            // empty map; one that has it explicitly null is the same thing said out loud.
+            if (name == "JobDataMap" && reader.TokenType != JsonToken.Null)
+            {
+                jobDataMap = new JobDataMap(JobDataValues.ReadMap(reader, serializer));
+                jobDataMap.ClearDirtyFlag();
+                continue;
+            }
+
+            source[name] = JToken.Load(reader);
+        }
+
+        return (source, jobDataMap);
     }
 
     public override bool CanConvert(Type objectType) => typeof(ITrigger).IsAssignableFrom(objectType);

--- a/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
+++ b/src/Quartz.Serialization.Newtonsoft/JobDataValues.cs
@@ -86,6 +86,30 @@ internal static class JobDataValues
     }
 
     /// <summary>
+    /// Writes a whole map, entry by entry, as the object the System.Text.Json serializer writes for it.
+    /// </summary>
+    /// <remarks>
+    /// Both converters that write a job data map come through here — the one that writes a map on its
+    /// own and the one that writes the map inside a trigger — because a map written two ways is a map
+    /// that reads back two ways, which is how the trigger converter came to refuse a
+    /// <c>Dictionary&lt;string, string&gt;</c> that the write gate had already accepted.
+    /// </remarks>
+    public static void WriteMap(JsonWriter writer, IDictionary<string, object?> map, JsonSerializer serializer)
+    {
+        // Entry by entry rather than by handing Json.NET a Dictionary<string, object>, because the slot
+        // a value sits in is what decides whether a $type goes beside it - and a string map has to go
+        // out as the plain object the built-in serializer writes.
+        writer.WriteStartObject();
+        foreach (KeyValuePair<string, object?> pair in map)
+        {
+            writer.WritePropertyName(pair.Key);
+            Write(writer, pair.Value, serializer);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
     /// Writes one entry's value, as the bytes the System.Text.Json serializer writes for it.
     /// </summary>
     /// <remarks>

--- a/src/Quartz.Serialization.Newtonsoft/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.Newtonsoft/Util/SerializationExtensions.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Globalization;
 
 using Newtonsoft.Json;
@@ -242,37 +241,5 @@ internal static class Utf8JsonWriterExtensions
         var group = key.Value<string>("Group");
 
         return new JobKey(name!, group!);
-    }
-
-    public static void WriteJobDataMapValue(this JsonWriter writer, JobDataMap jobDataMap)
-    {
-        writer.WriteStartObject();
-
-        foreach (var pair in jobDataMap)
-        {
-            writer.WritePropertyName(pair.Key);
-            writer.WriteValue(pair.Value);
-        }
-
-        writer.WriteEndObject();
-    }
-
-    public static JobDataMap? GetJobDataMap(this JObject? jsonElement)
-    {
-        if (jsonElement == null)
-        {
-            return null;
-        }
-
-        var properties = jsonElement.ToObject<IDictionary>()!;
-
-        var result = new JobDataMap();
-        foreach (string key in properties.Keys)
-        {
-            result.Add(key, properties[key]);
-        }
-
-        result.ClearDirtyFlag();
-        return result;
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
@@ -187,8 +187,9 @@ public class EnlistedTransactionTest
     /// Only the <see cref="DbTransaction" /> form. Microsoft.Data.Sqlite implements no
     /// <see cref="System.Data.Common.DbConnection.EnlistTransaction" />, so a connection opened inside
     /// a <see cref="TransactionScope" /> does not join it and the scope's outcome governs nothing —
-    /// which is a fact about the driver rather than about Quartz, and is written down on
-    /// <c>tutorial/job-stores.md</c> beside the in-process locking caveat.
+    /// which is a fact about the driver rather than about Quartz. <c>EnlistConnection</c> refuses such
+    /// a connection instead of writing through it, which
+    /// <c>EnlistmentRefusalSqliteTest</c> pins in the unit project against this very driver.
     /// </remarks>
     [Test]
     public Task SqliteRollingBackTheApplicationTransactionDiscardsTheSchedule()

--- a/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
+++ b/src/Quartz.Tests.Unit/Configuration/JsonSchedulingTests.cs
@@ -61,6 +61,76 @@ public class JsonSchedulingTests
         trigger.RepeatInterval.Should().Be(TimeSpan.FromSeconds(10));
     }
 
+    /// <summary>
+    /// A recurrence rule is a schedule a file can declare, and everything the declaration says has to
+    /// reach the trigger: the rule, the anchor it repeats from, the misfire instruction and the zone
+    /// the rule's days and times are read in.
+    /// </summary>
+    /// <remarks>
+    /// The anchor is the trigger's own <c>StartTime</c> rather than a field of the recurrence section:
+    /// a rule repeats from a moment the way <c>DTSTART</c> does, and every other schedule type in this
+    /// format already starts from that field.
+    /// </remarks>
+    [Test]
+    public void AddQuartz_WithRecurrenceTriggerInJson_CarriesTheRuleAnchorMisfireAndZone()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedule:Jobs:0:Name", "recurringJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Jobs.NativeJob, Quartz.Jobs" },
+            { "Schedule:Jobs:0:Durable", "true" },
+            { "Schedule:Triggers:0:Name", "recurrenceTrigger" },
+            { "Schedule:Triggers:0:JobName", "recurringJob" },
+            { "Schedule:Triggers:0:StartTime", "2026-01-05T09:00:00Z" },
+            { "Schedule:Triggers:0:Recurrence:Rule", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO" },
+            { "Schedule:Triggers:0:Recurrence:TimeZone", "America/New_York" },
+            { "Schedule:Triggers:0:Recurrence:MisfireInstruction", "DoNothing" },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz(config);
+
+        var provider = services.BuildServiceProvider();
+
+        IRecurrenceTrigger trigger = provider.ScheduledTriggers().Should().ContainSingle()
+            .Which.Should().BeAssignableTo<IRecurrenceTrigger>(
+                "a Recurrence section is what makes the trigger a recurrence one").Subject;
+
+        trigger.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO");
+        trigger.StartTimeUtc.Should().Be(new DateTimeOffset(2026, 1, 5, 9, 0, 0, TimeSpan.Zero),
+            "every second week is counted from somewhere, and the trigger's start time is where");
+        trigger.MisfireInstruction.Should().Be(RecurrenceTriggerMisfireInstruction.DoNothing);
+        trigger.TimeZone.Should().Be(TimeZones.FindById("America/New_York"),
+            "a rule naming a day names it in some zone, and a schedule read on a machine in another one has to fire the same");
+    }
+
+    [Test]
+    public void AddQuartz_WithAnUnparseableRecurrenceRule_IsRejected()
+    {
+        var config = BuildConfig(new Dictionary<string, string>
+        {
+            { "Schedule:Jobs:0:Name", "recurringJob" },
+            { "Schedule:Jobs:0:JobType", "Quartz.Jobs.NativeJob, Quartz.Jobs" },
+            { "Schedule:Jobs:0:Durable", "true" },
+            { "Schedule:Triggers:0:Name", "recurrenceTrigger" },
+            { "Schedule:Triggers:0:JobName", "recurringJob" },
+            { "Schedule:Triggers:0:Recurrence:Rule", "FREQ=FORTNIGHTLY" },
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddQuartz(config);
+
+        var provider = services.BuildServiceProvider();
+
+        Action act = () => provider.ScheduledTriggers();
+
+        act.Should().Throw<SchedulerConfigException>(
+                "a rule nobody can parse is a mistake to report while the application is still starting")
+            .WithMessage("*FREQ=FORTNIGHTLY*");
+    }
+
     [TestCase("DoNothing", 2)]
     [TestCase("FireOnceNow", 1)]
     [TestCase("FireAndProceed", 1)]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
@@ -86,6 +86,123 @@ public sealed class AmbientConnectionTest
         applicationConnection.BeginTransactionCount.Should().Be(0, "an enlisted connection joins the transaction the application already has");
     }
 
+    /// <summary>
+    /// Being inside a <see cref="TransactionScope" /> is not the same as the connection being in it,
+    /// so the connection is asked to join rather than assumed to have joined. On a driver that
+    /// implements enlistment the ask is a no-op when the connection is already enlisted, and the
+    /// enlistment it wanted when it is not.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_AsksTheConnectionToJoinTheAmbientTransaction()
+    {
+        var applicationConnection = new RecordingDbConnection();
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            Transaction ambient = Transaction.Current!;
+
+            using (CreateScheduler().EnlistConnection(applicationConnection))
+            {
+                applicationConnection.EnlistedIn.Should().BeSameAs(ambient,
+                    "the enlistment is established before the job store writes anything, which is the only moment "
+                    + "a connection that cannot join can still be refused");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The refusal this exists for. <c>Microsoft.Data.Sqlite</c> overrides no
+    /// <see cref="DbConnection.EnlistTransaction" />, so a connection opened inside a scope never joins
+    /// it: the job store would write through the connection, every statement would commit on the spot,
+    /// and a scope that was never completed would leave the schedule behind. Reported as
+    /// https://github.com/quartznet/quartznet/issues/3666.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_OnADriverThatCannotJoinAnAmbientTransaction_IsRefused()
+    {
+        var applicationConnection = new RecordingDbConnection(new NotSupportedException());
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            Action enlist = () => CreateScheduler().EnlistConnection(applicationConnection);
+
+            enlist.Should().Throw<SchedulerException>(
+                    "writing through a connection the scope does not govern is the silent failure this refusal replaces")
+                .Which.Message.Should().Contain(nameof(RecordingDbConnection), "the failure has to say which driver it is about")
+                .And.Contain("EnlistTransaction(connection.BeginTransaction())", "and what to do instead");
+        }
+    }
+
+    /// <summary>
+    /// Only "there is no such thing here" is a refusal. A driver that answers anything else has an
+    /// enlistment of its own, which is what was being established — and the ordinary answer is "the
+    /// connection is not open", because an enlisted connection is opened by the job store rather than
+    /// at the moment it is enlisted.
+    /// </summary>
+    [Test]
+    public async Task EnlistConnection_WhenTheDriverHasAnOpinionOtherThanUnsupported_IsAccepted()
+    {
+        var applicationConnection = new RecordingDbConnection(new InvalidOperationException("Connection is not open."));
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection,
+                "refusing here would refuse the ordinary case, where the connection is still closed and joins the "
+                + "scope as the job store opens it");
+        }
+    }
+
+    /// <summary>
+    /// And the probe belongs to the ambient form alone. A caller who hands over a transaction is
+    /// governed by that transaction, and asking a connection with an open local transaction to enlist
+    /// is what MySqlConnector and Oracle refuse outright.
+    /// </summary>
+    [Test]
+    public async Task EnlistConnection_WithATransactionOfItsOwn_DoesNotAskTheConnectionToJoinTheScope()
+    {
+        var applicationConnection = new RecordingDbConnection(new NotSupportedException());
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection, applicationTransaction))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Transaction.Should().BeSameAs(applicationTransaction,
+                "the caller's own transaction governs the writes, so the scope has nothing to be joined for");
+        }
+    }
+
+    /// <summary>
+    /// The way out the refusal points at has to keep working on the very driver that is refused: a
+    /// transaction of the connection's own is used directly and needs no enlistment at all, ambient
+    /// scope or no ambient scope.
+    /// </summary>
+    [Test]
+    public async Task EnlistTransaction_OnADriverThatCannotJoinAnAmbientTransaction_IsStillAccepted()
+    {
+        var applicationConnection = new RecordingDbConnection(new NotSupportedException());
+        applicationConnection.Open();
+
+        var jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistTransaction(applicationConnection.BeginTransaction()))
+        {
+            var holder = await jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().NotBeNull("the caller's own transaction governs the writes, and the scope has no say");
+        }
+    }
+
     [Test]
     public void EnlistConnection_WithNothingToJoin_IsRefused()
     {
@@ -452,7 +569,20 @@ public sealed class AmbientConnectionTest
 
     private sealed class RecordingDbConnection : DbConnection
     {
+        private readonly Exception? enlistmentFailure;
         private ConnectionState state = ConnectionState.Closed;
+
+        /// <param name="enlistmentFailure">
+        /// What this connection's driver answers when asked to join an ambient transaction. The default
+        /// is the answer five of the six drivers Quartz ships a delegate for give when the connection is
+        /// already enlisted in it: nothing at all. <see cref="NotSupportedException" /> is what a driver
+        /// that overrides nothing reaches — <c>Microsoft.Data.Sqlite</c> — and anything else is a driver
+        /// with an implementation and an opinion about this particular connection.
+        /// </param>
+        internal RecordingDbConnection(Exception? enlistmentFailure = null)
+        {
+            this.enlistmentFailure = enlistmentFailure;
+        }
 
         internal int OpenCount { get; private set; }
 
@@ -463,6 +593,21 @@ public sealed class AmbientConnectionTest
         /// which is how ADO.NET providers behave unless enlistment is suppressed or switched off.
         /// </summary>
         internal Transaction? EnlistedIn { get; private set; }
+
+        /// <summary>
+        /// Recording the transaction is what a provider does when the connection is not enlisted yet;
+        /// when it is already enlisted in this very transaction they all return without doing anything,
+        /// and so does this.
+        /// </summary>
+        public override void EnlistTransaction(Transaction? transaction)
+        {
+            if (enlistmentFailure is not null)
+            {
+                throw enlistmentFailure;
+            }
+
+            EnlistedIn ??= transaction;
+        }
 
         [System.Diagnostics.CodeAnalysis.AllowNull]
         public override string ConnectionString { get; set; } = "";

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
@@ -1,0 +1,157 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using System.Data.Common;
+using System.Transactions;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Jobs;
+
+using IsolationLevel = System.Transactions.IsolationLevel;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// Against the one shipped driver that cannot join an ambient transaction, on a real database file.
+/// <c>Microsoft.Data.Sqlite</c> overrides no <see cref="DbConnection.EnlistTransaction" />, so a
+/// connection opened inside a <see cref="TransactionScope" /> never joins it — and until the store
+/// established the enlistment rather than assuming it, the scheduling written through that connection
+/// committed on the spot and survived a scope that was never completed. Reported as
+/// https://github.com/quartznet/quartznet/issues/3666.
+/// </summary>
+/// <remarks>
+/// A file database rather than a fake: the driver's own answer is the whole of what is being pinned,
+/// and it is exactly the part a stand-in cannot supply.
+/// </remarks>
+public sealed class EnlistmentRefusalSqliteTest
+{
+    private string databaseFile = null!;
+    private string connectionString = null!;
+    private ServiceProvider? container;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-enlistment-refusal-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public async Task DeleteDatabase()
+    {
+        if (container is not null)
+        {
+            await container.DisposeAsync();
+            container = null;
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task EnlistingAConnectionInsideATransactionScopeIsRefused()
+    {
+        IScheduler scheduler = await GetScheduler(nameof(EnlistingAConnectionInsideATransactionScopeIsRefused));
+
+        TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            await using SqliteConnection connection = new(connectionString);
+            await connection.OpenAsync();
+
+            Action enlist = () => scheduler.EnlistConnection(connection);
+
+            enlist.Should().Throw<SchedulerException>(
+                    "the scope governs nothing this connection does, so accepting it would commit the scheduling "
+                    + "whatever the application decided")
+                .Which.Message.Should().Contain("Microsoft.Data.Sqlite.SqliteConnection",
+                    "the failure has to name the driver, because that is what the reader has to change or work around")
+                .And.Contain("EnlistTransaction(connection.BeginTransaction())",
+                    "and the form that does work on this very driver");
+        }
+    }
+
+    /// <summary>
+    /// The way out the refusal points at, on the driver that is refused: a transaction of the
+    /// connection's own governs the writes, and rolling it back takes the schedule with it.
+    /// </summary>
+    [Test]
+    public async Task EnlistingTheConnectionsOwnTransactionStillDiscardsTheScheduleOnRollback()
+    {
+        IScheduler scheduler = await GetScheduler(nameof(EnlistingTheConnectionsOwnTransactionStillDiscardsTheScheduleOnRollback));
+        JobKey jobKey = new JobKey("enlisted", "sqlite");
+
+        await using (SqliteConnection connection = new(connectionString))
+        {
+            await connection.OpenAsync();
+            await using DbTransaction transaction = await connection.BeginTransactionAsync();
+
+            using (scheduler.EnlistTransaction(transaction))
+            {
+                await scheduler.ScheduleJob(
+                    JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build(),
+                    TriggerBuilder.Create().WithIdentity(jobKey.Name, jobKey.Group).ForJob(jobKey)
+                        .StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+                (await scheduler.Exists(jobKey)).Should().BeTrue("the job store wrote through the enlisted transaction");
+            }
+
+            await transaction.RollbackAsync();
+        }
+
+        (await scheduler.Exists(jobKey)).Should().BeFalse(
+            "the schedule belongs to the transaction the application rolled back, which is the guarantee the "
+            + "refusal above exists to keep honest");
+    }
+
+    private async Task<IScheduler> GetScheduler(string schedulerName)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = schedulerName;
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+                store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
+            });
+        });
+
+        container = services.BuildServiceProvider();
+
+        return await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+    }
+}

--- a/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Unit/Plugins/Json/JsonSchedulingDataProcessorTest.cs
@@ -103,6 +103,69 @@ public class JsonSchedulingDataProcessorTest
         trigger.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday });
     }
 
+    /// <summary>
+    /// A recurrence rule is a schedule a file can declare, and everything the declaration says has to
+    /// reach the trigger: the rule, the anchor it repeats from, the misfire instruction and the zone
+    /// the rule's days and times are read in.
+    /// </summary>
+    /// <remarks>
+    /// The anchor is the trigger's own <c>StartTime</c> rather than a field of the recurrence section:
+    /// a rule repeats from a moment the way <c>DTSTART</c> does, and every other schedule type in this
+    /// format already starts from that field.
+    /// </remarks>
+    [Test]
+    public void ParsesRecurrenceTrigger()
+    {
+        var json = """
+        {
+            "Schedule": {
+                "Jobs": [{ "Name": "rJob", "JobType": "Quartz.Jobs.NativeJob, Quartz.Jobs", "Durable": true }],
+                "Triggers": [{
+                    "Name": "rTrigger", "JobName": "rJob",
+                    "StartTime": "2026-01-05T09:00:00Z",
+                    "Recurrence": {
+                        "Rule": "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO",
+                        "TimeZone": "America/New_York",
+                        "MisfireInstruction": "DoNothing"
+                    }
+                }]
+            }
+        }
+        """;
+
+        var processor = CreateProcessor();
+        processor.ProcessJsonContent(json);
+
+        var trigger = (IRecurrenceTrigger) processor.ParsedTriggers[0];
+        trigger.RecurrenceRule.Should().Be("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO");
+        trigger.StartTimeUtc.Should().Be(new DateTimeOffset(2026, 1, 5, 9, 0, 0, TimeSpan.Zero),
+            "every second week is counted from somewhere, and the trigger's start time is where");
+        trigger.MisfireInstruction.Should().Be(RecurrenceTriggerMisfireInstruction.DoNothing);
+        trigger.TimeZone.Should().Be(TimeZones.FindById("America/New_York"),
+            "a rule naming a day names it in some zone, and a file read on a machine in another one has to fire the same");
+    }
+
+    [Test]
+    public void RejectsAnUnparseableRecurrenceRule()
+    {
+        var json = """
+        {
+            "Schedule": {
+                "Jobs": [{ "Name": "rJob", "JobType": "Quartz.Jobs.NativeJob, Quartz.Jobs", "Durable": true }],
+                "Triggers": [{ "Name": "rTrigger", "JobName": "rJob", "Recurrence": { "Rule": "FREQ=FORTNIGHTLY" } }]
+            }
+        }
+        """;
+
+        var processor = CreateProcessor();
+
+        Action act = () => processor.ProcessJsonContent(json);
+
+        act.Should().Throw<SchedulerConfigException>(
+                "a rule nobody can parse is a mistake to report while the scheduler is still starting")
+            .WithMessage("*FREQ=FORTNIGHTLY*");
+    }
+
     [Test]
     public void ParsesJobDataMap()
     {

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -51,6 +51,7 @@ namespace Quartz.Tests.Unit.Simpl;
 public class JobDataMapPortabilityTest
 {
     private IObjectSerializer newtonsoftSerializer;
+    private IObjectSerializer newtonsoftTriggerConverterSerializer;
     private IObjectSerializer systemTextJsonSerializer;
 
     [SetUp]
@@ -58,6 +59,11 @@ public class JobDataMapPortabilityTest
     {
         newtonsoftSerializer = new NewtonsoftJsonObjectSerializer();
         systemTextJsonSerializer = new SystemTextJsonObjectSerializer();
+
+        // The second Json.NET store format: with the trigger converters registered a trigger is written
+        // as the object the built-in serializer writes rather than as Json.NET's reflection over the
+        // trigger type, which is what makes a blob either of them wrote readable by both.
+        newtonsoftTriggerConverterSerializer = new NewtonsoftJsonObjectSerializer { RegisterTriggerConverters = true };
     }
 
     /// <summary>
@@ -122,6 +128,95 @@ public class JobDataMapPortabilityTest
             {
                 throw new AssertionException($"{label}: reading '{key}' back threw {e.GetType().Name}: {e.Message}", e);
             }
+        }
+    }
+
+    /// <summary>
+    /// The same values again, carried where a job store actually carries most of them: inside a
+    /// trigger, written by the trigger converters rather than by the map's own converter.
+    /// </summary>
+    /// <remarks>
+    /// That path wrote its map by a route of its own, and the route could not write what the gate had
+    /// already accepted: a <c>Dictionary&lt;string, string&gt;</c> in a trigger's map failed with
+    /// "Unsupported type", so the value could not be stored at all. Reading it had the mirror problem —
+    /// the whole trigger was parsed before the map was reached, by which time a string inside a string
+    /// map that merely looked like a timestamp had become one.
+    /// </remarks>
+    [TestCaseSource(nameof(PortableValues))]
+    public void AValueTheAccessorsCoverSurvivesInsideATriggerToo(string key, object value, Action<JobDataMap> assert)
+    {
+        ITrigger original = TriggerBuilder.Create()
+            .WithIdentity("portable", "portability")
+            .ForJob("job", "jobs")
+            .UsingJobData(new JobDataMap { { key, value } })
+            .StartAt(new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero))
+            .Build();
+
+        foreach ((string label, IObjectSerializer writer, IObjectSerializer reader) in TriggerPairings())
+        {
+            ITrigger restored = reader.Deserialize<IOperableTrigger>(writer.Serialize(original))!;
+
+            restored.JobDataMap.Should().ContainKey(key, "{0}: the key must survive the crossing", label);
+
+            try
+            {
+                assert(restored.JobDataMap);
+            }
+            catch (AssertionException e)
+            {
+                throw new AssertionException($"{label}: {e.Message}", e);
+            }
+            catch (Exception e)
+            {
+                throw new AssertionException($"{label}: reading '{key}' back threw {e.GetType().Name}: {e.Message}", e);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A trigger blob written before the map went through the shared halves. Its top-level entries are
+    /// what the reader made of them — a string shaped like a timestamp is a <see cref="DateTimeOffset" />,
+    /// because that is the one reading of it a job could have been storing — and reading has to keep
+    /// saying so, since these blobs are in databases already.
+    /// </summary>
+    /// <remarks>
+    /// Written out here rather than produced by the current writer, so that a writer which changes
+    /// again cannot change what this asserts.
+    /// </remarks>
+    [Test]
+    public void ATriggerBlobWrittenBeforeTheSharedHalvesStillReadsTheSame()
+    {
+        byte[] written = Encoding.UTF8.GetBytes(
+            """
+            {
+              "TriggerType": "SimpleTrigger",
+              "Key": { "Name": "legacy", "Group": "portability" },
+              "JobKey": { "Name": "job", "Group": "jobs" },
+              "Description": null,
+              "CalendarName": null,
+              "JobDataMap": { "when": "1982-06-28T01:01:01+03:00", "count": 3, "name": "monthly" },
+              "MisfireInstruction": 0,
+              "StartTimeUtc": "2024-07-01T00:00:00+00:00",
+              "EndTimeUtc": null,
+              "Priority": 5,
+              "NextFireTimeUtc": null,
+              "PreviousFireTimeUtc": null,
+              "RepeatCount": 0,
+              "RepeatIntervalTimeSpan": "00:00:00",
+              "TimesTriggered": 0
+            }
+            """);
+
+        foreach ((string label, IObjectSerializer reader) in TriggerReaders())
+        {
+            ITrigger restored = reader.Deserialize<IOperableTrigger>(written)!;
+
+            restored.StartTimeUtc.Should().Be(new DateTimeOffset(2024, 7, 1, 0, 0, 0, TimeSpan.Zero),
+                "{0}: how a trigger's own timestamps read back is not something a job data fix gets to change", label);
+            restored.JobDataMap.GetDateTimeOffset("when").Should().Be(new DateTimeOffset(1982, 6, 28, 1, 1, 1, TimeSpan.FromHours(3)),
+                "{0}: a top-level entry that parsed as a date read back as one, and an upgrade does not get to make a stored value unreadable", label);
+            restored.JobDataMap.GetInt("count").Should().Be(3, "{0}: numbers are numbers on either side", label);
+            restored.JobDataMap.GetString("name").Should().Be("monthly", "{0}: and a string that looks like nothing else is a string", label);
         }
     }
 
@@ -377,6 +472,24 @@ public class JobDataMapPortabilityTest
     private IEnumerable<(string Label, IObjectSerializer Reader)> Readers()
     {
         yield return ("newtonsoft", newtonsoftSerializer);
+        yield return ("system.text.json", systemTextJsonSerializer);
+    }
+
+    /// <summary>
+    /// The same crossings for a trigger, where the Json.NET side is the one with its trigger converters
+    /// registered — the only shape of Json.NET blob the built-in serializer can read a trigger out of.
+    /// </summary>
+    private IEnumerable<(string Label, IObjectSerializer Writer, IObjectSerializer Reader)> TriggerPairings()
+    {
+        yield return ("newtonsoft(converters) -> newtonsoft(converters)", newtonsoftTriggerConverterSerializer, newtonsoftTriggerConverterSerializer);
+        yield return ("newtonsoft(converters) -> system.text.json", newtonsoftTriggerConverterSerializer, systemTextJsonSerializer);
+        yield return ("system.text.json -> newtonsoft(converters)", systemTextJsonSerializer, newtonsoftTriggerConverterSerializer);
+        yield return ("system.text.json -> system.text.json", systemTextJsonSerializer, systemTextJsonSerializer);
+    }
+
+    private IEnumerable<(string Label, IObjectSerializer Reader)> TriggerReaders()
+    {
+        yield return ("newtonsoft(converters)", newtonsoftTriggerConverterSerializer);
         yield return ("system.text.json", systemTextJsonSerializer);
     }
 }

--- a/src/Quartz/Configuration/JsonSchedulingHelper.cs
+++ b/src/Quartz/Configuration/JsonSchedulingHelper.cs
@@ -279,28 +279,31 @@ internal static class JsonSchedulingHelper
         var cronSection = triggerSection.GetSection(nameof(JsonTriggerDefinition.Cron));
         var calendarSection = triggerSection.GetSection(nameof(JsonTriggerDefinition.CalendarInterval));
         var dailySection = triggerSection.GetSection(nameof(JsonTriggerDefinition.DailyTimeInterval));
+        var recurrenceSection = triggerSection.GetSection(nameof(JsonTriggerDefinition.Recurrence));
 
         var scheduleCount = 0;
         if (simpleSection.Exists()) scheduleCount++;
         if (cronSection.Exists()) scheduleCount++;
         if (calendarSection.Exists()) scheduleCount++;
         if (dailySection.Exists()) scheduleCount++;
+        if (recurrenceSection.Exists()) scheduleCount++;
 
         if (scheduleCount == 0)
         {
             throw new SchedulerConfigException(
-                $"JSON trigger '{triggerName}' must specify exactly one schedule type: Simple, Cron, CalendarInterval, or DailyTimeInterval.");
+                $"JSON trigger '{triggerName}' must specify exactly one schedule type: Simple, Cron, CalendarInterval, DailyTimeInterval, or Recurrence.");
         }
 
         if (scheduleCount > 1)
         {
             throw new SchedulerConfigException(
-                $"JSON trigger '{triggerName}' has multiple schedule types. Specify exactly one: Simple, Cron, CalendarInterval, or DailyTimeInterval.");
+                $"JSON trigger '{triggerName}' has multiple schedule types. Specify exactly one: Simple, Cron, CalendarInterval, DailyTimeInterval, or Recurrence.");
         }
 
         if (simpleSection.Exists()) return BuildSimpleSchedule(simpleSection);
         if (cronSection.Exists()) return BuildCronSchedule(cronSection, triggerName);
         if (calendarSection.Exists()) return BuildCalendarIntervalSchedule(calendarSection);
+        if (recurrenceSection.Exists()) return BuildRecurrenceSchedule(recurrenceSection, triggerName);
         return BuildDailyTimeIntervalSchedule(dailySection);
     }
 
@@ -353,6 +356,48 @@ internal static class JsonSchedulingHelper
         if (misfireInstruction is not null)
         {
             builder.WithMisfireInstruction((CronTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Cron, misfireInstruction));
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Reads a recurrence schedule, whose rule is the whole of the repetition and whose anchor is the
+    /// trigger's own start time.
+    /// </summary>
+    /// <remarks>
+    /// The rule is validated here rather than at the first firing, for the reason a cron expression is:
+    /// a schedule file that names a rule nobody can parse is a mistake to report while the application
+    /// is still starting.
+    /// </remarks>
+    private static RecurrenceScheduleBuilder BuildRecurrenceSchedule(IConfigurationSection section, string triggerName)
+    {
+        var rule = section[nameof(JsonRecurrenceSchedule.Rule)];
+        if (string.IsNullOrWhiteSpace(rule))
+        {
+            throw new SchedulerConfigException($"JSON trigger '{triggerName}': Recurrence schedule is missing required 'Rule' property.");
+        }
+
+        RecurrenceScheduleBuilder builder;
+        try
+        {
+            builder = RecurrenceScheduleBuilder.Create(rule!);
+        }
+        catch (Exception ex)
+        {
+            throw new SchedulerConfigException($"JSON trigger '{triggerName}': invalid recurrence rule '{rule}'. {ex.Message}", ex);
+        }
+
+        var timeZoneStr = section[nameof(JsonRecurrenceSchedule.TimeZone)];
+        if (timeZoneStr is not null)
+        {
+            builder.InTimeZone(TimeZones.FindById(timeZoneStr));
+        }
+
+        var misfireInstruction = section[nameof(JsonRecurrenceSchedule.MisfireInstruction)];
+        if (misfireInstruction is not null)
+        {
+            builder.WithMisfireInstruction((RecurrenceTriggerMisfireInstruction) MisfireInstructionNames.Resolve(TriggerFamily.Recurrence, misfireInstruction));
         }
 
         return builder;

--- a/src/Quartz/Configuration/JsonSchedulingModels.cs
+++ b/src/Quartz/Configuration/JsonSchedulingModels.cs
@@ -38,6 +38,7 @@ internal sealed class JsonTriggerDefinition
     public JsonCronSchedule? Cron { get; set; }
     public JsonCalendarIntervalSchedule? CalendarInterval { get; set; }
     public JsonDailyTimeIntervalSchedule? DailyTimeInterval { get; set; }
+    public JsonRecurrenceSchedule? Recurrence { get; set; }
 }
 
 internal sealed class JsonSimpleSchedule
@@ -58,6 +59,26 @@ internal sealed class JsonCalendarIntervalSchedule
 {
     public int RepeatInterval { get; set; }
     public string RepeatIntervalUnit { get; set; } = "Day";
+    public string? MisfireInstruction { get; set; }
+}
+
+/// <summary>
+/// A schedule stated as an RFC 5545 recurrence rule.
+/// </summary>
+/// <remarks>
+/// The rule says how the firings repeat and the trigger's own <c>StartTime</c> says what they repeat
+/// from — a rule is anchored to a moment, exactly as <c>DTSTART</c> anchors an iCalendar one, so
+/// <c>FREQ=WEEKLY;INTERVAL=2</c> means "every second week counted from the start time" and a trigger
+/// given no start time is anchored to the moment its scheduler read the file.
+/// </remarks>
+internal sealed class JsonRecurrenceSchedule
+{
+    /// <summary>
+    /// The RFC 5545 rule, for example <c>FREQ=WEEKLY;INTERVAL=2;BYDAY=MO</c>.
+    /// </summary>
+    public string Rule { get; set; } = "";
+
+    public string? TimeZone { get; set; }
     public string? MisfireInstruction { get; set; }
 }
 

--- a/src/Quartz/SchedulerEnlistmentExtensions.cs
+++ b/src/Quartz/SchedulerEnlistmentExtensions.cs
@@ -108,7 +108,9 @@ public static class SchedulerEnlistmentExtensions
     /// Pass only a connection when the transaction is an ambient
     /// <see cref="System.Transactions.TransactionScope" /> the connection is already enlisted in.
     /// Sharing the one connection is what keeps such a scope from being promoted to a distributed
-    /// transaction, which providers like Npgsql do not support at all.
+    /// transaction, which providers like Npgsql do not support at all. That the connection is enlisted
+    /// is established here rather than assumed, so a driver that cannot join the scope is refused
+    /// instead of written through.
     /// </remarks>
     /// <param name="scheduler">The scheduler whose job store should use the connection.</param>
     /// <param name="connection">The connection to use. Opened if it is not open already.</param>
@@ -117,6 +119,12 @@ public static class SchedulerEnlistmentExtensions
     /// A scope that ends the enlistment when disposed. Dispose it after committing, so that any
     /// scheduling change the job store recorded is signalled to the scheduler once it is visible.
     /// </returns>
+    /// <exception cref="SchedulerException">
+    /// A <see cref="System.Transactions.TransactionScope" /> is current and the connection's driver
+    /// implements no <see cref="DbConnection.EnlistTransaction" />, so the connection cannot join it —
+    /// <c>Microsoft.Data.Sqlite</c> is the shipped case. Enlist a
+    /// <see cref="DbTransaction" /> of the connection's own instead.
+    /// </exception>
     public static IDisposable EnlistConnection(
         this IScheduler scheduler,
         DbConnection connection,
@@ -150,13 +158,71 @@ public static class SchedulerEnlistmentExtensions
 
         var schedulerName = ResolveSchedulerName(scheduler, connection);
 
-        // Remembered so a later operation can tell that the scope has since ended, instead of
-        // quietly running with no transaction at all.
-        return AmbientConnection.Enlist(
-            schedulerName,
-            connection,
-            transaction,
-            transaction is null ? System.Transactions.Transaction.Current : null);
+        System.Transactions.Transaction? ambient = transaction is null ? System.Transactions.Transaction.Current : null;
+        if (ambient is not null)
+        {
+            JoinAmbientTransaction(scheduler, connection, ambient);
+        }
+
+        // The ambient transaction is remembered so a later operation can tell that the scope has since
+        // ended, instead of quietly running with no transaction at all.
+        return AmbientConnection.Enlist(schedulerName, connection, transaction, ambient);
+    }
+
+    /// <summary>
+    /// Establishes that the connection really does take part in the ambient transaction, rather than
+    /// assuming it does because there is one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A connection opened inside a <see cref="System.Transactions.TransactionScope" /> joins it as it
+    /// opens — unless its driver implements no enlistment at all, in which case nothing happens and
+    /// nothing says so. <c>Microsoft.Data.Sqlite</c> is such a driver: its connection overrides no
+    /// <see cref="DbConnection.EnlistTransaction" />, so a call reaches the base implementation, which
+    /// throws <see cref="NotSupportedException" />. Accepting that connection would have the job store
+    /// write through it with every statement committing on the spot, and a scope that was never
+    /// completed would leave the schedule behind — which looks exactly like a working enlistment right
+    /// up to the first rollback.
+    /// </para>
+    /// <para>
+    /// Asking the connection to join the transaction it is supposed to be in already is what tells the
+    /// two apart, and every driver Quartz ships a delegate for treats that as a no-op: SqlClient and
+    /// Npgsql return early when their enlisted transaction equals this one, MySqlConnector and Firebird
+    /// on the same comparison, and Oracle re-records the transaction and traces "already enlisted" when
+    /// the local identifier matches. A connection that is <em>not</em> yet enlisted — opened before the
+    /// scope, or with enlistment switched off in its connection string — is enlisted by the call, which
+    /// is what the caller was asking for either way.
+    /// </para>
+    /// <para>
+    /// Only <see cref="NotSupportedException" /> is a refusal. Anything else a driver answers means it
+    /// has an enlistment implementation and an opinion about this particular connection — "the
+    /// connection is not open" is the ordinary one, since an enlisted connection is opened by the job
+    /// store rather than here — and having an implementation at all is the whole of what this asks.
+    /// </para>
+    /// </remarks>
+    private static void JoinAmbientTransaction(IScheduler scheduler, DbConnection connection, System.Transactions.Transaction ambient)
+    {
+        try
+        {
+            connection.EnlistTransaction(ambient);
+        }
+        catch (NotSupportedException e)
+        {
+            throw new SchedulerException(
+                $"Scheduler '{scheduler.SchedulerName}' cannot take part in the ambient transaction through a "
+                + $"{connection.GetType().FullName} ({connection.GetType().Assembly.GetName().Name}): the driver implements no "
+                + "DbConnection.EnlistTransaction, so the connection never joined the TransactionScope and every statement the "
+                + "job store issued on it would commit on the spot - a scope that rolled back would leave the schedule behind. "
+                + "Begin a transaction on the connection and enlist that instead: "
+                + "scheduler.EnlistTransaction(connection.BeginTransaction()).",
+                e);
+        }
+        catch (Exception)
+        {
+            // See the remarks: a driver that answers anything but "not supported" has an enlistment of
+            // its own, which is what was being established. Letting its answer out would refuse the
+            // ordinary case, where the connection is still closed because the job store opens it.
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Three format-and-behaviour decisions the freeze left open, one per commit. None of them moves a
public-API baseline: a new JSON schedule kind is a file format, and the enlistment change is a silent
no-op becoming a refusal.

## 1. A trigger's job data goes through the same halves a map on its own does (#3611)

With `RegisterTriggerConverters = true`, `TriggerConverter` wrote the `JobDataMap` through
`writer.WriteValue(object)` per entry. That cannot write a `Dictionary<string, string>`, a `DateOnly`
or a `TimeOnly` at all — three values the write gate had already accepted — so the entry was refused
*after* the gate said yes, with `Unsupported type: …Dictionary\`2… Path JobDataMap`, and a deployment
on that path could not store the value. (The issue names the dictionary; the two date shapes fell out
of the same call and are fixed by the same change.)

Both converters now write through `JobDataValues.WriteMap` and the trigger one reads through
`JobDataValues.ReadMap` — the halves #3609 added for the default path. The read has to happen while
the reader is still on the map, because date parsing is a reader setting: a map parsed as part of a
`JObject.Load` over the whole trigger has already turned every timestamp-shaped string into a date,
**nested ones included**, which is how a stored string map came back holding values the application
never put in it. `ReadTrigger` therefore reads the trigger property by property and scopes
`DateParseHandling.None` to the map exactly as the default path does. What `StartTimeUtc` and its
siblings read back as is untouched — turning date parsing off for the whole trigger would have changed
that, and those blobs are in databases already.

`JobDataMapPortabilityTest` now carries the whole accessor set across the converters-on path in both
directions, plus a hand-written blob pinning that a trigger written before this change still reads the
same. Shown failing without the fix: three cases (`dictionary`, `dateOnly`, `timeOnly`) throw
`Failed to serialize ITrigger to json`; with the write half alone but the old read, `dictionary` comes
back as `Newtonsoft.Json.Linq.JObject` — the silent outcome the issue predicted.

**Reviewer decision:** the job data map is the one property `ReadTrigger` does not put into the
`JObject` it hands to `ITriggerSerializer.DeserializeFields`. Nothing reads it from there (the trigger
that method is handed already carries the map) and keeping it would mean parsing the map twice; if you
would rather a third-party serializer still saw the raw token, say so.

## 2. A recurrence rule is a schedule a file can declare (#3624)

`RecurrenceTrigger` is a 4.0 flagship and could be declared nowhere but code. A trigger may now carry a
`Recurrence` section holding the RFC 5545 `Rule`, the `TimeZone` the rule's days and times are read in,
and the `MisfireInstruction`. The anchor is the trigger's existing `StartTime` rather than a field of
its own: a rule repeats from a moment the way `DTSTART` does — `RecurrenceTriggerImpl` computes every
occurrence from `StartTimeUtc` — and every other schedule type in this format already starts from that
field. An unparseable rule is refused as the file is read and names the rule, for the reason a cron
expression is.

Both readers gain it, `Quartz/Configuration/JsonSchedulingHelper.cs` and
`Quartz.Plugins/Plugins/Json/JsonSchedulingDataProcessor.cs`, with a round-trip test on each asserting
rule, anchor, misfire instruction and zone. `configuration/json.md` documents the kind and states that
the XML format stays frozen without it (#3601's ruling), so a reader is not left looking for the XML
twin; the freeze table in `packages/quartz-plugins.md` gains the row and loses the sentence saying
recurrence is in neither format, and the migration guide's JSON-only list gains it too.

## 3. A connection that cannot join the ambient transaction is refused (#3666)

`Microsoft.Data.Sqlite` overrides no `DbConnection.EnlistTransaction`, so a connection opened inside a
`TransactionScope` never joins it. `EnlistConnection` took that connection anyway, the store wrote
through it, every statement committed on the spot, and a scope that was never completed left the
schedule behind.

Being inside a scope is now established rather than assumed: the connection is asked to join the
transaction it is supposed to be in already, and a driver answering `NotSupportedException` is refused
with a `SchedulerException` naming the driver and pointing at `EnlistTransaction(DbTransaction)` —
which works on that very driver.

**The per-driver facts, verified before the shape was fixed** (decompiled from the shipped assemblies,
then exercised against the containers):

| driver | re-enlisting in the same transaction |
|---|---|
| Microsoft.Data.SqlClient 7.0.2 | early return on `EnlistedTransaction.Equals(transaction)` |
| Npgsql 10.0.3 | early return on the same comparison |
| MySqlConnector 2.6.2 | early return on `m_enlistedTransaction.Transaction.Equals(transaction)` |
| FirebirdSql 10.3.4 | whole body skipped when `_enlistmentNotification.SystemTransaction == transaction` |
| Oracle.ManagedDataAccess 23.26 | re-records the transaction and traces "already enlisted" when the local identifier matches |
| Microsoft.Data.Sqlite 11.0.0-preview.7 | no override at all — `DbConnection`'s `NotSupportedException` |

So the ask is a no-op on all five that implement enlistment, and it *enlists* a connection that was not
enlisted yet, which is what the caller wanted either way. Only `NotSupportedException` is a refusal:
anything else means the driver has an implementation and an opinion about this connection — "not open
yet" is the ordinary one, since an enlisted connection is opened by the job store — and having an
implementation at all is the whole of what the probe asks. The probe runs for the ambient form only; a
caller who hands over a `DbTransaction` is governed by that transaction, and asking a connection with
an open local transaction to enlist is what MySqlConnector and Oracle refuse outright. That is what
keeps the documented way out working on SQLite.

Pinned in the unit project on a file SQLite database (`UseSqlite` + `ProvisionSchema()`): the refusal
itself against the real driver, and the `DbTransaction` form still discarding the schedule on rollback.
`AmbientConnectionTest` covers the three arms with a fake whose driver answer is a constructor
argument. `tutorial/job-stores.md`'s SQLite paragraph is rewritten from "documented caveat" to
"refused, with this message".

## Verification

- `dotnet build Quartz.slnx` — 0 warnings, 0 errors
- `dotnet test src/Quartz.Tests.Unit` — 5202 passed, 0 failed, 36 skipped
- `dotnet test src/Quartz.Tests.AspNetCore` — 605 passed, 0 failed
- `dotnet run --project src/Quartz.Benchmark -c Release -- --smoke` — exit 0, 282 benchmarks
- `npm run docs:check-links` — no dead links or anchors; `dotnet fallout VerifyDocsSnippets` — up to date
- `EnlistedTransactionTest`, one dialect at a time with Docker: PostgreSQL 6/6, SQL Server 3/3,
  MySQL 3/3, Firebird 3/3, Oracle 3/3, SQLite 2/2 — every dialect that has an ambient-scope case ran it

Closes #3651
Closes #3624
Closes #3611
Closes #3666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqrmFVgN97Z6aRpjBU3LRQ
