### PR TITLE
The 3.x branch gets the five fixes main already has, and its own two bugs

### DIFF
--- a/src/Quartz.Serialization.Json/Converters/StringKeyDirtyFlagMapConverter.cs
+++ b/src/Quartz.Serialization.Json/Converters/StringKeyDirtyFlagMapConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 using Quartz.Util;
 
@@ -10,6 +11,12 @@ namespace Quartz.Converters;
 
 internal sealed class StringKeyDirtyFlagMapConverter : JsonConverter
 {
+    /// <summary>
+    /// The property name Json.NET writes a value's type under, which is metadata rather than an entry
+    /// of the map it sits in.
+    /// </summary>
+    private const string TypeMarker = "$type";
+
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
     {
         var map = (StringKeyDirtyFlagMap) value!;
@@ -18,9 +25,96 @@ internal sealed class StringKeyDirtyFlagMapConverter : JsonConverter
 
     public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
-        IDictionary<string, object> innerMap = serializer.Deserialize<IDictionary<string, object>>(reader)!;
+        IDictionary<string, object> innerMap = ReadMap(reader, serializer);
         JobDataMap map = new JobDataMap(innerMap);
         return map;
+    }
+
+    /// <summary>
+    /// Reads the map entry by entry rather than as an <c>IDictionary&lt;string, object&gt;</c>, so that
+    /// a stored <c>Dictionary&lt;string, string&gt;</c> comes back as one however it was written.
+    /// </summary>
+    /// <remarks>
+    /// A value in an <see cref="object" />-typed slot is written by Json.NET with a <c>$type</c> beside
+    /// it, and by <c>Quartz.Serialization.SystemTextJson</c> as a plain JSON object. Handing the plain
+    /// form to Json.NET gets a <see cref="JObject" /> back — a shape the job that stored a dictionary
+    /// cannot cast — so a map written by the built-in serializer was unreadable here (#3582). Nothing
+    /// this branch writes changes: a payload with a <c>$type</c> is still built by Json.NET out of the
+    /// type it names, which is what keeps every blob already in a job store column loading.
+    /// </remarks>
+    private static Dictionary<string, object> ReadMap(JsonReader reader, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            throw new JsonSerializationException(
+                $"A job data map is stored as a JSON object, and this payload holds {reader.TokenType} where the map should be.");
+        }
+
+        Dictionary<string, object> map = new Dictionary<string, object>();
+
+        while (reader.Read() && reader.TokenType == JsonToken.PropertyName)
+        {
+            string name = (string) reader.Value!;
+            reader.Read();
+            map[name] = ReadValue(reader, serializer)!;
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Reads one entry's value, which is a string map when the payload holds an object Json.NET wrote
+    /// no type beside.
+    /// </summary>
+    /// <remarks>
+    /// The object is loaded with date parsing off, so an entry that merely looks like a timestamp stays
+    /// the string the application stored. Json.NET would otherwise hand back a
+    /// <see cref="DateTimeOffset" /> and rendering it as a string again would reformat it — a quieter
+    /// way to lose a value than the one this fixes. Everything that is not an object keeps the reading
+    /// it has always had, date parsing included.
+    /// </remarks>
+    private static object? ReadValue(JsonReader reader, JsonSerializer serializer)
+    {
+        if (reader.TokenType != JsonToken.StartObject)
+        {
+            return serializer.Deserialize<object>(reader);
+        }
+
+        DateParseHandling previous = reader.DateParseHandling;
+        reader.DateParseHandling = DateParseHandling.None;
+
+        JObject source;
+        try
+        {
+            source = JObject.Load(reader);
+        }
+        finally
+        {
+            reader.DateParseHandling = previous;
+        }
+
+        if (source[TypeMarker] != null)
+        {
+            return source.ToObject<object>(serializer);
+        }
+
+        Dictionary<string, string> stringMap = new Dictionary<string, string>(source.Count);
+        foreach (JProperty property in source.Properties())
+        {
+            // Structure inside the map is a blob no reader has an answer for - the built-in serializer
+            // fails on it too - and saying so as a serialization exception is what keeps a cast
+            // exception from escaping from somewhere further away.
+            if (!(property.Value is JValue entry))
+            {
+                throw new JsonSerializationException(
+                    $"A stored string map holds structure under '{property.Name}', and a string map's values are strings. " +
+                    "A value with structure of its own has to be serialized by the job and stored as a string.");
+            }
+
+            stringMap[property.Name] = entry.Value<string>()!;
+        }
+
+        return stringMap;
     }
 
     public override bool CanConvert(Type objectType)

--- a/src/Quartz.Serialization.Json/Converters/TimeOfDayConverter.cs
+++ b/src/Quartz.Serialization.Json/Converters/TimeOfDayConverter.cs
@@ -1,0 +1,80 @@
+using System;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Quartz.Converters;
+
+/// <summary>
+/// A <see cref="TimeOfDay" /> is read back out of the hour, minute and second Json.NET writes for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Without this, a trigger written as a plain object graph - which is what
+/// <c>RegisterTriggerConverters</c> being off means, and off is the default - could not be read back at
+/// all. <see cref="TimeOfDay" /> has two public constructors and no
+/// parameterless one, so Json.NET had nothing to build <c>EndTimeOfDay</c> with and the read threw
+/// <c>Unable to find a constructor to use for type Quartz.TimeOfDay</c>. <c>StartTimeOfDay</c> was the
+/// silent half of the same defect: its getter hands out a default <c>00:00:00</c> for Json.NET to
+/// populate in place, and every member of a <see cref="TimeOfDay" /> is read-only, so a trigger stored
+/// with a start of 03:30 came back starting at midnight and nothing said so (#3508).
+/// </para>
+/// <para>
+/// Only the read side is this converter's: <see cref="CanWrite" /> is <see langword="false" />, so the
+/// object form Json.NET has always written is still what goes out, and every blob already sitting in a
+/// job store column is a blob this reads. Nothing about the stored bytes changes.
+/// </para>
+/// <para>
+/// <see cref="QuartzContractResolver" /> attaches this per property, to members typed as a
+/// <see cref="TimeOfDay" />, the same way it attaches <see cref="TimeZoneInfoConverter" /> and for the
+/// same reason: the serializer's converter list is consulted for a value's runtime type wherever the
+/// value appears, so a <see cref="TimeOfDay" /> held as an <see cref="object" /> - a job data map value -
+/// would lose the <c>$type</c> that path carries. Scoped to typed members, this reaches every trigger's
+/// times of day and nothing else.
+/// </para>
+/// </remarks>
+internal sealed class TimeOfDayConverter : JsonConverter
+{
+    public override bool CanWrite => false;
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        // CanWrite is false, so Json.NET writes the value with the default contract and never calls this.
+        throw new NotSupportedException("A time of day is written by the default contract.");
+    }
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+                return null;
+
+            case JsonToken.StartObject:
+                JObject source = JObject.Load(reader);
+                return new TimeOfDay(ReadPart(source, "Hour"), ReadPart(source, "Minute"), ReadPart(source, "Second"));
+
+            default:
+                throw new JsonSerializationException($"Could not read a time of day from a {reader.TokenType} token");
+        }
+    }
+
+    /// <summary>
+    /// One part of the time, or zero when the payload does not carry it - which is what populating a
+    /// default <see cref="TimeOfDay" /> in place used to leave behind.
+    /// </summary>
+    private static int ReadPart(JObject source, string name)
+    {
+        foreach (JProperty property in source.Properties())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value.Value<int>();
+            }
+        }
+
+        return 0;
+    }
+
+    public override bool CanConvert(Type objectType) => objectType == typeof(TimeOfDay);
+}

--- a/src/Quartz.Serialization.Json/QuartzContractResolver.cs
+++ b/src/Quartz.Serialization.Json/QuartzContractResolver.cs
@@ -35,6 +35,15 @@ namespace Quartz;
 /// <see cref="object" />-typed slots exactly as they were.
 /// </para>
 /// <para>
+/// <b>A property typed as a <see cref="TimeOfDay" /> is built rather than populated.</b> The type has
+/// two public constructors and no parameterless one, so a trigger written as a plain object graph could
+/// not be read back at all - the read threw on <c>EndTimeOfDay</c> - and <c>StartTimeOfDay</c>, whose
+/// getter hands out a default for Json.NET to populate, came back as <c>00:00:00</c> however it was
+/// stored, since every member of a <see cref="TimeOfDay" /> is read-only.
+/// <see cref="TimeOfDayConverter" /> is attached here per property, and reads only: the object form
+/// Json.NET has always written is still what goes out.
+/// </para>
+/// <para>
 /// This is a resolver rather than a <see cref="JsonConverter" /> on purpose: a converter registered
 /// on the serializer is not consulted for a value whose type came from a <c>$type</c> property - a
 /// trigger stored as a blob, say - and the rules here apply on every path.
