### PR TITLE
A stable tag is dry-run before the first one is pushed

### DIFF
--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -139,7 +139,7 @@
         },
         "Database": {
           "type": "string",
-          "description": "Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, basic, all)"
+          "description": "Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, redis, basic, all)"
         },
         "FeedzApiKey": {
           "type": "string",

--- a/.fallout/build.schema.json
+++ b/.fallout/build.schema.json
@@ -31,6 +31,7 @@
         "DocsBuild",
         "DocsLogEvents",
         "DocsSnippets",
+        "ExamplesSmoke",
         "GenerateMigrations",
         "GenerateSchema",
         "IntegrationTest",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,29 @@
 
 version: 2
 updates:
+  # The actions the workflows use. Nothing watched them before, so a pinned major goes stale in silence
+  # until GitHub deprecates the runtime behind it and the leg starts failing - which is how the two
+  # hand-written docs workflows sat three majors behind on actions/checkout while the generated ones
+  # moved on.
+  #
+  # Eleven of the fifteen workflows are generated from build/Build.CI.GitHubActions.cs and carry the
+  # action versions Fallout writes, so a bump Dependabot proposes for one of those is not a bump to
+  # keep: the next 'fallout --generate-configuration' run puts the old version straight back. Move
+  # Fallout instead, and let the generator write the new versions. The four hand-written workflows -
+  # docs.yml, docs-pr.yml, sonar.yml and issue-triage.yml - are the ones this ecosystem is for.
+  #
+  # One group, because an action bump is a one-line change and fifteen separate pull requests for the
+  # same major would be fifteen reviews of the same decision.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+
   - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,13 +15,22 @@ on:
       - 'src/*/Verify/LogEventCatalogTest_*.verified.txt'
 permissions:
   contents: read
+
+# One deploy at a time. The last step force-pushes a whole site into quartznet.github.io, so two runs
+# started by two quick pushes to main race each other and whichever finishes last wins - which is not
+# necessarily the newer commit. The published site is a pure function of main, so a superseded run has
+# nothing to contribute and is cancelled rather than queued.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build and deploy
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 'Setup: .NET SDK'
         uses: actions/setup-dotnet@v6
@@ -53,6 +62,14 @@ jobs:
 
       - name: Build
         run: npm run docs:build
+
+      # A broken link is a property of the site as a whole, and the pull request leg only ever sees the
+      # pages one change touched: a heading renamed on one page 404s every fragment that pointed at it
+      # from a page that change did not include. This is the whole-site run, and it is the last gate
+      # before the deploy. The checker's own control - docs:check-links-test - stays on the pull request
+      # leg, which is where a change to the checker is reviewed.
+      - name: Check links and anchors
+        run: npm run docs:check-links
 
       - name: Deploy
         working-directory: ./docs/.vuepress/dist

--- a/.github/workflows/pr-tests-unit.yml
+++ b/.github/workflows/pr-tests-unit.yml
@@ -48,8 +48,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, ExamplesSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke ExamplesSmoke PublishTrimmed PublishAot
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -62,8 +62,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, ExamplesSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke ExamplesSmoke PublishTrimmed PublishAot
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
@@ -76,5 +76,5 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, PublishTrimmed, PublishAot'
-        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke PublishTrimmed PublishAot
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, BenchmarkSmoke, WolverineSmoke, ExamplesSmoke, PublishTrimmed, PublishAot'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest BenchmarkSmoke WolverineSmoke ExamplesSmoke PublishTrimmed PublishAot

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,8 @@ jobs:
           global-json-file: global.json
       - name: 'Restore: dotnet tools'
         run: dotnet tool restore
-      - name: 'Run: Compile, UnitTest, Pack, Publish'
-        run: dotnet fallout Compile UnitTest Pack Publish
+      - name: 'Run: VerifyMigrations, VerifySchema, Compile, UnitTest, Pack, Publish'
+        run: dotnet fallout VerifyMigrations VerifySchema Compile UnitTest Pack Publish
       - name: 'Publish: packages'
         uses: actions/upload-artifact@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,17 @@ Integration tests provision their database dependencies through Testcontainers f
 
 * Ensure your Docker daemon is running
 * Name the database to run against: `.\build.cmd Compile UnitTest IntegrationTest --database postgres`.
-  The values are `postgres`, `sqlserver`, `mysql`, `oracle`, `firebird`, `sqlite`, `basic` (everything
-  that needs no database) and `all`, and they set both the test-category filter and the
+  The values are `postgres`, `sqlserver`, `mysql`, `oracle`, `firebird`, `sqlite`, `redis`, `basic`
+  (everything that needs no database) and `all`, and they set both the test-category filter and the
   `QUARTZ_TEST_DATABASE` variable the Testcontainers fixture reads. Naming none means `all`, which
-  starts six containers — including Oracle — before a single test runs.
+  starts seven containers — two for SQL Server, and one of them Oracle — before a single test runs.
 
-This builds and runs tests the way the CI server does.
+This builds and runs tests the way the CI server does. `IntegrationTest` is skipped on one machine
+only: a Windows or macOS CI leg, neither of which has a Docker daemon. It runs on yours.
+
+The half-hour clustered soak is excluded from every one of those runs, `all` included, because a leg
+that ran it would read as a hung job rather than as thoroughness. It is a release gate, run by hand
+through `dotnet test` rather than through the build; `ClusteredSoakTestBase` gives the command.
 
 ## Documentation
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,8 +2,19 @@
 
   <PropertyGroup>
 
-    <Title>Quartz.NET</Title>
+    <!--
+      There is deliberately no <Title> here. nuget.org shows the title in a search result and Visual
+      Studio's package manager shows it in the list, so a shared one makes every package look like the
+      same package: six of the ten shipped as "Quartz.NET" through beta.1. Each packable project writes
+      its own, and PackageMetadataTest fails a new one that forgets - with no default to inherit, NuGet
+      falls back to the package id, which is at least distinct.
+    -->
     <Product>Quartz.NET</Product>
+    <!--
+      The fallback description, and the tail every package appends its own sentence to. Quartz and
+      Quartz.HttpClient used to take it whole, which is how two package pages described the framework
+      rather than the package.
+    -->
     <Description>Quartz Scheduling Framework for .NET</Description>
     <Copyright>Copyright Marko Lahma</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -11,12 +22,27 @@
     <Authors>Marko Lahma, Quartz.NET</Authors>
     <WarningsAsErrors>True</WarningsAsErrors>
 
+    <!--
+      The icon ships inside the package, and there is no PackageIconUrl beside it: NuGet deprecated that
+      property, it is a second answer to the same question, and the URL that used to be here named a
+      'master' branch this repository does not have. NU5048 reports it only when PackageIcon is missing,
+      so nothing was going to notice; PackageMetadataTest does.
+    -->
     <PackageIcon>quartz-logo-small.png</PackageIcon>
-    <PackageIconUrl>https://raw.githubusercontent.com/quartznet/quartznet/master/src/quartz-logo-small.png</PackageIconUrl>
+    <!-- The shared half of every package's tags. Each one adds what makes it itself. -->
     <PackageTags>scheduling;tasks;jobs;triggers;scheduler;threading</PackageTags>
     <PackageProjectUrl>https://www.quartz-scheduler.net/</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/quartznet/quartznet/releases</PackageReleaseNotes>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <!--
+      Where the source is, said outright rather than only inferred. SourceLink fills these in from the
+      git remote when they are empty and PublishRepositoryUrl is set, and leaves a value that is already
+      there alone — so naming them is what makes a pack from a tree with no .git still carry a
+      repository element, and the source zip PackZip produces is exactly such a tree. The commit
+      attribute beside them stays SourceLink's, because only git knows it.
+    -->
+    <RepositoryUrl>https://github.com/quartznet/quartznet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,13 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.Data.SQLite" Version="11.0.0-preview.7.26381.103" />
+    <!--
+      The stable 10.x line, aligned with the Microsoft.Extensions.* versions above. It spent a while on
+      11.0.0-preview.* - it was moved there while .NET 10 was itself in preview and Dependabot kept it
+      walking that line - which no shipped package took, because only the tests, the examples and the
+      trim canary reference it. PackageDependencyTest is what keeps that true.
+    -->
+    <PackageVersion Include="Microsoft.Data.SQLite" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -62,12 +62,18 @@ using Quartz.Build;
 // Releases live in their own workflow file because a nuget.org trusted publishing policy is scoped by
 // workflow file name and offers no branch or tag filter — keeping this separate from 'build' is what
 // stops every ordinary CI run from being able to mint a nuget.org API key.
+//
+// VerifyMigrations and VerifySchema lead, as they do on the pull request leg. Both are generated
+// artefacts a release ships — database/migrations/ is what an upgrading deployment runs, and the
+// embedded create-if-missing schema is what ProvisionSchema executes — and a tag is the last moment
+// either can still be wrong. They cost seconds and they run before anything is built, so a stale
+// script fails the release in the first minute rather than after the packages have been made.
 [GitHubActions(
     "publish",
     GitHubActionsImage.WindowsLatest,
     OnPushTags = ["v*.*.*"],
     PublishArtifacts = true,
-    InvokedTargets = [nameof(ICompile.Compile), nameof(UnitTest), nameof(IPack.Pack), nameof(Publish)],
+    InvokedTargets = [nameof(VerifyMigrations), nameof(VerifySchema), nameof(ICompile.Compile), nameof(UnitTest), nameof(IPack.Pack), nameof(Publish)],
     CacheKeyFiles = [],
     TimeoutMinutes = 20,
     EnvironmentName = "nuget",

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -21,10 +21,12 @@ using Quartz.Build;
     // line tools ILCompiler links with, so there is nothing to install, and if that stops being true the
     // leg says so out loud rather than the claim going unchecked on a third platform.
     //
-    // BenchmarkSmoke and WolverineSmoke are on this workflow alone. Every change reaches main through a
-    // pull request, so this is where a broken benchmark or a broken example is caught while somebody is
-    // still looking; the push and release legs have ten-minute budgets and nothing to do with either.
-    InvokedTargets = [nameof(VerifyMigrations), nameof(VerifySchema), nameof(ICompile.Compile), nameof(UnitTest), nameof(BenchmarkSmoke), nameof(WolverineSmoke), nameof(PublishTrimmed), nameof(PublishAot)],
+    // BenchmarkSmoke, WolverineSmoke and ExamplesSmoke are on this workflow alone. Every change reaches
+    // main through a pull request, so this is where a broken benchmark or a broken example is caught
+    // while somebody is still looking; the push and release legs have ten-minute budgets and nothing to
+    // do with any of them. ExamplesSmoke runs the two applications PublishTrimmed only ever published,
+    // on all three images, because a host that refuses to start does so per platform.
+    InvokedTargets = [nameof(VerifyMigrations), nameof(VerifySchema), nameof(ICompile.Compile), nameof(UnitTest), nameof(BenchmarkSmoke), nameof(WolverineSmoke), nameof(ExamplesSmoke), nameof(PublishTrimmed), nameof(PublishAot)],
     CacheKeyFiles = [],
     // Generating native code is minutes rather than seconds, and it happens after everything else here.
     TimeoutMinutes = 20,

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -492,6 +495,232 @@ partial class Build : FalloutBuild, ICompile, IPack
                 .SetApplicationArguments("--smoke")
             );
         });
