### PR TITLE
The 3.20 index alignment points at the file that supersedes it

### DIFF
--- a/build/Build.DatabaseMigrations.Scripts.cs
+++ b/build/Build.DatabaseMigrations.Scripts.cs
@@ -319,7 +319,7 @@ partial class Build
                         "3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but",
                         "     several of these indexes could not serve a single-scheduler lookup at all.",
                         "",
-                        $"4.x  Superseded. ../4.0/schema_30_to_40_upgrade_{d}.sql converges the same index",
+                        $"4.x  Superseded. ../4.0/schema_30_to_40_indexes_{d}.sql converges the same index",
                         "     set onto the 4.x shape -- run that instead when upgrading to 4.x.",
                     ],
                     indexExtra)

--- a/database/migrations/3.20/index_alignment_firebird.sql
+++ b/database/migrations/3.20/index_alignment_firebird.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_firebird.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_firebird.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current

--- a/database/migrations/3.20/index_alignment_mysql_innodb.sql
+++ b/database/migrations/3.20/index_alignment_mysql_innodb.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_mysql_innodb.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_mysql_innodb.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current

--- a/database/migrations/3.20/index_alignment_oracle.sql
+++ b/database/migrations/3.20/index_alignment_oracle.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_oracle.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_oracle.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current

--- a/database/migrations/3.20/index_alignment_postgres.sql
+++ b/database/migrations/3.20/index_alignment_postgres.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_postgres.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_postgres.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current

--- a/database/migrations/3.20/index_alignment_sqlServer.sql
+++ b/database/migrations/3.20/index_alignment_sqlServer.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_sqlServer.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_sqlServer.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current

--- a/database/migrations/3.20/index_alignment_sqlite.sql
+++ b/database/migrations/3.20/index_alignment_sqlite.sql
@@ -10,7 +10,7 @@
 --   3.x  OPTIONAL, performance only. Nothing stops working if it is not applied, but
 --        several of these indexes could not serve a single-scheduler lookup at all.
 --
---   4.x  Superseded. ../4.0/schema_30_to_40_upgrade_sqlite.sql converges the same index
+--   4.x  Superseded. ../4.0/schema_30_to_40_indexes_sqlite.sql converges the same index
 --        set onto the 4.x shape -- run that instead when upgrading to 4.x.
 --
 -- Brings an existing database's index set in line with what the current


### PR DESCRIPTION
Companion to #3697 on `main`, which splits the 3.x-to-4.0 upgrade into two files:
the columns and the table stay in `schema_30_to_40_upgrade_<dialect>.sql`, and the index set moves into
`schema_30_to_40_indexes_<dialect>.sql` — the half that waits for the last 3.x node to shut down. Four
pages told a reader to run "sections 1 to 5" of a single file and defer section 6, and nothing said
how; two files make that advice two commands.

`migrations/3.20/index_alignment_<dialect>.sql` names the script that supersedes it in its own header,
so on both branches it has to name the new one. These six files are a migration **both branches can
run**, which `AGENTS.md` requires to stay byte-identical on `main` and `3.x` — nothing in CI checks it,
which is why this PR exists rather than a note.

The change is one line of `build/Build.DatabaseMigrations.Scripts.cs`:

```diff
-$"4.x  Superseded. ../4.0/schema_30_to_40_upgrade_{d}.sql converges the same index",
+$"4.x  Superseded. ../4.0/schema_30_to_40_indexes_{d}.sql converges the same index",
```

`dotnet fallout GenerateMigrations` wrote the six scripts; `dotnet fallout VerifyMigrations` passes
("All generated migration scripts are up to date").

## Byte identity with `main`

Same git blob for every dialect — `git rev-parse <branch>:database/migrations/3.20/index_alignment_<d>.sql`:

| Dialect | `rc1/p5-rehearsal` (main) | `3x/index-alignment-superseded-pointer` | |
|---|---|---|---|
| `sqlServer` | `64492c6661374615024c67d6876f0100fa03bdd1` | `64492c6661374615024c67d6876f0100fa03bdd1` | match |
| `postgres` | `515cfedbe3c8c013ac136a654197688e1bb36cba` | `515cfedbe3c8c013ac136a654197688e1bb36cba` | match |
| `mysql_innodb` | `080eefb5fa9b626f50e3f7b12a3d7d9f86dafc54` | `080eefb5fa9b626f50e3f7b12a3d7d9f86dafc54` | match |
| `oracle` | `35c0ab471fb5a35cd16d3b22ff8f5fb3c4271e1a` | `35c0ab471fb5a35cd16d3b22ff8f5fb3c4271e1a` | match |
| `sqlite` | `9f0d338ab899fab3e6cd120911490fe1c9cef0c5` | `9f0d338ab899fab3e6cd120911490fe1c9cef0c5` | match |
| `firebird` | `fe3b10c90f072fa7b8ff7c399d242f03ed341bfd` | `fe3b10c90f072fa7b8ff7c399d242f03ed341bfd` | match |

The same content as md5, for the record: `35160417…`/`dc396f3f…`/`cf997591…`/`2258bab9…`/`427a97c2…`/`fd4014dd…`.

Nothing else on this branch changes: `database/migrations/4.0/` lives on `main` only, and the pointer
this header carries is the whole of what 3.x has to know about the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm

