### PR TITLE
What 4.0 costs per firing, and what it does over a night, are numbers we can take

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -496,18 +496,43 @@ partial class Build : FalloutBuild, ICompile, IPack
     static readonly string[] DatabaseCategories =
         ["db-postgres", "db-sqlserver", "db-mysql", "db-oracle", "db-firebird", "db-sqlite", "db-redis"];
 
-    string GetTestFilter(string database) => database switch
+    /// <summary>
+    /// The category a release gate carries, and the one thing every integration leg leaves out.
+    /// </summary>
+    /// <remarks>
+    /// The clustered soak (<c>ClusteredSoakTestBase</c>) runs for half an hour by design, and a leg
+    /// that ran it would read as a hung job rather than as thoroughness. It is run by hand before a
+    /// tag, exactly as the benchmarks are; <c>BenchmarkSmoke</c> excludes the same name on the
+    /// benchmark side, through <c>BenchmarkCategories</c>.
+    /// </remarks>
+    const string LongRunningCategory = "LongRunning";
+
+    /// <summary>
+    /// What one integration leg runs: the fixtures for its database, and never a release gate.
+    /// </summary>
+    /// <remarks>
+    /// The <c>LongRunning</c> exclusion is applied whether or not a database was named, because an
+    /// unnamed one applies no filter at all — which is what a local <c>dotnet fallout IntegrationTest</c>
+    /// does, and it would otherwise pick up an hour of soak.
+    /// </remarks>
+    string GetTestFilter(string database)
     {
-        "postgres" => "TestCategory=db-postgres",
-        "sqlserver" => "TestCategory=db-sqlserver",
-        "mysql" => "TestCategory=db-mysql",
-        "oracle" => "TestCategory=db-oracle",
-        "firebird" => "TestCategory=db-firebird",
-        "sqlite" => "TestCategory=db-sqlite",
-        "redis" => "TestCategory=db-redis",
-        "basic" => string.Join("&", DatabaseCategories.Select(c => $"TestCategory!={c}")),
-        _ => null
-    };
+        string databaseFilter = database switch
+        {
+            "postgres" => "TestCategory=db-postgres",
+            "sqlserver" => "TestCategory=db-sqlserver",
+            "mysql" => "TestCategory=db-mysql",
+            "oracle" => "TestCategory=db-oracle",
+            "firebird" => "TestCategory=db-firebird",
+            "sqlite" => "TestCategory=db-sqlite",
+            "redis" => "TestCategory=db-redis",
+            "basic" => string.Join("&", DatabaseCategories.Select(c => $"TestCategory!={c}")),
+            _ => null
+        };
+
+        var excludeLongRunning = $"TestCategory!={LongRunningCategory}";
+        return string.IsNullOrEmpty(databaseFilter) ? excludeLongRunning : $"{databaseFilter}&{excludeLongRunning}";
+    }
 
     Target IntegrationTest => _ => _
         .DependsOn<ICompile>()

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -630,6 +630,16 @@ shape changed — only what a mapping that stated nothing, and a contradictory p
   settings and the default that made one of them inert. `OverwriteExistingData` defaults to `true`, so
   a configuration that only sets `IgnoreDuplicates` is the one this catches; set
   `OverwriteExistingData` to `false` beside it.