@@ -43,6 +52,7 @@ namespace Quartz;
 internal sealed class QuartzContractResolver : DefaultContractResolver
 {
     private static readonly TimeZoneInfoConverter timeZoneInfoConverter = new TimeZoneInfoConverter();
+    private static readonly TimeOfDayConverter timeOfDayConverter = new TimeOfDayConverter();
 
     public QuartzContractResolver()
     {
@@ -61,6 +71,11 @@ internal sealed class QuartzContractResolver : DefaultContractResolver
         if (property.PropertyType == typeof(TimeZoneInfo))
         {
             property.Converter = timeZoneInfoConverter;
+        }
+
+        if (property.PropertyType == typeof(TimeOfDay))
+        {
+            property.Converter = timeOfDayConverter;
         }
 
         return property;

--- a/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
@@ -184,6 +184,12 @@ internal static class Utf8JsonWriterExtensions
         writer.WriteEndObject();
     }
 
+    /// <summary>
+    /// The property name Json.NET writes a value's type under, which is metadata rather than an entry
+    /// of the map it sits in.
+    /// </summary>
+    internal const string TypeMarker = "$type";
+
     public static JobDataMap GetJobDataMap(this JsonElement jsonElement, JsonSerializerOptions options)
     {
         var result = new JobDataMap();
@@ -220,7 +226,15 @@ internal static class Utf8JsonWriterExtensions
                     }
                     break;
                 case JsonValueKind.Object:
-                    value = property.Value.Deserialize<Dictionary<string, string>>(options);
+                    Dictionary<string, string>? stringMap = property.Value.Deserialize<Dictionary<string, string>>(options);
+
+                    // A blob Quartz.Serialization.Json wrote carries the type it wrote the map under,
+                    // because Json.NET names the type of any value an object-typed slot cannot. That is
+                    // metadata to the reader that wrote it, and it has to be metadata here too: handing
+                    // it back would put an assembly-qualified type name into the application's own key
+                    // space, under a name it never stored anything at (#3582).
+                    stringMap?.Remove(TypeMarker);
+                    value = stringMap;
                     break;
                 default:
                     throw new JsonException($"Unsupported value kind: {property.Value.ValueKind}");

--- a/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
+++ b/src/Quartz.Tests.Integration/Xml/XMLSchedulingDataProcessorTest.cs
@@ -427,9 +427,16 @@ public class XMLSchedulingDataProcessorTest
         }
     }
 
+    /// <summary>
+    /// The data source is the fixture's own, derived from its provider. It used to be the literal
+    /// "default", which nothing in this fixture registers: the two tests that call this passed only when
+    /// <c>AdoJobStoreSmokeTest</c> had run first in the same process and left a process-global "default"
+    /// pointing at SQL Server, so a filtered run failed before any assertion and a Postgres run updated
+    /// the wrong database (#3573).
+    /// </summary>
     private void ModifyStoredJobType()
     {
-        using (var conn = DBConnectionManager.Instance.GetConnection("default"))
+        using (var conn = DBConnectionManager.Instance.GetConnection(DatabaseHelper.GetDataSourceName(provider)))
         {
             conn.Open();
             using (IDbCommand dbCommand = conn.CreateCommand())

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -767,6 +767,72 @@ public class JobStoreSupportTest
             .MustHaveHappenedOnceExactly();
     }
 
+    /// <summary>
+    /// The leak #3507 reported, on the store that leaves a row behind. A firing abandoned between the
+    /// commit and the job - a job listener that fails, a veto, a scheduler shutting down - comes back
+    /// with no instruction, and <c>TriggerFired</c> had already stored the trigger COMPLETE because
+    /// firing left it with no fire time. Outside a cluster nothing ever sweeps a COMPLETE row up, so
+    /// the trigger was one <c>GetTrigger</c> kept handing back for good.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteWithNoInstructionDeletesATriggerThatCannotFireAgain()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IOperableTrigger trigger = CreateTestTrigger();
+        trigger.SetNextFireTimeUtc(null);
+        IJobDetail job = CreateConcurrentJob();
+
+        A.CallTo(() => driverDelegate.SelectTriggerStatus(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .Returns(Task.FromResult(new TriggerStatus(AdoConstants.StateComplete, null, trigger.Key, job.Key)));
+
+        await jobStoreSupport.CallTriggeredJobComplete(conn, trigger, job, SchedulerInstruction.NoInstruction);
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// No instruction settles nothing, so a trigger with a firing still ahead of it is left alone - and
+    /// so is one that was rescheduled while the firing was in flight, which is what the read-back is for.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteWithNoInstructionLeavesATriggerThatCanFireAgain()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IOperableTrigger trigger = CreateTestTrigger();
+        trigger.SetNextFireTimeUtc(SystemTime.UtcNow().AddHours(1));
+        IJobDetail job = CreateConcurrentJob();
+
+        await jobStoreSupport.CallTriggeredJobComplete(conn, trigger, job, SchedulerInstruction.NoInstruction);
+
+        A.CallTo(() => driverDelegate.SelectTriggerStatus(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+        A.CallTo(() => driverDelegate.DeleteTrigger(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The trigger was rescheduled while the firing was in flight, so the row in the database has a fire
+    /// time ahead of it and is nobody's leftover. This is why the branch reads the status back rather
+    /// than trusting the copy it was handed.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteWithNoInstructionKeepsATriggerRescheduledDuringTheFiring()
+    {
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IOperableTrigger trigger = CreateTestTrigger();
+        trigger.SetNextFireTimeUtc(null);
+        IJobDetail job = CreateConcurrentJob();
+
+        A.CallTo(() => driverDelegate.SelectTriggerStatus(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .Returns(Task.FromResult(new TriggerStatus(AdoConstants.StateWaiting, SystemTime.UtcNow().AddHours(1), trigger.Key, job.Key)));
+
+        await jobStoreSupport.CallTriggeredJobComplete(conn, trigger, job, SchedulerInstruction.NoInstruction);
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(conn, trigger.Key, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+    }
+
     private static IOperableTrigger CreateTestTrigger(string name = "t1", string fireInstanceId = "test-fire-id")
     {
         IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
@@ -1112,6 +1178,15 @@ public class JobStoreSupportTest
         internal Task<bool> CallIsTriggerGroupPaused(ConnectionAndTransactionHolder conn, string groupName)
         {
             return IsTriggerGroupPaused(conn, groupName, CancellationToken.None);
+        }
+
+        internal Task CallTriggeredJobComplete(
+            ConnectionAndTransactionHolder conn,
+            IOperableTrigger trigger,
+            IJobDetail jobDetail,
+            SchedulerInstruction triggerInstCode)
+        {
+            return TriggeredJobComplete(conn, trigger, jobDetail, triggerInstCode, CancellationToken.None);
         }
     }
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerImplTest.cs
@@ -1513,4 +1513,52 @@ public class DailyTimeIntervalTriggerImplTest
             times[i].Should().BeAfter(times[i - 1], $"fire time {i} must come after fire time {i - 1}");
         }
     }
+    /// <summary>
+    /// #3386: the fire times are a whole number of intervals from the start of the day, counted in
+    /// whole seconds, so a start time carrying milliseconds used to truncate onto an interval boundary
+    /// lying before the trigger's own start.
+    /// </summary>
+    [Test]
+    public void TheFirstFireTimeIsNeverBeforeASubSecondStartTime()
+    {
+        DailyTimeIntervalTriggerImpl trigger = new DailyTimeIntervalTriggerImpl
+        {
+            Key = new TriggerKey("sub-second-start"),
+            JobKey = new JobKey("job"),
+            StartTimeUtc = new DateTimeOffset(2026, 1, 15, 22, 50, 0, 680, TimeSpan.Zero),
+            StartTimeOfDay = new TimeOfDay(2, 15, 0),
+            RepeatIntervalUnit = IntervalUnit.Minute,
+            RepeatInterval = 5,
+            TimeZone = TimeZoneInfo.Utc
+        };
+
+        trigger.StartTimeUtc.Should().Be(
+            new DateTimeOffset(2026, 1, 15, 22, 50, 0, TimeSpan.Zero),
+            "the start time is rounded down to the whole second the arithmetic works in");
+
+        DateTimeOffset? first = trigger.ComputeFirstFireTimeUtc(null);
+
+        first.Should().Be(trigger.GetNextFireTimeUtc());
+        first.Should().Be(
+            new DateTimeOffset(2026, 1, 15, 22, 50, 0, TimeSpan.Zero),
+            "22:50 is 74100 seconds after the 02:15 start of the day, an exact multiple of the five-minute interval");
+        first.Should().BeOnOrAfter(trigger.StartTimeUtc, "a trigger must never fire before it starts");
+    }
+
+    /// <inheritdoc cref="TheFirstFireTimeIsNeverBeforeASubSecondStartTime" />
+    [Test]
+    public void TheEndTimeIsRoundedDownToTheWholeSecondToo()
+    {
+        DailyTimeIntervalTriggerImpl trigger = new DailyTimeIntervalTriggerImpl
+        {
+            Key = new TriggerKey("sub-second-end"),
+            StartTimeUtc = new DateTimeOffset(2026, 1, 15, 8, 0, 0, 250, TimeSpan.Zero),
+            EndTimeUtc = new DateTimeOffset(2026, 1, 16, 8, 0, 0, 750, TimeSpan.Zero)
+        };
+
+        trigger.StartTimeUtc.Should().Be(new DateTimeOffset(2026, 1, 15, 8, 0, 0, TimeSpan.Zero));
+        trigger.EndTimeUtc.Should().Be(
+            new DateTimeOffset(2026, 1, 16, 8, 0, 0, TimeSpan.Zero),
+            "both boundaries are said in the units the trigger reasons in");
+    }
 }

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -1,0 +1,211 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Newtonsoft.Json.Linq;
+
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A job data blob written by one serializer has to be readable by the other. Both are documented
+/// store formats and an application is free to switch between them, so a column's contents outlive
+/// the choice that wrote them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>Dictionary&lt;string, string&gt;</c> is the one job data value with structure that both
+/// formats carry, and it is the entry the two disagreed about (#3582). Json.NET names the type of any
+/// value an <see cref="object" />-typed slot cannot, so <c>Quartz.Serialization.Json</c> writes the map
+/// with a <c>$type</c> beside it; <c>Quartz.Serialization.SystemTextJson</c> writes the plain object and
+/// its reader takes every property of an object as an entry of the map. So a map written by one and
+/// read by the other came back with an assembly-qualified type name in the application's own key space,
+/// and the crossing failed the other way too: a plain object is a shape Json.NET has no answer for, so
+/// a map the built-in serializer wrote came back as a <see cref="JObject" /> the job that stored it
+/// cannot cast.
+/// </para>
+/// <para>
+/// Both readers were fixed and neither writer was: this is a released branch and what it writes is
+/// what other 3.x nodes read. <see cref="TheNewtonsoftWriterStillNamesTheTypeBesideAStringMap" /> is
+/// what says so.
+/// </para>
+/// </remarks>
+public class JobDataMapPortabilityTest
+{
+    private static readonly Dictionary<string, string> stringMap = new Dictionary<string, string>
+    {
+        ["one"] = "1",
+        // Not decoration: Json.NET parses a string that looks like a timestamp into a DateTimeOffset
+        // wherever it reads a value, and rendering that back as a string reformats it - in the reading
+        // machine's culture, and with the reading machine's offset when the text carried none. A string
+        // map has to hand back the strings that went into it.
+        ["when"] = "1982-06-28T01:01:01+03:00"
+    };
+
+    private IObjectSerializer newtonsoftSerializer;
+    private IObjectSerializer systemTextJsonSerializer;
+
+    [SetUp]
+    public void SetUp()
+    {
+        JsonObjectSerializer newtonsoft = new JsonObjectSerializer();
+        newtonsoft.Initialize();
+        newtonsoftSerializer = newtonsoft;
+
+        SystemTextJsonObjectSerializer systemTextJson = new SystemTextJsonObjectSerializer();
+        systemTextJson.Initialize();
+        systemTextJsonSerializer = systemTextJson;
+    }
+
+    [TestCase("newtonsoft", "newtonsoft")]
+    [TestCase("newtonsoft", "system.text.json")]
+    [TestCase("system.text.json", "newtonsoft")]
+    [TestCase("system.text.json", "system.text.json")]
+    public void AStringMapReadsBackAsItselfWhicheverSerializerWroteIt(string writerName, string readerName)
+    {
+        IObjectSerializer writer = SerializerNamed(writerName);
+        IObjectSerializer reader = SerializerNamed(readerName);
+
+        JobDataMap original = new JobDataMap { { "dictionary", new Dictionary<string, string>(stringMap) } };
+
+        JobDataMap restored = reader.DeSerialize<JobDataMap>(writer.Serialize(original));
+
+        restored.Should().ContainKey("dictionary");
+        restored["dictionary"].Should().BeOfType<Dictionary<string, string>>(
+                "a string map is the one shape past the scalars the store format carries, and it has to come back as itself whichever serializer wrote it")
+            .Which.Should().Equal(stringMap,
+                "the entries the application stored are the entries it gets back - no type name added, and no timestamp-shaped value reformatted");
+    }
+
+    /// <summary>
+    /// The scalars have always crossed, and a read written entry by entry must not change that.
+    /// </summary>
+    [TestCase("newtonsoft", "newtonsoft")]
+    [TestCase("newtonsoft", "system.text.json")]
+    [TestCase("system.text.json", "newtonsoft")]
+    [TestCase("system.text.json", "system.text.json")]
+    public void TheScalarValuesStillCross(string writerName, string readerName)
+    {
+        IObjectSerializer writer = SerializerNamed(writerName);
+        IObjectSerializer reader = SerializerNamed(readerName);
+
+        JobDataMap original = new JobDataMap
+        {
+            { "string", "value" },
+            { "bool", true },
+            { "int", 123 },
+            { "long", 9_000_000_000L },
+            { "double", 12.34 },
+            { "null", null }
+        };
+
+        JobDataMap restored = reader.DeSerialize<JobDataMap>(writer.Serialize(original));
+
+        restored.GetString("string").Should().Be("value");
+        restored.GetBoolean("bool").Should().BeTrue();
+        restored.GetInt("int").Should().Be(123);
+        restored.GetLong("long").Should().Be(9_000_000_000L);
+        restored.GetDouble("double").Should().Be(12.34);
+        restored["null"].Should().BeNull();
+    }
+
+    /// <summary>
+    /// The payloads that are already in databases. Json.NET wrote a string map with the type it had
+    /// written it under, and both readers have to hand back the map the application stored, without the
+    /// type name in it.
+    /// </summary>
+    /// <remarks>
+    /// The payload is written out here rather than produced by the current writer, so that a writer that
+    /// changes cannot change what this asserts. Only the type name itself is taken from the runtime,
+    /// because it names <c>System.Private.CoreLib</c> on <c>net10.0</c> and <c>mscorlib</c> on
+    /// <c>net472</c> and a literal would read on one framework only.
+    /// </remarks>
+    [TestCase("newtonsoft")]
+    [TestCase("system.text.json")]
+    public void ABlobThatNamesTheTypeBesideAStringMapStillReadsBackAsTheMap(string readerName)
+    {
+        IObjectSerializer reader = SerializerNamed(readerName);
+        string typeName = typeof(Dictionary<string, string>).AssemblyQualifiedName;
+        byte[] written = Encoding.UTF8.GetBytes(
+            "{\"dictionary\":{\"$type\":\"" + typeName + "\",\"one\":\"1\",\"when\":\"1982-06-28T01:01:01+03:00\"}}");
+
+        JobDataMap restored = reader.DeSerialize<JobDataMap>(written);
+
+        restored["dictionary"].Should().BeOfType<Dictionary<string, string>>(
+                "an upgrade does not get to make a stored map unreadable")
+            .Which.Should().Equal(stringMap,
+                "the type Json.NET wrote the map under is metadata, not an entry of the application's");
+    }
+
+    /// <summary>
+    /// This branch changes no byte it writes. The fix is on both readers alone, because a 3.x node that
+    /// has not been upgraded is reading these columns and only the payload it already understands is
+    /// safe to hand it.
+    /// </summary>
+    [Test]
+    public void TheNewtonsoftWriterStillNamesTheTypeBesideAStringMap()
+    {
+        JobDataMap original = new JobDataMap { { "dictionary", new Dictionary<string, string>(stringMap) } };
+
+        JObject written = JObject.Parse(Encoding.UTF8.GetString(newtonsoftSerializer.Serialize(original)));
+
+        written["dictionary"]["$type"].Value<string>().Should().StartWith("System.Collections.Generic.Dictionary",
+            "dropping the type name is a wire change on a released branch, and this half of the fix deliberately does not make one");
+    }
+
+    /// <summary>
+    /// And the built-in serializer still writes the plain object it always wrote, which is the shape the
+    /// Newtonsoft reader learned to read.
+    /// </summary>
+    [Test]
+    public void TheSystemTextJsonWriterStillWritesThePlainObject()
+    {
+        JobDataMap original = new JobDataMap { { "dictionary", new Dictionary<string, string> { ["one"] = "1" } } };
+
+        Encoding.UTF8.GetString(systemTextJsonSerializer.Serialize(original)).Should().Be("{\"dictionary\":{\"one\":\"1\"}}");
+    }
+
+    /// <summary>
+    /// Structure inside a stored string map is a blob neither reader has an answer for, and the
+    /// Newtonsoft reader now says so as a serialization failure rather than letting a cast fail somewhere
+    /// further away.
+    /// </summary>
+    [Test]
+    public void StructureNestedInsideAStoredStringMapFailsAsASerializationError()
+    {
+        byte[] written = Encoding.UTF8.GetBytes("{\"dictionary\":{\"inner\":{\"deeper\":\"1\"}}}");
+
+        Action read = () => newtonsoftSerializer.DeSerialize<JobDataMap>(written);
+
+        read.Should().Throw<Newtonsoft.Json.JsonSerializationException>()
+            .WithMessage("*inner*", "the failure has to say which entry it is about");
+    }
+
+    private IObjectSerializer SerializerNamed(string name)
+    {
+        return name == "newtonsoft" ? newtonsoftSerializer : systemTextJsonSerializer;
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerTimeZoneTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/NewtonsoftTriggerTimeZoneTest.cs
@@ -136,9 +136,8 @@ public class NewtonsoftTriggerTimeZoneTest
     }
 
     /// <summary>
-    /// The daily trigger's write side is asserted on its own because its read side cannot be reached
-    /// with the trigger converters off - see
-    /// <see cref="ReadingADailyTimeIntervalTriggerAsAPlainObjectGraphFailsOnItsTimeOfDay" />.
+    /// The daily trigger's write side is asserted on its own as well as through the round trip, because
+    /// the zone's written shape is the thing #3494 was about.
     /// </summary>
     [TestCase(true)]
     [TestCase(false)]
@@ -154,47 +153,50 @@ public class NewtonsoftTriggerTimeZoneTest
             "the spelling of a resolved zone's id belongs to the platform and the tz database, so it is compared against the zone in hand");
     }
 
-    [Test]
-    public void DailyTimeIntervalTriggerKeepsItsTimeZone()
+    /// <summary>
+    /// #3508. With the trigger converters off - which is the default - a
+    /// <see cref="DailyTimeIntervalTriggerImpl" /> could not be read back at all:
+    /// <see cref="TimeOfDay" /> has two public constructors and no parameterless one, so Json.NET had
+    /// nothing to build <c>EndTimeOfDay</c> with and the read threw. <c>StartTimeOfDay</c> was the
+    /// silent half - its getter hands out a default <c>00:00:00</c> for Json.NET to populate, and every
+    /// member of a <see cref="TimeOfDay" /> is read-only, so a trigger stored starting at 03:30 came
+    /// back starting at midnight with nothing said.
+    /// </summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void DailyTimeIntervalTriggerKeepsItsTimeZone(bool registerTriggerConverters)
     {
         DailyTimeIntervalTriggerImpl trigger = CreateDailyTimeIntervalTrigger();
 
-        DailyTimeIntervalTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters: true);
+        DailyTimeIntervalTriggerImpl restored = RoundTrip(trigger, registerTriggerConverters);
 
-        restored.StartTimeOfDay.Should().Be(new TimeOfDay(3, 30), "the rest of the trigger has to read as it always did");
-        restored.EndTimeOfDay.Should().Be(new TimeOfDay(4, 40));
+        restored.StartTimeOfDay.Should().Be(new TimeOfDay(3, 30),
+            "a start of day read back as midnight is a trigger firing hours before the window it was given");
+        restored.EndTimeOfDay.Should().Be(new TimeOfDay(4, 40),
+            "the end of day is the half the read used to fail on outright");
+        restored.RepeatInterval.Should().Be(42, "the rest of the trigger has to read as it always did");
+        restored.RepeatIntervalUnit.Should().Be(IntervalUnit.Second);
         restored.DaysOfWeek.Should().BeEquivalentTo(new[] { DayOfWeek.Monday, DayOfWeek.Wednesday });
         restored.TimeZone.Should().Be(NonLocalZone,
             "the daily window is wall-clock time in the stored zone, so a lost zone moves every firing");
     }
 
     /// <summary>
-    /// A defect of the same family as #3494 and deliberately not fixed here: with the trigger
-    /// converters off a <see cref="DailyTimeIntervalTriggerImpl" /> cannot be read back at all, because
-    /// <see cref="TimeOfDay" /> has two public constructors and no parameterless one, so Json.NET has
-    /// nothing to build <c>EndTimeOfDay</c> with. It has nothing to do with the time zone - the zone is
-    /// written correctly, as
-    /// <see cref="DailyTimeIntervalTriggerWritesItsTimeZoneAsAnId" /> shows - and repairing it needs a
-    /// converter of its own, so it is recorded here rather than quietly folded in.
+    /// The converter reads and does not write, so the object form Json.NET has always written for a
+    /// <see cref="TimeOfDay" /> is still what goes out - which is what makes the fix reach the blobs that
+    /// are already in job store columns rather than only the ones written from now on.
     /// </summary>
-    /// <remarks>
-    /// This is a loud failure rather than a silent one, which is why it is the lesser bug: nothing
-    /// comes back wrong, the read throws. <c>StartTimeOfDay</c> is the silent half of it - its getter
-    /// hands out a default <c>00:00:00</c> for Json.NET to populate, and every member of a
-    /// <see cref="TimeOfDay" /> is read-only.
-    /// </remarks>
     [Test]
-    public void ReadingADailyTimeIntervalTriggerAsAPlainObjectGraphFailsOnItsTimeOfDay()
+    public void ADailyTimeIntervalTriggerStillWritesItsTimesOfDayAsObjects()
     {
-        JsonObjectSerializer serializer = CreateSerializer(registerTriggerConverters: false);
-        byte[] bytes = serializer.Serialize(CreateDailyTimeIntervalTrigger());
+        JObject written = Write(CreateDailyTimeIntervalTrigger(), registerTriggerConverters: false);
 
-        Action read = () => serializer.DeSerialize<DailyTimeIntervalTriggerImpl>(bytes);
-
-        read.Should().Throw<Newtonsoft.Json.JsonSerializationException>()
-            .WithInnerException<Newtonsoft.Json.JsonSerializationException>()
-            .WithMessage("*Quartz.TimeOfDay*",
-                "the read fails on the time of day and not on the zone, which is what makes this a separate defect");
+        written["StartTimeOfDay"].Type.Should().Be(JTokenType.Object);
+        written["StartTimeOfDay"]["Hour"].Value<int>().Should().Be(3);
+        written["StartTimeOfDay"]["Minute"].Value<int>().Should().Be(30);
+        written["StartTimeOfDay"]["Second"].Value<int>().Should().Be(0);
+        written["EndTimeOfDay"]["Hour"].Value<int>().Should().Be(4);
+        written["EndTimeOfDay"]["Minute"].Value<int>().Should().Be(40);
     }
 
     private static DailyTimeIntervalTriggerImpl CreateDailyTimeIntervalTrigger()

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -1219,6 +1219,69 @@ public class RAMJobStoreTest
     }
 
     /// <summary>
+    /// Pausing wrote Paused over every state but Complete, so a trigger that had failed into Error lost
+    /// that state the moment its group, its job or the trigger itself was paused: the failure vanished
+    /// from every listing, and <see cref="IJobStore.ResetTriggerFromErrorState" /> had nothing left to
+    /// reset. The ADO store only writes PAUSED over WAITING and ACQUIRED, and PAUSED_BLOCKED over
+    /// BLOCKED, and this store now names the same pausable set.
+    /// </summary>
+    [Test]
+    public async Task PausingATriggerInErrorLeavesTheErrorWhereItIs()
+    {
+        TriggerKey key = await StoreAndFailATrigger("failing");
+
+        (await fJobStore.GetTriggerState(key)).Should().Be(TriggerState.Error);
+
+        await fJobStore.PauseTrigger(key);
+        (await fJobStore.GetTriggerState(key)).Should().Be(TriggerState.Error,
+            "a trigger in error is a failure somebody has to see, not something a pause may quietly clear");
+
+        await fJobStore.PauseTriggers(GroupMatcher<TriggerKey>.GroupEquals(key.Group));
+        (await fJobStore.GetTriggerState(key)).Should().Be(TriggerState.Error,
+            "pausing the group the trigger is in is the way the error used to disappear");
+
+        await fJobStore.ResetTriggerFromErrorState(key);
+        (await fJobStore.GetTriggerState(key)).Should().Be(TriggerState.Paused,
+            "the group is paused, so the trigger comes out of error into the pause rather than past it");
+    }
+
+    /// <summary>
+    /// The pausable set is named rather than excluded one state at a time, so the states that are
+    /// pausable have to keep pausing.
+    /// </summary>
+    [Test]
+    public async Task PausingAWaitingTriggerStillPausesIt()
+    {
+        await StoreTriggerInGroup("waiting", "triggerGroup1");
+        TriggerKey key = new TriggerKey("waiting", "triggerGroup1");
+
+        await fJobStore.PauseTrigger(key);
+
+        (await fJobStore.GetTriggerState(key)).Should().Be(TriggerState.Paused);
+    }
+
+    /// <summary>
+    /// Stores a repeating trigger, fires it and completes the firing in error, which is the only way a
+    /// store gets a trigger into <see cref="TriggerState.Error" />.
+    /// </summary>
+    private async Task<TriggerKey> StoreAndFailATrigger(string name)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        IOperableTrigger trigger = new SimpleTriggerImpl(name, "triggerGroup1", fJobDetail.Name, fJobDetail.Group, now.AddSeconds(30), null, SimpleTriggerImpl.RepeatIndefinitely, TimeSpan.FromMinutes(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(now.AddSeconds(60), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        TriggerFiredBundle bundle = fired.First().TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.SetTriggerError);
+
+        return trigger.Key;
+    }
+
+    /// <summary>
     /// Fires one trigger of the given job and hands back the bundle, which is what leaves a
     /// <see cref="DisallowConcurrentExecutionAttribute" /> job blocked.
     /// </summary>

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -1068,6 +1068,68 @@ public class RAMJobStoreTest
             "the group is no longer paused, so a trigger stored into it now runs");
     }
 
+    /// <summary>
+    /// The leak #3507 reported. A firing can be abandoned between the store committing it and the job
+    /// running - a job listener that fails, a veto, a scheduler shutting down - and the run shell hands
+    /// such a firing back with no instruction, which settles nothing about the schedule. For a trigger
+    /// that can fire again that is right; for one <see cref="IJobStore.TriggersFired" /> already advanced
+    /// past its last firing it left a trigger that waits forever, never fired and never removed, and that
+    /// an operator still reads as about to fire.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteWithNoInstructionRemovesATriggerThatCannotFireAgain()
+    {
+        JobDetailImpl job = new JobDetailImpl("spentJob", "jobGroup1", typeof(NoOpJob));
+        job.Durable = false;
+        await fJobStore.StoreJob(job, false);
+
+        DateTimeOffset fireAt = DateTimeOffset.UtcNow.AddSeconds(30);
+        IOperableTrigger trigger = new SimpleTriggerImpl("once", "triggerGroup1", job.Name, job.Group, fireAt, null, 0, TimeSpan.Zero);
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(fireAt.AddSeconds(10), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        TriggerFiredBundle bundle = fired.First().TriggerFiredBundle;
+        bundle.Should().NotBeNull();
+        bundle.Trigger.GetNextFireTimeUtc().Should().BeNull("the firing that was committed was this trigger's last");
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.RetrieveTrigger(trigger.Key)).Should().BeNull(
+            "the trigger's only firing is over, however badly it went, so nothing is left to keep");
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.None,
+            "a trigger with no fire time left in it must not be reported to an operator as one about to fire");
+        (await fJobStore.RetrieveJob(job.Key)).Should().BeNull(
+            "the job is not durable and its only trigger is gone, which is where DeleteTrigger sends it too");
+    }
+
+    /// <summary>
+    /// The other half of the same branch: no instruction settles nothing, so a trigger that still has a
+    /// firing ahead of it is left exactly as it was.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteWithNoInstructionLeavesATriggerThatCanFireAgain()
+    {
+        DateTimeOffset fireAt = DateTimeOffset.UtcNow.AddSeconds(30);
+        IOperableTrigger trigger = new SimpleTriggerImpl("repeating", "triggerGroup1", fJobDetail.Name, fJobDetail.Group, fireAt, null, SimpleTriggerImpl.RepeatIndefinitely, TimeSpan.FromMinutes(5));
+        trigger.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(trigger, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(fireAt.AddSeconds(10), 1, TimeSpan.Zero);
+        var fired = await fJobStore.TriggersFired(acquired);
+        TriggerFiredBundle bundle = fired.First().TriggerFiredBundle;
+        bundle.Trigger.GetNextFireTimeUtc().Should().NotBeNull("the trigger repeats, so the firing was not its last");
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.RetrieveTrigger(trigger.Key)).Should().NotBeNull(
+            "an abandoned firing says nothing about a schedule that still has firings in it");
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
+    }
+
     private Task StoreTriggerInGroup(string name, string group)
     {
         IOperableTrigger trigger = new SimpleTriggerImpl(

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -1130,6 +1130,113 @@ public class RAMJobStoreTest
         (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
     }
 
+    /// <summary>
+    /// #3463. A trigger blocked behind a <see cref="DisallowConcurrentExecutionAttribute" /> job cannot
+    /// be acquired and is not swept, so however late it gets while it waits, the completion that
+    /// unblocks it is the first thing that can settle the debt. The ADO store settles it there, in
+    /// <c>RecoverUnblockedMisfires</c> and in the same transaction; this store put the trigger back in
+    /// the queue and did nothing else, so until the next acquisition a caller read it with the fire time
+    /// it had already missed.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteAppliesTheMisfirePolicyOfATriggerItUnblocks()
+    {
+        JobDetailImpl job = new JobDetailImpl("blockingJob", "jobGroup1", typeof(DisallowConcurrentNoOpJob));
+        job.Durable = true;
+        await fJobStore.StoreJob(job, false);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TriggerFiredBundle bundle = await FireTriggerOf(job, now);
+
+        // Stored while the job is blocked, so the store takes it in blocked and never offers it for
+        // acquisition - which is precisely why nothing but this completion can notice it going overdue.
+        IOperableTrigger overdue = new SimpleTriggerImpl("overdue", "triggerGroup1", job.Name, job.Group, now.AddHours(-1), null, 0, TimeSpan.Zero);
+        overdue.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(overdue, false);
+        (await fJobStore.GetTriggerState(overdue.Key)).Should().Be(TriggerState.Blocked);
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        fSignaler.fMisfireCount.Should().Be(1,
+            "the misfire is the trigger's, and the moment it stops being blocked is the moment it can be settled");
+        (await fJobStore.GetTriggerState(overdue.Key)).Should().Be(TriggerState.Normal);
+        (await fJobStore.RetrieveTrigger(overdue.Key)).GetNextFireTimeUtc().Should().BeOnOrAfter(now,
+            "a one-shot trigger's smart policy is to fire now, so what a caller reads must be a fire time still ahead of it and not the one it missed");
+    }
+
+    /// <summary>
+    /// The other half of the policy: a trigger the misfire leaves with nothing to fire is removed rather
+    /// than left as a Complete entry <c>RetrieveTrigger</c> would keep handing back, which is what the
+    /// ADO store does with such a row.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteRemovesAnUnblockedTriggerTheMisfirePolicyFinishes()
+    {
+        JobDetailImpl job = new JobDetailImpl("blockingJob", "jobGroup1", typeof(DisallowConcurrentNoOpJob));
+        job.Durable = true;
+        await fJobStore.StoreJob(job, false);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TriggerFiredBundle bundle = await FireTriggerOf(job, now);
+
+        IOperableTrigger overdue = new SimpleTriggerImpl("overdue", "triggerGroup1", job.Name, job.Group, now.AddHours(-1), null, 0, TimeSpan.Zero);
+        overdue.MisfireInstruction = MisfireInstruction.SimpleTrigger.RescheduleNextWithExistingCount;
+        overdue.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(overdue, false);
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.RetrieveTrigger(overdue.Key)).Should().BeNull(
+            "the policy said to take the next firing and there is none, so the trigger is finished and nothing is left to hand back");
+        (await fJobStore.GetTriggerState(overdue.Key)).Should().Be(TriggerState.None);
+    }
+
+    /// <summary>
+    /// A paused trigger accrues no misfire - pausing is a decision not to fire, and resuming is what
+    /// settles the debt - so unblocking one is a state change and nothing more.
+    /// </summary>
+    [Test]
+    public async Task TriggeredJobCompleteAppliesNoMisfirePolicyToATriggerThatIsAlsoPaused()
+    {
+        JobDetailImpl job = new JobDetailImpl("blockingJob", "jobGroup1", typeof(DisallowConcurrentNoOpJob));
+        job.Durable = true;
+        await fJobStore.StoreJob(job, false);
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TriggerFiredBundle bundle = await FireTriggerOf(job, now);
+
+        IOperableTrigger overdue = new SimpleTriggerImpl("overdue", "triggerGroup1", job.Name, job.Group, now.AddHours(-1), null, 0, TimeSpan.Zero);
+        overdue.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(overdue, false);
+        await fJobStore.PauseTrigger(overdue.Key);
+        (await fJobStore.GetTriggerState(overdue.Key)).Should().Be(TriggerState.Paused);
+
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        fSignaler.fMisfireCount.Should().Be(0, "a paused trigger has missed nothing it was going to fire");
+        (await fJobStore.GetTriggerState(overdue.Key)).Should().Be(TriggerState.Paused,
+            "unblocking leaves the pause where it was, for the resume to lift");
+    }
+
+    /// <summary>
+    /// Fires one trigger of the given job and hands back the bundle, which is what leaves a
+    /// <see cref="DisallowConcurrentExecutionAttribute" /> job blocked.
+    /// </summary>
+    private async Task<TriggerFiredBundle> FireTriggerOf(IJobDetail job, DateTimeOffset now)
+    {
+        IOperableTrigger running = new SimpleTriggerImpl("running", "triggerGroup1", job.Key.Name, job.Key.Group, now.AddSeconds(30), null, 0, TimeSpan.Zero);
+        running.ComputeFirstFireTimeUtc(null);
+        await fJobStore.StoreTrigger(running, false);
+
+        var acquired = await fJobStore.AcquireNextTriggers(now.AddSeconds(60), 1, TimeSpan.Zero);
+        acquired.Should().HaveCount(1);
+
+        var fired = await fJobStore.TriggersFired(acquired);
+        TriggerFiredBundle bundle = fired.First().TriggerFiredBundle;
+        bundle.Should().NotBeNull();
+        return bundle;
+    }
+
     private Task StoreTriggerInGroup(string name, string group)
     {
         IOperableTrigger trigger = new SimpleTriggerImpl(

--- a/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeDailyTimeIntervalTrigger.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/JsonObjectSerializerTest_SerializeDailyTimeIntervalTrigger.verified.txt
@@ -9,7 +9,7 @@
   "CalendarName": null,
   "JobDataMap": {},
   "MisfireInstruction": 0,
-  "StartTimeUtc": "2024-07-01T00:00:00.5+00:00",
+  "StartTimeUtc": "2024-07-01T00:00:00+00:00",
   "EndTimeUtc": "2024-07-02T00:00:01+00:00",
   "Priority": 5,
   "NextFireTimeUtc": "2024-07-01T03:32:06+00:00",

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -476,13 +476,20 @@ public class QuartzSchedulerThread
                                 {
                                     // the scheduler is being stopped, so we can't run the job
                                     // use TriggeredJobComplete to properly unblock other triggers
-                                    // for DisallowConcurrentExecution jobs (TriggersFired already ran)
-                                    await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.NoInstruction, CancellationToken.None).ConfigureAwait(false);
+                                    // for DisallowConcurrentExecution jobs (TriggersFired already ran).
+                                    // The bundle's trigger rather than the acquired one, here and in the
+                                    // three completions below: it is the copy the firing advanced - which
+                                    // the run shell also completes with - and its fire time is how the
+                                    // store tells an abandoned firing of a spent trigger from one of a
+                                    // trigger that will fire again (#3507). The in-memory store advances
+                                    // the acquired instance itself, so only the ADO store can tell the
+                                    // two copies apart, and only it was left with the leftover.
+                                    await qsRsrcs.JobStore.TriggeredJobComplete(bndle.Trigger, bndle.JobDetail, SchedulerInstruction.NoInstruction, CancellationToken.None).ConfigureAwait(false);
                                 }
                                 else
                                 {
                                     // we consider this a serious error and expect that job instantiation will never succeed in the future either
-                                    await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.SetAllJobTriggersError, CancellationToken.None).ConfigureAwait(false);
+                                    await qsRsrcs.JobStore.TriggeredJobComplete(bndle.Trigger, bndle.JobDetail, SchedulerInstruction.SetAllJobTriggersError, CancellationToken.None).ConfigureAwait(false);
                                 }
 
                                 continue;
@@ -520,14 +527,14 @@ public class QuartzSchedulerThread
                                     // Use TriggeredJobComplete to properly unblock other triggers
                                     // for DisallowConcurrentExecution jobs (TriggersFired already ran)
                                     Log.Debug("ThreadPool.RunInThread() returned false due to scheduler shutdown, completing trigger");
-                                    await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.NoInstruction, CancellationToken.None).ConfigureAwait(false);
+                                    await qsRsrcs.JobStore.TriggeredJobComplete(bndle.Trigger, bndle.JobDetail, SchedulerInstruction.NoInstruction, CancellationToken.None).ConfigureAwait(false);
                                 }
                                 else
                                 {
                                     // this case should never happen, as it is indicative of a bug in the thread pool or
                                     // a thread pool being used concurrently - which the docs say not to do...
                                     Log.Error("ThreadPool.RunInThread() returned false");
-                                    await qsRsrcs.JobStore.TriggeredJobComplete(trigger, bndle.JobDetail, SchedulerInstruction.SetAllJobTriggersError, CancellationToken.None).ConfigureAwait(false);
+                                    await qsRsrcs.JobStore.TriggeredJobComplete(bndle.Trigger, bndle.JobDetail, SchedulerInstruction.SetAllJobTriggersError, CancellationToken.None).ConfigureAwait(false);
                                 }
                             }
                         }

--- a/src/Quartz/IDailyTimeIntervalTrigger.cs
+++ b/src/Quartz/IDailyTimeIntervalTrigger.cs
@@ -46,6 +46,11 @@ namespace Quartz;
 /// <para>If startTime is before startTimeOfDay, then it has no affect. Else if startTime after startTimeOfDay, then the first fire time
 /// for that day will be normal startTimeOfDay incremental values after startTime value. Same reversal logic is applied to endTime
 /// with endTimeOfDay.</para>
+///
+/// <para>The trigger's <see cref="ITrigger.StartTimeUtc" /> and <see cref="ITrigger.EndTimeUtc" /> are
+/// rounded down to the whole second when they are set, because the fire times are computed as a whole
+/// number of intervals from the start of the day. A start time carrying milliseconds would otherwise be
+/// able to produce a first fire time before itself.</para>
 /// </remarks>
 /// <see cref="DailyTimeIntervalTriggerImpl" />
 /// <see cref="DailyTimeIntervalScheduleBuilder"/>

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -4524,6 +4524,25 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                 await Delegate.UpdateTriggerStatesForJob(conn, trigger.JobKey, StateError, cancellationToken).ConfigureAwait(false);
                 conn.SignalSchedulingChangeOnTxCompletion = SchedulerConstants.SchedulingSignalDateTime;
             }
+            else if (!trigger.GetNextFireTimeUtc().HasValue)
+            {
+                // Every instruction that settles the trigger is above, so what reaches here is a
+                // firing that never happened - one a job listener abandoned, or one the scheduler
+                // could not dispatch - completed with no instruction. That settles nothing about the
+                // schedule of a trigger that can fire again, and for those this branch is not taken.
+                // This one cannot fire again: TriggerFired stored it COMPLETE because firing left it
+                // with no fire time, and outside a cluster nothing ever sweeps a COMPLETE row up, so
+                // the trigger is one GetTrigger keeps handing back for good (#3507). The row is
+                // deleted the way the DeleteTrigger branch above deletes one.
+                var stat = await Delegate.SelectTriggerStatus(conn, trigger.Key, cancellationToken).ConfigureAwait(false);
+                if (stat != null && !stat.NextFireTimeUtc.HasValue)
+                {
+                    // Read back rather than trusted, exactly as the DeleteTrigger branch does: the
+                    // trigger may have been rescheduled while the firing was in flight, and a trigger
+                    // with a fire time ahead of it is nobody's leftover.
+                    await RemoveTrigger(conn, trigger.Key, jobDetail, cancellationToken).ConfigureAwait(false);
+                }
+            }
 
             if (jobDetail.ConcurrentExecutionDisallowed)
             {

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -215,15 +215,19 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
     }
 
     /// <summary>
