### PR TITLE
A RAMJobStore firing costs less than 3.20's again

### DIFF
--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -700,20 +700,28 @@ deployment left at the defaults gets.
 |-------------- |--------------- |------------------- |------------------- |------------ |
 | PostgreSQL    | 10             | 9.87 ms / 136 KB   | 6.18 ms / 56 KB    | 1.6x faster, 2.4x less garbage |
 | PostgreSQL    | 50             | 9.21 ms / 132 KB   | 6.13 ms / 53 KB    | 1.5x faster, 2.5x less garbage |
-| `RAMJobStore` | 10             | 2.31 µs / 3.25 KB  | 3.44 µs / 3.62 KB  | 1.5x slower |
-| `RAMJobStore` | 50             | 2.23 µs / 3.25 KB  | 3.02 µs / 3.63 KB  | 1.4x slower |
+| `RAMJobStore` | 10             | 2.58 µs / 3.25 KB  | 2.16 µs / 2.57 KB  | 1.2x faster, 21 % less garbage |
+| `RAMJobStore` | 50             | 2.71 µs / 3.29 KB  | 1.81 µs / 2.57 KB  | 1.5x faster, 21 % less garbage |
 
-That is about 162 firings a second per node on PostgreSQL and about 300,000 on `RAMJobStore`, on this
-machine. The persistent-store gain is the batched fire path: a firing now costs **1.27 database
-commits**, where it used to cost one round trip per statement. The in-memory loss is 4.0's per-firing
-machinery — a DI scope, the middleware pipeline, the execution-group ledger — and against six
-milliseconds of database it is invisible in any deployment that has one
-([#3674](https://github.com/quartznet/quartznet/issues/3674)).
+That is about 162 firings a second per node on PostgreSQL and about 460,000 to 550,000 on
+`RAMJobStore`, on this machine. The persistent-store gain is the batched fire path: a firing now costs
+**1.27 database commits**, where it used to cost one round trip per statement. The in-memory rows are
+medians of five alternating pairs taken under load rather than the single tight figures the PostgreSQL
+rows are, so read their ratio and not their absolute; the benchmark README carries the ranges.
 
-**A bigger pool does not start firings faster.** Five times the threads bought 14 % on `RAMJobStore`
-and nothing measurable on PostgreSQL, because a node's store operations serialise on the
-`TRIGGER_ACCESS` lock. What `MaxConcurrency` buys is more *jobs* running at once, which is the point
-of it — see [Sizing a cluster](#sizing-a-cluster) above.
+The `RAMJobStore` rows went the other way before beta.1 — 4.0 was 1.4x *slower* there, which
+[#3674](https://github.com/quartznet/quartznet/issues/3674) was filed to explain. It was not the
+per-firing machinery a reader would guess: measured one at a time, the DI scope, the middleware
+pipeline, the execution-group ledger and the retry-policy check are each cheaper than the 3.x code
+they replaced or cost nothing at all. It was two things in the in-memory store — a dictionary
+allocated and discarded on every firing, and a lock taken asynchronously where 3.x takes a monitor, so
+that most store calls on the fire path suspended and cost a thread-pool hop. Both are fixed.
+
+**A bigger pool does not start firings faster.** Five times the threads bought about 17 % on
+`RAMJobStore` and nothing measurable on PostgreSQL, because a node's store operations serialise on one
+lock — `TRIGGER_ACCESS` on a persistent store, the store's own monitor on the in-memory one. What
+`MaxConcurrency` buys is more *jobs* running at once, which is the point of it — see
+[Sizing a cluster](#sizing-a-cluster) above.
 
 ### Scheduling and cron
 

--- a/src/Quartz.Benchmark/README.md
+++ b/src/Quartz.Benchmark/README.md
@@ -242,7 +242,8 @@ same order twice. The tie-break stays the key.
 
 ## Fire throughput and per-fire allocation (2026-09-02, AMD Ryzen 9 5950X)
 
-Taken on `1e6af15e1` to answer #3653. The numbers already in this file are about parsing an
+Taken on `1e6af15e1` to answer #3653, and the `RAMJobStore` half re-taken after #3676 - see that
+subsection, which says what moved and why. The numbers already in this file are about parsing an
 expression and putting a trigger into a store; this section is about the thing a production reader
 actually asks - **how many trigger firings a second, and how much garbage per firing** - and it is
 the first time 4.0 has had one. It is also where the migration guide's claim that the batched fire
@@ -263,13 +264,17 @@ process, acquisition loop and worker threads included, not what one thread of it
 .NET 10.0.11 (10.0.1126.37416), X64 RyuJIT x86-64-v3, Concurrent Workstation GC. PostgreSQL 15.1 in
 Docker Desktop, reached over loopback, at its shipped durability settings (`fsync = on`,
 `synchronous_commit = on`). The 3.x rows were taken on `origin/3.x` at `b33c70487`, against a
-database built from **3.x's own** `database/tables/tables_postgres.sql` rather than 4.0's.
+database built from **3.x's own** `database/tables/tables_postgres.sql` rather than 4.0's; the
+re-taken `RAMJobStore` rows are `origin/3.x` at `9ee33fec1` against `main` at `e74dd6345` plus #3676.
 
 **Read the Error column.** This is a working machine and something else is usually running on it, so
-the means carry more spread than a dedicated box would give. These runs came out tight anyway -
-every Error below is under 1.5% of its Mean, which is unlike the older sections in this file - and
-that is what lets the 3.x-to-4.0 ratios be read as ratios rather than as directions. The allocation
-column is exact whatever the load, and the effects below are multiples rather than percentages.
+the means carry more spread than a dedicated box would give. The PostgreSQL sitting came out tight -
+every Error there is under 1.5% of its Mean, which is unlike the older sections in this file - and
+that is what lets its 3.x-to-4.0 ratios be read as ratios rather than as directions. The
+`RAMJobStore` sitting did not: it was re-run under load, so those rows carry ranges over five
+alternating pairs and Errors up to 10%, and the safe reading of them is the medians and the
+allocation column. The allocation column is exact whatever the load, and the effects below are
+multiples rather than percentages.
 
 **Two settings are not at their defaults, and both had to move.** `MaxBatchSize` tracks
 `MaxConcurrency` - the scheduler refuses a batch larger than the pool that would have to run it, so
@@ -291,12 +296,22 @@ same rows; those are real costs and none of them is in these numbers.
 
 ### RAMJobStore
 
-| Version | MaxConcurrency | Mean     | Error     | Allocated | Fires/second |
-|-------- |--------------- |---------:|----------:|----------:|-------------:|
-| 4.0     | 10             | 3.436 us | 0.0258 us |   3.62 KB |      291,000 |
-| 4.0     | 50             | 3.024 us | 0.0352 us |   3.63 KB |      330,700 |
-| 3.20    | 10             | 2.314 us | 0.0266 us |   3.25 KB |      432,200 |
-| 3.20    | 50             | 2.228 us | 0.0317 us |   3.25 KB |      448,800 |
+**Re-measured on 2026-09-02 after #3676, which is what #3674 turned into.** The first sitting had 4.0
+at 3.4 us and 3.62 KB a firing against 3.20's 2.3 us and 3.25 KB; the rows below replace it. Both arms
+were re-run in one sitting on this machine, **five alternating pairs**, the order reversed between
+them, and the machine was busy throughout - so these are ranges over the five runs rather than the one
+figure a quiet box would give, and the medians are what the verdict below reads.
+
+| Version | MaxConcurrency | Mean (5 runs)   | Median   | Error       | Allocated       | Fires/second      |
+|-------- |--------------- |---------------: |--------: |-----------: |---------------: |-----------------: |
+| 4.0     | 10             | 1.865-2.604 us  | 2.164 us | 1.6%-2.7%   | 2.56-2.58 KB    | 384,000-536,000   |
+| 4.0     | 50             | 1.347-2.102 us  | 1.805 us | 0.9%-7.8%   | 2.56-2.57 KB    | 476,000-742,000   |
+| 3.20    | 10             | 2.456-3.237 us  | 2.579 us | 1.7%-6.0%   | 3.21-3.28 KB    | 309,000-407,000   |
+| 3.20    | 50             | 2.234-4.382 us  | 2.713 us | 1.6%-10.5%  | 3.25-3.30 KB    | 228,000-448,000   |
+
+The allocation column is the one to trust without qualification: four of the five 4.0 runs read
+2.56 KB or 2.57 KB at both pool sizes and the fifth read 3.35 KB at `MaxConcurrency` 50 with an 8%
+Error, which is the only reading in the set that does not repeat.
 
 ### PostgreSQL
 
@@ -316,18 +331,25 @@ client, a firing now costs **1.27 commits** - 42,337 transactions over 33,404 fi
 which is one `TriggeredJobComplete` plus a share of an acquisition and a `TriggersFired` amortised
 across the batch.
 
-**On `RAMJobStore`, 4.0 is about 1.4x slower per firing than 3.20 and allocates 11% more** - 3.0-3.4
-us against 2.2-2.3 us. Recorded rather than acted on, and not investigated here: the 4.0 fire path
-carries things 3.x's did not, including a DI scope per firing, the job-execution middleware pipeline,
-the execution-group ledger and the retry-policy check. Against 3 us of scheduler work the persistent
-store's 6 ms makes this invisible in any deployment that has a database, which is why it is at the
-bottom of this section rather than the top. Filed as #3674.
+**On `RAMJobStore`, 4.0 is faster per firing than 3.20 and allocates 21% less** - 2.56 KB against
+3.25 KB, and 2.16 us against 2.58 us by the medians at `MaxConcurrency` 10, 1.81 us against 2.71 us at
+50. It was not, until #3676. The first sitting had it 1.4x *slower*, which is what #3674 was filed to
+explain, and the explanation was not the list this paragraph used to carry - a DI scope per firing,
+the middleware pipeline, the execution-group ledger, the retry-policy check. Measured one at a time,
+every one of those is *cheaper* than the 3.x code it replaced or costs nothing at all: the scope 328
+bytes against 456, the execution context 248 against 480, the listener notifications 48 against 720,
+and the pipeline, the activity, the meters and the retry check zero apiece. The regression was two
+things in the store, both fixed in #3676: a `Dictionary` allocated and thrown away on every firing to
+hold the trigger's running executions, and a lock taken with `await SemaphoreSlim.WaitAsync` where
+3.x's is a monitor, which made 64% of `TriggersFired` calls, 41% of `TriggeredJobComplete` calls and
+31% of acquisitions suspend and cost a thread-pool hop each. The full attribution is on #3674.
 
 **Pool size does not move either store much, and on PostgreSQL it does not move it at all.** Five
-times the threads buys 14% on `RAMJobStore` and nothing measurable on PostgreSQL, because the store's
-own operations serialise on the trigger-access lock: what a bigger pool buys is more *jobs* running
-at once, not more firings being started. This is the same fact `operations.md` states as "adding
-nodes does not make a single trigger fire faster", measured.
+times the threads buys about 17% on 4.0's `RAMJobStore` by the medians above, nothing on 3.20's, and
+nothing measurable on PostgreSQL, because the store's own operations serialise on one lock - the
+trigger-access lock on a persistent store, the monitor on the in-memory one. What a bigger pool buys
+is more *jobs* running at once, not more firings being started. This is the same fact `operations.md`
+states as "adding nodes does not make a single trigger fire faster", measured.
 
 **The PostgreSQL figure is a commit-latency figure as much as a Quartz one.** Re-running the 4.0 arm
 with `synchronous_commit = off` gives 3.605 ms at `MaxConcurrency` 10 and 4.140 ms at 50 - 1.7x

--- a/src/Quartz.Tests.Unit/Impl/RAMJobStoreFireInstanceReuseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/RAMJobStoreFireInstanceReuseTest.cs
@@ -1,0 +1,164 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// What a firing sees of the executions that came before it, now that the map a trigger's running
+/// executions live in is handed on from one firing to the next instead of being allocated for each.
+/// </summary>
+/// <remarks>
+/// The reuse is invisible by design, which is exactly why it is worth pinning: a map that came back
+/// out of the spare list still holding an entry, or one handed on while an execution was still using
+/// it, would show up as a firing of one trigger being reported under another — and nothing else in
+/// the suite asks <c>QueryFireInstances</c> what it holds across a completion.
+/// </remarks>
+[TestFixture]
+public sealed class RAMJobStoreFireInstanceReuseTest
+{
+    private static readonly DateTimeOffset now = new(2030, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private RAMJobStore store = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        store = TestJobStores.Ram();
+        await store.Initialize(TestJobStores.Identity());
+        await store.SchedulerStarted();
+    }
+
+    [Test]
+    public async Task AFiringSeesNothingOfTheTriggerThatFinishedBeforeIt()
+    {
+        IJobDetail job = CreateJob();
+        IOperableTrigger first = CreateTrigger("first", job, now);
+        IOperableTrigger second = CreateTrigger("second", job, now.AddMinutes(1));
+
+        await store.ScheduleJob(job, first);
+        await store.AddTrigger(second);
+
+        IOperableTrigger firstFiring = await Fire(first.Key);
+        await store.TriggeredJobComplete(firstFiring, job, SchedulerInstruction.NoInstruction);
+
+        IOperableTrigger secondFiring = await Fire(second.Key);
+
+        PagedResult<FireInstance> executing = await store.QueryFireInstances(new FireInstanceQuery());
+
+        executing.Items.Should().ContainSingle(
+            "the first trigger's only execution has completed, so the second trigger's is the one that is running")
+            .Which.Should().Match<FireInstance>(
+                instance => instance.FireInstanceId == secondFiring.FireInstanceId && instance.TriggerKey.Equals(second.Key),
+                "a map that outlives the firing it was created for must carry none of that firing into the next one");
+    }
+
+    [Test]
+    public async Task ATriggerThatFiresAgainReportsOnlyItsNewExecution()
+    {
+        IJobDetail job = CreateJob();
+        IOperableTrigger trigger = CreateTrigger("only", job, now);
+
+        await store.ScheduleJob(job, trigger);
+
+        IOperableTrigger firstFiring = await Fire(trigger.Key);
+        await store.TriggeredJobComplete(firstFiring, job, SchedulerInstruction.NoInstruction);
+
+        IOperableTrigger secondFiring = await Fire(trigger.Key);
+
+        PagedResult<FireInstance> executing = await store.QueryFireInstances(new FireInstanceQuery());
+
+        executing.Items.Select(x => x.FireInstanceId).Should().Equal([secondFiring.FireInstanceId],
+            "one firing of the trigger is running, and it is the second one — the first was completed");
+        secondFiring.FireInstanceId.Should().NotBe(firstFiring.FireInstanceId,
+            "each firing is its own occurrence, so the two are told apart by their fire instance ids");
+    }
+
+    [Test]
+    public async Task ATriggerKeepsTheExecutionStillRunningWhenAnEarlierOneCompletes()
+    {
+        IJobDetail job = CreateJob();
+        IOperableTrigger trigger = CreateTrigger("only", job, now);
+
+        await store.ScheduleJob(job, trigger);
+
+        IOperableTrigger earlier = await Fire(trigger.Key);
+        IOperableTrigger later = await Fire(trigger.Key);
+
+        await store.TriggeredJobComplete(earlier, job, SchedulerInstruction.NoInstruction);
+
+        PagedResult<FireInstance> executing = await store.QueryFireInstances(new FireInstanceQuery());
+
+        executing.Items.Select(x => x.FireInstanceId).Should().Equal([later.FireInstanceId],
+            "a trigger whose second execution is still running keeps it when the first one completes");
+    }
+
+    /// <summary>
+    /// Acquires and fires the trigger that is due next, which the callers arrange to be the one they
+    /// name.
+    /// </summary>
+    private async Task<IOperableTrigger> Fire(TriggerKey expected)
+    {
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = now.AddDays(1),
+            MaxCount = 1,
+        });
+
+        acquired.Select(x => x.Key).Should().Equal([expected],
+            "the trigger due next is the one this step is about");
+
+        List<TriggerFiredResult> results = await store.TriggersFired(acquired);
+        results.Should().ContainSingle().Which.TriggerFiredBundle.Should().NotBeNull(
+            "the firing has to be committed before the store records an execution for it");
+
+        return acquired[0];
+    }
+
+    private static IJobDetail CreateJob()
+    {
+        return JobBuilder.Create<ReuseTestJob>()
+            .WithIdentity("job", "reuse")
+            .Build();
+    }
+
+    private static IOperableTrigger CreateTrigger(string name, IJobDetail job, DateTimeOffset startAt)
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity(name, "reuse")
+            .ForJob(job)
+            .StartAt(startAt)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        // Job stores keep what they are given; working out when a trigger first fires is the
+        // scheduler's job, and nothing is acquirable until it has been done.
+        trigger.ComputeFirstFireTimeUtc(calendar: null);
+        return trigger;
+    }
+
+    private sealed class ReuseTestJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -46,7 +46,30 @@ namespace Quartz.Impl;
 /// <author>Marko Lahma (.NET)</author>
 public sealed class RAMJobStore : IJobStore
 {
-    private readonly SemaphoreSlim lockObject = new(initialCount: 1, maxCount: 1);
+    /// <summary>
+    /// The one lock every operation of this store is serialised on.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A monitor rather than a <see cref="SemaphoreSlim" /> awaited on, which is what #3674 measured
+    /// the cost of: every section it guards is synchronous in-memory work of a microsecond or two —
+    /// every <c>await</c> in this file raises <see cref="PendingSignals" /> <em>after</em> the lock —
+    /// so an asynchronous wait bought nothing and cost a great deal. Under ten workers on
+    /// <c>FireThroughputBenchmark</c>, 64% of <see cref="TriggersFired" /> calls, 41% of
+    /// <see cref="TriggeredJobComplete" /> calls and 31% of acquisitions did not complete on the thread
+    /// that began them: each of those boxed a state machine, allocated a wait node and cost a
+    /// thread-pool hop. 3.x, which has always taken a monitor here, suspends nowhere on that path, and
+    /// taking one back is worth about a microsecond and 0.7 KB a firing.
+    /// </para>
+    /// <para>
+    /// The consequence to know about is that <b>a caller waiting for this lock does not observe its
+    /// cancellation token</b>. It could not usefully: the wait is bounded by the section in front of
+    /// it, which does no I/O and cannot block. Cancellation is still observed everywhere it means
+    /// something — the token reaches the store, and the signaler notifications raised after the lock
+    /// take it. 3.x behaves the same way, for the same reason.
+    /// </para>
+    /// </remarks>
+    private readonly Lock lockObject = new();
 
     private readonly ConcurrentDictionary<JobKey, JobWrapper> jobsByKey = [];
     private readonly ConcurrentDictionary<TriggerKey, TriggerWrapper> triggersByKey = new();
@@ -233,8 +256,7 @@ public sealed class RAMJobStore : IJobStore
     {
         PendingSignals pending = default;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // unschedule jobs (delete triggers)
             foreach (string group in new List<string>(triggersByGroup.Keys))
@@ -265,10 +287,6 @@ public sealed class RAMJobStore : IJobStore
             resumedJobsInPausedGroups.Clear();
             executingFireInstances.Clear();
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
@@ -287,15 +305,10 @@ public sealed class RAMJobStore : IJobStore
         // with its trigger is one operation, and between the two locks another caller could see the job
         // without the trigger that gives it a reason to exist. The ADO store has always done both
         // inside one ExecuteInLock.
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             AddJobNoLock(job, replace: false);
             AddTriggerNoLock(trigger, replace: false, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -307,17 +320,14 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="job">The <see cref="IJob" /> to be stored.</param>
     /// <param name="options">How to store it; see <see cref="IJobStore.AddJob" />.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    public async ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
+    public ValueTask AddJob(IJobDetail job, AddJobOptions options = default, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             AddJobNoLock(job, options.Replace);
         }
-        finally
-        {
-            lockObject.Release();
-        }
+
+        return default;
     }
 
     private void AddJobNoLock(IJobDetail job, bool replace)
@@ -366,14 +376,9 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         bool deleted;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             deleted = RemoveJobNoLock(jobKey, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -413,8 +418,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<JobKey> deleted = new List<JobKey>(jobKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (JobKey key in jobKeys)
             {
@@ -423,10 +427,6 @@ public sealed class RAMJobStore : IJobStore
                     deleted.Add(key);
                 }
             }
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -444,8 +444,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<JobKey> deleted;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<JobKey> matching = GetJobKeysNoLock(matcher);
             deleted = new List<JobKey>(matching.Count);
@@ -456,10 +455,6 @@ public sealed class RAMJobStore : IJobStore
                     deleted.Add(key);
                 }
             }
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -472,8 +467,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<TriggerKey> deleted = new List<TriggerKey>(triggerKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (TriggerKey key in triggerKeys)
             {
@@ -482,10 +476,6 @@ public sealed class RAMJobStore : IJobStore
                     deleted.Add(key);
                 }
             }
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -500,8 +490,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<TriggerKey> deleted;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<TriggerKey> matching = GetTriggerKeysNoLock(matcher);
             deleted = new List<TriggerKey>(matching.Count);
@@ -513,10 +502,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
         return deleted;
@@ -527,8 +512,7 @@ public sealed class RAMJobStore : IJobStore
     {
         PendingSignals pending = default;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // make sure there are no collisions...
             if (!options.Replace)
@@ -562,10 +546,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
@@ -593,14 +573,9 @@ public sealed class RAMJobStore : IJobStore
     {
         PendingSignals pending = default;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             AddTriggerNoLock(trigger, options.Replace, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -702,14 +677,9 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         bool deleted;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             deleted = RemoveTriggerNoLock(key, removeOrphanedJob, keepExecutions: false, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -775,8 +745,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         bool found;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             found = triggersByKey.TryGetValue(triggerKey, out var tw);
 
@@ -817,31 +786,26 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
         return found;
     }
 
     /// <inheritdoc />
-    public async ValueTask<bool> UpdateTriggerDetails(TriggerKey triggerKey, TriggerDetailsUpdate update, CancellationToken cancellationToken = default)
+    public ValueTask<bool> UpdateTriggerDetails(TriggerKey triggerKey, TriggerDetailsUpdate update, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             if (!triggersByKey.TryGetValue(triggerKey, out TriggerWrapper? tw))
             {
-                return false;
+                return new ValueTask<bool>(false);
             }
 
             if (!update.HasDescription && !update.HasPriority && !update.HasJobDataMap
                 && !update.HasCalendarName && !update.HasMisfireInstruction && !update.HasPreferredNode
                 && !update.HasExecutionGroup && !update.HasRetryPolicy)
             {
-                return true;
+                return new ValueTask<bool>(true);
             }
 
             IOperableTrigger trigger = tw.Trigger;
@@ -910,11 +874,7 @@ public sealed class RAMJobStore : IJobStore
                 trigger.RetryPolicy = update.RetryPolicy;
             }
 
-            return true;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(true);
         }
     }
 
@@ -925,17 +885,12 @@ public sealed class RAMJobStore : IJobStore
     /// <returns>
     /// The desired <see cref="IJob" />, or null if there is no match.
     /// </returns>
-    public async ValueTask<IJobDetail?> GetJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask<IJobDetail?> GetJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             jobsByKey.TryGetValue(jobKey, out JobWrapper? jw);
-            return jw?.JobDetail.Clone();
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<IJobDetail?>(jw?.JobDetail.Clone());
         }
     }
 
@@ -945,17 +900,12 @@ public sealed class RAMJobStore : IJobStore
     /// <returns>
     /// The desired <see cref="ITrigger" />, or null if there is no match.
     /// </returns>
-    public async ValueTask<IOperableTrigger?> GetTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask<IOperableTrigger?> GetTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             triggersByKey.TryGetValue(triggerKey, out var tw);
-            return (IOperableTrigger?) tw?.Trigger.Clone();
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<IOperableTrigger?>((IOperableTrigger?) tw?.Trigger.Clone());
         }
     }
 
@@ -966,16 +916,11 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="jobKey">the identifier to check for</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>true if a Job exists with the given identifier</returns>
-    public async ValueTask<bool> Exists(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask<bool> Exists(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return jobsByKey.ContainsKey(jobKey);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(jobsByKey.ContainsKey(jobKey));
         }
     }
 
@@ -986,16 +931,11 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="triggerKey">triggerKey the identifier to check for</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>true if a Trigger exists with the given identifier</returns>
-    public async ValueTask<bool> Exists(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask<bool> Exists(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return triggersByKey.ContainsKey(triggerKey);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(triggersByKey.ContainsKey(triggerKey));
         }
     }
 
@@ -1006,18 +946,13 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="calendarName">the name to check for</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     /// <returns>true if a calendar is stored under the given name</returns>
-    public async ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
+    public ValueTask<bool> Exists(string calendarName, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // Deliberately not GetCalendar: that clones the calendar, which for an AnnualCalendar with a
             // decade of excluded days copies every one of them to answer a yes-or-no question.
-            return calendarsByName.ContainsKey(calendarName);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(calendarsByName.ContainsKey(calendarName));
         }
     }
 
@@ -1031,18 +966,13 @@ public sealed class RAMJobStore : IJobStore
     /// <seealso cref="TriggerState.Blocked" />
     /// <seealso cref="TriggerState.None"/>
     /// <seealso cref="TriggerState.Executing" />
-    public async ValueTask<TriggerState> GetTriggerState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask<TriggerState> GetTriggerState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // Both facts have to be read under the same lock, or a fire landing between the two reads
             // would produce a state that was never actually true.
-            return triggersByKey.TryGetValue(triggerKey, out var tw) ? ToTriggerStateNoLock(tw) : TriggerState.None;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<TriggerState>(triggersByKey.TryGetValue(triggerKey, out var tw) ? ToTriggerStateNoLock(tw) : TriggerState.None);
         }
     }
 
@@ -1077,28 +1007,22 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask<bool> ResetTriggerFromErrorState(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return ResetTriggerFromErrorStateNoLock(triggerKey);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(ResetTriggerFromErrorStateNoLock(triggerKey));
         }
     }
 
     /// <summary>
     /// Resets the whole set inside one lock pass rather than taking the lock per key.
     /// </summary>
-    public async ValueTask<List<TriggerKey>> ResetTriggersFromErrorState(
+    public ValueTask<List<TriggerKey>> ResetTriggersFromErrorState(
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<TriggerKey> reset = new List<TriggerKey>(triggerKeys.Count);
             foreach (TriggerKey triggerKey in triggerKeys)
@@ -1109,11 +1033,7 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
 
-            return reset;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<TriggerKey>>(reset);
         }
     }
 