+
+    /// <summary>
+    /// Starts each example application and waits for it to say it is doing what it exists to show.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="PublishTrimmed" /> publishes <c>Quartz.Examples.Worker</c> and
+    /// <c>Quartz.Examples.AspNetCore</c> and has never started either, so an example that compiles and
+    /// publishes but cannot get through <c>Build().Run()</c> passed every leg there is. Both were broken
+    /// at beta.1 — one by a pair of scheduling options that refuse each other at startup, the other by a
+    /// job asking for an <c>IHttpClientFactory</c> nothing registered, which Development's registration
+    /// validation turns into a refusal to start — and nothing in CI could have noticed either. This is
+    /// what would have.
+    /// </para>
+    /// <para>
+    /// Development is the environment on purpose: it is the one the examples are read and run in, and the
+    /// one that validates the whole container at build time rather than discovering a missing
+    /// registration on first use. Each application is started from its build output rather than through
+    /// <c>dotnet run</c>, so the process this target holds is the application itself — killing
+    /// <c>dotnet run</c> would leave a web server listening on the runner.
+    /// </para>
+    /// <para>
+    /// The third example is the interactive tour, whose <c>--list</c> is the part of it a machine can
+    /// run; it walks the catalogue every entry is registered in and exits.
+    /// </para>
+    /// <para>
+    /// Beside <see cref="BenchmarkSmoke" /> and <see cref="WolverineSmoke" />, after the unit tests, for
+    /// the reason those give: all of them want the machine, and a failing test is the one worth reading
+    /// first.
+    /// </para>
+    /// </remarks>
+    Target ExamplesSmoke => _ => _
+        .DependsOn<ICompile>()
+        .After(UnitTest)
+        .Before<IPack>()
+        .Executes(() =>
+        {
+            var solution = ((IHasSolution) this).Solution;
+            var configuration = ((ICompile) this).Configuration;
+
+            DotNetRun(s => s
+                .SetProjectFile(solution.AllProjects.First(x => x.Name == "Quartz.Examples"))
+                .SetConfiguration(configuration)
+                .SetApplicationArguments("--list")
+            );
+
+            RunExampleUntilItSays(
+                "Quartz.Examples.Worker",
+                new Dictionary<string, string>(StringComparer.Ordinal) { ["DOTNET_ENVIRONMENT"] = "Development" },
+                // The host is up, and the job the example schedules ran: the hosted service holds the
+                // scheduler back for ten seconds before the first trigger can fire, so the second line
+                // is the one that says the whole of it worked.
+                ["Application started", "job executing, triggered by"]);
+
+            RunExampleUntilItSays(
+                "Quartz.Examples.AspNetCore",
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["ASPNETCORE_ENVIRONMENT"] = "Development",
+                    // Kestrel's default endpoints are 5000 and an HTTPS 5001 that wants a development
+                    // certificate no runner has. Naming one loopback port answers both, and lets two of
+                    // these run at once without colliding. The example's launch profile also says 5000,
+                    // and is not read here: launchSettings.json belongs to 'dotnet run'.
+                    ["ASPNETCORE_URLS"] = $"http://127.0.0.1:{FreeLoopbackPort()}",
+                },
+                ["Application started"]);
+        });
+
+    /// <summary>
+    /// How long an example is given to say everything it was started to say.
+    /// </summary>
+    /// <remarks>
+    /// Generous rather than tight, because what the bound is for is a hang and a hang does not end: the
+    /// worker's hosted service waits ten seconds before starting its scheduler, and a cold runner spends
+    /// a while on the first JIT of an ASP.NET Core pipeline. Nothing here is a measurement.
+    /// </remarks>
+    static readonly TimeSpan ExampleStartTimeout = TimeSpan.FromMinutes(3);
+
+    /// <summary>
+    /// Starts one example, waits for every line it was started to produce, and stops it. A non-zero exit,
+    /// an exit at all, or a line that never arrives fails the target.
+    /// </summary>
+    void RunExampleUntilItSays(string projectName, IReadOnlyDictionary<string, string> environment, IReadOnlyList<string> markers)
+    {
+        var configuration = ((ICompile) this).Configuration;
+
+        // Where UseArtifactsOutput in Directory.Build.props puts a build. Asserted rather than assumed,
+        // so a layout that moves says so by name instead of failing as a process that would not start.
+        AbsolutePath assembly = ArtifactsDirectory / "bin" / projectName / configuration.ToString().ToLowerInvariant() / $"{projectName}.dll";
+        Assert.FileExists(assembly);
+
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = DotNetPath,
+            // The content root a host takes when it is not told one, which is where the example's
+            // appsettings.json and its XML schedule were copied to.
+            WorkingDirectory = assembly.Parent,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+
+        startInfo.ArgumentList.Add(assembly);
+
+        foreach (KeyValuePair<string, string> variable in environment)
+        {
+            startInfo.Environment[variable.Key] = variable.Value;
+        }
+
+        List<string> output = [];
+        HashSet<string> waiting = new(markers, StringComparer.Ordinal);
+
+        using Process process = new() { StartInfo = startInfo };
+
+        // One lock over both, because the reader threads write them and this thread reads them.
+        void Received(object sender, DataReceivedEventArgs line)
+        {
+            if (line.Data is null)
+            {
+                return;
+            }
+
+            lock (output)
+            {
+                output.Add(line.Data);
+                waiting.RemoveWhere(marker => line.Data.Contains(marker, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+
+        process.OutputDataReceived += Received;
+        process.ErrorDataReceived += Received;
+
+        Log.Information("Starting {Project} and waiting for {Markers}", projectName, Quoted(markers));
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        Stopwatch running = Stopwatch.StartNew();
+        bool exitedOnItsOwn = false;
+
+        while (running.Elapsed < ExampleStartTimeout)
+        {
+            lock (output)
+            {
+                if (waiting.Count == 0)
+                {
+                    break;
+                }
+            }
+
+            if (process.WaitForExit(250))
+            {
+                exitedOnItsOwn = true;
+                break;
+            }
+        }
+
+        string[] missing;
+        lock (output)
+        {
+            missing = [.. waiting];
+        }
+
+        if (exitedOnItsOwn)
+        {
+            // The overload with no timeout is the one that waits for the asynchronous readers as well,
+            // so the tail below is the whole of what the application said before it stopped.
+            process.WaitForExit();
+
+            Assert.Fail($"{projectName} exited with code {process.ExitCode} after {running.Elapsed.TotalSeconds:F0}s "
+                + $"instead of running, and never said {Quoted(missing)}.{Tail(output)}");
+        }
+
+        // A kill rather than Ctrl+C: on Windows a console control event goes to a process group rather
+        // than to one process, so sending one would stop this build too. What a graceful shutdown does is
+        // the hosted service's business and the unit suite's; what this target asks is whether the
+        // application starts and works at all.
+        if (!process.HasExited)
+        {
+            process.Kill(entireProcessTree: true);
+        }
+
+        process.WaitForExit();
+
+        if (missing.Length > 0)
+        {
+            Assert.Fail($"{projectName} was still running after {ExampleStartTimeout.TotalSeconds:F0}s "
+                + $"but never said {Quoted(missing)}.{Tail(output)}");
+        }
+
+        Log.Information("{Project} said all of it, {Elapsed:F0}s in", projectName, running.Elapsed.TotalSeconds);
+    }
+
+    static string Quoted(IReadOnlyCollection<string> markers) =>
+        string.Join(" and ", markers.Select(x => $"'{x}'"));
+
+    /// <summary>
+    /// The end of what an example printed, which is where the reason it stopped or stalled is.
+    /// </summary>
+    static string Tail(List<string> output)
+    {
+        lock (output)
+        {
+            return Environment.NewLine + "The last of its output:" + Environment.NewLine
+                + string.Join(Environment.NewLine, output.TakeLast(60));
+        }
+    }
+
+    /// <summary>
+    /// A loopback port nothing is listening on, found by binding one and letting it go.
+    /// </summary>
+    static int FreeLoopbackPort()
+    {
+        TcpListener listener = new(IPAddress.Loopback, 0);
+        listener.Start();
+
+        try
+        {
+            return ((IPEndPoint) listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener.Stop();
+        }
+    }
 
     static readonly string[] DatabaseCategories =
         ["db-postgres", "db-sqlserver", "db-mysql", "db-oracle", "db-firebird", "db-sqlite", "db-redis"];

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -28,7 +28,7 @@ partial class Build : FalloutBuild, ICompile, IPack
 {
     public static int Main() => Execute<Build>(x => ((ICompile) x).Compile);
 
-    [Parameter("Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, basic, all)")]
+    [Parameter("Database to test against (postgres, sqlserver, mysql, oracle, firebird, sqlite, redis, basic, all)")]
     readonly string Database;
 
     [Parameter("Collect line and branch coverage while running the unit tests, in OpenCover format")]
@@ -534,10 +534,29 @@ partial class Build : FalloutBuild, ICompile, IPack
         return string.IsNullOrEmpty(databaseFilter) ? excludeLongRunning : $"{databaseFilter}&{excludeLongRunning}";
     }
 
+    /// <summary>
+    /// The integration suite, against the database <see cref="Database" /> names or against every one of
+    /// them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The gate is about CI legs, and only about CI legs. Docker is what every fixture here needs, and
+    /// of the three images the workflows run on only Ubuntu has a daemon — so the Windows and macOS legs
+    /// skip the target rather than failing it, and it is the negation that says so.
+    /// </para>
+    /// <para>
+    /// It used to say <c>Host is GitHubActions &amp;&amp; Linux</c>, which also skipped every developer
+    /// machine: <c>build.cmd Compile UnitTest IntegrationTest</c> — the command CONTRIBUTING.md, the pull
+    /// request template and AGENTS.md all give — reported the target as skipped and exited zero, so a
+    /// contributor asked to run the integration tests before opening a pull request ran none of them and
+    /// was told nothing. A local run has a daemon or it does not, and Testcontainers says which in a
+    /// message worth reading; a silent skip says nothing at all.
+    /// </para>
+    /// </remarks>
     Target IntegrationTest => _ => _
         .DependsOn<ICompile>()
         .Before<IPack>()
-        .OnlyWhenDynamic(() => Host is GitHubActions && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        .OnlyWhenDynamic(() => Host is not GitHubActions || RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         .Executes(() =>
         {
             var database = Database?.ToLowerInvariant();

--- a/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
+++ b/src/Quartz.AspNetCore/Quartz.AspNetCore.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Quartz.NET ASP.NET Core integration; $(Description)</Description>
+    <Title>Quartz.NET ASP.NET Core Integration</Title>
+    <Description>Quartz.NET ASP.NET Core integration - the HTTP API a remote scheduler is driven through, and the health check endpoint; $(Description)</Description>
+    <PackageTags>$(PackageTags);aspnetcore;http-api;minimal-api;openapi;health-checks</PackageTags>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Quartz.Dashboard/Quartz.Dashboard.csproj
+++ b/src/Quartz.Dashboard/Quartz.Dashboard.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Description>Quartz.NET Blazor Server Dashboard; $(Description)</Description>
+    <Title>Quartz.NET Dashboard</Title>
+    <Description>Quartz.NET Blazor Server Dashboard - a live view of every scheduler in the application, its jobs, triggers and calendars; $(Description)</Description>
+    <PackageTags>$(PackageTags);dashboard;blazor;ui;monitoring;aspnetcore</PackageTags>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz.Dashboard</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Quartz</RootNamespace>
     <Title>Quartz.NET Redis Integration</Title>
     <Description>Quartz.NET Redis integration - distributed lock handler for clustered scheduling; $(Description)</Description>
+    <PackageTags>$(PackageTags);redis;clustering;distributed-lock;stackexchange-redis</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--

--- a/src/Quartz.HttpClient/Quartz.HttpClient.csproj
+++ b/src/Quartz.HttpClient/Quartz.HttpClient.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyTitle>Quartz.NET HTTP client</AssemblyTitle>
+    <AssemblyTitle>Quartz.NET HTTP Client</AssemblyTitle>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Quartz.NET HTTP Client</Title>
+    <Description>Quartz.NET HTTP client - an IScheduler that drives a scheduler in another process over the HTTP API Quartz.AspNetCore serves; $(Description)</Description>
+    <PackageTags>$(PackageTags);http;httpclient;rest;remote;client</PackageTags>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Quartz.Jobs/Quartz.Jobs.csproj
+++ b/src/Quartz.Jobs/Quartz.Jobs.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Quartz.NET Jobs; $(Description)</Description>
+    <Title>Quartz.NET Jobs</Title>
+    <Description>Quartz.NET Jobs - the jobs that ship ready to schedule: directory and file scanning, sending mail, and running a native process; $(Description)</Description>
+    <PackageTags>$(PackageTags);directory-scan;file-watcher;send-mail;native-job</PackageTags>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
+++ b/src/Quartz.Plugins.TimeZoneConverter/Quartz.Plugins.TimeZoneConverter.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
-    <Title>Quartz.NET TimeZoneConverter integration</Title>
-    <Description>Quartz.NET TimeZoneConverter integration https://github.com/mj1856/TimeZoneConverter; $(Description)</Description>
+    <Title>Quartz.NET TimeZoneConverter Integration</Title>
+    <Description>Quartz.NET TimeZoneConverter integration - resolves a trigger's time zone by either its IANA or its Windows id, on either operating system, through https://github.com/mj1856/TimeZoneConverter; $(Description)</Description>
+    <PackageTags>$(PackageTags);timezone;timezoneconverter;iana;tzdb</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <Authors>Sean Farrow, Quartz.NET</Authors>
+    <Authors>Sean Farrow, Marko Lahma, Quartz.NET</Authors>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--
       Trimmable, and the analyzers that make that a checked statement rather than a claim (issue #3431).

--- a/src/Quartz.Plugins/Quartz.Plugins.csproj
+++ b/src/Quartz.Plugins/Quartz.Plugins.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Quartz.NET Plugins; $(Description)</Description>
+    <Title>Quartz.NET Plugins</Title>
+    <Description>Quartz.NET Plugins - a schedule declared in XML or JSON and reloaded as the file changes, and job and trigger history logging; $(Description)</Description>
+    <PackageTags>$(PackageTags);plugins;xml-configuration;json-configuration;job-history</PackageTags>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
+++ b/src/Quartz.Serialization.Newtonsoft/Quartz.Serialization.Newtonsoft.csproj
@@ -3,8 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Quartz</RootNamespace>
-    <Title>Quartz.NET JSON Serialization</Title>
-    <Description>Quartz.NET JSON Serialization Support; $(Description)</Description>
+    <Title>Quartz.NET Json.NET Serialization</Title>
+    <Description>Quartz.NET Json.NET serialization - the job store serializer for a database already holding Newtonsoft.Json's output. New applications use the System.Text.Json one built into Quartz; $(Description)</Description>
+    <PackageTags>$(PackageTags);json;newtonsoft;serialization;job-store</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--

--- a/src/Quartz.Tests.Unit/PackageDependencyTest.cs
+++ b/src/Quartz.Tests.Unit/PackageDependencyTest.cs
@@ -1,0 +1,116 @@
+using System.Xml.Linq;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What a shipped package is allowed to depend on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// NuGet refuses a stable release that depends on a prerelease — NU5104, which
+/// <c>TreatWarningsAsErrors</c> makes fatal — and this repository has never produced a stable version:
+/// a local build carries a <c>dev-</c> suffix unconditionally, an untagged CI build a <c>preview-</c>
+/// one, and every tag so far has been a prerelease. So the rule has never been evaluated, and the only
+/// build that would evaluate it is the tag build that publishes to nuget.org (#3679).
+/// </para>
+/// <para>
+/// Central package management is what makes it checkable from source instead: a version is written in
+/// <c>Directory.Packages.props</c> and nowhere else, so a project's <c>PackageReference</c> plus that
+/// file is the dependency its nuspec will carry. <c>Directory.Packages.props</c> does pin a preview on
+/// purpose — <c>Microsoft.Data.SQLite</c>, for the tests and the trim canary — and this test is what
+/// says that pin may not reach a package that ships.
+/// </para>
+/// <para>
+/// The one door it does not walk is transitive pinning, which can add a dependency no project names:
+/// that needs a restore graph rather than a file, and the stable-version packing dry run recorded on
+/// #3679 is what covers it.
+/// </para>
+/// </remarks>
+public class PackageDependencyTest
+{
+    [TestCaseSource(nameof(ShippedPackageReferences))]
+    public void ShippedPackageTakesNoPrereleaseDependency(string project, string package, string version)
+    {
+        version.Should().NotBeNullOrEmpty(
+            $"{project} references {package}, and central package management is the only place its version may be written");
+
+        IsPrerelease(version).Should().BeFalse(
+            $"{project} ships, and NuGet refuses a stable release with a prerelease dependency (NU5104) — {package} {version} would fail the tag build rather than this one");
+    }
+
+    /// <summary>
+    /// Every (project, package) pair that becomes a dependency in a shipped package's nuspec.
+    /// </summary>
+    /// <remarks>
+    /// A reference marked <c>PrivateAssets="all"</c> is a build-time tool rather than a dependency, so
+    /// it is left out — the analyzer every shipped project gets from <c>Directory.Build.targets</c> is
+    /// exactly that, and it is why the nuspecs list no analyzer.
+    /// </remarks>
+    public static IEnumerable<TestCaseData> ShippedPackageReferences()
+    {
+        IReadOnlyDictionary<string, string> versions = CentralPackageVersions();
+
+        List<TestCaseData> cases = ShippedProjects.Find()
+            .SelectMany(project => PackageReferences(project)
+                .Select(package => new TestCaseData(project.Directory!.Name, package, versions.GetValueOrDefault(package))
+                    .SetArgDisplayNames(project.Directory!.Name, package)))
+            .ToList();
+
+        cases.Should().NotBeEmpty(
+            "the pairs are found by reading the shipped projects, and a walk that reaches none of them would pass anything");
+
+        return cases;
+    }
+
+    /// <summary>
+    /// Whether a version string names a prerelease: everything after the first <c>-</c> and before the
+    /// build metadata, which is what NuGet reads to decide that NU5104 applies.
+    /// </summary>
+    private static bool IsPrerelease(string version) =>
+        version.Split('+')[0].Contains('-', StringComparison.Ordinal);
+
+    private static IEnumerable<string> PackageReferences(FileInfo project) => XDocument
+        .Load(project.FullName)
+        .Descendants("PackageReference")
+        .Where(x => !string.Equals((string) x.Attribute("PrivateAssets"), "all", StringComparison.OrdinalIgnoreCase))
+        .Select(x => (string) x.Attribute("Include"))
+        .Where(x => !string.IsNullOrEmpty(x));
+
+    /// <summary>
+    /// Every <c>PackageVersion</c> in <c>Directory.Packages.props</c>, with the property references a
+    /// few of them use resolved against the same file's own properties.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> CentralPackageVersions()
+    {
+        FileInfo file = new(Path.Combine(RepositoryRoot.Find().FullName, "Directory.Packages.props"));
+        file.Exists.Should().BeTrue("every version in this repository is centrally managed, so this file is where they all are");
+
+        XDocument document = XDocument.Load(file.FullName);
+
+        Dictionary<string, string> properties = document
+            .Descendants("PropertyGroup")
+            .Elements()
+            .ToDictionary(x => x.Name.LocalName, x => x.Value.Trim(), StringComparer.OrdinalIgnoreCase);
+
+        return document
+            .Descendants("PackageVersion")
+            .ToDictionary(
+                x => (string) x.Attribute("Include"),
+                x => Resolve((string) x.Attribute("Version"), properties),
+                StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Substitutes a single <c>$(Name)</c> property reference, which is the only form the file uses —
+    /// Aspire ships its packages and its MSBuild SDK as one version, so they are written as a property.
+    /// </summary>
+    private static string Resolve(string version, IReadOnlyDictionary<string, string> properties)
+    {
+        if (version is null || !version.StartsWith("$(", StringComparison.Ordinal) || !version.EndsWith(')'))
+        {
+            return version;
+        }
+
+        return properties.GetValueOrDefault(version[2..^1], version);
+    }
+}

--- a/src/Quartz.Tests.Unit/PackageMetadataTest.cs
+++ b/src/Quartz.Tests.Unit/PackageMetadataTest.cs
@@ -1,0 +1,89 @@
+using System.Xml.Linq;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What tells a reader which package they are looking at.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="PackageReadmeTest" /> covers the page body; this covers the row above it. A shared default
+/// in <c>Directory.Build.props</c> is invisible on nuget.org, which renders the id when it has nothing
+/// better, and very visible in Visual Studio's package manager and <c>dotnet package search</c>, which
+/// render the title: six of the ten packages shipped through beta.1 titled "Quartz.NET", and two of
+/// them described as the framework rather than as themselves (#3679).
+/// </para>
+/// <para>
+/// Every packable project therefore writes its own title, description and tags, and this test is what
+/// notices a new one that does not. It reads the project files rather than a package, so it costs
+/// nothing and runs beside the rest of the unit suite.
+/// </para>
+/// </remarks>
+public class PackageMetadataTest
+{
+    /// <summary>
+    /// The properties a package page shows, which every shipped project has to answer for itself.
+    /// </summary>
+    private static readonly string[] OwnProperties = ["Title", "Description", "PackageTags"];
+
+    [TestCaseSource(nameof(ShippedProjectProperties))]
+    public void ShippedProjectDescribesItself(FileInfo project, string property)
+    {
+        Declared(project, property).Should().NotBeNullOrWhiteSpace(
+            $"nuget.org, Visual Studio's package manager and 'dotnet package search' all show {property} per package, "
+            + $"and {project.Name} would otherwise be shown as whatever Directory.Build.props happens to say");
+    }
+
+    [TestCaseSource(nameof(OwnPropertyNames))]
+    public void NoTwoShippedProjectsShareThem(string property)
+    {
+        IEnumerable<IGrouping<string, string>> shared = ShippedProjects.Find()
+            .Select(x => (Project: x.Directory!.Name, Value: Declared(x, property)))
+            .Where(x => !string.IsNullOrWhiteSpace(x.Value))
+            .GroupBy(x => x.Value, x => x.Project, StringComparer.Ordinal)
+            .Where(x => x.Count() > 1);
+
+        shared.Should().BeEmpty(
+            $"two packages with the same {property} are two rows a reader cannot tell apart, which is the whole reason the property is written per package");
+    }
+
+    /// <summary>
+    /// <c>PackageIconUrl</c> is NuGet's deprecated icon, and it is not set anywhere.
+    /// </summary>
+    /// <remarks>
+    /// The icon ships inside the package as <c>PackageIcon</c>, so the URL adds nothing but a second
+    /// answer to the same question — and the one that was here pointed into a <c>master</c> branch this
+    /// repository does not have. NuGet warns about the property (NU5048) only when <c>PackageIcon</c> is
+    /// absent, so nothing was going to report it.
+    /// </remarks>
+    [Test]
+    public void NothingSetsTheDeprecatedIconUrl()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+
+        List<FileInfo> files = [new(Path.Combine(root.FullName, "Directory.Build.props")), .. ShippedProjects.Find()];
+
+        IEnumerable<string> setting = files
+            .Where(x => XDocument.Load(x.FullName).Descendants("PackageIconUrl").Any())
+            .Select(x => x.Name);
+
+        setting.Should().BeEmpty(
+            "PackageIconUrl is deprecated and PackageIcon already ships the icon inside the package");
+    }
+
+    public static IEnumerable<TestCaseData> ShippedProjectProperties() => ShippedProjects.Find()
+        .SelectMany(project => OwnProperties
+            .Select(property => new TestCaseData(project, property).SetArgDisplayNames(project.Directory!.Name, property)));
+
+    public static IEnumerable<TestCaseData> OwnPropertyNames() => OwnProperties.Select(x => new TestCaseData(x));
+
+    /// <summary>
+    /// What the project file itself says, which is the only place that answers for one package —
+    /// anything inherited answers for all of them.
+    /// </summary>
+    private static string Declared(FileInfo project, string property) => XDocument
+        .Load(project.FullName)
+        .Descendants(property)
+        .Select(x => x.Value.Trim())
+        .SingleOrDefault();
+}

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <AssemblyTitle>Quartz.NET</AssemblyTitle>
     <TargetFramework>net10.0</TargetFramework>
+    <Title>Quartz.NET</Title>
+    <Description>Quartz.NET job scheduler - cron, calendar and interval triggers, clustering over a persistent job store, and Microsoft.Extensions hosting, logging, options and dependency injection throughout. The core package: everything else builds on this one.</Description>
+    <PackageTags>$(PackageTags);cron;clustering;background-jobs;hosted-service</PackageTags>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--


### PR DESCRIPTION
The rc.1 mechanics work: the tag build is rehearsed before a tag exists, the release leg checks the
artefacts it ships, the integration tests run on the machine that was told to run them, every package
says on nuget.org which package it is, and the two example applications are started rather than only
published.

No public API changed and no baseline moved.

Closes #3679

## G1 — the stable-version pack dry run

This repository has never produced a stable version: a local build carries a `dev-` suffix
unconditionally, an untagged CI build a `preview-` one, and every tag so far was a prerelease. So
NU5104 — "a stable release of a package should not have a prerelease dependency", fatal under
`TreatWarningsAsErrors` — had never been evaluated, and the first build that would evaluate it is the
tag build that publishes to nuget.org.

It has now been evaluated, at `917491d` (this branch's head). **Nothing failed.** Release day can
repeat exactly this.

### Pack

Fallout forces a `dev-` suffix on a local build, so the dry run goes around it with `dotnet pack`
directly — the same properties the tag build ends up with, because `v4.0.0` parses to
`VersionPrefix=4.0.0` with no suffix and `ContinuousIntegrationBuild` is on for every GitHub Actions
build:

```shell
dotnet pack src/<Project>/<Project>.csproj -c Release \
  -p:VersionPrefix=4.0.0 -p:VersionSuffix= -p:ContinuousIntegrationBuild=true -o <out>
```

run for each of the ten packable projects: `Quartz`, `Quartz.AspNetCore`, `Quartz.Aspire`,
`Quartz.Dashboard`, `Quartz.Extensions.Redis`, `Quartz.HttpClient`, `Quartz.Jobs`, `Quartz.Plugins`,
`Quartz.Plugins.TimeZoneConverter`, `Quartz.Serialization.Newtonsoft`.

Result: **20 packages (10 `.nupkg` + 10 `.snupkg`), 0 warnings, 0 errors.** No NU5104, no NU5048, no
NU5039.

### Nuspec inspection

Every nuspec read out of the produced package. All ten carry a `<license type="expression">Apache-2.0`,
an `<icon>` whose file is in the package, a `<readme>README.md` whose file is in the package, and

```xml
<repository type="git" url="https://github.com/quartznet/quartznet" commit="917491d881a292ad3b7a5b3f2bc2eab98523c218" />
```

Dependency versions, all ten, **prerelease: none**:

| Package | deps | title as nuget.org shows it |
|---|---|---|
| Quartz | 6 | Quartz.NET |
| Quartz.AspNetCore | 1 | Quartz.NET ASP.NET Core Integration |
| Quartz.Aspire | 9 | Quartz.NET Aspire Integration |
| Quartz.Dashboard | 2 | Quartz.NET Dashboard |
| Quartz.Extensions.Redis | 8 | Quartz.NET Redis Integration |
| Quartz.HttpClient | 8 | Quartz.NET HTTP Client |
| Quartz.Jobs | 7 | Quartz.NET Jobs |
| Quartz.Plugins | 7 | Quartz.NET Plugins |
| Quartz.Plugins.TimeZoneConverter | 8 | Quartz.NET TimeZoneConverter Integration |
| Quartz.Serialization.Newtonsoft | 8 | Quartz.NET Json.NET Serialization |

The issue asked specifically about `Directory.Packages.props`' `Microsoft.Data.SQLite` preview pin.
Confirmed from the shipped nuspecs: it reaches none of them. It is referenced only by the tests, the
examples and the trim canary — and it moves to the stable `10.0.11` in this PR anyway (see C3).

### Source Link

**`dotnet sourcelink test <file>.snupkg` does not work, and fails silently.** It exits 4 having
printed nothing, because the tool dispatches on the `.nupkg` extension; pointing it at the main
`.nupkg` instead exits 5 (`unable to read debug info` — a portable-PDB package has no debug info in
the `.dll`). Both look like a check that ran. The recipe that actually checks something is to take the
PDB out of the symbol package:

```shell
# once
dotnet tool install --global sourcelink

# per package
unzip -j <Id>.4.0.0.snupkg 'lib/net10.0/<Id>.pdb' -d pdb
sourcelink test pdb/<Id>.pdb
```

Result for all ten: `sourcelink test passed`, exit 0. The document root is what
`ContinuousIntegrationBuild` produces, resolving to the commit being packed:

```json
{"documents":{"/_/*":"https://raw.githubusercontent.com/quartznet/quartznet/917491d881a292ad3b7a5b3f2bc2eab98523c218/*"}}
```

`Quartz` alone has 1,124 documents, every one of them fetched and checksum-matched.

### What G1 leaves behind

Nothing failed, so there is no fix to point at — but the rule stays unevaluated between releases, so
`PackageDependencyTest` now evaluates the part of it that can be read out of the source: no shipped
project may reference a package whose central version is a prerelease. It fails with the NU5104
sentence and names the package. The door it cannot see is transitive pinning, which needs a restore
graph; the pack above is what covers that, and the test's remarks say so.

## Commit by commit

**`A package that ships cannot take a prerelease dependency`** — `PackageDependencyTest`, above.
Verified failing without the invariant by pointing `Quartz.Jobs` at the preview `Microsoft.Data.SQLite`:
`Microsoft.Data.SQLite 11.0.0-preview.7.26381.103 would fail the tag build rather than this one`.

**`The release leg checks its generated artefacts before it builds anything`** — C1.

- `publish.yml` runs `VerifyMigrations VerifySchema` before `Compile`. Both trees are generated and
  both ship: `database/migrations/` is what an upgrading deployment runs, and the embedded
  create-if-missing schema is what `ProvisionSchema` executes. They cost seconds and need nothing
  built, so a stale script fails the release in its first minute rather than after the packages exist.
  Edited in `build/Build.CI.GitHubActions.cs` and regenerated with
  `dotnet fallout --generate-configuration GitHubActions_publish --host GitHubActions`.
- `docs.yml` gets a `concurrency` group. Its last step force-pushes a whole site into
  `quartznet.github.io`, so two runs from two quick pushes to `main` raced and whichever finished last
  won. `cancel-in-progress: true`, because the published site is a pure function of `main` and a
  superseded run has nothing to contribute.
- `docs.yml` runs `npm run docs:check-links` before deploying. Until now only the pull request job
  checked links, and a pull request only sees the pages its own change touched — a renamed heading
  404s every fragment pointing at it from a page that change left alone. The checker's own control,
  `docs:check-links-test`, stays on the pull request leg, which is where a change to the checker is
  reviewed.
- `.github/dependabot.yml` gains the `github-actions` ecosystem, weekly, one group. **Reviewer note:**
  eleven of the fifteen workflows are generated and carry the versions Fallout writes, so a bump
  Dependabot proposes for one of those is not a bump to keep — the next generator run puts the old
  version back. That is written in the file beside the entry; the four hand-written workflows are what
  it is for.
- `docs.yml` and `docs-pr.yml` move `actions/checkout@v4` → `@v7`. `setup-dotnet` was already `@v6` in
  both, so there was nothing to move there.

**`The integration tests run on the machine that was told to run them`** — C2. The gate was
`Host is GitHubActions && Linux`. Only the CI half is a rule — Docker is what every fixture needs and
only the Ubuntu image has a daemon — and the other half skipped every developer machine, so
`build.cmd Compile UnitTest IntegrationTest`, which `CONTRIBUTING.md`, the pull request template and
`AGENTS.md` all give, reported a skipped target and exited zero. It is now
`Host is not GitHubActions || Linux`.

Verified: `dotnet fallout IntegrationTest --database basic` → **364 passed**, and
`--database sqlite` → **15 passed**, both on this machine, where before the change neither ran a test.

`CONTRIBUTING.md`'s paragraph is made exactly true while it is being read again — two things in it
were not: `redis` is a value the build accepts and the list omitted it (`--database redis` has its own
CI workflow), and `all` starts **seven** containers rather than six, because SQL Server gets two, the
second being the memory-optimised schema. The `[Parameter]` description gained `redis` too.

**`Each package says on nuget.org which package it is`** — C3.

- `<Title>` on all ten, and no shared default any more: six shipped through beta.1 as "Quartz.NET",
  which nuget.org hides (it renders the id) and Visual Studio's package manager and
  `dotnet package search` do not. With no default to inherit, a package that forgets falls back to its
  id, which is at least distinct — and `PackageMetadataTest` fails it.
- `<Description>` on `Quartz` and `Quartz.HttpClient`, which had been taking the shared one whole, so
  both pages described the framework rather than the package.
- `PackageTags` per package, on top of the shared six.
- `PackageIconUrl` dropped (G-15). Deprecated by NuGet, a second answer to a question `PackageIcon`
  already answers, and the URL named a `master` branch this repository does not have. NU5048 reports
  the property only when `PackageIcon` is absent, so nothing was going to say so; the test does now.
- `RepositoryUrl` / `RepositoryType` stated. Checked rather than assumed: SourceLink fills them from
  the git remote when they are empty and leaves a stated value alone, so the `commit` attribute is
  still git's and the URL is now what a pack from a tree with no `.git` would carry — which the source
  zip `PackZip` produces is.
- `Quartz.Plugins.TimeZoneConverter`'s `Authors` gains the maintainer, matching the pattern
  `Quartz.AspNetCore` already had.
- `Microsoft.Data.SQLite` **moves to the stable `10.0.11`**, aligned with the `Microsoft.Extensions.*`
  versions beside it. It drifted onto the `11.0.0-preview.*` line while .NET 10 was itself in preview
  (#3164) and Dependabot kept it walking there. Passing on it: the unit suite (5354), the
  `Quartz.Tests.AspNetCore` suite (630), `IntegrationTest --database sqlite` (15), `PublishTrimmed` and
  `PublishAot` — the AOT canary runs a whole SQLite store out of a native binary.

**Reviewer decision in this commit:** `Quartz.Serialization.Newtonsoft`'s title was
"Quartz.NET JSON Serialization", which now reads as a claim on JSON generally although the
System.Text.Json serializer is built into `Quartz`. It is "Quartz.NET Json.NET Serialization" here, and
the description says which of the two an application should reach for. Say the word and it goes back.

**`The example applications are started, not only published`** — C4. `PublishTrimmed` publishes
`Quartz.Examples.Worker` and `Quartz.Examples.AspNetCore` and has never started either, so an example
that compiles and publishes but cannot get through `Build().Run()` passed every leg there is. Both were
broken at beta.1 and nothing in CI could have noticed.

`ExamplesSmoke` starts each in the Development environment — the environment they are read and run in,
and the one that validates the whole container at build time — waits for the host to say
`Application started` and, for the worker, for its job to report that it ran, then stops them. An exit
before that, or a three-minute wait that runs out, fails the leg with the last 60 lines the application
printed. It also runs `dotnet run --project src/Quartz.Examples -- --list`.

Verified both ways:

```
[INF] Starting Quartz.Examples.Worker and waiting for 'Application started' and 'job executing, triggered by'
[INF] Quartz.Examples.Worker said all of it, 10s in
[INF] Starting Quartz.Examples.AspNetCore and waiting for 'Application started'
[INF] Quartz.Examples.AspNetCore said all of it, 1s in
ExamplesSmoke      Succeeded       0:15
```

and, with beta.1's option pair put back into the worker for one run:

```
ExamplesSmoke      Failed          0:04   // Exception: Quartz.Examples.Worker exited with code
-532462766 after 0s instead of running, and never said 'Application started' and
'job executing, triggered by'.
```

with the `OptionsValidationException` naming both options in the dumped tail. Two implementation
notes a reviewer may want to weigh:

- The applications are started **from their build output**, not through `dotnet run`, so the process
  the target holds is the application itself — killing `dotnet run` would leave a web server listening
  on the runner. The path comes from the `UseArtifactsOutput` layout and is asserted by name.
- The web example is handed a free loopback port, because Kestrel's default pair includes an HTTPS
  endpoint that wants a development certificate no runner has, and 5000 is a port a runner may already
  be using. Its launch profile is not read; `launchSettings.json` belongs to `dotnet run`.

It joins `pr-tests-unit` beside `BenchmarkSmoke` and `WolverineSmoke`, on all three images, through the
generator — a host that refuses to start does so per platform.

## G-13 — open-ended dependency upper bounds: leave them

Every published dependency is `[10.0.11, )`, and `Microsoft.Extensions.*` is runtime-major-aligned, so
in principle an unconstrained graph could float to a future major. Leaving it, for three reasons:

1. NuGet resolves the **lowest** applicable version, so nothing floats on its own. A Quartz dependency
   only reaches 11.x when the application itself asks for 11.x — at which point unifying is what the
   application wants, not an accident.
2. An upper bound would make Quartz 4.0 unusable on .NET 11 the day it ships, and would need a Quartz
   patch release for every runtime major to lift it. Nothing in `dotnet/runtime` or `dotnet/aspnetcore`
   expresses one either.
3. It is the ecosystem's convention, and a package that departs from it surprises its consumers rather
   than protecting them.

## Verification

Actually run on this branch, at `917491d`:

| | |
|---|---|
| `dotnet build Quartz.slnx` | succeeded, 0 warnings, 0 errors |
| `dotnet test src/Quartz.Tests.Unit` | **5354 passed**, 36 skipped, 0 failed |
| `dotnet test src/Quartz.Tests.AspNetCore` | **630 passed**, 0 failed |
| `dotnet fallout IntegrationTest --database basic` | **364 passed** |
| `dotnet fallout IntegrationTest --database sqlite` | **15 passed** |
| `dotnet fallout ExamplesSmoke` | succeeded, 15s |
| `dotnet fallout PublishTrimmed` | succeeded, canary green |
| `dotnet fallout PublishAot` | succeeded, canary green |
| `dotnet fallout BenchmarkSmoke` | succeeded, 284 benchmarks executed |
| `dotnet fallout VerifyMigrations VerifySchema VerifyDocsSnippets VerifyDocsLogEvents` | all succeeded |
| stable pack + nuspec inspection + `sourcelink test` | as above, all ten clean |

The container-backed integration legs other than `basic` and `sqlite` were not run here — this machine
was sharing its Docker daemon with another piece of work — so Postgres, SQL Server, MySQL, Oracle,
Firebird and Redis are left to the `pr-integration-*` workflows.

`PublishAot` needed `C:\Program Files (x86)\Microsoft Visual Studio\Installer` on `PATH` to run at all
on this machine: ILCompiler's link step shells out to a bare `vswhere.exe`. That is this machine, not
this branch — the CI images have it — and it is noted only so the next person does not read it as a
regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