-    /// The time at which the <see cref="IDailyTimeIntervalTrigger" /> should occur.
+    /// The time at which the <see cref="IDailyTimeIntervalTrigger" /> should occur, rounded down to
+    /// the whole second.
     /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="ToWholeSeconds" path="/summary" />
+    /// </remarks>
     public override DateTimeOffset StartTimeUtc
     {
         get
         {
             if (startTimeUtc == DateTimeOffset.MinValue)
             {
-                startTimeUtc = SystemTime.UtcNow();
+                startTimeUtc = ToWholeSeconds(SystemTime.UtcNow());
             }
             return startTimeUtc;
         }
@@ -234,33 +238,53 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
                 throw new ArgumentException("Start time cannot be DateTimeOffset.MinValue");
             }
 
+            DateTimeOffset rounded = ToWholeSeconds(value);
+
             DateTimeOffset? eTime = EndTimeUtc;
-            if (eTime != null && eTime < value)
+            if (eTime != null && eTime < rounded)
             {
                 throw new ArgumentException("End time cannot be before start time");
             }
 
-            startTimeUtc = value;
+            startTimeUtc = rounded;
         }
     }
 
     /// <summary>
-    /// the time at which the <see cref="IDailyTimeIntervalTrigger" /> should quit repeating.
+    /// the time at which the <see cref="IDailyTimeIntervalTrigger" /> should quit repeating, rounded
+    /// down to the whole second.
     /// </summary>