@@ -1152,7 +1072,7 @@ public sealed class RAMJobStore : IJobStore
     /// <param name="options">Whether an existing calendar of the same name may be over-written,
     /// and whether the triggers referencing it have their next fire time re-computed.</param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
-    public async ValueTask AddCalendar(
+    public ValueTask AddCalendar(
         string calendarName,
         ICalendar calendar,
         AddCalendarOptions options = default,
@@ -1160,8 +1080,7 @@ public sealed class RAMJobStore : IJobStore
     {
         calendar = calendar.Clone();
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             calendarsByName.TryGetValue(calendarName, out var obj);
 
@@ -1192,10 +1111,8 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
+
+        return default;
     }
 
     /// <summary>
@@ -1212,16 +1129,11 @@ public sealed class RAMJobStore : IJobStore
     /// 	<see langword="true" /> if a <see cref="ICalendar" /> with the given name
     /// was found and removed from the store.
     /// </returns>
-    public async ValueTask<bool> DeleteCalendar(string calendarName, CancellationToken cancellationToken = default)
+    public ValueTask<bool> DeleteCalendar(string calendarName, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return RemoveCalendarNoLock(calendarName);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(RemoveCalendarNoLock(calendarName));
         }
     }
 
@@ -1253,17 +1165,12 @@ public sealed class RAMJobStore : IJobStore
     /// <returns>
     /// The desired <see cref="ICalendar" />, or null if there is no match.
     /// </returns>
-    public async ValueTask<ICalendar?> GetCalendar(string calendarName, CancellationToken cancellationToken = default)
+    public ValueTask<ICalendar?> GetCalendar(string calendarName, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             calendarsByName.TryGetValue(calendarName, out var calendar);
-            return calendar?.Clone();
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<ICalendar?>(calendar?.Clone());
         }
     }
 