+* **A persistent store refuses a repeat interval it cannot hold exactly.**
+  **Changed since alpha.5:** duration columns keep whole milliseconds, and
+  `StdAdoDelegate.GetDbTimeSpanValue` cast `TotalMilliseconds` to `long`, so a `SimpleTrigger` whose
+  repeat interval was shorter than a millisecond was stored as `0` - and a trigger read back with a
+  zero repeat interval throws `DivideByZeroException` out of `GetFireTimeAfter` on its next firing,
+  which the store logs and swallows, leaving the row in `ACQUIRED` for ever. A job that stopped
+  running and said nothing. Scheduling such a trigger into an ADO store now raises
+  `ArgumentException` naming the trigger, the column and the rule; `RAMJobStore` keeps taking it,
+  because it has no column to round the value to. Round the interval to a whole number of
+  milliseconds. See [#3673](https://github.com/quartznet/quartznet/issues/3673).
 
 ### What is on nobody's list because it did not change
 

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -677,6 +677,81 @@ Adding nodes does not make a single trigger fire faster, and it does not shorten
 capacity for concurrent firings and it adds a node to fail over to. If the schedule is dominated by one
 long job, a second node changes nothing about it.
 
+## Performance
+
+The numbers below are the only end-to-end firing figures published for 4.0. They come from
+[`src/Quartz.Benchmark/README.md`](https://github.com/quartznet/quartznet/blob/main/src/Quartz.Benchmark/README.md),
+which carries the full method, the machine, the settings and the caveats; this is the summary, and it
+is here because a page about running a cluster is where somebody asks the question.
+
+**Read them as ratios, not as a capacity plan.** One machine, one PostgreSQL container over loopback,
+one node, no clustering. Your storage, your network and your jobs decide the absolute; what carries
+across is how 4.0 compares with 3.20 on the same box on the same day.
+
+### A firing, end to end
+
+One firing means acquire, fire, run a job that does nothing, complete. `MaxBatchSize` tracks
+`MaxConcurrency` in these runs, because the scheduler refuses a batch larger than the pool that would
+have to run it, and `BatchTriggerAcquisitionFireAheadTimeWindow` is one second rather than the shipped
+zero — without a window a batch is one trigger however large `MaxBatchSize` is, which is the shape a
+deployment left at the defaults gets.
+
+| Store         | MaxConcurrency | 3.20               | 4.0                | Per firing  |
+|-------------- |--------------- |------------------- |------------------- |------------ |
+| PostgreSQL    | 10             | 9.87 ms / 136 KB   | 6.18 ms / 56 KB    | 1.6x faster, 2.4x less garbage |
+| PostgreSQL    | 50             | 9.21 ms / 132 KB   | 6.13 ms / 53 KB    | 1.5x faster, 2.5x less garbage |
+| `RAMJobStore` | 10             | 2.31 µs / 3.25 KB  | 3.44 µs / 3.62 KB  | 1.5x slower |
+| `RAMJobStore` | 50             | 2.23 µs / 3.25 KB  | 3.02 µs / 3.63 KB  | 1.4x slower |
+
+That is about 162 firings a second per node on PostgreSQL and about 300,000 on `RAMJobStore`, on this
+machine. The persistent-store gain is the batched fire path: a firing now costs **1.27 database
+commits**, where it used to cost one round trip per statement. The in-memory loss is 4.0's per-firing
+machinery — a DI scope, the middleware pipeline, the execution-group ledger — and against six
+milliseconds of database it is invisible in any deployment that has one
+([#3674](https://github.com/quartznet/quartznet/issues/3674)).
+
+**A bigger pool does not start firings faster.** Five times the threads bought 14 % on `RAMJobStore`
+and nothing measurable on PostgreSQL, because a node's store operations serialise on the
+`TRIGGER_ACCESS` lock. What `MaxConcurrency` buys is more *jobs* running at once, which is the point
+of it — see [Sizing a cluster](#sizing-a-cluster) above.
+
+### Scheduling and cron
+
+Also measured against 3.14, and also in the benchmark README:
+
+| Operation                                       | 3.14                | 4.0                 |
+|------------------------------------------------ |-------------------- |-------------------- |
+| Parse a `CronExpression`                        | 3.0–4.6 µs / 8.7–12.9 KB | 236–338 ns / 576–688 B |
+| `GetNextValidTimeAfter`                         | ~1.29 µs / ~3.2 KB  | 315–373 ns / **0 B** |
+| `ScheduleJob`, cron trigger, into `RAMJobStore` | 31 µs / 38.7 KB     | 10.5 µs / 5 KB      |
+
+Two other measurements live closer to what they are about:
+[the acquisition index](db/index.md#indexes-and-the-acquisition-index-in-particular), over a hundred
+thousand triggers on four engines, and
+[the cluster-wide execution ceiling](tutorial/execution-groups.md#cluster-scoped-limits), which costs
+one aggregate per acquisition attempt.
+
+### What has been run against a cluster
+
+Before the 4.0.0-beta.1 tag, two clustered nodes sharing one scheduler name were run for **30 minutes
+against PostgreSQL and 30 minutes against SQL Server**, carrying every trigger family including
+recurrence, a `[DisallowConcurrentExecution]` job behind an overlap detector, a retry policy over a
+job that always fails, a job that overruns the budget `AddJobTimeout` enforces, and induced failures
+along the way: both nodes into standby past the misfire threshold, then one node killed with an
+`EXECUTING` row left behind and its check-in aged, then replaced once the survivor had recovered it.
+
+Both runs passed. Each ended with no `ACQUIRED` or `BLOCKED` triggers and an empty
+`QRTZ_FIRED_TRIGGERS`, every trigger family still firing at its schedule, **no overlapping firing of
+the serial job across the two nodes** — peak observed concurrency 1 over 2,662 firings of it on
+PostgreSQL and 2,367 on SQL Server — the retry policy re-firing a failing job 356 and 346 times, the
+timeout middleware interrupting 178 and 175 overruns, exactly one interrupted firing recovered by
+the survivor in each run, no unexpected scheduler error, no unobserved task exception, and a live
+heap and handle count no larger at the end than at the start (5 MB and ~635 handles throughout on
+PostgreSQL; 5 MB and ~730 on SQL Server).
+
+The harness is `ClusteredSoakTestBase` in `Quartz.Tests.Integration`; it is opt-in
+(`[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`) and is run before a tag rather than in CI.
+
 ## Health checks and probes
 
 The check that ships with `Quartz` asserts two things: that the scheduler is in a state that can fire,
@@ -749,6 +824,7 @@ lists the instruments, and [What to watch](../best-practices.md#what-to-watch).
 - [Best Practices](../best-practices.md) — the decisions this page assumes have been made
 - [Database Schema](db/) and [Schema Changes](../database/schema-changes.md) — what the tables hold and
   what each version added
+- [`Quartz.Benchmark`](https://github.com/quartznet/quartznet/blob/main/src/Quartz.Benchmark/README.md) — the numbers above, with their method and caveats
 - [Configuration Reference](configuration/reference.md#persistent-job-store) — every setting named here,
   with its default
 

--- a/src/Quartz.Benchmark/FireThroughput.cs
+++ b/src/Quartz.Benchmark/FireThroughput.cs
@@ -1,0 +1,237 @@
+using System.Globalization;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The workload the fire-throughput benchmarks measure, and the counting that turns it into a
+/// per-fire number. Shared by the <c>RAMJobStore</c> arm and the PostgreSQL one, which differ in
+/// nothing but the store they are pointed at.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The scheduler is built and started once, in <c>[GlobalSetup]</c>, and left running for the whole
+/// case; a benchmark invocation is <em>waiting for the next N fires to happen</em>. That is what makes
+/// <c>Mean</c> the time one fire costs and, with <c>OperationsPerInvoke</c> set to the same N, what
+/// makes fires per second <c>1e9 / Mean(ns)</c>. The alternative — building a scheduler per iteration
+/// and timing it from <c>Start</c> to the last fire — measures a scheduler starting up as much as a
+/// scheduler firing, and at these rates the startup is the larger half.
+/// </para>
+/// <para>
+/// The same arrangement is what makes <c>[MemoryDiagnoser]</c> mean something here. BenchmarkDotNet
+/// reads <c>GC.GetTotalAllocatedBytes</c>, which is process-wide rather than per-thread, so the
+/// allocations of the acquisition loop and of every worker running a job land in the measured window
+/// along with the caller's. A steady-state scheduler is therefore measured whole: the
+/// <c>Allocated</c> column is what one firing costs the process, not what one thread of it cost.
+/// </para>
+/// <para>
+/// <b>Every trigger is permanently overdue.</b> They repeat indefinitely at an interval of one tick
+/// under <see cref="MisfireInstruction.IgnoreMisfirePolicy" />, so each firing advances the next fire
+/// time by 100 ns and leaves it in the past — the scheduler never waits, and the misfire handler never
+/// looks at them (both the ADO scan and the acquisition filter special-case <c>MISFIRE_INSTR = -1</c>).
+/// This is <c>SchedulerBenchmark</c>'s arrangement, for its reason: what is being measured is the fire
+/// path, and a benchmark that spent its time asleep would be measuring the clock.
+/// </para>
+/// </remarks>
+internal static class FireThroughput
+{
+    /// <summary>
+    /// How many fires one invocation of the <c>RAMJobStore</c> arm waits for. Large enough that the
+    /// wait dominates the handful of instructions around it, small enough that BenchmarkDotNet's pilot
+    /// can still fit several invocations into an iteration.
+    /// </summary>
+    public const int RamFiresPerInvocation = 2_000;
+
+    /// <summary>
+    /// The same for the PostgreSQL arm, which is orders of magnitude slower per fire because every one
+    /// of them is round trips to a database.
+    /// </summary>
+    public const int AdoFiresPerInvocation = 250;
+
+    /// <summary>How many triggers are in flight, spread over <see cref="JobCount" /> jobs.</summary>
+    /// <remarks>
+    /// A schedule is triggers over a handful of jobs rather than one trigger each, and the store reads
+    /// the job on every firing either way. Two hundred is enough that a pool of fifty always has
+    /// something to take and that acquisition never runs dry between batches.
+    /// </remarks>
+    private const int TriggerCount = 200;
+
+    private const int JobCount = 25;
+
+    /// <summary>
+    /// The group everything this benchmark creates lives in, so the ADO arm can delete exactly its own
+    /// rows without disturbing whatever else the shared benchmark database holds.
+    /// </summary>
+    public const string Group = "fireThroughput";
+
+    /// <summary>
+    /// Batching only batches with a window: the store stops a batch at the first trigger's fire time
+    /// plus this, so at the shipped default of zero a batch is one trigger whatever
+    /// <c>MaxBatchSize</c> says. A second is far more than the span these triggers occupy, so the
+    /// batch is bounded by the pool rather than by the clock.
+    /// </summary>
+    public static readonly TimeSpan FireAheadWindow = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// How long a wait for fires may go without completing before it is called a broken harness. A
+    /// benchmark that hangs is indistinguishable from a slow one, and the smoke run has nobody
+    /// watching it.
+    /// </summary>
+    private static readonly TimeSpan FireTimeout = TimeSpan.FromMinutes(2);
+
+    private static long fireCount;
+
+    /// <summary>
+    /// The wait in progress, published for the job to see. Null between invocations.
+    /// </summary>
+    private static volatile Waiter? pending;
+
+    /// <summary>
+    /// Blocks until <paramref name="count" /> more fires have happened, and is the whole body of every
+    /// benchmark method here.
+    /// </summary>
+    /// <remarks>
+    /// The target is absolute and is published before it is checked, so a fire that lands between
+    /// reading the counter and publishing cannot be lost: either it arrives after publication and sets
+    /// the event, or it arrived before and the re-read below sees it. Waiting on an event rather than
+    /// spinning matters — a spin would take a core away from the pool whose throughput is the
+    /// measurement.
+    /// </remarks>
+    public static void AwaitFires(int count)
+    {
+        Waiter waiter = new(Interlocked.Read(ref fireCount) + count);
+        pending = waiter;
+
+        if (Interlocked.Read(ref fireCount) >= waiter.Target)
+        {
+            waiter.Done.Set();
+        }
+
+        bool completed = waiter.Done.Wait(FireTimeout);
+        pending = null;
+
+        if (!completed)
+        {
+            // Read only on the way out: everything between the two statements above is inside the
+            // measured window, and this is a diagnostic for the case where there is no measurement.
+            long seen = count - (waiter.Target - Interlocked.Read(ref fireCount));
+
+            throw new InvalidOperationException(string.Create(CultureInfo.InvariantCulture,
+                $"Waited {FireTimeout} for {count} firings and saw {seen}. The scheduler stopped firing, which is a broken harness rather than a slow one."));
+        }
+    }
+
+    /// <summary>Records a firing, and releases the wait it completes.</summary>
+    private static void Fired()
+    {
+        long count = Interlocked.Increment(ref fireCount);
+        Waiter? waiter = pending;
+        if (waiter is not null && count >= waiter.Target)
+        {
+            waiter.Done.Set();
+        }
+    }
+
+    /// <summary>
+    /// Builds a scheduler over the store <paramref name="configureStore" /> selects, schedules the
+    /// workload on it, starts it and waits until it is firing.
+    /// </summary>
+    /// <param name="instanceName">
+    /// The scheduler name, which on a persistent store is also the row key everything is written under.
+    /// </param>
+    /// <param name="maxConcurrency">
+    /// The thread pool's permit count. <c>MaxBatchSize</c> is set to the same number: the scheduler
+    /// refuses a batch larger than the pool that would have to run it, so across a 10-and-50 sweep the
+    /// two cannot be varied independently and the batch tracks the pool.
+    /// </param>
+    /// <param name="configureStore">Selects the job store; everything else is the same on both arms.</param>
+    public static async Task<IScheduler> StartScheduler(
+        string instanceName,
+        int maxConcurrency,
+        Action<IQuartzBuilder> configureStore)
+    {
+        QuartzSchedulerBuilder builder = QuartzSchedulerBuilder.Create(quartz =>
+        {
+            quartz.ConfigureScheduler(options =>
+            {
+                options.InstanceName = instanceName;
+                options.InstanceId = "NODE-01";
+
+                // Never reached: the triggers below are always due. It is short anyway so that a run
+                // which somehow did idle would end rather than sit out the default half minute.
+                options.IdleWaitTime = TimeSpan.FromSeconds(1);
+                options.MaxBatchSize = maxConcurrency;
+                options.BatchTriggerAcquisitionFireAheadTimeWindow = FireAheadWindow;
+            });
+
+            quartz.UseDefaultThreadPool(maxConcurrency);
+            configureStore(quartz);
+        });
+
+        IScheduler scheduler = await builder.BuildScheduler().ConfigureAwait(false);
+
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> schedule = [];
+        for (int i = 0; i < JobCount; i++)
+        {
+            IJobDetail job = JobBuilder.Create<NoOpJob>()
+                .WithIdentity("job-" + i.ToString(CultureInfo.InvariantCulture), Group)
+                .Build();
+
+            int triggersForThisJob = TriggerCount / JobCount;
+            ITrigger[] triggers = new ITrigger[triggersForThisJob];
+            for (int j = 0; j < triggersForThisJob; j++)
+            {
+                triggers[j] = TriggerBuilder.Create()
+                    .WithIdentity(string.Create(CultureInfo.InvariantCulture, $"trigger-{i}-{j}"), Group)
+                    .ForJob(job)
+                    .StartNow()
+                    .WithSimpleSchedule(simple => simple
+                        .RepeatForever()
+                        .WithInterval(TimeSpan.FromTicks(1))
+                        .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+                    .Build();
+            }
+
+            schedule.Add(job, triggers);
+        }
+
+        await scheduler.ScheduleJobs(schedule).ConfigureAwait(false);
+        await scheduler.Start().ConfigureAwait(false);
+
+        // Steady state before the first measurement: the pool has to be full and the store warm, or
+        // the first iteration measures a scheduler waking up.
+        AwaitFires(TriggerCount);
+
+        return scheduler;
+    }
+
+    /// <summary>
+    /// Shuts a scheduler down without waiting for the jobs in flight, which do nothing and would only
+    /// add a round trip each to the teardown.
+    /// </summary>
+    public static async Task StopScheduler(IScheduler scheduler)
+    {
+        await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The job under measurement: it records that it ran and returns. Everything the <c>Mean</c>
+    /// column holds is therefore the scheduler's and the store's.
+    /// </summary>
+    public sealed class NoOpJob : IJob
+    {
+        /// <summary>Counts the firing and releases whatever wait it completes.</summary>
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Fired();
+            return default;
+        }
+    }
+
+    /// <summary>One benchmark invocation's wait: the absolute fire count it is waiting for.</summary>
+    private sealed class Waiter(long target)
+    {
+        public long Target { get; } = target;
+
+        public ManualResetEventSlim Done { get; } = new(false);
+    }
+}

--- a/src/Quartz.Benchmark/FireThroughput.cs
+++ b/src/Quartz.Benchmark/FireThroughput.cs
@@ -24,10 +24,11 @@ namespace Quartz.Benchmark;
 /// <c>Allocated</c> column is what one firing costs the process, not what one thread of it cost.
 /// </para>
 /// <para>
-/// <b>Every trigger is permanently overdue.</b> They repeat indefinitely at an interval of one tick
+/// <b>Every trigger is permanently overdue.</b> They repeat indefinitely at <see cref="RepeatInterval" />
 /// under <see cref="MisfireInstruction.IgnoreMisfirePolicy" />, so each firing advances the next fire
-/// time by 100 ns and leaves it in the past — the scheduler never waits, and the misfire handler never
-/// looks at them (both the ADO scan and the acquisition filter special-case <c>MISFIRE_INSTR = -1</c>).
+/// time by a millisecond and leaves it in the past — the scheduler never waits, and the misfire handler
+/// never looks at them (both the ADO scan and the acquisition filter special-case
+/// <c>MISFIRE_INSTR = -1</c>).
 /// This is <c>SchedulerBenchmark</c>'s arrangement, for its reason: what is being measured is the fire
 /// path, and a benchmark that spent its time asleep would be measuring the clock.
 /// </para>
@@ -50,12 +51,36 @@ internal static class FireThroughput
     /// <summary>How many triggers are in flight, spread over <see cref="JobCount" /> jobs.</summary>
     /// <remarks>
     /// A schedule is triggers over a handful of jobs rather than one trigger each, and the store reads
-    /// the job on every firing either way. Two hundred is enough that a pool of fifty always has
-    /// something to take and that acquisition never runs dry between batches.
+    /// the job on every firing either way. The count is what decides the ceiling: a trigger that
+    /// repeats every <see cref="RepeatInterval" /> can sustain a thousand firings a second on its own,
+    /// so two thousand of them put the arrangement's own limit at two million a second — several times
+    /// what the fastest arm here reaches, which is what keeps the number a measurement of the scheduler
+    /// rather than of the schedule.
     /// </remarks>
-    private const int TriggerCount = 200;
+    private const int TriggerCount = 2_000;
 
-    private const int JobCount = 25;
+    private const int JobCount = 100;
+
+    /// <summary>
+    /// How far each firing advances its trigger, and the smallest interval a persistent store can
+    /// carry.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>StdAdoDelegate.GetDbTimeSpanValue</c> stores a <see cref="TimeSpan" /> as whole
+    /// milliseconds, so anything shorter than one is persisted as zero — and a simple trigger read
+    /// back with a zero repeat interval throws <see cref="DivideByZeroException" /> out of
+    /// <c>GetFireTimeAfter</c> on its next firing, which the store logs and swallows, leaving the row
+    /// stuck in <c>ACQUIRED</c>. This benchmark found that; it is filed rather than worked around, and
+    /// a millisecond is simply the smallest interval both stores agree on.
+    /// </para>
+    /// <para>
+    /// It has to be short for the reason the interval always did: a firing advances the trigger by one
+    /// of these, so as long as a trigger fires fewer than a thousand times a second it stays overdue
+    /// and the scheduler never waits.
+    /// </para>
+    /// </remarks>
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(1);
 
     /// <summary>
     /// The group everything this benchmark creates lives in, so the ADO arm can delete exactly its own
@@ -186,7 +211,7 @@ internal static class FireThroughput
                     .StartNow()
                     .WithSimpleSchedule(simple => simple
                         .RepeatForever()
-                        .WithInterval(TimeSpan.FromTicks(1))
+                        .WithInterval(RepeatInterval)
                         .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
                     .Build();
             }

--- a/src/Quartz.Benchmark/FireThroughput.cs
+++ b/src/Quartz.Benchmark/FireThroughput.cs
@@ -71,7 +71,7 @@ internal static class FireThroughput
     /// milliseconds, so anything shorter than one is persisted as zero — and a simple trigger read
     /// back with a zero repeat interval throws <see cref="DivideByZeroException" /> out of
     /// <c>GetFireTimeAfter</c> on its next firing, which the store logs and swallows, leaving the row
-    /// stuck in <c>ACQUIRED</c>. This benchmark found that; it is filed rather than worked around, and
+    /// stuck in <c>ACQUIRED</c>. This benchmark found that; it is filed as #3673 rather than worked around, and
     /// a millisecond is simply the smallest interval both stores agree on.
     /// </para>
     /// <para>

--- a/src/Quartz.Benchmark/FireThroughputBenchmark.cs
+++ b/src/Quartz.Benchmark/FireThroughputBenchmark.cs
@@ -1,0 +1,65 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// What a firing costs end to end against <c>RAMJobStore</c>: fires per second, and bytes allocated
+/// per fire, over a job that does nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the ceiling. Nothing here touches a network or a disk, so what the <c>Mean</c> column
+/// holds is the acquisition loop, the store's own bookkeeping, the thread pool and
+/// <c>JobRunShell</c> — the part of a firing that a persistent store adds round trips on top of.
+/// <see cref="FireThroughputPostgresBenchmark" /> is the same measurement with those round trips in
+/// it, and the two are meant to be read as a pair.
+/// </para>
+/// <para>
+/// <c>Mean</c> is the time one firing took, so fires per second is <c>1e9 / Mean(ns)</c>;
+/// <c>Allocated</c> is process-wide over the measured window, so it is what one firing costs the
+/// process rather than what one thread of it cost. <see cref="FireThroughput" /> says why the
+/// scheduler is started once and left running, and what the workload is.
+/// </para>
+/// <para>
+/// <c>MaxBatchSize</c> tracks <see cref="MaxConcurrency" /> because it has to: the scheduler refuses
+/// a batch larger than the pool that would have to run it, so the two cannot be swept independently
+/// across 10 and 50. The fire-ahead window is a second rather than the shipped default of zero,
+/// without which a batch is one trigger however large <c>MaxBatchSize</c> is. Both are stated in
+/// <c>README.md</c> beside the numbers, because a reader comparing these against their own
+/// deployment's defaults would otherwise be comparing two different things.
+/// </para>
+/// <para>
+/// In the <c>--smoke</c> run, deliberately. It builds a scheduler, schedules two hundred triggers and
+/// waits for firings, which is exactly the kind of harness #3439 found silently broken.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class FireThroughputBenchmark
+{
+    /// <summary>The thread pool's permit count; ten is the shipped default and fifty a large node.</summary>
+    [Params(10, 50)]
+    public int MaxConcurrency { get; set; }
+
+    private IScheduler scheduler = null!;
+
+    /// <summary>Starts the scheduler and gets it firing before anything is measured.</summary>
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        scheduler = await FireThroughput.StartScheduler(
+            instanceName: "RamThroughputBenchmark",
+            maxConcurrency: MaxConcurrency,
+            configureStore: quartz => quartz.UseInMemoryStore()).ConfigureAwait(false);
+    }
+
+    /// <summary>Stops the scheduler this case has been running throughout.</summary>
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await FireThroughput.StopScheduler(scheduler).ConfigureAwait(false);
+    }
+
+    /// <summary>One operation is one firing; the body waits for the next batch of them to happen.</summary>
+    [Benchmark(OperationsPerInvoke = FireThroughput.RamFiresPerInvocation)]
+    public void Fire() => FireThroughput.AwaitFires(FireThroughput.RamFiresPerInvocation);
+}

--- a/src/Quartz.Benchmark/FireThroughputPostgresBenchmark.cs
+++ b/src/Quartz.Benchmark/FireThroughputPostgresBenchmark.cs
@@ -1,0 +1,129 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The same firing, measured against a real PostgreSQL store: fires per second and bytes allocated
+/// per fire, over a job that does nothing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the number a production reader asks for, and the one the migration guide's claim about the
+/// batched fire path replacing "six to nine round trips" with one has never had.
+/// <see cref="FireThroughputBenchmark" /> is the same workload with the round trips taken out, so the
+/// difference between the two is what persistence costs.
+/// </para>
+/// <para>
+/// <b>Running it.</b> Start the database yourself and point the benchmark at it — a container per
+/// benchmark case is not a thing BenchmarkDotNet's process-per-case model can give you:
+/// </para>
+/// <code>
+/// docker run -d --name quartz-bench-pg -p 55432:5432 \
+///   -e POSTGRES_DB=quartznet -e POSTGRES_USER=quartznet -e POSTGRES_PASSWORD=quartznet postgres:15.1
+///
+/// QUARTZ_BENCHMARK_POSTGRES='Host=localhost;Port=55432;Database=quartznet;Username=quartznet;Password=quartznet'
+///
+/// dotnet run -c Release --project src/Quartz.Benchmark -- --filter '*FireThroughput*'
+/// </code>
+/// <para>
+/// The schema comes from <c>database/tables/</c> and is applied on first use by
+/// <see cref="BenchmarkDatabase" />, so the tables and their indexes are the ones a real deployment
+/// has.
+/// </para>
+/// <para>
+/// <b>One node, not clustered.</b> What is measured is the fire path — acquire, fire, complete — and
+/// clustering adds a check-in loop, a cluster-wide lock on every acquisition cycle and a second node
+/// competing for the same rows. Those are worth measuring and are not measured here; the number below
+/// is the per-firing cost of the store, and a clustered deployment pays it plus that. The soak in
+/// <c>Quartz.Tests.Integration</c> is where two nodes are exercised.
+/// </para>
+/// <para>
+/// Carries <see cref="BenchmarkCategories.RequiresDatabase" />, so it is outside the smoke run; the
+/// <c>RAMJobStore</c> arm is inside it and covers the shared harness.
+/// </para>
+/// </remarks>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
+[BenchmarkCategory(BenchmarkCategories.RequiresDatabase)]
+public class FireThroughputPostgresBenchmark
+{
+    /// <summary>
+    /// The scheduler name every row this benchmark writes is keyed by, so its own rows can be removed
+    /// without disturbing what the other database benchmarks seeded into the same schema.
+    /// </summary>
+    private const string SchedulerName = "PostgresThroughputBenchmark";
+
+    /// <summary>The thread pool's permit count; ten is the shipped default and fifty a large node.</summary>
+    [Params(10, 50)]
+    public int MaxConcurrency { get; set; }
+
+    private BenchmarkDatabase database = null!;
+    private IScheduler scheduler = null!;
+
+    /// <summary>
+    /// Applies the schema if it is not there, clears anything a previous parameter set left, then
+    /// starts the scheduler and gets it firing.
+    /// </summary>
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        database = await BenchmarkDatabase.Open(BenchmarkDialect.Postgres).ConfigureAwait(false);
+        await ClearOwnRows().ConfigureAwait(false);
+
+        string connectionString = database.Provider.ConnectionString;
+
+        scheduler = await FireThroughput.StartScheduler(
+            instanceName: SchedulerName,
+            maxConcurrency: MaxConcurrency,
+            configureStore: quartz => quartz.UsePersistentStore(store =>
+            {
+                store.UsePostgres(connectionString);
+                store.UseSystemTextJsonSerializer();
+            })).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stops the scheduler and takes its rows out again, so that the next parameter set starts from
+    /// the same empty schema this one did.
+    /// </summary>
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await FireThroughput.StopScheduler(scheduler).ConfigureAwait(false);
+        await ClearOwnRows().ConfigureAwait(false);
+        await database.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>One operation is one firing; the body waits for the next batch of them to happen.</summary>
+    [Benchmark(OperationsPerInvoke = FireThroughput.AdoFiresPerInvocation)]
+    public void Fire() => FireThroughput.AwaitFires(FireThroughput.AdoFiresPerInvocation);
+
+    /// <summary>
+    /// Deletes every row this benchmark's scheduler owns, children before parents.
+    /// </summary>
+    /// <remarks>
+    /// A leftover trigger from an earlier parameter set would be acquired along with this one's and
+    /// silently change how many triggers are in flight, which is the one thing the workload holds
+    /// constant across the sweep.
+    /// </remarks>
+    private async Task ClearOwnRows()
+    {
+        foreach (string table in (string[])
+                 [
+                     "QRTZ_FIRED_TRIGGERS",
+                     "QRTZ_SIMPLE_TRIGGERS",
+                     "QRTZ_CRON_TRIGGERS",
+                     "QRTZ_SIMPROP_TRIGGERS",
+                     "QRTZ_BLOB_TRIGGERS",
+                     "QRTZ_TRIGGERS",
+                     "QRTZ_JOB_DETAILS",
+                     "QRTZ_PAUSED_TRIGGER_GRPS",
+                     "QRTZ_SCHEDULER_STATE",
+                     "QRTZ_LOCKS",
+                 ])
+        {
+            await database.Execute($"DELETE FROM {table} WHERE SCHED_NAME = '{SchedulerName}'").ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -50,4 +50,15 @@
     <Compile Include="..\Quartz.Tests.Unit\TestJobStores.cs" />
   </ItemGroup>
 
+  <!--
+    The 3.x half of the published fire-throughput comparison. It is source for a 3.x checkout, not
+    source for this project: it names JobStoreTX, StdSchedulerFactory and a Task-returning IJob, none
+    of which exist here. Kept in the tree so the baseline can be re-run rather than taken on trust —
+    baseline-3x/README.md says how.
+  -->
+  <ItemGroup>
+    <Compile Remove="baseline-3x\**" />
+    <None Include="baseline-3x\**" />
+  </ItemGroup>
+
 </Project>

--- a/src/Quartz.Benchmark/README.md
+++ b/src/Quartz.Benchmark/README.md
@@ -265,9 +265,11 @@ Docker Desktop, reached over loopback, at its shipped durability settings (`fsyn
 `synchronous_commit = on`). The 3.x rows were taken on `origin/3.x` at `b33c70487`, against a
 database built from **3.x's own** `database/tables/tables_postgres.sql` rather than 4.0's.
 
-**Read the Error column.** The machine was quiet for these, and it shows: every Error below is under
-1.5% of its Mean. That is unlike the older sections in this file, and it is why the 3.x-to-4.0 ratios
-here can be read as ratios rather than as directions.
+**Read the Error column.** This is a working machine and something else is usually running on it, so
+the means carry more spread than a dedicated box would give. These runs came out tight anyway -
+every Error below is under 1.5% of its Mean, which is unlike the older sections in this file - and
+that is what lets the 3.x-to-4.0 ratios be read as ratios rather than as directions. The allocation
+column is exact whatever the load, and the effects below are multiples rather than percentages.
 
 **Two settings are not at their defaults, and both had to move.** `MaxBatchSize` tracks
 `MaxConcurrency` - the scheduler refuses a batch larger than the pool that would have to run it, so

--- a/src/Quartz.Benchmark/README.md
+++ b/src/Quartz.Benchmark/README.md
@@ -239,3 +239,106 @@ key's cached hash before the name — costs 64 ns more than the disease. Orderin
 that the ordinal order keeps adjacent, so the tree walk it lengthens costs more than the string
 comparison it skips; and a string's hash is seeded per process, so the order would stop being the
 same order twice. The tie-break stays the key.
+
+## Fire throughput and per-fire allocation (2026-09-02, AMD Ryzen 9 5950X)
+
+Taken on `1e6af15e1` to answer #3653. The numbers already in this file are about parsing an
+expression and putting a trigger into a store; this section is about the thing a production reader
+actually asks - **how many trigger firings a second, and how much garbage per firing** - and it is
+the first time 4.0 has had one. It is also where the migration guide's claim that the batched fire
+path replaced "six to nine round trips" with one finally gets a figure.
+
+`FireThroughputBenchmark` and `FireThroughputPostgresBenchmark` are the harness, and
+`baseline-3x/FireThroughputBaselineBenchmark.cs` is the 3.x half of the comparison - the same
+workload and the same settings written against 3.x's API, so both sides came off one machine in one
+sitting. `baseline-3x/README.md` says how to re-run it.
+
+**How to read the table.** One operation is one firing, so `Mean` is the time a firing took and fires
+per second is `1e9 / Mean(ns)`. `Allocated` is process-wide over the measured window rather than
+per-thread - BenchmarkDotNet reads `GC.GetTotalAllocatedBytes` - so it is what a firing costs the
+process, acquisition loop and worker threads included, not what one thread of it cost.
+
+**Machine and runtime.** BenchmarkDotNet v0.15.8; Windows 11 (10.0.26200.9168/25H2); AMD Ryzen 9
+5950X 3.40 GHz, 1 CPU, 32 logical and 16 physical cores; .NET SDK 10.0.400; host and job
+.NET 10.0.11 (10.0.1126.37416), X64 RyuJIT x86-64-v3, Concurrent Workstation GC. PostgreSQL 15.1 in
+Docker Desktop, reached over loopback, at its shipped durability settings (`fsync = on`,
+`synchronous_commit = on`). The 3.x rows were taken on `origin/3.x` at `b33c70487`, against a
+database built from **3.x's own** `database/tables/tables_postgres.sql` rather than 4.0's.
+
+**Read the Error column.** The machine was quiet for these, and it shows: every Error below is under
+1.5% of its Mean. That is unlike the older sections in this file, and it is why the 3.x-to-4.0 ratios
+here can be read as ratios rather than as directions.
+
+**Two settings are not at their defaults, and both had to move.** `MaxBatchSize` tracks
+`MaxConcurrency` - the scheduler refuses a batch larger than the pool that would have to run it, so
+across a 10-and-50 sweep the two cannot be varied independently, and the batch is the pool.
+`BatchTriggerAcquisitionFireAheadTimeWindow` is **one second** rather than the shipped zero: the
+store ends a batch at the first acquired trigger's own fire time plus the window, so at the default a
+batch is one trigger however large `MaxBatchSize` is. A deployment left at the shipped defaults gets
+the batch-of-one shape, which is one acquisition round trip per firing.
+
+**The workload.** Two thousand simple triggers over a hundred jobs, repeating indefinitely every
+millisecond under the ignore-misfires instruction, over a job that counts and returns. Every trigger
+is therefore permanently overdue, so the scheduler never waits and what is measured is the fire path
+rather than the clock. Two thousand of them put the arrangement's own ceiling at two million firings
+a second, several times what the fastest arm here reaches.
+
+**One node, and not clustered.** What is measured is acquire, fire, complete. Clustering adds a
+check-in loop, a cluster-wide lock on every acquisition cycle and a second node competing for the
+same rows; those are real costs and none of them is in these numbers.
+
+### RAMJobStore
+
+| Version | MaxConcurrency | Mean     | Error     | Allocated | Fires/second |
+|-------- |--------------- |---------:|----------:|----------:|-------------:|
+| 4.0     | 10             | 3.436 us | 0.0258 us |   3.62 KB |      291,000 |
+| 4.0     | 50             | 3.024 us | 0.0352 us |   3.63 KB |      330,700 |
+| 3.20    | 10             | 2.314 us | 0.0266 us |   3.25 KB |      432,200 |
+| 3.20    | 50             | 2.228 us | 0.0317 us |   3.25 KB |      448,800 |
+
+### PostgreSQL
+
+| Version | MaxConcurrency | Mean     | Error     | Allocated | Fires/second |
+|-------- |--------------- |---------:|----------:|----------:|-------------:|
+| 4.0     | 10             | 6.177 ms | 0.0911 ms |  56.47 KB |          162 |
+| 4.0     | 50             | 6.129 ms | 0.0638 ms |  52.78 KB |          163 |
+| 3.20    | 10             | 9.865 ms | 0.1322 ms | 136.09 KB |          101 |
+| 3.20    | 50             | 9.212 ms | 0.1014 ms | 132.10 KB |          109 |
+
+### Verdict
+
+**On a persistent store, 4.0 is 1.5x faster per firing than 3.20 and allocates 2.4x less** - 6.1 ms
+against 9.2-9.9 ms, and 53-56 KB against 132-136 KB. That is the batched fire path, and it is the
+number the migration guide's round-trip claim never had. Counted at the database rather than in the
+client, a firing now costs **1.27 commits** - 42,337 transactions over 33,404 firings in one run -
+which is one `TriggeredJobComplete` plus a share of an acquisition and a `TriggersFired` amortised
+across the batch.
+
+**On `RAMJobStore`, 4.0 is about 1.4x slower per firing than 3.20 and allocates 11% more** - 3.0-3.4
+us against 2.2-2.3 us. Recorded rather than acted on, and not investigated here: the 4.0 fire path
+carries things 3.x's did not, including a DI scope per firing, the job-execution middleware pipeline,
+the execution-group ledger and the retry-policy check. Against 3 us of scheduler work the persistent
+store's 6 ms makes this invisible in any deployment that has a database, which is why it is at the
+bottom of this section rather than the top. Filed as #3674.
+
+**Pool size does not move either store much, and on PostgreSQL it does not move it at all.** Five
+times the threads buys 14% on `RAMJobStore` and nothing measurable on PostgreSQL, because the store's
+own operations serialise on the trigger-access lock: what a bigger pool buys is more *jobs* running
+at once, not more firings being started. This is the same fact `operations.md` states as "adding
+nodes does not make a single trigger fire faster", measured.
+
+**The PostgreSQL figure is a commit-latency figure as much as a Quartz one.** Re-running the 4.0 arm
+with `synchronous_commit = off` gives 3.605 ms at `MaxConcurrency` 10 and 4.140 ms at 50 - 1.7x
+faster, so roughly 40% of the 6.1 ms is this container's fsync. A deployment on faster storage will
+see more firings a second than the table says; one on slower storage will see fewer. Read the
+3.20-to-4.0 ratio, which is taken on one machine and one database, rather than the absolute.
+
+### A finding, filed rather than fixed
+
+Writing this benchmark surfaced one: **a simple trigger with a sub-millisecond repeat interval is
+silently broken by any ADO store.** `StdAdoDelegate.GetDbTimeSpanValue` casts `TotalMilliseconds` to
+`long`, so an interval below a millisecond persists as **zero**; `SimpleTriggerImpl.GetFireTimeAfter`
+then divides by `repeatInterval.Ticks` and throws `DivideByZeroException` on the trigger's next
+firing, which `AdoJobStoreBase` logs and swallows - leaving the row in `ACQUIRED` for good. Nothing
+surfaces it, and `RAMJobStore` keeps the interval, so the two stores disagree. Filed as #3673. The
+workload above uses a millisecond because that is the smallest interval both stores agree on.

--- a/src/Quartz.Benchmark/baseline-3x/FireThroughputBaselineBenchmark.cs
+++ b/src/Quartz.Benchmark/baseline-3x/FireThroughputBaselineBenchmark.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+using Npgsql;
+
+using Quartz.Impl;
+
+namespace Quartz.Benchmark;
+
+/// <summary>
+/// The 3.x baseline for <c>FireThroughputBenchmark</c> and <c>FireThroughputPostgresBenchmark</c> on
+/// <c>main</c>: the same workload, the same settings and the same arithmetic, written against 3.x's
+/// API so the two numbers are a comparison rather than two measurements.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>This file is not compiled here.</b> It lives under <c>src/Quartz.Benchmark/baseline-3x/</c> on
+/// <c>main</c>, excluded by the project file, so the baseline half of a published comparison is
+/// reproducible without anybody having to reconstruct it. To run it, drop it into
+/// <c>src/Quartz.Benchmark/</c> of a <c>3.x</c> checkout with the two package references and the two
+/// project references named in <c>README.md</c> beside it, and run the filter below. Nothing is
+/// committed on <c>3.x</c>.
+/// </para>
+/// <para>
+/// <b>What is held identical to the 4.x arms</b>, because a difference in any of them would be
+/// measured as a difference in the scheduler: two hundred triggers over twenty-five jobs; simple
+/// triggers repeating indefinitely at an interval of one tick under the ignore-misfires instruction,
+/// so every trigger is permanently overdue and the loop never waits; <c>MaxBatchSize</c> equal to
+/// <c>MaxConcurrency</c>; a one-second batch fire-ahead window; a one-second idle wait; a job that
+/// counts and returns. The counting, the waiting and the fires-per-invocation constants are the same
+/// too, so <c>Mean</c> means the same thing on both sides — the time one firing took, from which
+/// fires per second is <c>1e9 / Mean(ns)</c>.
+/// </para>
+/// <para>
+/// <b>Three things differ, because 3.x is 3.x.</b> The store is <c>JobStoreTX</c> rather than
+/// <c>LocalTransactionJobStore</c> (the same store under its 3.x name); the scheduler is built from
+/// flat properties through <c>StdSchedulerFactory</c>, because that is 3.x's configuration surface;
+/// and <c>IJob.Execute</c> returns <c>Task</c> and takes no cancellation token. None of the three is
+/// on the fire path being measured.
+/// </para>
+/// <para>
+/// <b>The PostgreSQL arm assumes the schema is already there.</b> 3.x's benchmark project has no
+/// equivalent of 4.x's <c>BenchmarkDatabase</c>, and building one to apply <c>database/tables/</c>
+/// would be a second implementation to keep honest. Point it at the container the 4.x run used, which
+/// has the tables; this one only clears the rows its own scheduler name owns.
+/// </para>
+/// <code>
+/// $env:QUARTZ_BENCHMARK_POSTGRES='Host=localhost;Port=55432;Database=quartznet;Username=quartznet;Password=quartznet'
+/// dotnet run -c Release --project src/Quartz.Benchmark -- --filter '*FireThroughput*'
+/// </code>
+/// </remarks>
+internal static class FireThroughputBaseline
+{
+    public const int RamFiresPerInvocation = 2_000;
+
+    public const int AdoFiresPerInvocation = 250;
+
+    public const string Group = "fireThroughput";
+
+    private const int TriggerCount = 200;
+
+    private const int JobCount = 25;
+
+    private static readonly TimeSpan FireTimeout = TimeSpan.FromMinutes(2);
+
+    private static long fireCount;
+
+    private static volatile Waiter pending;
+
+    /// <summary>Blocks until <paramref name="count" /> more fires have happened.</summary>
+    public static void AwaitFires(int count)
+    {
+        Waiter waiter = new Waiter(Interlocked.Read(ref fireCount) + count);
+        pending = waiter;
+
+        if (Interlocked.Read(ref fireCount) >= waiter.Target)
+        {
+            waiter.Done.Set();
+        }
+
+        bool completed = waiter.Done.Wait(FireTimeout);
+        long seen = count - (waiter.Target - Interlocked.Read(ref fireCount));
+        pending = null;
+
+        if (!completed)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                "Waited {0} for {1} firings and saw {2}. The scheduler stopped firing, which is a broken harness rather than a slow one.",
+                FireTimeout, count, seen));
+        }
+    }
+
+    private static void Fired()
+    {
+        long count = Interlocked.Increment(ref fireCount);
+        Waiter waiter = pending;
+        if (waiter != null && count >= waiter.Target)
+        {
+            waiter.Done.Set();
+        }
+    }
+
+    /// <summary>
+    /// Builds the scheduler from flat properties — 3.x's configuration surface — schedules the
+    /// workload, starts it and waits until it is firing.
+    /// </summary>
+    public static async Task<IScheduler> StartScheduler(
+        string instanceName,
+        int maxConcurrency,
+        Action<NameValueCollection> configureStore)
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = instanceName,
+            ["quartz.scheduler.instanceId"] = "NODE-01",
+            ["quartz.scheduler.idleWaitTime"] = "1000",
+            ["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = maxConcurrency.ToString(CultureInfo.InvariantCulture),
+            ["quartz.scheduler.batchTriggerAcquisitionFireAheadTimeWindow"] = "1000",
+            ["quartz.threadPool.type"] = "Quartz.Simpl.DefaultThreadPool, Quartz",
+            ["quartz.threadPool.maxConcurrency"] = maxConcurrency.ToString(CultureInfo.InvariantCulture),
+        };
+
+        configureStore(properties);
+
+        ISchedulerFactory factory = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await factory.GetScheduler().ConfigureAwait(false);
+
+        Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>> schedule = new Dictionary<IJobDetail, IReadOnlyCollection<ITrigger>>();
+        for (int i = 0; i < JobCount; i++)
+        {
+            IJobDetail job = JobBuilder.Create<NoOpCountingJob>()
+                .WithIdentity("job-" + i.ToString(CultureInfo.InvariantCulture), Group)
+                .Build();
+
+            int triggersForThisJob = TriggerCount / JobCount;
+            ITrigger[] triggers = new ITrigger[triggersForThisJob];
+            for (int j = 0; j < triggersForThisJob; j++)
+            {
+                triggers[j] = TriggerBuilder.Create()
+                    .WithIdentity(string.Format(CultureInfo.InvariantCulture, "trigger-{0}-{1}", i, j), Group)
+                    .ForJob(job)
+                    .StartNow()
+                    .WithSimpleSchedule(simple => simple
+                        .RepeatForever()
+                        .WithInterval(TimeSpan.FromTicks(1))
+                        .WithMisfireHandlingInstructionIgnoreMisfires())
+                    .Build();
+            }
+
+            schedule.Add(job, triggers);
+        }
+
+        await scheduler.ScheduleJobs(schedule, replace: true).ConfigureAwait(false);
+        await scheduler.Start().ConfigureAwait(false);
+
+        AwaitFires(TriggerCount);
+
+        return scheduler;
+    }
+
+    public static Task StopScheduler(IScheduler scheduler) => scheduler.Shutdown(waitForJobsToComplete: false);
+
+    /// <summary>The job under measurement: it records that it ran and returns.</summary>
+    public class NoOpCountingJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context)
+        {
+            Fired();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class Waiter
+    {
+        public Waiter(long target)
+        {
+            Target = target;
+        }
+
+        public long Target { get; }
+
+        public ManualResetEventSlim Done { get; } = new ManualResetEventSlim(false);
+    }
+}
+
+/// <summary>3.x's RAMJobStore arm, matching <c>FireThroughputBenchmark</c> on <c>main</c>.</summary>
+[MemoryDiagnoser]
+public class FireThroughputBaselineBenchmark
+{
+    [Params(10, 50)]
+    public int MaxConcurrency { get; set; }
+
+    private IScheduler scheduler;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        scheduler = await FireThroughputBaseline.StartScheduler(
+            "RamThroughputBenchmark",
+            MaxConcurrency,
+            properties => properties["quartz.jobStore.type"] = "Quartz.Simpl.RAMJobStore, Quartz").ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await FireThroughputBaseline.StopScheduler(scheduler).ConfigureAwait(false);
+    }
+
+    [Benchmark(OperationsPerInvoke = FireThroughputBaseline.RamFiresPerInvocation)]
+    public void Fire() => FireThroughputBaseline.AwaitFires(FireThroughputBaseline.RamFiresPerInvocation);
+}
+
+/// <summary>
+/// 3.x's PostgreSQL arm, matching <c>FireThroughputPostgresBenchmark</c> on <c>main</c>. Single node,
+/// not clustered, for the same reason: what is measured is the fire path rather than the check-in
+/// loop.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RunStrategy.Throughput, warmupCount: 3, iterationCount: 10)]
+public class FireThroughputBaselinePostgresBenchmark
+{
+    private const string SchedulerName = "PostgresThroughputBenchmark";
+
+    [Params(10, 50)]
+    public int MaxConcurrency { get; set; }
+
+    private string connectionString;
+    private IScheduler scheduler;
+
+    [GlobalSetup]
+    public async Task Setup()
+    {
+        connectionString = Environment.GetEnvironmentVariable("QUARTZ_BENCHMARK_POSTGRES")
+            ?? throw new InvalidOperationException("QUARTZ_BENCHMARK_POSTGRES is not set; point it at the same database the 4.x run used, which already has the schema.");
+
+        await ClearOwnRows().ConfigureAwait(false);
+
+        scheduler = await FireThroughputBaseline.StartScheduler(
+            SchedulerName,
+            MaxConcurrency,
+            properties =>
+            {
+                properties["quartz.jobStore.type"] = "Quartz.Impl.AdoJobStore.JobStoreTX, Quartz";
+                properties["quartz.jobStore.driverDelegateType"] = "Quartz.Impl.AdoJobStore.PostgreSQLDelegate, Quartz";
+                properties["quartz.jobStore.dataSource"] = "default";
+                properties["quartz.jobStore.tablePrefix"] = "QRTZ_";
+                properties["quartz.dataSource.default.provider"] = "Npgsql";
+                properties["quartz.dataSource.default.connectionString"] = connectionString;
+                properties["quartz.serializer.type"] = "stj";
+            }).ConfigureAwait(false);
+    }
+
+    [GlobalCleanup]
+    public async Task Cleanup()
+    {
+        await FireThroughputBaseline.StopScheduler(scheduler).ConfigureAwait(false);
+        await ClearOwnRows().ConfigureAwait(false);
+    }
+
+    [Benchmark(OperationsPerInvoke = FireThroughputBaseline.AdoFiresPerInvocation)]
+    public void Fire() => FireThroughputBaseline.AwaitFires(FireThroughputBaseline.AdoFiresPerInvocation);
+
+    private async Task ClearOwnRows()
+    {
+        string[] tables =
+        {
+            "QRTZ_FIRED_TRIGGERS",
+            "QRTZ_SIMPLE_TRIGGERS",
+            "QRTZ_CRON_TRIGGERS",
+            "QRTZ_SIMPROP_TRIGGERS",
+            "QRTZ_BLOB_TRIGGERS",
+            "QRTZ_TRIGGERS",
+            "QRTZ_JOB_DETAILS",
+            "QRTZ_PAUSED_TRIGGER_GRPS",
+            "QRTZ_SCHEDULER_STATE",
+            "QRTZ_LOCKS",
+        };
+
+        await using NpgsqlConnection connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        foreach (string table in tables)
+        {
+            await using NpgsqlCommand command = connection.CreateCommand();
+            command.CommandText = "DELETE FROM " + table + " WHERE SCHED_NAME = @schedulerName";
+            command.Parameters.AddWithValue("schedulerName", SchedulerName);
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Quartz.Benchmark/baseline-3x/FireThroughputBaselineBenchmark.cs
+++ b/src/Quartz.Benchmark/baseline-3x/FireThroughputBaselineBenchmark.cs
@@ -31,8 +31,9 @@ namespace Quartz.Benchmark;
 /// <para>
 /// <b>What is held identical to the 4.x arms</b>, because a difference in any of them would be
 /// measured as a difference in the scheduler: two hundred triggers over twenty-five jobs; simple
-/// triggers repeating indefinitely at an interval of one tick under the ignore-misfires instruction,
-/// so every trigger is permanently overdue and the loop never waits; <c>MaxBatchSize</c> equal to
+/// triggers repeating indefinitely at a one-millisecond interval under the ignore-misfires
+/// instruction, so every trigger is permanently overdue and the loop never waits;
+/// <c>MaxBatchSize</c> equal to
 /// <c>MaxConcurrency</c>; a one-second batch fire-ahead window; a one-second idle wait; a job that
 /// counts and returns. The counting, the waiting and the fires-per-invocation constants are the same
 /// too, so <c>Mean</c> means the same thing on both sides — the time one firing took, from which
@@ -64,9 +65,16 @@ internal static class FireThroughputBaseline
 
     public const string Group = "fireThroughput";
 
-    private const int TriggerCount = 200;
+    private const int TriggerCount = 2_000;
 
-    private const int JobCount = 25;
+    private const int JobCount = 100;
+
+    /// <summary>
+    /// The same millisecond the 4.x arms use, and for the same reason: it is the smallest
+    /// interval a persistent store can carry, because StdAdoDelegate stores a TimeSpan as whole
+    /// milliseconds on both branches.
+    /// </summary>
+    private static readonly TimeSpan RepeatInterval = TimeSpan.FromMilliseconds(1);
 
     private static readonly TimeSpan FireTimeout = TimeSpan.FromMinutes(2);
 
@@ -149,7 +157,7 @@ internal static class FireThroughputBaseline
                     .StartNow()
                     .WithSimpleSchedule(simple => simple
                         .RepeatForever()
-                        .WithInterval(TimeSpan.FromTicks(1))
+                        .WithInterval(RepeatInterval)
                         .WithMisfireHandlingInstructionIgnoreMisfires())
                     .Build();
             }

--- a/src/Quartz.Benchmark/baseline-3x/README.md
+++ b/src/Quartz.Benchmark/baseline-3x/README.md
@@ -48,11 +48,19 @@ dotnet run -c Release --project src/Quartz.Benchmark -- --filter '*FireThroughpu
 ## What is held identical, and what is not
 
 Held identical, because a difference in any of them would be measured as a difference in the
-scheduler: two hundred triggers over twenty-five jobs; simple triggers repeating indefinitely at an
-interval of one tick under the ignore-misfires instruction, so every trigger is permanently overdue
-and the acquisition loop never waits; `MaxBatchSize` equal to `MaxConcurrency`; a one-second batch
-fire-ahead window; a one-second idle wait; a job that counts and returns; and the same
-fires-per-invocation constants, so `Mean` is the time one firing took on both sides.
+scheduler: two thousand triggers over a hundred jobs; simple triggers repeating indefinitely at a
+one-millisecond interval under the ignore-misfires instruction, so every trigger is permanently
+overdue and the acquisition loop never waits; `MaxBatchSize` equal to `MaxConcurrency`; a
+one-second batch fire-ahead window; a one-second idle wait; a job that counts and returns; and the
+same fires-per-invocation constants, so `Mean` is the time one firing took on both sides.
+
+A millisecond rather than anything shorter because that is the smallest interval a persistent
+store can carry on either branch: `StdAdoDelegate.GetDbTimeSpanValue` writes a `TimeSpan` as whole
+milliseconds, and a simple trigger read back with a zero repeat interval throws
+`DivideByZeroException` out of `GetFireTimeAfter` on its next firing. Two thousand triggers rather
+than two hundred because the count sets the arrangement's own ceiling — a trigger repeating every
+millisecond sustains a thousand firings a second, so two thousand of them put the limit several
+times above what the fastest arm reaches.
 
 Different, because 3.x is 3.x: the store is `JobStoreTX` rather than `LocalTransactionJobStore` — the
 same store under its 3.x name; the scheduler is built from flat properties through

--- a/src/Quartz.Benchmark/baseline-3x/README.md
+++ b/src/Quartz.Benchmark/baseline-3x/README.md
@@ -57,7 +57,7 @@ same fires-per-invocation constants, so `Mean` is the time one firing took on bo
 A millisecond rather than anything shorter because that is the smallest interval a persistent
 store can carry on either branch: `StdAdoDelegate.GetDbTimeSpanValue` writes a `TimeSpan` as whole
 milliseconds, and a simple trigger read back with a zero repeat interval throws
-`DivideByZeroException` out of `GetFireTimeAfter` on its next firing. Two thousand triggers rather
+`DivideByZeroException` out of `GetFireTimeAfter` on its next firing (#3673). Two thousand triggers rather
 than two hundred because the count sets the arrangement's own ceiling — a trigger repeating every
 millisecond sustains a thousand firings a second, so two thousand of them put the limit several
 times above what the fastest arm reaches.

--- a/src/Quartz.Benchmark/baseline-3x/README.md
+++ b/src/Quartz.Benchmark/baseline-3x/README.md
@@ -1,0 +1,60 @@
+# The 3.x baseline for the fire-throughput numbers
+
+`FireThroughputBenchmark` and `FireThroughputPostgresBenchmark` are only a comparison if the number
+they are compared against was taken the same way. `FireThroughputBaselineBenchmark.cs` in this folder
+is that other half: the same workload and the same settings, written against 3.x's API.
+
+**Nothing here is compiled.** `Quartz.Benchmark.csproj` excludes the folder. It is here so that the
+published comparison can be re-run rather than taken on trust, and so that the next person to move
+these numbers does not have to reconstruct the baseline from the prose.
+
+**Nothing is committed on `3.x`.** The baseline is a measurement of the released shape of 3.x, not a
+change to it.
+
+## Running it
+
+```shell
+# A checkout of 3.x, anywhere. A worktree of this repository is the easiest one.
+git worktree add ../quartznet-3x origin/3.x
+
+cp src/Quartz.Benchmark/baseline-3x/FireThroughputBaselineBenchmark.cs \
+   ../quartznet-3x/src/Quartz.Benchmark/
+```
+
+`3.x`'s benchmark project needs two references it does not carry, because nothing in it has ever
+touched a database:
+
+```xml
+<PackageReference Include="Npgsql" Version="8.0.7" />
+<ProjectReference Include="..\Quartz.Serialization.SystemTextJson\Quartz.Serialization.SystemTextJson.csproj" />
+```
+
+`Npgsql` is the driver `quartz.dataSource.default.provider = Npgsql` resolves, and the serializer
+project is what `quartz.serializer.type = stj` resolves; the version is the one `3.x`'s own
+integration tests pin, so the baseline is measured against the driver that branch is tested with.
+
+Then, against the same PostgreSQL container the 4.x run used — it already has the schema, which is
+why this harness does not apply one:
+
+```shell
+docker run -d --name quartz-bench-pg -p 55432:5432 \
+  -e POSTGRES_DB=quartznet -e POSTGRES_USER=quartznet -e POSTGRES_PASSWORD=quartznet postgres:15.1
+
+$env:QUARTZ_BENCHMARK_POSTGRES='Host=localhost;Port=55432;Database=quartznet;Username=quartznet;Password=quartznet'
+
+dotnet run -c Release --project src/Quartz.Benchmark -- --filter '*FireThroughput*'
+```
+
+## What is held identical, and what is not
+
+Held identical, because a difference in any of them would be measured as a difference in the
+scheduler: two hundred triggers over twenty-five jobs; simple triggers repeating indefinitely at an
+interval of one tick under the ignore-misfires instruction, so every trigger is permanently overdue
+and the acquisition loop never waits; `MaxBatchSize` equal to `MaxConcurrency`; a one-second batch
+fire-ahead window; a one-second idle wait; a job that counts and returns; and the same
+fires-per-invocation constants, so `Mean` is the time one firing took on both sides.
+
+Different, because 3.x is 3.x: the store is `JobStoreTX` rather than `LocalTransactionJobStore` — the
+same store under its 3.x name; the scheduler is built from flat properties through
+`StdSchedulerFactory`, which is 3.x's configuration surface; and `IJob.Execute` returns `Task` and
+takes no cancellation token. None of the three is on the fire path being measured.

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -75,11 +75,23 @@ public abstract class ClusteredJobStoreTestBase
             ("schedulerName", SchedulerName));
     }
 
+    /// <summary>
+    /// Builds one node of this fixture's cluster.
+    /// </summary>
+    /// <param name="instanceId">The node's instance id, which is what its rows are keyed by.</param>
+    /// <param name="checkinIntervalMs">How often this node writes its check-in row.</param>
+    /// <param name="checkinMisfireThresholdMs">How stale a peer's row has to be to be called dead.</param>
+    /// <param name="configure">Adjusts the flat properties before the scheduler is built.</param>
+    /// <param name="configureBuilder">
+    /// Adjusts the same scheduler through the typed builder, for the things flat properties cannot say
+    /// — <c>AddJobTimeout</c> registers middleware, and middleware has no property key.
+    /// </param>
     protected async Task<IScheduler> CreateScheduler(
         string instanceId,
         int checkinIntervalMs = 1000,
         int checkinMisfireThresholdMs = 2000,
-        Action<NameValueCollection> configure = null)
+        Action<NameValueCollection> configure = null,
+        Action<IQuartzBuilder> configureBuilder = null)
     {
         var properties = new NameValueCollection
         {
@@ -106,7 +118,7 @@ public abstract class ClusteredJobStoreTestBase
         // Cluster nodes share the scheduler (instance) name, and a factory's repository lookup is
         // name-only — but each factory owns its own repository, so every call here builds a genuinely
         // separate node rather than handing back the first one.
-        ISchedulerFactory factory = QuartzSchedulerBuilder.Create().UseProperties(properties).Build();
+        ISchedulerFactory factory = QuartzSchedulerBuilder.Create(configureBuilder).UseProperties(properties).Build();
         return await factory.GetScheduler();
     }
 

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakPostgresTest.cs
@@ -1,0 +1,20 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The clustered soak against PostgreSQL, whose store locks through
+/// <c>PostgreSqlSelectForUpdateLockHandler</c>.
+/// </summary>
+/// <remarks>
+/// <c>LongRunning</c> keeps it out of every integration leg — see <c>build/Build.cs</c>'s
+/// <c>GetTestFilter</c>, and <see cref="ClusteredSoakTestBase" /> for how to run it and why it is a
+/// release gate rather than a leg.
+/// </remarks>
+[Category("db-postgres")]
+[Category("LongRunning")]
+[NonParallelizable]
+public sealed class ClusteredSoakPostgresTest : ClusteredSoakTestBase
+{
+    public ClusteredSoakPostgresTest() : base(TestConstants.PostgresProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakSqlServerTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakSqlServerTest.cs
@@ -1,0 +1,26 @@
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The clustered soak against SQL Server, whose store locks through <c>SelectForUpdateLockHandler</c>
+/// with the <c>(UPDLOCK,ROWLOCK)</c> hint.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The second configuration rather than a duplicate of the first: the interesting code under a soak is
+/// the SQL, and the row locking, the recovery statements and the misfire scan differ per engine. A run
+/// on one engine says nothing about the other.
+/// </para>
+/// <para>
+/// <c>LongRunning</c> keeps it out of every integration leg — see <c>build/Build.cs</c>'s
+/// <c>GetTestFilter</c>, and <see cref="ClusteredSoakTestBase" /> for how to run it.
+/// </para>
+/// </remarks>
+[Category("db-sqlserver")]
+[Category("LongRunning")]
+[NonParallelizable]
+public sealed class ClusteredSoakSqlServerTest : ClusteredSoakTestBase
+{
+    public ClusteredSoakSqlServerTest() : base(TestConstants.DefaultSqlServerProvider)
+    {
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
@@ -145,6 +145,9 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
                 {
                     // Both nodes, not one. A single node in standby leaves the other acquiring, so
                     // nothing misfires; what produces a misfire is a due trigger that no node takes.
+                    // The issue asked for one node in standby; both is what that asks for with two
+                    // nodes, and it was ratified as written rather than replaced with a PreferredNode
+                    // pin that would have made the misfire a property of node affinity instead.
                     await nodeA.Standby();
                     await nodeB.Standby();
                     standbyDone = true;

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
@@ -1,0 +1,979 @@
+using System.Collections.Concurrent;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Two clustered nodes carrying every kind of work the scheduler can be asked to do, for half an hour,
+/// with the failures a cluster meets in production induced along the way — and then asked what they
+/// left behind.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>It is a release gate, not a CI leg.</b> The fixtures carry <c>[Category("LongRunning")]</c> and
+/// every integration leg excludes that category (<c>build/Build.cs</c>, <c>GetTestFilter</c>), because
+/// half an hour of wall time in a pull request's leg reads as a hung job rather than as thoroughness.
+/// Run it by hand before a tag:
+/// </para>
+/// <code>
+/// $env:QUARTZ_TEST_DATABASE = 'postgres'
+/// $env:QUARTZ_SOAK_MINUTES  = '30'
+/// dotnet test src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj `
+///   --filter 'FullyQualifiedName~ClusteredSoakPostgresTest'
+/// </code>
+/// <para>
+/// <b>What it is for.</b> Every other clustered fixture here asserts one property over a run of
+/// minutes: exactly-once acquisition, a killed node's residue, node affinity, tenancy. None of them
+/// runs long enough for a leak to show, none of them runs a
+/// <see cref="DisallowConcurrentExecutionAttribute" /> job on two live nodes and watches for an
+/// overlap — <c>ClusteredExactlyOnceTestBase</c> says in as many words why its own job is concurrent
+/// by design — and none of them puts retries, timeouts, misfires and a failover through the same
+/// scheduler at the same time. That combination is what a night in production is, and it is what this
+/// runs.
+/// </para>
+/// <para>
+/// <b>Both nodes are in this process</b>, which is what makes the overlap detector possible at all: a
+/// static counter sees a firing on either node, so "these two firings of the same job overlapped" is
+/// observable rather than inferred from rows. It is also the one way in which this is not a real
+/// two-machine cluster — the nodes share a GC heap and a thread pool, and the sampling below therefore
+/// watches the pair rather than either one.
+/// </para>
+/// <para>
+/// <b>The clock is the database's.</b> No <c>FakeTimeProvider</c>, for the reason
+/// <see cref="ClusteredJobStoreTestBase" /> gives: a cluster agrees on time through
+/// <c>LAST_CHECKIN_TIME</c>, and a node with a fake clock is a node in a cluster that does not exist.
+/// Where the test needs the past it moves a row, with <c>BackdateCheckin</c>.
+/// </para>
+/// </remarks>
+public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
+{
+    private const string Group = "clusterSoak";
+    private const string NodeA = "soak-node-a";
+    private const string NodeB = "soak-node-b";
+
+    /// <summary>
+    /// The entry id of the fired-trigger row the killed node leaves behind. Named rather than
+    /// generated so the end assertions can ask about that row specifically.
+    /// </summary>
+    private const string KilledEntryId = "soak-killed-executing-1";
+
+    /// <summary>
+    /// How long the run lasts unless <c>QUARTZ_SOAK_MINUTES</c> says otherwise.
+    /// </summary>
+    private const double DefaultSoakMinutes = 30;
+
+    /// <summary>
+    /// Each node's pool. Small on purpose: the workload below asks for a couple of firings a second,
+    /// and a pool with room to spare would never queue anything behind the serial job.
+    /// </summary>
+    private const int MaxConcurrency = 5;
+
+    /// <summary>
+    /// How stale a trigger has to be before the store calls it misfired. Ten seconds rather than the
+    /// default minute, so that the standby window can be seconds rather than minutes and still produce
+    /// real misfires.
+    /// </summary>
+    private static readonly TimeSpan MisfireThreshold = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// How long both nodes sit in standby. Three misfire thresholds, so every trigger that would have
+    /// fired inside it is unambiguously misfired rather than merely late.
+    /// </summary>
+    private static readonly TimeSpan StandbyWindow = TimeSpan.FromSeconds(30);
+
+    protected ClusteredSoakTestBase(string provider) : base(provider)
+    {
+    }
+
+    protected override string SchedulerName => "ClusterSoakTest";
+
+    /// <summary>
+    /// The soak. One test, because the phases are one run: the failures are induced in the middle of
+    /// a workload that is running throughout, and the assertions are about what the whole run left.
+    /// </summary>
+    [Test]
+    public async Task TwoNodes_SurviveAFullWorkloadWithFailuresInducedThroughout()
+    {
+        TimeSpan duration = SoakDuration();
+        SoakRecorder.Reset();
+
+        List<ResourceSample> samples = [];
+        List<string> timeline = [];
+
+        IScheduler nodeA = await CreateSoakScheduler(NodeA);
+        IScheduler nodeB = await CreateSoakScheduler(NodeB);
+
+        try
+        {
+            AttachRecorder(nodeA);
+            AttachRecorder(nodeB);
+
+            await nodeA.Start();
+            await nodeB.Start();
+
+            DateTimeOffset started = DateTimeOffset.UtcNow;
+            await ScheduleWorkload(nodeA, started);
+
+            Note(timeline, started, $"workload scheduled; running for {duration}");
+
+            // The phases, as fractions of the run, so a five-minute smoke exercises the same sequence a
+            // half-hour gate does. Each one is a failure a cluster meets in production.
+            DateTimeOffset standbyAt = started + duration * 0.25;
+            DateTimeOffset resumeAt = standbyAt + StandbyWindow;
+            DateTimeOffset killAt = started + duration * 0.55;
+            DateTimeOffset replaceAt = started + duration * 0.70;
+            DateTimeOffset deadline = started + duration;
+
+            // Long enough that a sample is a settled heap rather than a moment in a collection, short
+            // enough that a five-minute smoke still produces a series to read a trend off.
+            TimeSpan sampleInterval = TimeSpan.FromSeconds(Math.Min(60, duration.TotalSeconds / 6));
+            DateTimeOffset sampleAt = started + sampleInterval;
+
+            bool standbyDone = false;
+            bool resumeDone = false;
+            bool killDone = false;
+            bool replaceDone = false;
+
+            while (DateTimeOffset.UtcNow < deadline)
+            {
+                DateTimeOffset now = DateTimeOffset.UtcNow;
+
+                if (!standbyDone && now >= standbyAt)
+                {
+                    // Both nodes, not one. A single node in standby leaves the other acquiring, so
+                    // nothing misfires; what produces a misfire is a due trigger that no node takes.
+                    await nodeA.Standby();
+                    await nodeB.Standby();
+                    standbyDone = true;
+                    Note(timeline, now, $"both nodes in standby for {StandbyWindow} to induce misfires");
+                }
+                else if (standbyDone && !resumeDone && now >= resumeAt)
+                {
+                    await nodeA.Start();
+                    await nodeB.Start();
+                    resumeDone = true;
+                    Note(timeline, now, "both nodes resumed");
+                }
+                else if (resumeDone && !killDone && now >= killAt)
+                {
+                    await KillNodeB(nodeB);
+                    nodeB = null;
+                    killDone = true;
+                    Note(timeline, now, $"'{NodeB}' killed mid-flight, leaving an EXECUTING row behind");
+
+                    await WaitForCondition(
+                        async () => await CountRowsFor("QRTZ_SCHEDULER_STATE", NodeB) == 0,
+                        timeoutMs: 60_000,
+                        async () => $"'{NodeA}' to declare '{NodeB}' dead and clear its row. State:\n{await DumpDatabaseState()}");
+
+                    await WaitForCondition(
+                        () => Task.FromResult(SoakRecorder.RecoveredFirings.Count >= 1),
+                        timeoutMs: 60_000,
+                        async () => $"'{NodeA}' to replay the killed node's interrupted firing. State:\n{await DumpDatabaseState()}");
+
+                    Note(timeline, DateTimeOffset.UtcNow, "survivor recovered the killed node's work");
+                }
+                else if (killDone && !replaceDone && now >= replaceAt)
+                {
+                    nodeB = await CreateSoakScheduler(NodeB);
+                    AttachRecorder(nodeB);
+                    await nodeB.Start();
+                    replaceDone = true;
+                    Note(timeline, now, $"'{NodeB}' replaced and rejoined the cluster");
+                }
+
+                if (now >= sampleAt)
+                {
+                    samples.Add(ResourceSample.Take(now - started));
+                    sampleAt = now + sampleInterval;
+                }
+
+                await Task.Delay(500);
+            }
+
+            samples.Add(ResourceSample.Take(DateTimeOffset.UtcNow - started));
+            Note(timeline, DateTimeOffset.UtcNow, "run complete, shutting the cluster down");
+        }
+        finally
+        {
+            // Waiting for the jobs is the point rather than politeness: the "nothing left behind"
+            // assertions below are about a cluster that finished its work, not one that was cut off
+            // mid-firing.
+            await nodeA.Shutdown(waitForJobsToComplete: true);
+            if (nodeB is not null)
+            {
+                await nodeB.Shutdown(waitForJobsToComplete: true);
+            }
+
+            // Here rather than at the end of the run, so that a soak which fell over halfway through
+            // still says how far it got and what it had seen. That is most of what a run this long is
+            // for, and it is exactly the run that will not reach the end.
+            TestContext.Out.WriteLine(Report(timeline, samples, duration));
+        }
+
+        await AssertNothingLeftBehind();
+        AssertWorkloadRan(duration);
+        AssertNoOverlap();
+        AssertNoUnobservedFailures();
+        AssertResourcesFlat(samples);
+    }
+
+    /// <summary>
+    /// How long to run for, from <c>QUARTZ_SOAK_MINUTES</c>. A double so a smoke run can ask for a
+    /// fraction of a minute without a second variable.
+    /// </summary>
+    private static TimeSpan SoakDuration()
+    {
+        string configured = Environment.GetEnvironmentVariable("QUARTZ_SOAK_MINUTES");
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return TimeSpan.FromMinutes(DefaultSoakMinutes);
+        }
+
+        double.TryParse(configured, NumberStyles.Float, CultureInfo.InvariantCulture, out double minutes)
+            .Should().BeTrue("QUARTZ_SOAK_MINUTES is '{0}', which is not a number of minutes", configured);
+
+        minutes.Should().BeGreaterThan(0, "a soak of no time asserts nothing");
+
+        return TimeSpan.FromMinutes(minutes);
+    }
+
+    /// <summary>
+    /// One node of the soak cluster: the fixture's shared database, a short check-in interval so a
+    /// death is noticed in seconds, a misfire threshold short enough for the standby window to matter,
+    /// and the timeout middleware, which is the one thing here that flat properties cannot register.
+    /// </summary>
+    /// <remarks>
+    /// The check-in threshold is seven and a half intervals rather than the two the shorter fixtures
+    /// use. Those run for a minute; this runs for thirty, so it gets thirty times the opportunities
+    /// for a garbage collection and a slow round trip to line up and make a live node look dead — and
+    /// a spurious failover would replay work the soak then counts. The induced death does not depend
+    /// on the threshold at all: <c>KillNodeB</c> ages the row by five minutes.
+    /// </remarks>
+    private Task<IScheduler> CreateSoakScheduler(string instanceId)
+    {
+        return CreateScheduler(
+            instanceId,
+            checkinIntervalMs: 2000,
+            checkinMisfireThresholdMs: 15_000,
+            configure: properties =>
+            {
+                properties["quartz.threadPool.maxConcurrency"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
+                properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
+                properties["quartz.jobStore.misfireThreshold"] =
+                    ((int) MisfireThreshold.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
+            },
+            configureBuilder: quartz => quartz.AddJobTimeout());
+    }
+
+    /// <summary>
+    /// Every trigger family, the serial job the overlap detector watches, the failing job the retry
+    /// policy is attached to, the job that overruns its budget, and the job that only a recovery
+    /// trigger can run.
+    /// </summary>
+    /// <remarks>
+    /// The intervals are seconds rather than milliseconds because a soak is about duration, not
+    /// throughput: what is being watched is whether firing for half an hour leaves anything behind, and
+    /// a saturated cluster would only add queueing to the picture. <c>ExecutionCeilingBenchmark</c> and
+    /// <c>FireThroughputBenchmark</c> are where the rate is the question.
+    /// </remarks>
+    private async Task ScheduleWorkload(IScheduler scheduler, DateTimeOffset started)
+    {
+        IJobDetail counting = JobBuilder.Create<SoakCountingJob>()
+            .WithIdentity(SoakJobs.Counting, Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(counting, new AddJobOptions { Replace = true });
+
+        // One trigger per family, so a family that stopped firing is named by the assertion rather
+        // than hidden in an aggregate.
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Simple, Group)
+            .ForJob(counting)
+            .StartAt(started.AddSeconds(2))
+            .WithSimpleSchedule(x => x.RepeatForever().WithInterval(SoakTriggers.SimpleInterval))
+            .Build());
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Cron, Group)
+            .ForJob(counting)
+            .WithCronSchedule("0/5 * * * * ?")
+            .Build());
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.DailyTimeInterval, Group)
+            .ForJob(counting)
+            .StartAt(started.AddSeconds(2))
+            .WithDailyTimeIntervalSchedule(x => x.OnEveryDay().WithInterval(3, IntervalUnit.Second))
+            .Build());
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.CalendarInterval, Group)
+            .ForJob(counting)
+            .StartAt(started.AddSeconds(2))
+            .WithCalendarIntervalSchedule(x => x.WithInterval(4, IntervalUnit.Second))
+            .Build());
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Recurrence, Group)
+            .ForJob(counting)
+            .StartAt(started.AddSeconds(2))
+            .WithRecurrenceSchedule("FREQ=SECONDLY;INTERVAL=6")
+            .Build());
+
+        // Three triggers on one [DisallowConcurrentExecution] job, deliberately: the property under
+        // test is that the store queues them behind one another across both nodes, and one trigger
+        // could never show it.
+        IJobDetail serial = JobBuilder.Create<SoakSerialJob>()
+            .WithIdentity(SoakJobs.Serial, Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(serial, new AddJobOptions { Replace = true });
+
+        for (int i = 0; i < 3; i++)
+        {
+            await scheduler.ScheduleJob(TriggerBuilder.Create()
+                .WithIdentity(SoakTriggers.Serial + "-" + i.ToString(CultureInfo.InvariantCulture), Group)
+                .ForJob(serial)
+                .StartAt(started.AddSeconds(2 + i))
+                .WithSimpleSchedule(x => x.RepeatForever().WithInterval(TimeSpan.FromSeconds(2)))
+                .Build());
+        }
+
+        // Fails every time, so each scheduled firing costs one execution plus the policy's two
+        // retries. What is being watched is that the trigger goes back on its schedule when the
+        // attempts are spent rather than into the error state.
+        IJobDetail failing = JobBuilder.Create<SoakFailingJob>()
+            .WithIdentity(SoakJobs.Failing, Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(failing, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Failing, Group)
+            .ForJob(failing)
+            .StartAt(started.AddSeconds(5))
+            .WithRetryPolicy(RetryPolicy.Fixed(2, TimeSpan.FromSeconds(1)))
+            .WithSimpleSchedule(x => x.RepeatForever().WithInterval(SoakTriggers.FailingInterval))
+            .Build());
+
+        // Carries [JobTimeout("00:00:02")] and sleeps far past it, so every firing is interrupted by
+        // the middleware and reported as a failure.
+        IJobDetail overrunning = JobBuilder.Create<SoakOverrunningJob>()
+            .WithIdentity(SoakJobs.Overrunning, Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(overrunning, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Overrunning, Group)
+            .ForJob(overrunning)
+            .StartAt(started.AddSeconds(5))
+            .WithSimpleSchedule(x => x.RepeatForever().WithInterval(SoakTriggers.OverrunningInterval))
+            .Build());
+
+        // Its own trigger is a day out, so the only thing that can ever run it is the recovery trigger
+        // the survivor builds for the killed node's interrupted firing.
+        IJobDetail recoverable = JobBuilder.Create<SoakRecoverableJob>()
+            .WithIdentity(SoakJobs.Recoverable, Group)
+            .StoreDurably()
+            .RequestRecovery()
+            .Build();
+        await scheduler.AddJob(recoverable, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(SoakTriggers.Recoverable, Group)
+            .ForJob(recoverable)
+            .StartAt(started.AddDays(1))
+            .Build());
+    }
+
+    /// <summary>
+    /// Takes a node out the way a crash does: the row saying it was mid-firing stays behind, the
+    /// process stops, and its check-in goes stale. A polite shutdown cannot produce this state — it
+    /// releases what it holds on the way out — which is why the row is written by hand, exactly as
+    /// <c>ClusteredHardeningTestBase</c> does.
+    /// </summary>
+    private async Task KillNodeB(IScheduler nodeB)
+    {
+        await InsertFiredTrigger(
+            entryId: KilledEntryId,
+            triggerKey: new TriggerKey(SoakTriggers.Recoverable, Group),
+            jobKey: new JobKey(SoakJobs.Recoverable, Group),
+            instanceName: NodeB);
+
+        await nodeB.Shutdown(waitForJobsToComplete: false);
+
+        // Shutdown leaves the node's own SCHEDULER_STATE row behind — only a peer's ClusterRecover
+        // deletes it — so ageing it is what turns "stopped" into "died".
+        await BackdateCheckin(NodeB, TimeSpan.FromMinutes(5));
+    }
+
+    /// <summary>
+    /// Writes an <c>EXECUTING</c> fired-trigger row for a node, in the shape
+    /// <c>StdAdoDelegate.InsertFiredTrigger</c> writes for a running recoverable job.
+    /// </summary>
+    /// <remarks>
+    /// A near-copy of <c>ClusteredHardeningTestBase</c>'s private helper rather than a shared one:
+    /// that fixture is a sibling of this one, not an ancestor, and deriving from it to reach twenty
+    /// lines would drag its four <c>[Test]</c> methods into this fixture — where the
+    /// <c>LongRunning</c> category would then exclude them from the leg that is meant to run them.
+    /// </remarks>
+    private async Task InsertFiredTrigger(string entryId, TriggerKey triggerKey, JobKey jobKey, string instanceName)
+    {
+        long firedTime = DateTimeOffset.UtcNow.AddSeconds(-5).UtcTicks;
+
+        await ExecuteNonQuery(
+            "INSERT INTO QRTZ_FIRED_TRIGGERS "
+            + "(SCHED_NAME, ENTRY_ID, TRIGGER_NAME, TRIGGER_GROUP, INSTANCE_NAME, FIRED_TIME, SCHED_TIME, "
+            + "PRIORITY, STATE, JOB_NAME, JOB_GROUP, IS_NONCONCURRENT, REQUESTS_RECOVERY, EXECUTION_GROUP) "
+            + "VALUES (@schedulerName, @entryId, @triggerName, @triggerGroup, @instanceName, @firedTime, @schedTime, "
+            + "@priority, 'EXECUTING', @jobName, @jobGroup, @isNonConcurrent, @requestsRecovery, NULL)",
+            ("schedulerName", SchedulerName),
+            ("entryId", entryId),
+            ("triggerName", triggerKey.Name),
+            ("triggerGroup", triggerKey.Group),
+            ("instanceName", instanceName),
+            ("firedTime", firedTime),
+            ("schedTime", firedTime),
+            ("priority", 5),
+            ("jobName", jobKey.Name),
+            ("jobGroup", jobKey.Group),
+            ("isNonConcurrent", false),
+            ("requestsRecovery", true));
+    }
+
+    private Task<int> CountRowsFor(string table, string instanceName)
+    {
+        return CountRows(
+            $"SELECT COUNT(*) FROM {table} WHERE SCHED_NAME = @schedulerName AND INSTANCE_NAME = @instanceName",
+            ("schedulerName", SchedulerName),
+            ("instanceName", instanceName));
+    }
+
+    /// <summary>
+    /// What a cluster that has finished its work leaves in the tables: nothing in flight, and nothing
+    /// reserved.
+    /// </summary>
+    /// <remarks>
+    /// Polled rather than asserted outright. <c>Shutdown</c> returns once the scheduler thread has
+    /// stopped and the jobs have finished, but the last <c>TriggeredJobComplete</c> writes land on
+    /// their own connections, so an instant assertion here would be racing the teardown it is meant to
+    /// be checking.
+    /// </remarks>
+    private async Task AssertNothingLeftBehind()
+    {
+        await WaitForCondition(
+            async () => await CountRows(
+                "SELECT COUNT(*) FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_STATE IN ('ACQUIRED', 'BLOCKED')",
+                ("schedulerName", SchedulerName)) == 0,
+            timeoutMs: 60_000,
+            async () =>
+                "every trigger to be released. An ACQUIRED row is one a node reserved and never fired, and a "
+                + "BLOCKED row is a serial job's sibling that was never unblocked — both are triggers that will "
+                + $"never fire again without a recovery. State:\n{await DumpDatabaseState()}");
+
+        await WaitForCondition(
+            async () => await CountRows(
+                "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                ("schedulerName", SchedulerName)) == 0,
+            timeoutMs: 60_000,
+            async () =>
+                "QRTZ_FIRED_TRIGGERS to drain. A row left here makes a finished firing look in-flight to the "
+                + $"execution ceiling, to QueryFireInstances and to the next node that recovers this one. State:\n{await DumpDatabaseState()}");
+
+        int killedRows = await CountRows(
+            "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName AND ENTRY_ID = @entryId",
+            ("schedulerName", SchedulerName),
+            ("entryId", KilledEntryId));
+
+        killedRows.Should().Be(0,
+            "the survivor deletes the row when it takes the killed node's firing over; leaving it makes the "
+            + "corpse look busy and re-recovered on every subsequent check-in");
+    }
+
+    /// <summary>
+    /// That every family fired, roughly as often as its schedule says, and that the retry and timeout
+    /// paths produced what they promise.
+    /// </summary>
+    /// <remarks>
+    /// The band is wide on purpose. Two nodes share the work, thirty seconds of the run are spent in
+    /// standby, a node is killed and replaced, and misfire recovery decides for itself whether to
+    /// catch up — so the count a schedule implies is an order of magnitude, not a number. What a
+    /// tighter bound would buy is flakiness; what this catches is the failure that matters, which is a
+    /// family that stopped firing.
+    /// </remarks>
+    private void AssertWorkloadRan(TimeSpan duration)
+    {
+        foreach ((string trigger, TimeSpan interval) in SoakTriggers.CountedFamilies)
+        {
+            int fired = SoakRecorder.FiringsFor(trigger);
+            double expected = duration.TotalSeconds / interval.TotalSeconds;
+
+            fired.Should().BeGreaterThan(0,
+                "'{0}' is a whole trigger family; zero firings means that family never ran at all", trigger);
+
+            fired.Should().BeInRange((int) (expected * 0.3), (int) (expected * 2.0) + 5,
+                "'{0}' fires every {1} over a {2} run, so roughly {3:F0} times — a count far outside that is "
+                + "either a family that stalled or one that ran away", trigger, interval, duration, expected);
+        }
+
+        SoakRecorder.SerialFirings.Should().BeGreaterThan(0,
+            "the serial job is what the overlap detector watches; it has to have run for the check to mean anything");
+
+        SoakRecorder.FailingAttempts.Should().BeGreaterThan(0, "the retry policy needs a failure to act on");
+
+        SoakRecorder.FailingRetryAttempts.Should().BeGreaterThan(0,
+            "RetryPolicy.Fixed(2, 1s) re-fires a failed trigger twice more before letting the schedule take "
+            + "it back, and a re-fire carries a non-zero RetryAttempt. None at all means the policy was "
+            + "stored and never consulted");
+
+        SoakRecorder.TimedOutFirings.Should().BeGreaterThan(0,
+            "the overrunning job sleeps far past the two-second budget [JobTimeout] gives it, so AddJobTimeout "
+            + "has to have interrupted it and reported the overrun as a failure");
+
+        SoakRecorder.RecoveredFirings.Should().ContainSingle(
+            "the killed node left exactly one interrupted firing behind, and recovery replays it once — a "
+            + "second replay is one interrupted firing becoming two jobs")
+            .Which.Should().Be(NodeA, "the survivor is the only node that could have recovered it");
+    }
+
+    /// <summary>
+    /// The property N2b §4(b) records as settled by mechanism and never shown end to end: two live
+    /// nodes, one <see cref="DisallowConcurrentExecutionAttribute" /> job, no two firings of it at
+    /// once.
+    /// </summary>
+    private static void AssertNoOverlap()
+    {
+        SoakRecorder.Overlaps.Should().BeEmpty(
+            "[DisallowConcurrentExecution] means one firing of this job at a time across the whole cluster: "
+            + "acquisition takes only WAITING rows, firing one of a job's triggers moves its siblings to "
+            + "BLOCKED, and the BLOCKED row is in the shared database where the other node reads it. An entry "
+            + "here is two firings that overlapped, which is that chain broken somewhere");
+
+        SoakRecorder.MaxSerialConcurrency.Should().Be(1,
+            "the serial job's peak observed concurrency is the same statement counted rather than listed");
+    }
+
+    /// <summary>
+    /// Nothing failed that was not meant to fail, and nothing failed where nobody was looking.
+    /// </summary>
+    private static void AssertNoUnobservedFailures()
+    {
+        SoakRecorder.UnexpectedJobFailures.Should().BeEmpty(
+            "only the failing job and the overrunning one are supposed to throw; anything else that did is a "
+            + "job the scheduler could not run");
+
+        SoakRecorder.SchedulerErrors.Should().BeEmpty(
+            "a SchedulerError that does not name one of the two jobs this soak asks to fail is the scheduler "
+            + "saying it could not do its own work — instantiate a job, read the store, notify a listener. A "
+            + "run that produced one has found something");
+
+        // Finalizers are what raise UnobservedTaskException, so a run that never collected would report
+        // clean whatever it dropped.
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        SoakRecorder.UnobservedTaskExceptions.Should().BeEmpty(
+            "a faulted task nobody awaited is a failure the scheduler swallowed rather than reported");
+    }
+
+    /// <summary>
+    /// That half an hour of firing did not accumulate anything: the live heap after a full collection,
+    /// and the process's handle count, are where they were once the run had settled.
+    /// </summary>
+    /// <remarks>
+    /// The baseline is the second sample rather than the first. The first is taken while the pools,
+    /// the connection pool and the JIT are still filling, so a run measured against it would be
+    /// measuring startup. The bounds are generous — a factor and an absolute floor — because the
+    /// failure this is for is a leak, which is unbounded growth rather than a percentage.
+    /// </remarks>
+    private static void AssertResourcesFlat(IReadOnlyList<ResourceSample> samples)
+    {
+        samples.Count.Should().BeGreaterThanOrEqualTo(3,
+            "a trend needs a series; fewer samples than this says the run was too short to have taken any");
+
+        ResourceSample baseline = samples[1];
+        ResourceSample last = samples[^1];
+
+        last.HeapBytes.Should().BeLessThan(Math.Max(baseline.HeapBytes * 3, baseline.HeapBytes + 64L * 1024 * 1024),
+            "the heap is measured after a full blocking collection, so what it holds is live. Growing it "
+            + "threefold over a run whose workload never changes is something the run is keeping hold of");
+
+        last.HandleCount.Should().BeLessThan(Math.Max(baseline.HandleCount * 3, baseline.HandleCount + 500),
+            "handles are connections, timers, events and files. A cluster doing the same work at the end as "
+            + "at the start should need the same number of them");
+    }
+
+    /// <summary>
+    /// Wires a node's scheduler listener up, so that anything the scheduler could not do is recorded
+    /// rather than left in a log nobody reads.
+    /// </summary>
+    private static void AttachRecorder(IScheduler scheduler)
+    {
+        scheduler.ListenerManager.AddSchedulerListener(new SoakSchedulerListener());
+        scheduler.ListenerManager.AddJobListener(new SoakJobListener());
+    }
+
+    private static void Note(List<string> timeline, DateTimeOffset at, string what)
+    {
+        timeline.Add(string.Create(CultureInfo.InvariantCulture, $"{at:HH:mm:ss} {what}"));
+    }
+
+    /// <summary>
+    /// What the run did and what it cost, printed whether or not the assertions pass — a soak that
+    /// merely says "passed" has thrown away most of what it was run for.
+    /// </summary>
+    private static string Report(IReadOnlyList<string> timeline, IReadOnlyList<ResourceSample> samples, TimeSpan duration)
+    {
+        StringBuilder report = new();
+        report.AppendLine(CultureInfo.InvariantCulture, $"Soak over {duration}:");
+
+        foreach (string entry in timeline)
+        {
+            report.AppendLine("  " + entry);
+        }
+
+        report.AppendLine("Firings:");
+        foreach ((string trigger, int count) in SoakRecorder.FiringCounts())
+        {
+            report.AppendLine(CultureInfo.InvariantCulture, $"  {trigger,-28} {count}");
+        }
+
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"  {"serial (max concurrent)",-28} {SoakRecorder.SerialFirings} ({SoakRecorder.MaxSerialConcurrency})");
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"  {"failing (attempts)",-28} {SoakRecorder.FailingAttempts}, of which {SoakRecorder.FailingRetryAttempts} were retries");
+        report.AppendLine(CultureInfo.InvariantCulture, $"  {"timed out",-28} {SoakRecorder.TimedOutFirings}");
+        report.AppendLine(CultureInfo.InvariantCulture, $"  {"recovered",-28} {SoakRecorder.RecoveredFirings.Count}");
+
+        report.AppendLine("Resources:");
+        foreach (ResourceSample sample in samples)
+        {
+            report.AppendLine(CultureInfo.InvariantCulture,
+                $"  t+{sample.Elapsed.TotalMinutes,6:F1} min  heap {sample.HeapBytes / (1024 * 1024),5} MB  handles {sample.HandleCount,6}  threads {sample.ThreadCount,4}");
+        }
+
+        return report.ToString();
+    }
+
+    /// <summary>
+    /// The job names, and which of them are supposed to fail. Two of the workload's jobs throw by
+    /// design, and both the job listener and the scheduler listener have to be able to tell them from
+    /// a job that failed because something is wrong.
+    /// </summary>
+    private static class SoakJobs
+    {
+        public const string Counting = "countingJob";
+        public const string Serial = "serialJob";
+        public const string Failing = "failingJob";
+        public const string Overrunning = "overrunningJob";
+        public const string Recoverable = "recoverableJob";
+
+        public static bool MayFail(string jobName) => jobName is Failing or Overrunning;
+    }
+
+    /// <summary>The trigger names and intervals the workload is made of, in one place.</summary>
+    private static class SoakTriggers
+    {
+        public const string Simple = "family-simple";
+        public const string Cron = "family-cron";
+        public const string DailyTimeInterval = "family-dailyTimeInterval";
+        public const string CalendarInterval = "family-calendarInterval";
+        public const string Recurrence = "family-recurrence";
+        public const string Serial = "serial";
+        public const string Failing = "failing";
+        public const string Overrunning = "overrunning";
+        public const string Recoverable = "recoverable";
+
+        public static readonly TimeSpan SimpleInterval = TimeSpan.FromSeconds(2);
+        public static readonly TimeSpan FailingInterval = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan OverrunningInterval = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// The five trigger families, with the interval each one's schedule implies. Every one is a
+        /// different implementation of "when does this fire next", and a soak that ran only simple
+        /// triggers would exercise one of them.
+        /// </summary>
+        public static readonly (string Trigger, TimeSpan Interval)[] CountedFamilies =
+        [
+            (Simple, SimpleInterval),
+            (Cron, TimeSpan.FromSeconds(5)),
+            (DailyTimeInterval, TimeSpan.FromSeconds(3)),
+            (CalendarInterval, TimeSpan.FromSeconds(4)),
+            (Recurrence, TimeSpan.FromSeconds(6)),
+        ];
+    }
+
+    /// <summary>
+    /// One reading of what the process is holding. The heap is taken after a full blocking collection,
+    /// so it is the live set rather than whatever had not been collected yet.
+    /// </summary>
+    private sealed record ResourceSample(TimeSpan Elapsed, long HeapBytes, int HandleCount, int ThreadCount)
+    {
+        public static ResourceSample Take(TimeSpan elapsed)
+        {
+            long heap = GC.GetTotalMemory(forceFullCollection: true);
+            using Process process = Process.GetCurrentProcess();
+            process.Refresh();
+            return new ResourceSample(elapsed, heap, process.HandleCount, process.Threads.Count);
+        }
+    }
+
+    /// <summary>
+    /// Everything the run observed, in statics because both nodes are in this process and the jobs are
+    /// constructed by the scheduler rather than by the test.
+    /// </summary>
+    private static class SoakRecorder
+    {
+        private static readonly ConcurrentDictionary<string, int> firings = new();
+
+        private static int serialFirings;
+        private static int serialConcurrency;
+        private static int maxSerialConcurrency;
+        private static int failingAttempts;
+        private static int failingRetryAttempts;
+        private static int timedOutFirings;
+
+        public static ConcurrentQueue<string> Overlaps { get; private set; } = new();
+
+        public static ConcurrentQueue<string> RecoveredFirings { get; private set; } = new();
+
+        public static ConcurrentQueue<string> SchedulerErrors { get; private set; } = new();
+
+        public static ConcurrentQueue<string> UnexpectedJobFailures { get; private set; } = new();
+
+        public static ConcurrentQueue<string> UnobservedTaskExceptions { get; private set; } = new();
+
+        public static int SerialFirings => serialFirings;
+
+        public static int MaxSerialConcurrency => maxSerialConcurrency;
+
+        public static int FailingAttempts => failingAttempts;
+
+        /// <summary>
+        /// How many of those attempts were re-fires the policy asked for rather than occurrences the
+        /// schedule produced, told apart by the trigger's own <c>RetryAttempt</c> — zero on the
+        /// occurrence, one and then two on the retries, because <c>TryScheduleRetry</c> increments it
+        /// as it moves the fire time.
+        /// </summary>
+        public static int FailingRetryAttempts => failingRetryAttempts;
+
+        public static int TimedOutFirings => timedOutFirings;
+
+        public static void Reset()
+        {
+            firings.Clear();
+            Overlaps = new ConcurrentQueue<string>();
+            RecoveredFirings = new ConcurrentQueue<string>();
+            SchedulerErrors = new ConcurrentQueue<string>();
+            UnexpectedJobFailures = new ConcurrentQueue<string>();
+            UnobservedTaskExceptions = new ConcurrentQueue<string>();
+            Interlocked.Exchange(ref serialFirings, 0);
+            Interlocked.Exchange(ref serialConcurrency, 0);
+            Interlocked.Exchange(ref maxSerialConcurrency, 0);
+            Interlocked.Exchange(ref failingAttempts, 0);
+            Interlocked.Exchange(ref failingRetryAttempts, 0);
+            Interlocked.Exchange(ref timedOutFirings, 0);
+
+            TaskScheduler.UnobservedTaskException -= OnUnobservedTaskException;
+            TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+        }
+
+        private static void OnUnobservedTaskException(object sender, UnobservedTaskExceptionEventArgs e)
+        {
+            UnobservedTaskExceptions.Enqueue(e.Exception?.ToString() ?? "<null>");
+            e.SetObserved();
+        }
+
+        public static void RecordFiring(string triggerName)
+        {
+            firings.AddOrUpdate(triggerName, 1, static (_, count) => count + 1);
+        }
+
+        public static int FiringsFor(string triggerName) => firings.TryGetValue(triggerName, out int count) ? count : 0;
+
+        public static IEnumerable<(string Trigger, int Count)> FiringCounts()
+        {
+            return firings.Select(x => (x.Key, x.Value)).OrderBy(x => x.Key, StringComparer.Ordinal);
+        }
+
+        /// <summary>
+        /// Enters the serial job, and records the peak number of firings of it that were ever in
+        /// flight together. Anything above one is the property under test broken.
+        /// </summary>
+        public static void EnterSerial(string instanceId, string fireInstanceId)
+        {
+            Interlocked.Increment(ref serialFirings);
+            int inFlight = Interlocked.Increment(ref serialConcurrency);
+
+            int observed = Volatile.Read(ref maxSerialConcurrency);
+            while (inFlight > observed)
+            {
+                int previous = Interlocked.CompareExchange(ref maxSerialConcurrency, inFlight, observed);
+                if (previous == observed)
+                {
+                    break;
+                }
+
+                observed = previous;
+            }
+
+            if (inFlight > 1)
+            {
+                Overlaps.Enqueue(string.Create(CultureInfo.InvariantCulture,
+                    $"{inFlight} concurrent firings of the serial job; this one on '{instanceId}' as {fireInstanceId}"));
+            }
+        }
+
+        public static void ExitSerial() => Interlocked.Decrement(ref serialConcurrency);
+
+        public static void RecordFailingAttempt(bool isRetry)
+        {
+            Interlocked.Increment(ref failingAttempts);
+            if (isRetry)
+            {
+                Interlocked.Increment(ref failingRetryAttempts);
+            }
+        }
+
+        public static void RecordRecovery(string instanceId) => RecoveredFirings.Enqueue(instanceId);
+
+        /// <summary>
+        /// Records a <c>SchedulerError</c> that is not one of the two jobs this soak asks to fail.
+        /// </summary>
+        /// <remarks>
+        /// A job that throws is reported through <em>both</em> channels — <c>JobWasExecuted</c> gets
+        /// the <see cref="JobExecutionException" /> and scheduler listeners get a
+        /// <c>SchedulerError</c> naming the same firing (<c>JobRunShell</c>, the
+        /// <c>JobExecutionProcessException</c> path). That is by design: a listener that only watches
+        /// the scheduler should still learn that a job blew up. So "the scheduler could not do its own
+        /// work" has to be read as "an error for a job that was not supposed to fail", which is what
+        /// the key check below makes it.
+        /// </remarks>
+        public static void RecordSchedulerError(SchedulerErrorContext errorContext)
+        {
+            if (errorContext.JobKey is not null && SoakJobs.MayFail(errorContext.JobKey.Name))
+            {
+                return;
+            }
+
+            SchedulerErrors.Enqueue($"{errorContext.Message}: {errorContext.Exception}");
+        }
+
+        public static void RecordJobOutcome(IJobExecutionContext context, JobExecutionException exception)
+        {
+            if (exception is null)
+            {
+                return;
+            }
+
+            string jobName = context.JobDetail.Key.Name;
+            if (jobName == SoakJobs.Failing)
+            {
+                return;
+            }
+
+            if (jobName == SoakJobs.Overrunning)
+            {
+                Interlocked.Increment(ref timedOutFirings);
+                return;
+            }
+
+            UnexpectedJobFailures.Enqueue(string.Create(CultureInfo.InvariantCulture,
+                $"{context.JobDetail.Key} through {context.Trigger.Key}: {exception.Message}"));
+        }
+    }
+
+    /// <summary>Counts a firing per trigger, which is how each family is shown to have kept running.</summary>
+    public sealed class SoakCountingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.RecordFiring(context.Trigger.Key.Name);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// The job the overlap detector watches. It holds its slot long enough that a second firing would
+    /// have to overlap it rather than merely follow it.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class SoakSerialJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.EnterSerial(context.Scheduler.SchedulerInstanceId, context.FireInstanceId);
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                SoakRecorder.ExitSerial();
+            }
+        }
+    }
+
+    /// <summary>Fails every time, so the trigger's retry policy has something to do.</summary>
+    public sealed class SoakFailingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.RecordFailingAttempt(context.Trigger.RetryAttempt > 0);
+            throw new InvalidOperationException("The soak's failing job fails on purpose, so the retry policy has something to retry.");
+        }
+    }
+
+    /// <summary>
+    /// Runs far past the budget it declares, so <c>AddJobTimeout</c> has to interrupt it. It does not
+    /// swallow the cancellation: what is under test is the ordinary path, where the job honours the
+    /// token it was handed.
+    /// </summary>
+    [JobTimeout("00:00:02")]
+    public sealed class SoakOverrunningJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Only ever reached through a recovery trigger: its own trigger is a day out, so a firing of this
+    /// job is proof that the survivor replayed the killed node's work.
+    /// </summary>
+    public sealed class SoakRecoverableJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.RecordRecovery(context.Scheduler.SchedulerInstanceId);
+            return default;
+        }
+    }
+
+    /// <summary>Records what the scheduler could not do.</summary>
+    private sealed class SoakSchedulerListener : ISchedulerListener
+    {
+        public ValueTask SchedulerError(IScheduler scheduler, SchedulerErrorContext errorContext, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.RecordSchedulerError(errorContext);
+            return default;
+        }
+    }
+
+    /// <summary>Records which firings failed, and separates the ones that are supposed to.</summary>
+    private sealed class SoakJobListener : IJobListener
+    {
+        public ValueTask JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException, CancellationToken cancellationToken = default)
+        {
+            SoakRecorder.RecordJobOutcome(context, jobException);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/DurationStorageRuleTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/DurationStorageRuleTest.cs
@@ -1,0 +1,78 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#endregion
+
+using Quartz.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The whole-milliseconds rule at its two doors: the check a trigger's write site makes first, and
+/// the conversion every dialect's delegate performs, which is the backstop for a caller that does not.
+/// </summary>
+/// <remarks>
+/// <see cref="SubMillisecondIntervalSqliteTest" /> proves the rule through a real store. This pins the
+/// two members themselves — that a whole number of milliseconds passes both, that a null passes the
+/// conversion, and that a finer value is refused by the conversion on its own, so a dialect that
+/// bypasses the write-site check still cannot write a zero (#3673).
+/// </remarks>
+[TestFixture]
+public sealed class DurationStorageRuleTest
+{
+    [Test]
+    public void AWholeNumberOfMillisecondsIsStorable()
+    {
+        Action check = () => AdoJobStoreUtil.RequireStorableDuration(TimeSpan.FromMilliseconds(250), AdoConstants.ColumnRepeatInterval, new TriggerKey("t", "g"));
+
+        check.Should().NotThrow("250 ms is exactly what the column keeps");
+    }
+
+    [Test]
+    public void AFinerValueIsRefusedNamingTheTriggerAndTheColumn()
+    {
+        Action check = () => AdoJobStoreUtil.RequireStorableDuration(TimeSpan.FromTicks(1), AdoConstants.ColumnRepeatInterval, new TriggerKey("t", "g"));
+
+        check.Should().Throw<ArgumentException>()
+            .WithMessage("*'g.t'*")
+            .WithMessage($"*{AdoConstants.ColumnRepeatInterval}*",
+                "the message has to say which trigger and which column, because the alternative was a row stored as zero");
+    }
+
+    [Test]
+    public void TheConversionKeepsWholeMillisecondsAndPassesNullThrough()
+    {
+        StdAdoDelegate adoDelegate = new StdAdoDelegate();
+
+        adoDelegate.GetDbTimeSpanValue(TimeSpan.FromMilliseconds(1500)).Should().Be(1500L,
+            "the column holds the millisecond count, and 1.5 s is a whole number of them");
+        adoDelegate.GetDbTimeSpanValue(null).Should().BeNull("a null duration is a null column");
+    }
+
+    [Test]
+    public void TheConversionRefusesWhatItCannotHoldExactly()
+    {
+        StdAdoDelegate adoDelegate = new StdAdoDelegate();
+
+        Action convert = () => adoDelegate.GetDbTimeSpanValue(TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond + 1));
+
+        convert.Should().Throw<ArgumentException>()
+            .WithMessage("*whole milliseconds*",
+                "truncating to a millisecond would read back as a different value; the delegate is the last door and refuses too");
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
@@ -1,0 +1,211 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl;
+using Quartz.Tests;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// A repeat interval shorter than a millisecond is refused by a persistent store, loudly, instead of
+/// being written as zero.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>REPEAT_INTERVAL</c> holds whole milliseconds — <c>StdAdoDelegate.GetDbTimeSpanValue</c> casts
+/// <c>TotalMilliseconds</c> to <c>long</c> — so anything shorter used to be stored as <c>0</c>. That is
+/// not merely lossy: the trigger read back has a zero repeat interval, and
+/// <c>SimpleTriggerImpl.GetFireTimeAfter</c> divides by it, so the trigger throws
+/// <see cref="DivideByZeroException" /> on its next firing. <c>AdoJobStoreBase</c> catches that, logs
+/// it and returns, leaving the row in <c>ACQUIRED</c> for good — a job that stops running and says
+/// nothing. Found by the fire-throughput benchmark, filed as
+/// <see href="https://github.com/quartznet/quartznet/issues/3673">#3673</see>.
+/// </para>
+/// <para>
+/// The refusal is what makes the divide-by-zero unreachable, so the store's catch is left alone: it is
+/// there for the failures nobody has thought of, and this one is now thought of.
+/// </para>
+/// <para>
+/// SQLite in a file rather than a container, so the claim is pinned where the coverage gate can see
+/// it. The rule is <c>StdAdoDelegate</c>'s and therefore every dialect's; nothing here is SQLite's.
+/// </para>
+/// </remarks>
+public sealed class SubMillisecondIntervalSqliteTest
+{
+    /// <summary>Half a millisecond: representable in a <see cref="TimeSpan" />, not in the column.</summary>
+    private static readonly TimeSpan SubMillisecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2);
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-submilli-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task SchedulingASubMillisecondRepeatIntervalIsRefusedRatherThanRoundedToZero()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+
+        Func<Task> act = () => handle.Scheduler.ScheduleJob(Job(), Trigger(SubMillisecond)).AsTask();
+
+        (await act.Should().ThrowAsync<Exception>(
+                "a store that cannot hold the interval has to say so at schedule time; writing zero produces a "
+                + "trigger that throws DivideByZeroException on its next firing and then sits in ACQUIRED for ever")
+            .WithMessage("*millisecond*"))
+            .WithMessage("*REPEAT_INTERVAL*",
+                "the message has to name the column, because that is what the caller has to change the value to fit");
+    }
+
+    /// <summary>
+    /// The refusal is the store's, not the trigger's: a whole millisecond is fine, which is what makes
+    /// the message's advice followable.
+    /// </summary>
+    [Test]
+    public async Task AWholeMillisecondIsAccepted()
+    {
+        await using SchedulerHandle handle = await BuildScheduler();
+
+        await handle.Scheduler.ScheduleJob(Job(), Trigger(TimeSpan.FromMilliseconds(1)));
+
+        ITrigger? stored = await handle.Scheduler.GetTrigger(new TriggerKey("fast", "submilli"));
+
+        stored.Should().BeOfType<Quartz.Impl.Triggers.SimpleTriggerImpl>()
+            .Which.RepeatInterval.Should().Be(TimeSpan.FromMilliseconds(1),
+                "a millisecond is exactly what the column holds, so it has to round-trip unchanged");
+    }
+
+    /// <summary>
+    /// <c>RAMJobStore</c> keeps whatever it was given, and goes on doing so. The refusal is a property
+    /// of what a database column can hold, and the in-memory store has no column.
+    /// </summary>
+    [Test]
+    public async Task TheInMemoryStoreStillAcceptsIt()
+    {
+        RAMJobStore store = TestJobStores.Ram();
+        IScheduler scheduler = await QuartzSchedulerBuilder
+            .Create(q =>
+            {
+                q.ConfigureScheduler(options => options.InstanceName = "submilli-ram");
+                q.UseJobStore(store);
+            })
+            .BuildScheduler();
+
+        try
+        {
+            await scheduler.ScheduleJob(Job(), Trigger(SubMillisecond));
+
+            ITrigger? stored = await scheduler.GetTrigger(new TriggerKey("fast", "submilli"));
+
+            stored.Should().BeOfType<Quartz.Impl.Triggers.SimpleTriggerImpl>()
+                .Which.RepeatInterval.Should().Be(SubMillisecond,
+                    "the in-memory store holds the TimeSpan it was handed; there is no column to round it to");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private static IJobDetail Job()
+    {
+        return JobBuilder.Create<NoOpIntervalJob>().WithIdentity("fast", "submilli").Build();
+    }
+
+    private static ITrigger Trigger(TimeSpan interval)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("fast", "submilli")
+            // Far enough out that nothing fires while the test drives the store by hand.
+            .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
+            .Build();
+    }
+
+    private async Task<SchedulerHandle> BuildScheduler()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "submilli";
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+        });
+
+        ServiceProvider container = services.BuildServiceProvider();
+
+        // Never started: the trigger is a year out and the test drives the store directly.
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        return new SchedulerHandle(container, scheduler);
+    }
+
+    private sealed class SchedulerHandle : IAsyncDisposable
+    {
+        private readonly ServiceProvider container;
+
+        public SchedulerHandle(ServiceProvider container, IScheduler scheduler)
+        {
+            this.container = container;
+            Scheduler = scheduler;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Scheduler.Shutdown(waitForJobsToComplete: false);
+            await container.DisposeAsync();
+        }
+    }
+
+    public sealed class NoOpIntervalJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
@@ -69,4 +69,42 @@ internal static class AdoJobStoreUtil
         var unqualifiedPrefix = lastDot >= 0 ? tablePrefix.Substring(lastDot + 1) : tablePrefix;
         return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, unqualifiedPrefix);
     }
+
+    /// <summary>
+    /// Refuses a duration the schema cannot hold exactly, naming the trigger and the column it was
+    /// going into.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Duration columns hold whole milliseconds - see <c>StdAdoDelegate.GetDbTimeSpanValue</c>, which
+    /// casts <c>TotalMilliseconds</c> to <c>long</c> - so a shorter interval used to be written as
+    /// <c>0</c>. For a simple trigger that is not merely lossy: the trigger read back has a zero
+    /// repeat interval, <c>SimpleTriggerImpl.GetFireTimeAfter</c> divides by it, and the resulting
+    /// <see cref="DivideByZeroException" /> is caught and logged by the store - leaving the row in
+    /// <c>ACQUIRED</c> for good, which is a job that stops running and says nothing (#3673).
+    /// </para>
+    /// <para>
+    /// Refused here rather than rounded, because rounding half a millisecond to zero and rounding it
+    /// to one are both schedules the caller did not ask for. The message names the column so that
+    /// what to change the value to is not a guess.
+    /// </para>
+    /// </remarks>
+    /// <param name="value">The duration about to be persisted.</param>
+    /// <param name="column">The column it is going into, as the schema spells it.</param>
+    /// <param name="triggerKey">The trigger that carries it.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="value" /> carries ticks below a whole millisecond.
+    /// </exception>
+    public static void RequireStorableDuration(TimeSpan value, string column, TriggerKey triggerKey)
+    {
+        if (value.Ticks % TimeSpan.TicksPerMillisecond == 0)
+        {
+            return;
+        }
+
+        string message = string.Create(CultureInfo.InvariantCulture,
+            $"Trigger '{triggerKey}' has an interval of {value:c}, which a persistent job store cannot hold: {column} keeps whole milliseconds, so it would be stored as {(long) value.TotalMilliseconds} ms and read back as a different schedule. Round the interval to a whole number of milliseconds, or keep this trigger in the in-memory store.");
+
+        Throw.ArgumentException(message, nameof(value));
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
@@ -81,6 +81,7 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
         CancellationToken cancellationToken = default)
     {
         ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
+        AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, AdoConstants.ColumnRepeatInterval, trigger.Key);
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefixCached(StdAdoConstants.SqlInsertSimpleTrigger, TablePrefix));
         DbAccessor.AddCommandParameter(cmd, SqlParameters.SchedulerName, SchedulerName);