+    /// <remarks>
+    /// <inheritdoc cref="ToWholeSeconds" path="/summary" />
+    /// </remarks>
     /// <see cref="DailyTimeIntervalTriggerImpl.FinalFireTimeUtc"/>
     public override DateTimeOffset? EndTimeUtc
     {
         get => endTimeUtc;
         set
         {
+            DateTimeOffset? rounded = value == null ? null : ToWholeSeconds(value.Value);
+
             DateTimeOffset sTime = StartTimeUtc;
-            if (value != null && sTime > value)
+            if (rounded != null && sTime > rounded)
             {
                 throw new ArgumentException("End time cannot be before start time");
             }
 
-            endTimeUtc = value;
+            endTimeUtc = rounded;
         }
+    }
+
+    /// <summary>
+    /// This trigger's boundary times carry no sub-second part, the way <c>CronTriggerImpl</c>'s start
+    /// time does not: <see cref="GetFireTimeAfter" /> counts whole seconds from the start of the day,
+    /// so a start time of <c>22:50:00.68</c> truncated to 74100 seconds after a 02:15 start-of-day
+    /// landed exactly on a 5-minute boundary and produced a first fire time of <c>22:50:00.000</c> -
+    /// before the trigger's own start.
+    /// </summary>
+    private static DateTimeOffset ToWholeSeconds(DateTimeOffset value)
+    {
+        return value.AddTicks(-(value.Ticks % TimeSpan.TicksPerSecond));
     }
 
     /// <summary>

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -2002,16 +2002,54 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
                 {
                     blockedJobs.Remove(jd.Key);
 
-                    foreach (TriggerWrapper ttw in GetTriggerWrappersForJobInternal(jd.Key))
+                    List<TriggerWrapper> triggerWrappersForJob = GetTriggerWrappersForJobInternal(jd.Key);
+
+                    // Triggers this completion unblocked that have nothing left to fire. Removing one
+                    // mutates the very list being walked, so they are collected and removed afterwards.
+                    List<TriggerKey>? finalized = null;
+
+                    for (int i = 0; i < triggerWrappersForJob.Count; i++)
                     {
+                        TriggerWrapper ttw = triggerWrappersForJob[i];
+
                         if (ttw.state == InternalTriggerState.Blocked)
                         {
                             ttw.state = InternalTriggerState.Waiting;
-                            timeTriggers.Add(ttw);
+
+                            // A trigger that sat blocked while the job ran may well have passed a fire
+                            // time meanwhile, and nothing else would notice it: acquisition is the only
+                            // other place the policy runs, and a blocked trigger is never acquired. So
+                            // the trigger would be handed to a caller with a past-due fire time still on
+                            // it until then. The ADO store applies the policy as it unblocks
+                            // (RecoverUnblockedMisfires, in the same transaction), and this is the same
+                            // moment (#3463).
+                            ApplyMisfire(ttw);
+
+                            if (ttw.state == InternalTriggerState.Waiting)
+                            {
+                                timeTriggers.Add(ttw);
+                            }
+                            else
+                            {
+                                // Nothing left to fire. The ADO store deletes such a trigger rather than
+                                // leaving a COMPLETE row that GetTrigger would keep handing back, so a
+                                // one-shot trigger that missed its firing while blocked goes away here too.
+                                (finalized ??= new List<TriggerKey>()).Add(ttw.TriggerKey);
+                            }
                         }
-                        if (ttw.state == InternalTriggerState.PausedAndBlocked)
+                        else if (ttw.state == InternalTriggerState.PausedAndBlocked)
                         {
+                            // A paused trigger accrues no misfire - pausing is a decision not to fire, and
+                            // resuming is what settles the debt - so this one is a state change and nothing more.
                             ttw.state = InternalTriggerState.Paused;
+                        }
+                    }
+
+                    if (finalized != null)
+                    {
+                        foreach (TriggerKey finalizedKey in finalized)
+                        {
+                            RemoveTriggerInternal(finalizedKey);
                         }
                     }
 

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -2074,6 +2074,18 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
                     SetAllTriggersOfJobToState(trigger.JobKey, InternalTriggerState.Complete);
                     signaler.SignalSchedulingChange(null, cancellationToken);
                 }
+                else if (!tw.Trigger.GetNextFireTimeUtc().HasValue)
+                {
+                    // Every instruction that settles the trigger is above, so what reaches here is a
+                    // firing that never happened - one a job listener abandoned, or one the scheduler
+                    // could not dispatch - completed with no instruction. That settles nothing about the
+                    // schedule of a trigger that can fire again, and for those this branch is not taken.
+                    // This one cannot fire again: TriggersFired advanced it and left it with no fire
+                    // time, so left here it waits forever, never fired and never removed, and is listed
+                    // to an operator as a trigger that will fire (#3507). Nothing left to fire is
+                    // finished however the last firing ended, so it goes the way DeleteTrigger sends it.
+                    RemoveTriggerInternal(trigger.Key);
+                }
             }
         }
         return Task.CompletedTask;

--- a/src/Quartz/Simpl/RAMJobStore.cs
+++ b/src/Quartz/Simpl/RAMJobStore.cs
@@ -1259,6 +1259,16 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Moves one trigger into the paused state.
+    /// </summary>
+    /// <remarks>
+    /// Only a trigger that is waiting, acquired or blocked is pausable, which is the set the ADO
+    /// store writes PAUSED over. Anything else keeps the state it is in: a completed trigger has
+    /// nothing left to pause, a paused one is already there, and a trigger in error is a failure
+    /// somebody has to see - pausing its group must not quietly clear it, or
+    /// <see cref="ResetTriggerFromErrorState" /> finds nothing left to reset.
+    /// </remarks>
     private void PauseTriggerInternal(TriggerKey triggerKey)
     {
         lock (lockObject)
@@ -1268,20 +1278,20 @@ public class RAMJobStore : IJobStore, INextVersionJobStore
             {
                 return;
             }
-            // if the trigger is "complete" pausing it does not make sense...
-            if (tw.state == InternalTriggerState.Complete)
-            {
-                return;
-            }
 
             if (tw.state == InternalTriggerState.Blocked)
             {
                 tw.state = InternalTriggerState.PausedAndBlocked;
             }
-            else
+            else if (tw.state == InternalTriggerState.Waiting || tw.state == InternalTriggerState.Acquired)
             {
                 tw.state = InternalTriggerState.Paused;
             }
+            else
+            {
+                return;
+            }
+
             timeTriggers.Remove(tw);
         }
     }


### PR DESCRIPTION
Seven fixes for the `3.x` maintenance branch: five that `main` already has, and two that are 3.x's own.
One commit each, in the issue's order; each compiles and passes on its own, and each behavioural fix
carries a test that fails without it. Nothing here touches `database/migrations/` or `database/README.md`,
so the cross-branch byte-identity rule is not engaged, and no public API baseline moved.

## What changed

