### PR TITLE
The SQLite tutorial's restart check is true of its own listing

### DIFF
--- a/docs/documentation/quartz-4.x/tutorial/job-stores.md
+++ b/docs/documentation/quartz-4.x/tutorial/job-stores.md
@@ -266,15 +266,26 @@ builder.AddQuartz(q =>
         .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever()));
 });
 
+// ScheduleJob declares HelloJob and its trigger on every start, and by default a declaration
+// replaces what the store holds, StartNow() included. This keeps the stored trigger instead, so a
+// restart carries on from the file rather than scheduling afresh.
+builder.Services.Configure<QuartzOptions>(options => options.Scheduling.IgnoreDuplicates = true);
+
 builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 ```
 <!-- endSnippet -->
 
 Start it, watch the job fire, stop it, start it again: the trigger's next fire time comes back out of
 `quartz.db` rather than being scheduled afresh, which is the difference from `UseInMemoryStore()` and
-the only thing worth checking here. The file appears beside the executable — `Data Source=quartz.db` is
-relative to the working directory, so give it an absolute path if the process might be started from
-somewhere else.
+the only thing worth checking here. The `IgnoreDuplicates` line is what makes it so: `ScheduleJob`
+declares the job and its trigger on every start, and by default a declaration replaces what the store
+holds — `StartNow()` included — so without that line every restart schedules the trigger afresh and
+the file might as well not be there.
+[Persistent job stores](../packages/microsoft-di-integration.md#persistent-job-stores) on the DI page
+has the two settings and how they relate.
+
+The file appears beside the executable — `Data Source=quartz.db` is relative to the working directory,
+so give it an absolute path if the process might be started from somewhere else.
 
 Two things it will not do. It cannot [cluster](advanced-enterprise-features.md), for the reason in the
 warning above. And it is not a production store for a busy scheduler: SQLite serializes writers, so

--- a/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
+++ b/src/Quartz.Documentation.Samples/Tutorial/JobStoresSamples.cs
@@ -92,6 +92,11 @@ public static class JobStoresSamples
                 .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromSeconds(10)).RepeatForever()));
         });
 
+        // ScheduleJob declares HelloJob and its trigger on every start, and by default a declaration
+        // replaces what the store holds, StartNow() included. This keeps the stored trigger instead, so a
+        // restart carries on from the file rather than scheduling afresh.
+        builder.Services.Configure<QuartzOptions>(options => options.Scheduling.IgnoreDuplicates = true);
+
         builder.AddQuartzHostedService(options => options.WaitForJobsToComplete = true);
 
         #endregion


### PR DESCRIPTION
The [SQLite section of the job-stores tutorial](https://www.quartz-scheduler.net/documentation/quartz-4.x/tutorial/job-stores.html#the-cheapest-persistent-store-to-try) says: stop it, start it again, and the trigger's next fire time comes back out of `quartz.db` rather than being scheduled afresh — "the only thing worth checking here". Built from the page against the published 4.0.0-rc.1, the listing did the opposite. The second run logged `Replacing job:` and re-set the trigger's start time, because `ScheduleJob` declares the job and trigger on every start and `Scheduling.OverwriteExistingData` defaults to `true`. With `IgnoreDuplicates = true` the next fire time comes straight out of the file, as the page promises.

The sample gains that line with a comment saying why, the page says what the line does, and links the DI page's explanation of the two settings. The page did not mention either setting before; only the DI page did.

Found by the published-rc.1 gate. Under the 4.0 release rule this is class 1 — docs and a sample — so `v4.0.0` stays on the rc.1 commit.

Checks: `DocsSnippets` regenerated the block, the samples project builds, `VerifyDocsSnippets` (111 files), `docs:check-links` (223 pages, no dead links or anchors) and `docs:lint` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