@@ -179,6 +180,7 @@ public sealed class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelega
     private List<SqlStatementParameter> BuildUpdateParameters(IOperableTrigger trigger)
     {
         ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
+        AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, AdoConstants.ColumnRepeatInterval, trigger.Key);
 
         return
         [

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -2603,6 +2603,8 @@ public partial class StdAdoDelegate
         var persistenceDelegate = FindTriggerPersistenceDelegate(trigger);
         if (trigger is ISimpleTrigger simpleTrigger && persistenceDelegate is not null)
         {
+            AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, AdoConstants.ColumnRepeatInterval, trigger.Key);
+
             into.Add(new SqlStatement(ReplaceTablePrefix(StdAdoConstants.SqlUpdateSimpleTrigger),
             [
                 new SqlStatementParameter(SqlParameters.SchedulerName, schedulerName),

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -301,6 +301,18 @@ public partial class StdAdoDelegate : IDriverDelegate, IDbAccessor
     /// <returns></returns>
     public object? GetDbTimeSpanValue(TimeSpan? timeSpanValue)
     {
+        // Whole milliseconds is the whole of the format, so a value carrying anything finer is a value
+        // this cannot store. Refused rather than truncated: the callers that know which trigger and
+        // which column it belongs to check first and say so (AdoJobStoreUtil.RequireStorableDuration),
+        // and this catches whatever they do not cover.
+        if (timeSpanValue is { } value && value.Ticks % TimeSpan.TicksPerMillisecond != 0)
+        {
+            string message = string.Create(CultureInfo.InvariantCulture,
+                $"{value:c} cannot be stored: this store keeps durations as whole milliseconds, so it would be written as {(long) value.TotalMilliseconds} ms and read back as a different value.");
+
+            Throw.ArgumentException(message, nameof(timeSpanValue));
+        }
+
         return timeSpanValue is not null ? (long?) timeSpanValue.Value.TotalMilliseconds : null;
     }
 


### PR DESCRIPTION
Two of the questions a production reader asks about 4.0 have never had an answer, and both are
measurements rather than code. This lands the two harnesses that produce them, the numbers they
produced, the fix for the bug the first of them found, and the one build change that keeps neither
harness in CI.

## The benchmark (OPS-F11)

`FireThroughputBenchmark` and `FireThroughputPostgresBenchmark` measure a firing end to end — acquire,
fire, run a job that does nothing, complete — against `RAMJobStore` and against a real PostgreSQL
store, at `MaxConcurrency` 10 and 50, with `[MemoryDiagnoser]`. `baseline-3x/` carries the same
workload written against 3.x's API, so both sides came off one machine in one sitting.

The scheduler is built once in `[GlobalSetup]` and left running, so an invocation is *wait for the
next N fires*. That is what makes `Mean` the time one firing took, and it is why the worker threads
are inside the measured window: BenchmarkDotNet reads `GC.GetTotalAllocatedBytes`, which is
process-wide, so `Allocated` is what a firing costs the process rather than what one thread of it did.

### The numbers

AMD Ryzen 9 5950X, .NET 10.0.11, PostgreSQL 15.1 in Docker over loopback at its shipped durability
settings. 3.20 rows taken on `origin/3.x` (`b33c70487`) against **3.x's own** schema. This is a
working machine with other things on it; these runs came out tight anyway — every Error is under
1.5 % of its Mean, and the allocation column is exact whatever the load.

| Store | MaxConcurrency | 3.20 | 4.0 | Fires/second (4.0) |
|---|---|---|---|---|
| PostgreSQL | 10 | 9.865 ms / 136.09 KB | **6.177 ms** / **56.47 KB** | 162 |
| PostgreSQL | 50 | 9.212 ms / 132.10 KB | **6.129 ms** / **52.78 KB** | 163 |
| `RAMJobStore` | 10 | 2.314 µs / 3.25 KB | 3.436 µs / 3.62 KB | 291,000 |
| `RAMJobStore` | 50 | 2.228 µs / 3.25 KB | 3.024 µs / 3.63 KB | 330,700 |

**On a persistent store 4.0 is 1.5× faster per firing than 3.20 and allocates 2.4× less.** That is
the batched fire path, and it is the figure the migration guide's "six to nine round trips replaced
with one" has never had. Counted at the database rather than in the client, a firing now costs
**1.27 commits** — 42,337 transactions over 33,404 firings in one run.

**On `RAMJobStore` 4.0 is about 1.4× slower and allocates 11 % more.** Recorded, not acted on: against
six milliseconds of database, three microseconds of scheduler is invisible in any deployment that has
one. Filed as #3674 and left there.

**Pool size does not start firings faster.** Five times the threads bought 14 % on `RAMJobStore` and
nothing measurable on PostgreSQL, because a node's store operations serialise on `TRIGGER_ACCESS`.
That is `operations.md`'s "adding nodes does not make a single trigger fire faster", measured.

**Two settings could not be left at their defaults**, and both are stated beside the numbers.
`MaxBatchSize` tracks `MaxConcurrency`, because `QuartzOptionsValidators` refuses a batch larger than
the pool that would run it. `BatchTriggerAcquisitionFireAheadTimeWindow` is one second rather than
the shipped zero: the store ends a batch at the first acquired trigger's fire time plus the window,
so at the default a batch is one trigger however large `MaxBatchSize` is.

## The soak (V6.9), and what both runs said

`ClusteredSoakTestBase` runs two clustered nodes over one database for `QUARTZ_SOAK_MINUTES` (30 by
default): every trigger family including recurrence, a `[DisallowConcurrentExecution]` job behind an
overlap detector, a retry policy over a job that always fails, a job that overruns the budget
`AddJobTimeout` enforces, and a job only a recovery trigger can reach — with the failures induced
along the way. Both nodes run in one process, which is what makes the overlap detector possible: a
static counter sees a firing on either of them.

**PostgreSQL, 30 minutes — passed.**

```
  08:42:22 workload scheduled; running for 00:30:00
  08:49:52 both nodes in standby for 00:00:30 to induce misfires
  08:50:22 both nodes resumed
  08:58:52 'soak-node-b' killed mid-flight, leaving an EXECUTING row behind
  08:58:52 survivor recovered the killed node's work
  09:03:22 'soak-node-b' replaced and rejoined the cluster
  09:12:22 run complete, shutting the cluster down
  family-calendarInterval 446 · family-cron 357 · family-dailyTimeInterval 594
  family-recurrence 297 · family-simple 890
  serial 2662 firings, max concurrent 1 · failing 534 attempts, 356 of them retries
  timed out 178 · recovered 1
  heap 4-5 MB and 624-645 handles across all 31 samples
```

**SQL Server, 30 minutes — passed.**

```
  09:20:16 workload scheduled; running for 00:30:00
  09:27:46 both nodes in standby … 09:28:16 resumed
  09:36:46 'soak-node-b' killed … 09:36:46 survivor recovered its work
  09:41:16 'soak-node-b' replaced and rejoined
  09:50:16 run complete
  family-calendarInterval 440 · family-cron 351 · family-dailyTimeInterval 587
  family-recurrence 294 · family-simple 867
  serial 2367 firings, max concurrent 1 · failing 521 attempts, 346 of them retries
  timed out 175 · recovered 1
  heap 4-5 MB and 725-746 handles across all 31 samples
```

End-state assertions, both runs: **no `ACQUIRED` or `BLOCKED` trigger rows**, **`QRTZ_FIRED_TRIGGERS`
empty**, the killed node's `ENTRY_ID` gone, every family's fire count inside the band its schedule
implies, **peak observed concurrency of the `[DisallowConcurrentExecution]` job = 1**, at least one
retry re-fire, at least one timeout, exactly one recovered firing and it was the survivor's, no
unexpected scheduler error, no unobserved task exception, and heap and handle count no larger at the
end than once the run had settled.

**N2b §4(b)'s open question — can a `[DisallowConcurrentExecution]` job double-fire across two nodes —
is now answered by observation on two engines rather than by mechanism.**

## The bug the benchmark found, fixed here (#3673)

`REPEAT_INTERVAL` holds whole milliseconds — `StdAdoDelegate.GetDbTimeSpanValue` casts
`TotalMilliseconds` to `long` — so a `SimpleTrigger` with a sub-millisecond repeat interval was
stored as `0`. Not merely lossy: the trigger read back has a zero repeat interval,
`SimpleTriggerImpl.GetFireTimeAfter` divides by it, and `AdoJobStoreBase` catches the
`DivideByZeroException`, logs it and returns — leaving the row in `ACQUIRED` for ever. A job that
stops running and says nothing. **The benchmark's first PostgreSQL run hit exactly this**: zero
firings, nothing reported anywhere the caller could see.

`AdoJobStoreUtil.RequireStorableDuration` now refuses any `TimeSpan` carrying ticks below a whole
millisecond, naming the trigger, the column and what to do about it, and the three places that write
a simple trigger's interval call it. `GetDbTimeSpanValue` carries the same rule as a backstop, so no
other path can truncate a duration silently either. **`AdoJobStoreBase`'s catch is untouched** — it is
there for the failures nobody has thought of, and the refusal is what makes this one unreachable.
`RAMJobStore` goes on accepting the interval, because it has no column to round it to.

`SubMillisecondIntervalSqliteTest` pins all three claims on a file SQLite database — refusal, a whole
millisecond accepted, and the in-memory store still taking it — so the rule is held where the
coverage gate can see it. It failed before the fix and passes after. One line added to the migration
guide under *Between the alphas and beta.1*.

## The build change

`GetTestFilter` mapped a database to its own `TestCategory` and nothing else, so a fixture carrying
both `db-postgres` and `LongRunning` would have run in the postgres leg — half an hour of wall time
in a pull request, which reads as a hung job rather than as thoroughness. Every leg now excludes
`LongRunning`, whether or not a database was named, because an unnamed one applies no filter at all.

## Docs

`src/Quartz.Benchmark/README.md` gains a `##` section in the house style. `operations.md` gains a
`## Performance` section linking it, carrying the headline table plus the cron and `ScheduleJob`
numbers that existed and were unreachable from the docs site (OPS-F10), and saying what was soaked
and for how long — so the maturity ledger cites a measurement rather than an intention.

## Verification

- `dotnet build Quartz.slnx` — succeeded, 0 warnings.
- `dotnet test src/Quartz.Tests.Unit` — **5205 passed**, 0 failed, 36 skipped.
- `dotnet test src/Quartz.Tests.AspNetCore` — **605 passed**, 0 failed.
- `Quartz.Tests.Integration`, `db-sqlite` leg — 15 passed, 0 failed.
- Both 30-minute soaks — passed, above.
- `dotnet fallout BenchmarkSmoke` — succeeded, 284 benchmarks; both `FireThroughputBenchmark` cases
  in it, `FireThroughputPostgresBenchmark` correctly excluded.
- `dotnet fallout VerifyDocsSnippets`, `VerifyDocsLogEvents`, `npm run docs:check-links` (223 pages,
  1270 links, 778 fragments, no dead anchors), `docs:check-links-test` (7/7), `npm run docs:build`
  (224 pages) — all clean.
- No public API baseline moved.

## For a reviewer

- **The issue says "a node put in standby"; the soak puts *both* nodes in standby.** With two nodes,
  one in standby leaves the other acquiring and nothing misfires. Ruled fine, and now said so on the
  fixture.
- **The PostgreSQL benchmark runs one node, not clustered.** Clustering adds a check-in loop, a
  cluster-wide lock per acquisition cycle and a second node competing for the same rows; none of that
  is in the number. The soak is where two nodes are exercised.
- **The PostgreSQL figure is a commit-latency figure as much as a Quartz one.** With
  `synchronous_commit = off` the 4.0 arm runs at 3.605 ms / 4.140 ms — 1.7× faster — so roughly 40 %
  of the 6.1 ms is this container's fsync. The 3.20-to-4.0 ratio is the durable part.
- **`ClusteredJobStoreTestBase.CreateScheduler` gains an optional `Action<IQuartzBuilder>`**, because
  `AddJobTimeout` registers middleware and middleware has no property key. Additive.
- **The soak's check-in misfire threshold is 15 s against a 2 s interval**, where the minute-long
  fixtures use 2 s against 1 s: thirty times the run length is thirty times the chances for a
  collection and a slow round trip to make a live node look dead, and a spurious failover would
  replay work the soak then counts.

Closes #3653
Closes #3673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqrmFVgN97Z6aRpjBU3LRQ