**1. Both serializers read a string dictionary written either way** — the read-side half of #3582
(follows main's `e22ce3da2`, read side only).

`Quartz.Serialization.Json` reads a job data map entry by entry, so an object with no `$type` beside it
comes back as the `Dictionary<string, string>` it is instead of a `JObject` the job cannot cast; the
object is loaded with `DateParseHandling.None`, so an entry that merely looks like a timestamp stays the
string the application stored rather than being reformatted in the reading machine's culture.
`Quartz.Serialization.SystemTextJson` drops the `$type` property rather than handing an
assembly-qualified type name back as an entry of the application's own key space.

**Neither writer changed, deliberately.** 3.x is a released branch and what it writes is what other 3.x
nodes read; making the two write the same bytes is the wire decision `main` took in #3609, and this is
the half that can be taken here alone. `TheNewtonsoftWriterStillNamesTheTypeBesideAStringMap` and
`TheSystemTextJsonWriterStillWritesThePlainObject` are what hold that line.

**2. A trigger with nothing left to fire is finished however its last firing ended** — #3507
(follows main's `0516f95b4`). **This is the one with a data consequence.**

A firing abandoned between the store committing it and the job running comes back with no instruction,
which settles nothing — right for a trigger that can fire again, wrong for one `TriggersFired` had
already advanced past its last firing. `RAMJobStore` kept it as a waiting trigger with no fire time,
never firing it and never removing it, and reported it to an operator as about to fire; `JobStoreSupport`
kept the `COMPLETE` row, which only a cluster's recovery sweep ever deletes. Both stores now finish such
a trigger, the ADO store after reading the status back so a trigger rescheduled while the firing was in
flight is left alone. `QuartzSchedulerThread` completes an abandoned firing with the bundle's trigger
rather than the acquired one — the same object in the in-memory store, a clone in the ADO store, whose
acquired copy still carries the fire time the firing consumed.

**3. The in-memory store applies the misfire policy of a trigger it unblocks** — #3463
(follows main's `7ee511659`).

A trigger blocked behind a `[DisallowConcurrentExecution]` job is never acquired and never swept, so the
completion that unblocks it is the first thing that can settle the debt — which is where the ADO store
settles it, in `RecoverUnblockedMisfires`. `TriggeredJobComplete` now runs `ApplyMisfire` over each
trigger it unblocks; what has nothing left to fire is removed rather than left as a `Complete` entry
`RetrieveTrigger` keeps handing back. A `PausedAndBlocked` trigger is a state change and nothing more.

**4. A daily time interval trigger never fires before it starts** — #3386 (follows main's `3e5e2b9a7`).

`StartTimeUtc` and `EndTimeUtc` are rounded down to the whole second when set, the way
`CronTriggerImpl.StartTimeUtc` always has been, because the fire times are a whole number of intervals
from the start of the day counted in whole seconds. `CalendarIntervalTriggerImpl` and `SimpleTriggerImpl`
anchor on `StartTimeUtc` itself and are left alone.

*Reviewer's call:* this moves one Verify snapshot,
`JsonObjectSerializerTest_SerializeDailyTimeIntervalTrigger.verified.txt` — the sub-second start time it
captured is no longer a start time this trigger can hold. Accepted from Verify's own received file, not
edited by hand, and identical to the change main took in `3e5e2b9a7`.

**5. Pausing a trigger no longer throws its error away** — follows main's `40a5b9abc` (no issue number).

`RAMJobStore`'s pause wrote `Paused` over every state but `Complete`, so a trigger that had failed into
`Error` lost it the moment its group, its job or the trigger itself was paused: the failure vanished from
every listing and `ResetTriggerFromErrorState` had nothing to reset. `PauseTriggerInternal` now names the
pausable set — waiting, acquired, blocked — which is what the ADO store writes `PAUSED` over. As a
side-effect it also stops a second pause of an already blocked-and-paused trigger dropping the blocked
half of its state.

*Reviewer's call:* this is a behaviour change on a released branch. Code that pauses a group to suppress
a failing trigger has to pause and then reset it; the pause no longer does both. `ResetTriggerFromErrorState`
already lands such a trigger in `Paused` when its group is paused, so the two-step is one call longer and
nothing else.

**6. The XML scheduling test opens its own fixture's data source** — #3573.

`ModifyStoredJobType` opened `DBConnectionManager.Instance.GetConnection("default")`, a name this fixture
never registers. Its two callers passed only when `AdoJobStoreSmokeTest` had run first in the same process
and left a process-global `default` pointing at SQL Server — so a filtered run failed before any assertion,
and a Postgres run sent the `UPDATE` to the wrong database. The name is now derived from the fixture's own
provider.

**7. A trigger's time of day survives being read back** — #3508.

With the Newtonsoft trigger converters off — the default — a `DailyTimeIntervalTriggerImpl` could not be
read back at all: `Quartz.TimeOfDay` has two public constructors and no parameterless one, so Json.NET had
nothing to build `EndTimeOfDay` with. `StartTimeOfDay` was the silent half — its getter hands out a default
`00:00:00` for Json.NET to populate in place, and every member of a `TimeOfDay` is read-only, so a trigger
stored with a window opening at 03:30 read back opening at midnight with nothing said.

`QuartzContractResolver` now attaches a `TimeOfDayConverter` to members typed as a `TimeOfDay`, the way it
attaches `TimeZoneInfoConverter` and for the same reason: scoped to typed members, an `object`-typed slot —
a job data map value — is written and read exactly as it was. **The converter reads and does not write**,
so the object form Json.NET has always written is still what goes out, which is what makes this a fix for
what a released 3.20 has already blob-stored and not only for what is written from now on. The beta.1
upgrade rehearsal hit exactly that: a 3.20 node cannot read back a `DailyTimeIntervalTrigger` it stored as
a blob with the converters off.

## Verification

Every number below was observed in this worktree, on `7b01688a49`.

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s), 0 Error(s)

dotnet test src/Quartz.Tests.Unit -f net10.0
  Passed! - Failed: 0, Passed: 1902, Skipped: 4, Total: 1906

dotnet test src/Quartz.Tests.Unit -f net472
  Passed! - Failed: 0, Passed: 1891, Skipped: 5, Total: 1896

dotnet test src/Quartz.Tests.AspNetCore
  Passed! - Failed: 0, Passed: 122, Skipped: 0, Total: 122

QUARTZ_TEST_DATABASE=postgres dotnet test src/Quartz.Tests.Integration -f net10.0 \
  --filter "TestCategory!=db-sqlserver&TestCategory!=db-mysql&TestCategory!=db-oracle&TestCategory!=db-firebird&TestCategory!=db-sqlserver-mot"
  Passed! - Failed: 0, Passed: 118, Skipped: 0, Total: 118  (4 m 15 s)
```

Postgres was the one provider run, one container at a time; SQL Server, MySQL, Oracle and Firebird were
not run locally and are left to CI. `AdoJobStoreSmokeTest.TestPostgreSql("newtonsoft")` and
`("binary")` both passed, which is item 2's ADO half and items 1 and 7's serializer end to end.

Each fix was also shown failing on its own base, which is the part a green suite cannot tell you:

- **Item 1**, with the two readers reverted: 4 of 13 failed — `newtonsoft -> system.text.json` came back
  with `additional keys {"$type"}`, `system.text.json -> newtonsoft` came back as
  `Newtonsoft.Json.Linq.JObject`, the legacy `$type` blob read by System.Text.Json carried the type name
  as an entry, and nested structure threw nothing.
- **Item 2**, reverted: `RetrieveTrigger` still returned the spent trigger, and the ADO store never called
  `DeleteTrigger`.
- **Item 3**, reverted: `fMisfireCount` was 0, and the finished trigger was still there with
  `misfireInstruction: 5`.
- **Item 5**, reverted: the errored trigger read back `TriggerState.Paused`.
- **Item 6**, reverted, filtered Postgres run: both callers failed with
  `Quartz.SchedulerException : There is no DataSource named 'default'` — the exact failure #3573 predicts.
- **Item 7**, with the resolver hook reverted: `Newtonsoft.Json.JsonSerializationException : Unable to find
  a constructor to use for type Quartz.TimeOfDay ... Path 'EndTimeOfDay.Hour'` — the exact text #3508
  recorded.

Item 4 has no revert run of its own: the Verify snapshot moving *is* the failure, and it is in the diff.

## Deviations from the spec

- **The `$type` write gate from main's #3609 is not ported.** It is part of `e22ce3da2` but belongs to
  4.x's `JobDataValues` write gate, which 3.x has no equivalent of. A 3.x map storing a literal `$type`
  key stays as unreadable as it is today rather than becoming a new exception on a released branch.
  The issue scopes item 1 to the read side, and this is what that means in practice.
- Item 5's commit fixes one thing main's commit message does not mention: pausing an already
  `PausedAndBlocked` trigger used to drop it to `Paused`. It falls out of naming the pausable set and is
  called out in the commit.

Closes #3654
Closes #3573
Closes #3508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqrmFVgN97Z6aRpjBU3LRQ
