### PR TITLE
The cluster soak is re-run on the build that will be tagged

### DIFF
--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -760,6 +760,17 @@ the survivor in each run, no unexpected scheduler error, no unobserved task exce
 heap and handle count no larger at the end than at the start (5 MB and ~635 handles throughout on
 PostgreSQL; 5 MB and ~730 on SQL Server).
 
+**The PostgreSQL run was repeated on the release candidate** — 30 minutes on `2e207e37b`, on
+2026-09-03 — because sixteen commits had touched `Quartz` since the runs above. It passed with the
+same shape and, on the same machine, numbers within a firing or two of the first: peak observed
+concurrency **1** over 2,661 firings of the serial job, every family still on its schedule (890
+simple, 591 daily-time-interval, 444 calendar-interval, 355 cron, 296 recurrence), 534 attempts at
+the failing job of which 356 were the retry policy's, 178 overruns interrupted, and the survivor
+replaying the killed node's one interrupted firing a second after the kill. It ended as the others
+did: nothing `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS` empty, no unexpected scheduler error, no
+unobserved task exception, and a live heap of 4–5 MB behind 619–640 handles from the first minute to
+the thirtieth. The SQL Server figures above stand from the beta.1 run; it was not repeated.
+
 The harness is `ClusteredSoakTestBase` in `Quartz.Tests.Integration`; it is opt-in
 (`[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`) and is run before a tag rather than in CI.
 


### PR DESCRIPTION
The clustered soak was run again on `2e207e37b` — the rc.1 candidate — against PostgreSQL for 30
minutes, and `operations.md` now records that run beside the beta.1 pair it already carried. Sixteen
commits had touched `Quartz` since those runs, so the maturity ledger should cite a measurement of
the build that ships.

**It passed.** `Passed: 1`, 30.1031 minutes, exit code 0. No tolerance was widened and the fixture is
untouched — the diff is one paragraph of prose.

## The run

```
01:17:37 workload scheduled; running for 00:30:00
01:25:07 both nodes in standby for 00:00:30 to induce misfires
01:25:37 both nodes resumed
01:34:07 'soak-node-b' killed mid-flight, leaving an EXECUTING row behind
01:34:08 survivor recovered the killed node's work
01:38:37 'soak-node-b' replaced and rejoined the cluster
01:47:37 run complete, shutting the cluster down
```

```
Firings:
  family-calendarInterval      444
  family-cron                  355
  family-dailyTimeInterval     591
  family-recurrence            296
  family-simple                890
  serial (max concurrent)      2661 (1)
  failing (attempts)           534, of which 356 were retries
  timed out                    178
  recovered                    1
```

## The numbers, against beta.1's PostgreSQL run

| | rc.1 | beta.1 |
|---|---|---|
| Serial job firings / peak concurrency | 2,661 / **1** | 2,662 / 1 |
| Retry re-fires | 356 | 356 |
| Overruns interrupted | 178 | 178 |
| Interrupted firings recovered | 1, by `soak-node-a` | 1, by the survivor |
| Live heap | 4–5 MB | 5 MB |
| Handles | 619–640 | ~635 |

Every trigger family came in **within 2 % of its nominal count** — 890/900 simple, 591/600
daily-time-interval, 444/450 calendar-interval, 355/360 cron, 296/300 recurrence — against a fixture
band that tolerates a factor of three either way, despite 30 seconds of standby, a kill and a
replacement.

End state was clean on all three checks: no `ACQUIRED` or `BLOCKED` trigger, `QRTZ_FIRED_TRIGGERS`
drained, and the killed node's planted `soak-killed-executing-1` row deleted by the survivor.
`AssertNoOverlap`, `AssertNoUnobservedFailures` and `AssertResourcesFlat` all passed: no overlap
entries, no unexpected job failure, no scheduler error, no unobserved task exception, and a final
sample (5 MB, 630 handles) indistinguishable from the baseline (5 MB, 624 handles).

Thirty-one heap samples, one a minute, each taken after a full blocking collection — the series is
flat end to end, and thread count trends gently *down*.

## Why the paragraph names the build rather than the index

The soak was queued on the understanding that the schema had moved under it. For PostgreSQL it has
not: `IDX_QRTZ_T_NFT_ST_MISFIRE` was only ever created on SQL Server, MySQL, Oracle and Firebird —
`db/index.md` says "which PostgreSQL and SQLite never had" — and
`git diff v4.0.0-beta.1 2e207e37bb -- database/tables/tables_postgres.sql` is empty. The DDL this run
provisioned is byte-identical to beta.1's. So the paragraph gives the true reason, which is that the
build moved, and notes that the SQL Server figures still stand from beta.1 rather than implying they
were re-taken. **SQL Server is the dialect where that index actually dropped, and it was not
re-run.**

## Notes

- The log carries no warning, error, exception or transient database failure. It also carries no
  scheduler log lines at all: the fixture builds nodes through `QuartzSchedulerBuilder`, whose
  `BridgeLoggingToLogProvider()` installs `LogProviderLoggerFactory` when no provider is registered,
  and the fixture never calls `LogProvider.SetLogProvider` — so everything resolves to `NullLogger`.
  The new 1020 event almost certainly *did* fire (`KillNodeB` shuts a busy node down with
  `waitForJobsToComplete: false`, which is exactly its condition); it simply cannot be observed here.
  Worth wiring a factory into the harness if a future gate wants to assert on it.
- Not a quiet machine: another agent's upgrade rehearsal had `rc1g4-postgres` and `rc1g4-sqlserver`
  running alongside at least the early part of this run (both were gone by the time it finished). It
  did not show in the numbers.
- `src/Quartz.Benchmark/README.md` has no soak section, so it is untouched.
- `npm run docs:check-links`: 223 pages, 1,340 internal links, 842 fragments, no dead links or
  anchors. `markdownlint-cli2` on the changed page: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
