### PR TITLE
The SQL Server soak is re-run on the commit that carries the tag

### DIFF
--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -808,7 +808,22 @@ the failing job of which 356 were the retry policy's, 178 overruns interrupted, 
 replaying the killed node's one interrupted firing a second after the kill. It ended as the others
 did: nothing `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS` empty, no unexpected scheduler error, no
 unobserved task exception, and a live heap of 4–5 MB behind 619–640 handles from the first minute to
-the thirtieth. The SQL Server figures above stand from the beta.1 run; it was not repeated.
+the thirtieth.
+
+**SQL Server was then run on the tagged commit itself** — 30 minutes on `97505ecce`, on 2026-09-03 —
+because this is the dialect whose schema moved: rc.1 drops `IDX_QRTZ_T_NFT_ST_MISFIRE`, so the run
+provisioned a `tables_sqlServer.sql` the beta.1 run never saw, and the build under it also carries
+the rc.1 store changes — the paused-job-group probe every trigger store now makes, and the
+column-level schema validation each of the three nodes passed through at startup. It passed, and
+firing for firing it is ahead of the beta.1 run rather than behind it: peak observed concurrency
+**1** over 2,578 firings of the serial job, every family within about 1% of what its schedule implies
+(890 simple, 594 daily-time-interval, 446 calendar-interval, 357 cron, 297 recurrence), 532 attempts
+at the failing job of which 355 were the retry policy's, 178 overruns interrupted, and `soak-node-a`
+replaying the killed node's one interrupted firing in the same second as the kill. It ended as the
+others did: nothing `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS` empty and the killed node's
+`EXECUTING` row gone with it, no unexpected scheduler error, no unobserved task exception, and a live
+heap of 4–5 MB behind 706–756 handles across all thirty samples. No tolerance was widened for either
+run; the fixture is the one in the tag.
 
 The harness is `ClusteredSoakTestBase` in `Quartz.Tests.Integration`; it is opt-in
 (`[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`) and is run before a tag rather than in CI.


### PR DESCRIPTION
The SQL Server half of the clustered-soak gate, run on `97505ecce` — the commit `v4.0.0-rc.1` points
at, and the one 4.0.0 will be tagged on. Yesterday's repeat covered PostgreSQL and said in as many
words that the SQL Server figures still stood from beta.1; this closes that, and it is the dialect
with the most reason to be re-measured:

- **The schema moved.** rc.1 drops `IDX_QRTZ_T_NFT_ST_MISFIRE`, so this run provisioned a
  `tables_sqlServer.sql` the beta.1 run never saw. `tables_postgres.sql` is byte-identical between
  the two tags, which is why the PostgreSQL repeat could not have caught anything here.
- **The store changed under it, after the PostgreSQL repeat.** Storing a trigger's state now also
  probes `QRTZ_PAUSED_JOB_GRPS` for the job's group (bb8b8fc27), and schema validation now probes
  the 4.0 columns one at a time (894522a9e), which each of the three nodes passed through at startup
  — the fixture leaves `SchemaProvisioning` at its `Validate` default.

## The run

30 minutes, `QUARTZ_TEST_DATABASE=sqlserver`, `QUARTZ_SOAK_MINUTES=30`, `ClusteredSoakSqlServerTest`,
SQL Server 2022-CU14 under Testcontainers. **Passed**, with no tolerance widened — the diff is one
paragraph of prose and nothing else.

```
Soak over 00:30:00:
  03:38:46 workload scheduled; running for 00:30:00
  03:46:17 both nodes in standby for 00:00:30 to induce misfires
  03:46:46 both nodes resumed
  03:55:17 'soak-node-b' killed mid-flight, leaving an EXECUTING row behind
  03:55:17 survivor recovered the killed node's work
  03:59:47 'soak-node-b' replaced and rejoined the cluster
  04:08:47 run complete, shutting the cluster down
Firings:
  family-calendarInterval      446
  family-cron                  357
  family-dailyTimeInterval     594
  family-recurrence            297
  family-simple                890
  serial (max concurrent)      2578 (1)
  failing (attempts)           532, of which 355 were retries
  timed out                    178
  recovered                    1
```

Every family within about 1% of what its schedule implies over 1,800 seconds (900 / 600 / 450 / 360 /
300 against 890 / 594 / 446 / 357 / 297), so nothing stalled and nothing ran away. The recovery was
`soak-node-a`, exactly once, in the same second as the kill — the fixture asserts both the count and
the node.

The end-state assertions all held: nothing left `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS`
drained, and the killed node's named `EXECUTING` row gone with it. No unexpected job failure, no
`SchedulerError` outside the two jobs the soak asks to fail, no unobserved task exception.

Heap and handles, thirty samples, one a minute — 4–5 MB live after a full blocking collection
throughout, handles 706–756, threads 58–65:

```
  t+   1.0 min  heap     4 MB  handles    721  threads   65
  t+   2.0 min  heap     4 MB  handles    714  threads   63
  ...
  t+  14.0 min  heap     5 MB  handles    756  threads   65     <- handle peak
  ...
  t+  20.1 min  heap     4 MB  handles    706  threads   58     <- handle trough
  ...
  t+  30.0 min  heap     4 MB  handles    720  threads   60
```

## Against the earlier runs

| | beta.1 SQL Server | rc.1 PostgreSQL | **rc.1 SQL Server** |
|---|---|---|---|
| serial firings (peak concurrency) | 2,367 (1) | 2,661 (1) | **2,578 (1)** |
| retries | 346 | 356 | **355** |
| overruns interrupted | 175 | 178 | **178** |
| recovered | 1 | 1 | **1** |
| heap / handles | 5 MB / ~730 | 4–5 MB / 619–640 | **4–5 MB / 706–756** |

The extra paused-job-group probe on every trigger store cost nothing measurable: this run is 9% ahead
of beta.1's on the serial job and level with it on everything else. The handle band stays the SQL
Server one (~700–750 against PostgreSQL's ~620–640), as it was on beta.1.

## Notes

- The soak was run twice on this commit. The first run passed at default verbosity, which does not
  print what the fixture writes to `TestContext.Out`, so it was repeated with a TRX to capture the
  report; both passed. The figures here are the second run's.
- Other work was on the machine throughout; CPU sat at 3–19% and 17 GB of 32 was free.
- `npm run docs:check-links` is clean (223 pages, 1,345 internal links, 847 fragments), as is
  `markdownlint-cli2` on the edited page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