@@ -1340,14 +1247,13 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<JobHeader>> QueryJobs(JobQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<JobHeader>> QueryJobs(JobQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         List<IJobDetail> matches = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             GroupMatcher<JobKey>? matcher = query.Group;
             NameMatcher<JobKey>? nameMatcher = query.Name;
@@ -1383,10 +1289,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         if (query.Take > 0)
         {
@@ -1394,7 +1296,7 @@ public sealed class RAMJobStore : IJobStore
             matches.Sort(static (left, right) => CompareByGroupThenName(left.Key.Group, left.Key.Name, right.Key.Group, right.Key.Name));
         }
 
-        return Page(matches, query, static job => new JobHeader(
+        return new ValueTask<PagedResult<JobHeader>>(Page(matches, query, static job => new JobHeader(
             job.Key,
             job.Description,
             // the ADO store persists JobType.FullName, so a listing has to report the same string
@@ -1402,18 +1304,17 @@ public sealed class RAMJobStore : IJobStore
             job.Durable,
             job.ConcurrentExecutionDisallowed,
             job.PersistJobDataAfterExecution,
-            job.RequestsRecovery));
+            job.RequestsRecovery)));
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<TriggerHeader>> QueryTriggers(TriggerQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<TriggerHeader>> QueryTriggers(TriggerQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         List<TriggerMatch> matches = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             GroupMatcher<TriggerKey>? matcher = query.Group;
             if (matcher is not null && StringOperator.Equality.Equals(matcher.CompareWithOperator))
@@ -1436,10 +1337,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         if (query.Take > 0)
         {
@@ -1451,7 +1348,7 @@ public sealed class RAMJobStore : IJobStore
                 right.Trigger.Key.Name));
         }
 
-        return Page(matches, query, static match => new TriggerHeader(
+        return new ValueTask<PagedResult<TriggerHeader>>(Page(matches, query, static match => new TriggerHeader(
             match.Trigger.Key,
             match.Trigger.JobKey,
             match.Trigger.Description,
@@ -1465,7 +1362,7 @@ public sealed class RAMJobStore : IJobStore
             match.Trigger.Priority,
             match.Trigger.ExecutionGroup,
             match.Trigger.RetryPolicy?.ToStoredString(),
-            match.Trigger.RetryAttempt));
+            match.Trigger.RetryAttempt)));
     }
 
     private void CollectMatchingTriggersNoLock(
@@ -1502,14 +1399,13 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<JobGroup>> QueryJobGroups(JobGroupQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<JobGroup>> QueryJobGroups(JobGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         List<JobGroup> groups = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             if (query.Paused == true)
             {
@@ -1539,25 +1435,20 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         groups.Sort(static (left, right) => StringComparer.Ordinal.Compare(left.Name, right.Name));
 
-        return Page(groups, query, static group => group);
+        return new ValueTask<PagedResult<JobGroup>>(Page(groups, query, static group => group));
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<TriggerGroup>> QueryTriggerGroups(TriggerGroupQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<TriggerGroup>> QueryTriggerGroups(TriggerGroupQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         List<TriggerGroup> groups = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             if (query.Paused == true)
             {
@@ -1587,14 +1478,10 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         groups.Sort(static (left, right) => StringComparer.Ordinal.Compare(left.Name, right.Name));
 
-        return Page(groups, query, static group => group);
+        return new ValueTask<PagedResult<TriggerGroup>>(Page(groups, query, static group => group));
     }
 
     /// <summary>
@@ -1606,15 +1493,14 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<string>> QueryCalendarNames(CalendarQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<string>> QueryCalendarNames(CalendarQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         NameMatcher? nameMatcher = query.Name;
         List<string> names = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (string calendarName in calendarsByName.Keys)
             {
@@ -1624,18 +1510,14 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         names.Sort(StringComparer.Ordinal);
 
-        return Page(names, query, static name => name);
+        return new ValueTask<PagedResult<string>>(Page(names, query, static name => name));
     }
 
     /// <inheritdoc />
-    public async ValueTask<PagedResult<FireInstance>> QueryFireInstances(FireInstanceQuery query, CancellationToken cancellationToken = default)
+    public ValueTask<PagedResult<FireInstance>> QueryFireInstances(FireInstanceQuery query, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
 
@@ -1648,8 +1530,7 @@ public sealed class RAMJobStore : IJobStore
 
         if (thisNode)
         {
-            await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
+            lock (lockObject)
             {
                 // Everything is projected into records under the lock and nothing that could still change
                 // escapes it, so the page is a snapshot rather than a view.
@@ -1662,10 +1543,6 @@ public sealed class RAMJobStore : IJobStore
                 {
                     CollectAcquiredFireInstancesNoLock(query, matches);
                 }
-            }
-            finally
-            {
-                lockObject.Release();
             }
         }
 
@@ -1686,7 +1563,7 @@ public sealed class RAMJobStore : IJobStore
             });
         }
 
-        return Page(matches, query, static instance => instance);
+        return new ValueTask<PagedResult<FireInstance>>(Page(matches, query, static instance => instance));
     }
 
     private void CollectExecutingFireInstancesNoLock(FireInstanceQuery query, List<FireInstance> matches)
@@ -1827,15 +1704,14 @@ public sealed class RAMJobStore : IJobStore
     }
 
     /// <inheritdoc />
-    public async ValueTask<List<IJobDetail>> GetJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
+    public ValueTask<List<IJobDetail>> GetJobs(IReadOnlyCollection<JobKey> jobKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(jobKeys);
 
         List<IJobDetail> jobs = new(jobKeys.Count);
         HashSet<JobKey> seen = new(jobKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (JobKey jobKey in jobKeys)
             {
@@ -1845,24 +1721,19 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
-        return jobs;
+        return new ValueTask<List<IJobDetail>>(jobs);
     }
 
     /// <inheritdoc />
-    public async ValueTask<List<IOperableTrigger>> GetTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
+    public ValueTask<List<IOperableTrigger>> GetTriggers(IReadOnlyCollection<TriggerKey> triggerKeys, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(triggerKeys);
 
         List<IOperableTrigger> triggers = new(triggerKeys.Count);
         HashSet<TriggerKey> seen = new(triggerKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (TriggerKey triggerKey in triggerKeys)
             {
@@ -1872,12 +1743,8 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
-        return triggers;
+        return new ValueTask<List<IOperableTrigger>>(triggers);
     }
 
     /// <summary>
@@ -1944,10 +1811,9 @@ public sealed class RAMJobStore : IJobStore
     /// If there are no matches, a zero-length array should be returned.
     /// </para>
     /// </summary>
-    public async ValueTask<List<IOperableTrigger>> GetTriggersForJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask<List<IOperableTrigger>> GetTriggersForJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             if (triggersByJob.TryGetValue(jobKey, out List<TriggerWrapper>? jobList))
             {
@@ -1956,14 +1822,10 @@ public sealed class RAMJobStore : IJobStore
                 {
                     trigList.Add((IOperableTrigger) jobList[i].Trigger.Clone());
                 }
-                return trigList;
+                return new ValueTask<List<IOperableTrigger>>(trigList);
             }
 
-            return [];
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<IOperableTrigger>>([]);
         }
     }
 
@@ -2014,28 +1876,22 @@ public sealed class RAMJobStore : IJobStore
     /// <summary>
     /// Pause the <see cref="ITrigger" /> with the given name.
     /// </summary>
-    public async ValueTask<bool> PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
+    public ValueTask<bool> PauseTrigger(TriggerKey triggerKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return PauseTriggerNoLock(triggerKey);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(PauseTriggerNoLock(triggerKey));
         }
     }
 
     /// <summary>
     /// Pauses the whole set inside one lock pass rather than taking the lock per key.
     /// </summary>
-    public async ValueTask<List<TriggerKey>> PauseTriggers(
+    public ValueTask<List<TriggerKey>> PauseTriggers(
         IReadOnlyCollection<TriggerKey> triggerKeys,
         CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<TriggerKey> paused = new List<TriggerKey>(triggerKeys.Count);
             foreach (TriggerKey triggerKey in triggerKeys)
@@ -2046,11 +1902,7 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
 
-            return paused;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<TriggerKey>>(paused);
         }
     }
 
@@ -2097,16 +1949,11 @@ public sealed class RAMJobStore : IJobStore
     /// paused.
     /// </para>
     /// </summary>
-    public async ValueTask<List<string>> PauseTriggerGroups(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
+    public ValueTask<List<string>> PauseTriggerGroups(GroupMatcher<TriggerKey> matcher, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return PauseTriggersNoLock(matcher);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<string>>(PauseTriggersNoLock(matcher));
         }
     }
 
@@ -2153,28 +2000,22 @@ public sealed class RAMJobStore : IJobStore
     /// Pause the <see cref="IJobDetail" /> with the given
     /// name - by pausing all of its current <see cref="ITrigger" />s.
     /// </summary>
-    public async ValueTask<bool> PauseJob(JobKey jobKey, CancellationToken cancellationToken = default)
+    public ValueTask<bool> PauseJob(JobKey jobKey, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
-            return PauseJobNoLock(jobKey);
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<bool>(PauseJobNoLock(jobKey));
         }
     }
 
     /// <summary>
     /// Pauses the whole set inside one lock pass rather than taking the lock per key.
     /// </summary>
-    public async ValueTask<List<JobKey>> PauseJobs(
+    public ValueTask<List<JobKey>> PauseJobs(
         IReadOnlyCollection<JobKey> jobKeys,
         CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<JobKey> paused = new List<JobKey>(jobKeys.Count);
             foreach (JobKey jobKey in jobKeys)
@@ -2185,11 +2026,7 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
 
-            return paused;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<JobKey>>(paused);
         }
     }
 
@@ -2219,10 +2056,9 @@ public sealed class RAMJobStore : IJobStore
     /// paused.
     /// </para>
     /// </summary>
-    public async ValueTask<List<string>> PauseJobGroups(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
+    public ValueTask<List<string>> PauseJobGroups(GroupMatcher<JobKey> matcher, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<string> pausedGroups = [];
             StringOperator op = matcher.CompareWithOperator;
@@ -2261,11 +2097,7 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
 
-            return pausedGroups;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<string>>(pausedGroups);
         }
     }
 
@@ -2281,14 +2113,9 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         bool resumed;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             resumed = ResumeTriggerNoLock(triggerKey, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2305,8 +2132,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<TriggerKey> resumed = new List<TriggerKey>(triggerKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (TriggerKey triggerKey in triggerKeys)
             {
@@ -2315,10 +2141,6 @@ public sealed class RAMJobStore : IJobStore
                     resumed.Add(triggerKey);
                 }
             }
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2372,14 +2194,9 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<string> resumedGroups;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             resumedGroups = ResumeTriggersNoLock(matcher, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2437,14 +2254,9 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         bool resumed;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             resumed = ResumeJobNoLock(jobKey, ref pending);
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2461,8 +2273,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<JobKey> resumed = new List<JobKey>(jobKeys.Count);
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (JobKey jobKey in jobKeys)
             {
@@ -2471,10 +2282,6 @@ public sealed class RAMJobStore : IJobStore
                     resumed.Add(jobKey);
                 }
             }
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2516,8 +2323,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         var resumedGroups = new List<string>();
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             var keys = GetJobKeysNoLock(matcher);
 
@@ -2544,10 +2350,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
         return resumedGroups;
@@ -2562,20 +2364,17 @@ public sealed class RAMJobStore : IJobStore
     /// </para>
     /// </summary>
     /// <seealso cref="ResumeAll(CancellationToken)" />
-    public async ValueTask PauseAll(CancellationToken cancellationToken = default)
+    public ValueTask PauseAll(CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (string groupName in triggersByGroup.Keys)
             {
                 PauseTriggersNoLock(GroupMatcher<TriggerKey>.GroupEquals(groupName));
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
+
+        return default;
     }
 
     /// <summary>
@@ -2591,8 +2390,7 @@ public sealed class RAMJobStore : IJobStore
     {
         PendingSignals pending = default;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // TODO need a match all here!
             pausedJobGroups.Clear();
@@ -2605,10 +2403,6 @@ public sealed class RAMJobStore : IJobStore
 
             // make sure we don't have anything left in groups
             pausedTriggerGroups.Clear();
-        }
-        finally
-        {
-            lockObject.Release();
         }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
@@ -2714,8 +2508,7 @@ public sealed class RAMJobStore : IJobStore
         PendingSignals pending = default;
         List<IOperableTrigger> result = [];
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // return empty list if store has no triggers. Returning from inside the lock skips the
             // notification flush below, which is only safe because nothing has been recorded yet.
@@ -2877,10 +2670,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         // Before the batch is handed back, so that every misfire this pass applied has been announced
         // by the time the caller can fire anything it acquired.
@@ -2893,10 +2682,9 @@ public sealed class RAMJobStore : IJobStore
     /// fire the given <see cref="ITrigger" />, that it had previously acquired
     /// (reserved).
     /// </summary>
-    public async ValueTask ReleaseAcquiredTrigger(IOperableTrigger trigger, CancellationToken cancellationToken = default)
+    public ValueTask ReleaseAcquiredTrigger(IOperableTrigger trigger, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // Releasing means the scheduler is not going to run this fire after all, so anything recorded
             // for it has to go: the scheduler releases the whole batch when TriggersFired fails part-way,
@@ -2912,10 +2700,8 @@ public sealed class RAMJobStore : IJobStore
                 timeTriggers.Add(tw);
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
+
+        return default;
     }
 
     /// <summary>
@@ -2923,10 +2709,9 @@ public sealed class RAMJobStore : IJobStore
     /// given <see cref="ITrigger" /> (executing its associated <see cref="IJob" />),
     /// that it had previously acquired (reserved).
     /// </summary>
-    public async ValueTask<List<TriggerFiredResult>> TriggersFired(IReadOnlyCollection<IOperableTrigger> triggers, CancellationToken cancellationToken = default)
+    public ValueTask<List<TriggerFiredResult>> TriggersFired(IReadOnlyCollection<IOperableTrigger> triggers, CancellationToken cancellationToken = default)
     {
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             List<TriggerFiredResult> results = new(triggers.Count);
 
@@ -3074,11 +2859,7 @@ public sealed class RAMJobStore : IJobStore
                 results.Add(TriggerFiredResult.Fired(bndle));
             }
 
-            return results;
-        }
-        finally
-        {
-            lockObject.Release();
+            return new ValueTask<List<TriggerFiredResult>>(results);
         }
     }
 
@@ -3093,8 +2874,7 @@ public sealed class RAMJobStore : IJobStore
     {
         PendingSignals pending = default;
 
-        await lockObject.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             // It's possible that the job is null if:
             //   1- it was deleted during execution
@@ -3287,10 +3067,6 @@ public sealed class RAMJobStore : IJobStore
                 }
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
         await pending.Raise(signaler, cancellationToken).ConfigureAwait(false);
     }
@@ -3330,12 +3106,11 @@ public sealed class RAMJobStore : IJobStore
     /// Peeks the triggers.
     /// </summary>
     /// <returns></returns>
-    internal async ValueTask<string> PeekTriggers()
+    internal ValueTask<string> PeekTriggers()
     {
         StringBuilder str = new StringBuilder();
 
-        await lockObject.WaitAsync().ConfigureAwait(false);
-        try
+        lock (lockObject)
         {
             foreach (TriggerWrapper tw in triggersByKey.Values)
             {
@@ -3351,19 +3126,20 @@ public sealed class RAMJobStore : IJobStore
                 str.Append("->");
             }
         }
-        finally
-        {
-            lockObject.Release();
-        }
 
-        return str.ToString();
+        return new ValueTask<string>(str.ToString());
     }
 
     /// <summary>
-    /// Whether some caller is currently inside the store's critical section. For tests that assert
-    /// where a notification is raised from; nothing in the store's own logic asks.
+    /// Whether the calling thread is currently inside the store's critical section. For tests that
+    /// assert where a notification is raised from; nothing in the store's own logic asks.
     /// </summary>
-    internal bool LockHeld => lockObject.CurrentCount == 0;
+    /// <remarks>
+    /// A notification is raised on the thread that ran the section it belongs to, so what those tests
+    /// want to know is whether <em>this</em> thread still holds the lock — which is also the only
+    /// question a monitor can answer without racing.
+    /// </remarks>
+    internal bool LockHeld => lockObject.IsHeldByCurrentThread;
 
     /// <summary>
     /// The notifications a locked section owes the signaler, raised once the lock is released.
@@ -3371,11 +3147,15 @@ public sealed class RAMJobStore : IJobStore
     /// <remarks>
     /// <para>
     /// Every notification this store raises runs listener code on the calling thread, and a listener is
-    /// entitled to call back into the scheduler, which calls straight back into this store. The store's
-    /// lock is a <see cref="SemaphoreSlim" /> and is not re-entrant, so a notification raised from
-    /// inside it deadlocks the caller against itself. The sites that would notify therefore record
-    /// instead, and each public entry point raises what it collected after releasing the lock, in the
-    /// order it was recorded.
+    /// entitled to call back into the scheduler, which calls straight back into this store. It is also
+    /// entitled to take as long as it likes, and to <see langword="await" /> — which C# will not let it
+    /// do under <see cref="lockObject" /> at all (CS1996). Raising a notification inside the lock would
+    /// therefore mean running arbitrary listener code with the whole store held, and, because a monitor
+    /// is re-entrant where the semaphore this used to be was not, letting that listener re-enter and
+    /// mutate the store half-way through an operation instead of deadlocking against it. The sites that
+    /// would notify record instead, and each public entry point raises what it collected after leaving
+    /// the lock, in the order it was recorded. That is also what keeps every locked section here
+    /// synchronous, which is the property the monitor depends on.
     /// </para>
     /// <para>
     /// A <see langword="default" /> value is an empty collector that has allocated nothing, which is

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -74,6 +74,29 @@ public sealed class RAMJobStore : IJobStore
     private readonly Dictionary<TriggerKey, Dictionary<string, FireInstanceEntry>> executingFireInstances = [];
 
     /// <summary>
+    /// The fire-instance maps no execution is using, kept for the next firing rather than left to the
+    /// collector.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A trigger gets one of those maps when a firing starts and no other execution of it is in flight,
+    /// and loses it when its last execution completes. An ordinary schedule runs one firing of a trigger
+    /// at a time, so that is a dictionary allocated and thrown away on <em>every</em> firing — around
+    /// four hundred bytes of the roughly three and a half kilobytes a <c>RAMJobStore</c> firing costs.
+    /// Handing it back here instead costs a push and a pop.
+    /// </para>
+    /// <para>
+    /// It cannot grow without bound: a map reaches this stack only after having been live, so the number
+    /// in existence is the largest number of triggers that have ever been executing at once, which the
+    /// thread pool caps. Only <see cref="ReleaseExecutionNoLock" /> returns one, and only after taking it
+    /// out of <see cref="executingFireInstances" /> — the trigger-removal paths drop their maps rather
+    /// than pooling them, because <see cref="ReplaceTrigger" /> keeps a reference to put back should the
+    /// replacement fail. Guarded by the store lock, like everything else here.
+    /// </para>
+    /// </remarks>
+    private readonly Stack<Dictionary<string, FireInstanceEntry>> spareFireInstanceMaps = new();
+
+    /// <summary>
     /// What one running execution is, beyond its id. The in-memory counterpart of an EXECUTING row of
     /// the ADO store's FIRED_TRIGGERS table, and the source of the <see cref="FireInstance" />s
     /// <see cref="QueryFireInstances" /> reports.
@@ -1036,6 +1059,12 @@ public sealed class RAMJobStore : IJobStore
     /// Records that an execution of the trigger has finished, forgetting the trigger entirely once its
     /// last one has. An unknown fire instance is a no-op, so a repeated completion cannot miscount.
     /// </summary>
+    /// <remarks>
+    /// The emptied map goes to <see cref="spareFireInstanceMaps" /> for the next firing to use. It has
+    /// left <see cref="executingFireInstances" /> by then and held nothing when it did, so what comes
+    /// back out of the stack is reachable from nowhere else and carries no execution of the trigger it
+    /// used to belong to.
+    /// </remarks>
     private void ReleaseExecutionNoLock(TriggerKey triggerKey, string fireInstanceId)
     {
         if (executingFireInstances.TryGetValue(triggerKey, out var fireInstances)
@@ -1043,6 +1072,7 @@ public sealed class RAMJobStore : IJobStore
             && fireInstances.Count == 0)
         {
             executingFireInstances.Remove(triggerKey);
+            spareFireInstanceMaps.Push(fireInstances);
         }
     }
 
@@ -3027,7 +3057,7 @@ public sealed class RAMJobStore : IJobStore
                 // behind that no completion will ever clear. Released in TriggeredJobComplete.
                 if (!executingFireInstances.TryGetValue(tw.TriggerKey, out var fireInstances))
                 {
-                    fireInstances = [];
+                    fireInstances = spareFireInstanceMaps.TryPop(out var spare) ? spare : [];
                     executingFireInstances[tw.TriggerKey] = fireInstances;
                 }
 


### PR DESCRIPTION
Closes #3674.

`RAMJobStore` was 1.4x slower per firing than 3.20 and allocated 11 % more. It is now **faster than
3.20 at both pool sizes and allocates 21 % less**. Two commits, both in the store, and neither of them
is any of the things the issue guessed.

## What it actually was

The investigation is written up in full [on the issue](https://github.com/quartznet/quartznet/issues/3674#issuecomment-5508586551)
— an in-path allocation probe on both branches, a single-threaded driver that runs the same fire path
uncontended, and five ablation builds. The short version: **every 4.0 feature the issue suspected is
cheaper than the 3.x code it replaced.** Measured one at a time, per firing, uncontended:

| | 4.0 | 3.20 |
|---|---:|---:|
| job factory — DI scope vs `PropertySettingJobFactory` | **328 B** | 456 B |
| `JobExecutionContextImpl` | **248 B** | 480 B |
| trigger + job listener notifications | **48 B** | 720 B |
| middleware pipeline, `Activity`, meters, retry check | **0 B** | — |

The regression was two things in `RAMJobStore`:

**1. A `Dictionary` allocated and thrown away on every firing** (`01f7ad4`). `executingFireInstances`
holds a trigger's running executions in an inner map, created when a firing starts and no other
execution of that trigger is in flight, and dropped when its last one completes — which for an
ordinary schedule is every firing. It is handed on to the next firing instead.

**2. The lock became `await SemaphoreSlim.WaitAsync` where 3.x's is a monitor** (`eb753b3`). Every
section it guards is synchronous in-memory work of a microsecond or two — every `await` in the file
raises `PendingSignals` *after* the lock — so the asynchronous wait bought nothing and charged for a
suspension whenever the lock was busy. Under ten workers, **64 % of `TriggersFired` calls, 41 % of
`TriggeredJobComplete` calls and 31 % of acquisitions did not finish on the thread that began them**;
each boxed a state machine, allocated a wait node and cost a thread-pool hop. 3.x suspends nowhere on
that path. It is now `System.Threading.Lock` and `lock (lockObject)` at all 52 sites.

## The numbers

`FireThroughputBenchmark` RAM against `baseline-3x/FireThroughputBaselineBenchmark.cs` on
`origin/3.x` at `9ee33fec1`, **five alternating pairs in one sitting**, order reversed between them,
on a machine with other work on it throughout:

| Version | MaxConcurrency | Mean (5 runs) | Median | Error | Allocated |
|---|---|---:|---:|---:|---:|
| **4.0** | 10 | 1.865–2.604 µs | **2.164 µs** | 1.6–2.7 % | **2.56–2.58 KB** |
| **4.0** | 50 | 1.347–2.102 µs | **1.805 µs** | 0.9–7.8 % | **2.56–2.57 KB** |
| 3.20 | 10 | 2.456–3.237 µs | 2.579 µs | 1.7–6.0 % | 3.21–3.28 KB |
| 3.20 | 50 | 2.234–4.382 µs | 2.713 µs | 1.6–10.5 % | 3.25–3.30 KB |

Ranges rather than single figures because the box was busy; the allocation column is exact whatever
the load, and four of the five 4.0 runs read 2.56 or 2.57 KB at both pool sizes (the fifth read
3.35 KB at 50 with an 8 % Error, the only reading in the set that does not repeat).

The in-tree `RAMJobStoreBenchmark.AcquireAndFireAndComplete_MultipleTriggersForJobsThatDisallowConcurrentExecution`
case — one acquisition of two triggers, one `TriggersFired`, two completions — moved 3.45 KB → 2.74 KB
on the first commit alone.

## What a reviewer should decide

- **Signatures are untouched** — same `IJobStore` contract, same `ValueTask`/`ValueTask<T>`, same
  trailing `CancellationToken cancellationToken = default`. 32 members that were left `async` with
  nothing to await are now plain `ValueTask`-returning methods, so an argument failure they used to
  report through a faulted `ValueTask` now throws before returning one. Every caller in the tree awaits
  at the call site, so the two are the same thing to all of them — but it is the one observable change
  in the pair and it is worth a look.
- **A caller waiting for the lock no longer observes its cancellation token.** It could not usefully:
  the wait is bounded by the section in front of it, which does no I/O and cannot block. Cancellation
  is still observed where it means something, and this is what 3.x has always done. Said in the field's
  own doc comment.
- **The spare-map list is uncapped.** A map reaches it only after having been live, so the number in
  existence is the largest number of triggers ever executing at once, which the thread pool caps; a cap
  would be unreachable. Worth agreeing with.
- `RAMJobStoreFireInstanceReuseTest` guards the reuse — nothing of a finished trigger reaches the next
  firing, a trigger that fires again reports only its new execution, and a trigger whose second
  execution is still running keeps it when the first completes. The last fails if the emptied-map guard
  goes; checked by removing it. The lock change has no new test: the existing `RAMJobStore` contract,
  concurrency and notification-ordering tests are the guard, `LockHeld` now answers
  `IsHeldByCurrentThread`, and `RAMJobStoreNotifiesAfterUnlockTest` still passes unchanged.

`src/Quartz.Benchmark/README.md` and `docs/documentation/quartz-4.x/operations.md` carried the old
"about 1.4x slower" rows and the wrong reason for them; both now carry these numbers and what the
investigation found.

## Verification

```
dotnet build Quartz.slnx                                          0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                                 Failed: 0, Passed: 5212, Skipped: 36
dotnet test src/Quartz.Tests.AspNetCore                           Failed: 0, Passed: 605, Skipped: 0
dotnet test src/Quartz.Tests.Integration --filter ~RAMJobStore    Failed: 0, Passed: 101, Skipped: 0
dotnet fallout BenchmarkSmoke                                     Succeeded, 284 benchmarks
dotnet fallout VerifyDocsSnippets                                 Succeeded, 106 markdown files checked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqrmFVgN97Z6aRpjBU3LRQ
