### PR TITLE
The production-upgrade findings: one stop, an administration node without the job classes, and a documented cron dialect

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -112,7 +112,7 @@ Two shipped pools are worth knowing by name, because `UseThreadPool<T>()` is how
 
 | Type | For |
 |---|---|
-| `Quartz.Impl.ZeroSizeThreadPool` | a scheduler that exists only to *write* the schedule and is never started. `UseThreadPool<ZeroSizeThreadPool>()` creates no worker threads at all, and both of the members a running scheduler would call throw `NotSupportedException` — so calling `Start()` on such a scheduler fails loudly rather than sitting there firing nothing |
+| `Quartz.Impl.ZeroSizeThreadPool` | a scheduler that exists only to *write* the schedule and is never started. `UseThreadPool<ZeroSizeThreadPool>()` creates no worker threads at all, and both of the members a running scheduler would call throw `NotSupportedException` — so calling `Start()` on such a scheduler fails loudly rather than sitting there firing nothing. Such a process needs no reference to the assemblies its job classes live in, and no `ITypeLoader` of its own: the persistent store edits the schedule on the stored type name alone |
 | `Quartz.Impl.TaskSchedulingThreadPool` | the open base of `DefaultThreadPool`. A pool of your own derives from it and overrides one member, `GetDefaultScheduler()`, rather than implementing `IThreadPool`'s six from scratch |
 
 `ThreadPoolOptions` belongs to the built-in pools — they are what read `MaxConcurrency` — so

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -259,6 +259,46 @@ be added later without breaking anything, and it is filed for 4.1; auto-detectio
 because by then the existing reading of a six-field expression is the one people's schedules depend on.
 :::
 
+### If your expressions came from another .NET cron library
+
+Cronos and NCrontab are crontab-derived, and an expression written for either parses here — six fields
+have the same shape. Almost all of them also fire at the same instants. Two things differ, and both are
+silent, because the expression is perfectly valid Quartz cron; it simply means something else.
+
+**The day-of-week numbering.** Quartz numbers `1-7` with Sunday `1`; those libraries number `0-6` with
+Sunday `0`, and crontab itself `0-7` with both ends Sunday. So `0 0 2 * * 1` is 02:00 on **Sunday** here
+and 02:00 on **Monday** there — the same divergence [a Spring expression
+has](#an-expression-copied-from-spring), and the same answer: write the day as a name. `SUN` through
+`SAT` mean the same day in every one of these dialects.
+
+**Both day fields restricted.** Quartz fires on the **union** of day-of-month and day-of-week, which is
+crontab's rule; Cronos takes their intersection. `0 0 2 5 * MON` is "the 5th, and every Monday" here and
+"the 5th, if it is a Monday" there. Putting `?` in one of the two fields says which one is in charge and
+settles it.
+
+Everything else carries across. Searching from `2026-08-21T00:00:00Z`, against Cronos 0.11.0:
+
+| Expression | Quartz | Cronos | |
+|:---|:---|:---|:---|
+| `0 0 2 * * MON` | 2026-08-24 02:00 | 2026-08-24 02:00 | same |
+| `0 0 7 * * *` | 2026-08-21 07:00 | 2026-08-21 07:00 | same |
+| `0 0 */1 * * *` | 2026-08-21 01:00 | 2026-08-21 01:00 | same |
+| `0 */15 * * * *` | 2026-08-21 00:15 | 2026-08-21 00:15 | same |
+| `0 30 6 * * MON,TUE,WED,THU,FRI` | 2026-08-21 06:30 | 2026-08-21 06:30 | same |
+| `0 0 2 * * 1` | 2026-08-23 (**Sunday**) | 2026-08-24 (**Monday**) | **differ** |
+| `0 0 2 5 * MON` | 2026-08-24 (union) | 2026-10-05 (intersection) | **differ** |
+
+A **five**-field expression from one of those libraries is a different matter: `CronFormat.Unix` reads it
+and renumbers the days for you, so `CronExpression.Parse("0 2 * * 1", CronFormat.Unix)` is Monday, as its
+author meant. See [The Unix five-field form](#the-unix-five-field-form).
+
+::: tip Upgrading from 3.x with such an expression in the database
+3.x required `?` in exactly one day field, so an expression with two restricted day fields was
+*rejected* on the way in. It stores and fires on 4.0. The migration guide has an audit for finding the
+two shapes above among the expressions you already hold:
+[If your expressions came from another cron library](migration-guide.md#if-your-expressions-came-from-another-cron-library).
+:::
+
 ## H (hash) for load distribution
 
 The `H` symbol (for "hash") can be used in place of a specific value to spread scheduled tasks

--- a/docs/documentation/quartz-4.x/how-tos/external-leader.md
+++ b/docs/documentation/quartz-4.x/how-tos/external-leader.md
@@ -157,6 +157,8 @@ is elected. A process that will *never* be elected — an admin API, a migration
 schedules work for other processes to run — wants `q.UseThreadPool<ZeroSizeThreadPool>()` instead, which
 is why that type is public. It creates no worker threads, and the two members a running scheduler calls
 throw `NotSupportedException`, so such a scheduler is never started and says so if something starts it.
+Such a process need not reference the assemblies its job classes live in: the store reads, edits, pauses,
+reschedules, triggers and deletes on the stored type name alone.
 :::
 
 The health check follows the same distinction. It reports *degraded* — not *unhealthy* — both while a

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5629,6 +5629,93 @@ Two sources are **not** reachable from this query. `CronCalendar` expressions li
 in `QRTZ_CALENDARS` and surface only at deserialization, and expressions built in code or held in
 configuration files never reach the database at all.
 
+### If your expressions came from another cron library
+
+That audit is about Quartz expressions 3.x stored happily, and it will not catch this one. 4.0 also
+*loosened* the day fields: 3.x required `?` in exactly one of day-of-month and day-of-week, and 4.0
+reads `*` and `?` there as synonyms that restrict nothing, taking the union when both name days —
+crontab's rule, and what `cron-expressions.md` has always described.
+
+The consequence is for expressions that came from a six-field .NET dialect derived from crontab, Cronos
+being the common one. On 3.x such an expression **failed to store**: the operator got a job with no
+trigger, which is bad but visible. On 4.0 it stores and fires, and two shapes fire on a different day
+than the library they were written for.
+
+| Expression | Quartz 4.0 | Cronos | |
+|---|---|---|---|
+| `0 0 2 * * MON` | 2026-08-24 02:00 | 2026-08-24 02:00 | same |
+| `0 0 7 * * *` | 2026-08-21 07:00 | 2026-08-21 07:00 | same |
+| `0 30 6 * * MON,TUE,WED,THU,FRI` | 2026-08-21 06:30 | 2026-08-21 06:30 | same |
+| `0 0 2 * * 1` | 2026-08-23 (**Sunday**) | 2026-08-24 (**Monday**) | **differ** |
+| `0 0 2 5 * MON` | 2026-08-24 (the union) | 2026-10-05 (the intersection) | **differ** |
+
+Searching from `2026-08-21T00:00:00Z`. The last two rows are the only ones that matter: Quartz numbers
+the days of the week 1-7 from Sunday and those dialects number them 0-6, so the same digit is a
+different day — in every numeric form, `1` and `1-5` and `*/2` and the `#n` and `L` forms with them, so
+`6#3` is the third Saturday here and the third Friday there; and Quartz fires on the union of the two
+day fields where Cronos fires on their intersection. Writing the day as a **name** — `MON` — settles
+the first, and `?` in one day field settles the second. Five-field expressions are not affected:
+`CronFormat.Unix` renumbers them, and
+[The Unix five-field form](cron-expressions.md#the-unix-five-field-form) is where that is described,
+along with [the same trap for a Spring expression](cron-expressions.md#an-expression-copied-from-spring).
+
+Nothing can warn on a valid expression, so the audit is a second query. It is C# rather than SQL because
+what it does is split a field and look at the characters in it, and six database dialects spell that six
+ways:
+
+<!-- snippet: sample_cron_dialect_audit -->
+```csharp
+// Both shapes below are valid Quartz expressions, so nothing rejects them and nothing logs.
+// What this lists is the expressions worth reading again if they were carried over from a
+// crontab-derived library such as Cronos or NCrontab.
+await using DbCommand command = connection.CreateCommand();
+command.CommandText = "SELECT TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION FROM QRTZ_CRON_TRIGGERS";
+
+await using DbDataReader reader = await command.ExecuteReaderAsync();
+
+while (await reader.ReadAsync())
+{
+    string name = reader.GetString(0);
+    string group = reader.GetString(1);
+    string expression = reader.GetString(2);
+
+    // A stored expression is always the canonical six-field Quartz form: seconds, minutes,
+    // hours, day-of-month, month, day-of-week, and optionally a year.
+    string[] fields = expression.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+    if (fields.Length < 6)
+    {
+        continue;
+    }
+
+    string dayOfMonth = fields[3];
+    string dayOfWeek = fields[5];
+
+    // Quartz numbers the days 1-7 from Sunday; the other dialects number them 0-6 (Unix: 0-7),
+    // also from Sunday. So a day written as a number names a different day in each, in every
+    // form that carries one: '1', '1-5', '*/2', and the '6#3' and '6L' forms with it.
+    if (IsNumericDay(dayOfWeek))
+    {
+        Console.WriteLine($"{group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
+    }
+
+    // Quartz fires on the union of the two day fields, as crontab does; Cronos intersects them.
+    if (!IsUnrestricted(dayOfMonth) && !IsUnrestricted(dayOfWeek))
+    {
+        Console.WriteLine($"{group}.{name}: both day fields restricted — this fires on their union");
+    }
+}
+
+// A day named by number rather than by name, whatever decorates it. A letter anywhere says the
+// days were written as names and there is nothing to renumber — except 'L', which is a
+// position rather than a name and shifts with the digit in front of it.
+static bool IsNumericDay(string field)
+    => field.Any(char.IsDigit) && !field.Any(c => char.IsLetter(c) && c != 'L');
+
+// '*' and '?' both mean "this field restricts nothing"; either one leaves the other in charge.
+static bool IsUnrestricted(string field) => field is "*" or "?";
+```
+<!-- endSnippet -->
+
 ## Daylight saving time
 
 Three schedules fire at different times than they did on 3.x. None needs a code change, but all three change
@@ -11583,6 +11670,8 @@ shape changed and only what a mis-stated configuration does is different.
 | rc.1 | A paused **job** group binds what is added to it on the ADO store, as it always did in memory: a trigger stored for a job in a recorded-paused group is born `PAUSED`. A pre-release that paused a job group and then deployed a job into it ran that job | [The two job stores answer the same way](#the-two-job-stores-answer-the-same-way) |
 | rc.1 | The 3.x-to-4.0 migration is **two files**: `schema_30_to_40_upgrade_<database>.sql` is the mandatory half and is safe during a mixed window, and the index set moved out of it into `schema_30_to_40_indexes_<database>.sql`, which is the half that waits for the last 3.x node. Section 6 of the old single file *is* that new file | [Database Schema Migration](#database-schema-migration) |
 | rc.1 | The schema no longer creates `IDX_QRTZ_T_NFT_ST_MISFIRE`, and the 3.x-to-4.0 migration drops it. **Run `schema_30_to_40_indexes_<database>.sql`** — section 6 of the old single file — on a schema built from an earlier pre-release; nothing fails if you do not, the index is only maintained for nothing | [The misfire index is dropped](#the-misfire-index-is-dropped-optional) |
+| rc.2 | The persistent store no longer resolves a job's class on `RescheduleJob` or `UpdateTriggerDetails`, and answers both attribute flags from `IS_NONCONCURRENT` / `IS_UPDATE_DATA` rather than from the type. A process that cannot load its job classes needs no `ITypeLoader` of its own, and no placeholder type | [A job type name is never resolved by the contract types](#a-job-type-name-is-never-resolved-by-the-contract-types) |
+| rc.2 | Documented; nothing changed in the parser. An expression carried over from a crontab-derived .NET library parses on 4.0 where 3.x refused it, and two shapes — a numeric day-of-week, and both day fields restricted — fire on a different day | [If your expressions came from another cron library](#if-your-expressions-came-from-another-cron-library) |
 
 :::
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -2633,6 +2633,23 @@ that a client's runtime goes looking for. If you were relying on `Build()` to sn
 build time — for instance by building a detail, unloading the assembly and reading the flags — read them
 before the assembly goes.
 
+The persistent store does not resolve one outside firing either. A process that cannot load its job
+classes — the `UseThreadPool<ZeroSizeThreadPool>()` administration node, a web application that edits
+schedules without referencing the worker that runs them — reads, pauses, resumes, reschedules, updates,
+triggers, adds triggers to and deletes jobs on the stored name alone, and both attribute flags come from
+`QRTZ_JOB_DETAILS.IS_NONCONCURRENT` and `IS_UPDATE_DATA` rather than from the type. `RescheduleJob` is
+the call that used to fail — `JobPersistenceException: Couldn't replace trigger: Could not load type
+'Acme.Jobs.MessageCleanupJob, Acme.Jobs'` — because it resolved the class in order to answer "may this
+job run concurrently?", and the row now answers that. Such a process therefore needs no `ITypeLoader` of
+its own, and the placeholder type 3.x required is no longer the way to get there; a placeholder was
+always a hazard, because whether it carried `[DisallowConcurrentExecution]` decided whether a
+replacement trigger was stored `WAITING` or `BLOCKED` for a job it was standing in for. Only the firing
+path resolves a job's class, and that runs where the job runs.
+
+`IScheduler.Interrupt` is the one administration operation this does not reach: it is documented as not
+cluster aware, cancels the tokens of the firings running in the scheduler it is called on, and an
+administration node runs none. That is a property of the operation rather than of the missing assembly.
+
 ## One shape per registration method
 
 The `AddJob` / `AddTrigger` / `AddCalendar` grid had overloads that said the same thing twice, and

--- a/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
+++ b/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
@@ -1,3 +1,5 @@
+using System.Data.Common;
+
 using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.Extensibility;
@@ -108,6 +110,70 @@ public static class MigrationGuideSamples
 
         services.AddSingleton<LateBound<IMessageBus>>();
         services.AddQuartz(q => q.UseJobFactory<BusAwareJobFactory>());
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Lists the stored cron expressions that a crontab-derived dialect would read differently.
+    /// </summary>
+    /// <remarks>
+    /// C# rather than SQL because what it does is split a field and look at the characters in it, and
+    /// six database dialects spell that six ways. This one runs anywhere the application's own
+    /// connection does.
+    /// </remarks>
+    public static async Task AuditCronDialect(DbConnection connection)
+    {
+        #region sample_cron_dialect_audit
+
+        // Both shapes below are valid Quartz expressions, so nothing rejects them and nothing logs.
+        // What this lists is the expressions worth reading again if they were carried over from a
+        // crontab-derived library such as Cronos or NCrontab.
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION FROM QRTZ_CRON_TRIGGERS";
+
+        await using DbDataReader reader = await command.ExecuteReaderAsync();
+
+        while (await reader.ReadAsync())
+        {
+            string name = reader.GetString(0);
+            string group = reader.GetString(1);
+            string expression = reader.GetString(2);
+
+            // A stored expression is always the canonical six-field Quartz form: seconds, minutes,
+            // hours, day-of-month, month, day-of-week, and optionally a year.
+            string[] fields = expression.Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+            if (fields.Length < 6)
+            {
+                continue;
+            }
+
+            string dayOfMonth = fields[3];
+            string dayOfWeek = fields[5];
+
+            // Quartz numbers the days 1-7 from Sunday; the other dialects number them 0-6 (Unix: 0-7),
+            // also from Sunday. So a day written as a number names a different day in each, in every
+            // form that carries one: '1', '1-5', '*/2', and the '6#3' and '6L' forms with it.
+            if (IsNumericDay(dayOfWeek))
+            {
+                Console.WriteLine($"{group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
+            }
+
+            // Quartz fires on the union of the two day fields, as crontab does; Cronos intersects them.
+            if (!IsUnrestricted(dayOfMonth) && !IsUnrestricted(dayOfWeek))
+            {
+                Console.WriteLine($"{group}.{name}: both day fields restricted — this fires on their union");
+            }
+        }
+
+        // A day named by number rather than by name, whatever decorates it. A letter anywhere says the
+        // days were written as names and there is nothing to renumber — except 'L', which is a
+        // position rather than a name and shifts with the digit in front of it.
+        static bool IsNumericDay(string field)
+            => field.Any(char.IsDigit) && !field.Any(c => char.IsLetter(c) && c != 'L');
+
+        // '*' and '?' both mean "this field restricts nothing"; either one leaves the other in charge.
+        static bool IsUnrestricted(string field) => field is "*" or "?";
 
         #endregion
     }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
@@ -22,8 +22,13 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// $env:QUARTZ_TEST_DATABASE = 'postgres'
 /// $env:QUARTZ_SOAK_MINUTES  = '30'
 /// dotnet test src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj `
-///   --filter 'FullyQualifiedName~ClusteredSoakPostgresTest'
+///   --filter 'FullyQualifiedName~ClusteredSoakPostgresTest' `
+///   --logger 'console;verbosity=detailed'
 /// </code>
+/// <para>
+/// The logger argument is what makes the run worth doing by hand: the report below is written to
+/// <c>TestContext.Out</c>, and the default console verbosity prints a passing test's output nowhere.
+/// </para>
 /// <para>
 /// <b>What it is for.</b> Every other clustered fixture here asserts one property over a run of
 /// minutes: exactly-once acquisition, a killed node's residue, node affinity, tenancy,

--- a/src/Quartz.Tests.Unit/CronDialectDivergenceTest.cs
+++ b/src/Quartz.Tests.Unit/CronDialectDivergenceTest.cs
@@ -1,0 +1,103 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The two ways a six-field expression written for a crontab-derived .NET library — Cronos, NCrontab —
+/// means something else here, and the rows that mean the same thing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both divergences are documented rather than fixed (#3706): a bare numeric day-of-week is one day out
+/// because Quartz numbers <c>1-7</c> from Sunday and those libraries number <c>0-6</c> from Sunday, and
+/// an expression restricting both day fields fires on their union here and on their intersection there.
+/// Neither can be detected — a six-field expression from either dialect is a perfectly valid Quartz
+/// expression — so what this fixture does is hold the published table to the parser.
+/// </para>
+/// <para>
+/// The instants are the ones <c>cron-expressions.md</c> and the migration guide print, measured against
+/// Cronos 0.11.0. A change here is a change to a documented table, and to somebody's schedule.
+/// </para>
+/// </remarks>
+[TestFixture]
+public class CronDialectDivergenceTest
+{
+    /// <summary>The instant both published tables search from.</summary>
+    private static readonly DateTimeOffset SearchFrom = new(2026, 8, 21, 0, 0, 0, TimeSpan.Zero);
+
+    [TestCase("0 0 2 * * MON", "2026-08-24T02:00:00Z", "a named day means the same day in every dialect")]
+    [TestCase("0 0 7 * * *", "2026-08-21T07:00:00Z", "no day field restricts anything, so this is 07:00 daily either way")]
+    [TestCase("0 0 */1 * * *", "2026-08-21T01:00:00Z", "an hourly step is a step in both")]
+    [TestCase("0 */15 * * * *", "2026-08-21T00:15:00Z", "and so is a quarter-hourly one")]
+    [TestCase("0 30 6 * * MON,TUE,WED,THU,FRI", "2026-08-21T06:30:00Z", "a list of names carries across; 21 August 2026 is a Friday")]
+    public void AnExpressionFromACrontabDerivedLibraryUsuallyMeansTheSameThing(string expression, string expected, string because)
+    {
+        NextFireAfterTheSearchInstant(expression).Should().Be(DateTimeOffset.Parse(expected), because);
+    }
+
+    /// <summary>
+    /// The numbering: the same digit is a different day.
+    /// </summary>
+    [Test]
+    public void ANumericDayOfWeekIsOneDayEarlierThanACrontabDerivedLibraryMeansIt()
+    {
+        DateTimeOffset? next = NextFireAfterTheSearchInstant("0 0 2 * * 1");
+
+        next.Should().Be(
+            new DateTimeOffset(2026, 8, 23, 2, 0, 0, TimeSpan.Zero),
+            "Quartz numbers the days 1-7 with Sunday 1, so '1' is Sunday - where Cronos and NCrontab "
+            + "number 0-6 with Sunday 0 and read the same digit as Monday, 2026-08-24");
+
+        next!.Value.DayOfWeek.Should().Be(DayOfWeek.Sunday, "which is the whole point of the row");
+    }
+
+    /// <summary>
+    /// The day rule: both fields restrict, and Quartz takes their union.
+    /// </summary>
+    [Test]
+    public void BothDayFieldsRestrictedFiresOnTheirUnionRatherThanTheirIntersection()
+    {
+        DateTimeOffset? next = NextFireAfterTheSearchInstant("0 0 2 5 * MON");
+
+        next.Should().Be(
+            new DateTimeOffset(2026, 8, 24, 2, 0, 0, TimeSpan.Zero),
+            "'the 5th, and every Monday' - crontab's rule, which the first Monday after the search "
+            + "instant satisfies. Cronos ANDs the two fields and would answer 2026-10-05, the next 5th "
+            + "that is a Monday");
+
+        next!.Value.DayOfWeek.Should().Be(DayOfWeek.Monday);
+
+        // Past the last Monday of August, so the next Monday is 7 September and the next 5th is earlier.
+        NextFireAfterTheSearchInstant("0 0 2 5 * MON", after: new DateTimeOffset(2026, 8, 31, 3, 0, 0, TimeSpan.Zero))
+            .Should().Be(
+                new DateTimeOffset(2026, 9, 5, 2, 0, 0, TimeSpan.Zero),
+                "and the day-of-month half fires on its own - 5 September 2026 is a Saturday, which the "
+                + "intersection reading would skip");
+    }
+
+    private static DateTimeOffset? NextFireAfterTheSearchInstant(string expression, DateTimeOffset? after = null)
+    {
+        return new CronExpression(expression, TimeZoneInfo.Utc).GetNextValidTimeAfter(after ?? SearchFrom);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
@@ -1,0 +1,573 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The administration node the documentation describes: a process that edits the schedule and does not
+/// have the job classes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two schedulers over one SQLite file, built from two containers so each has its own repository and its
+/// own <see cref="ITypeLoader" />, sharing a scheduler name because the rows are keyed by it. The worker
+/// resolves the stored class names; the administration node resolves nothing, which is what a web
+/// application that does not reference the worker's assembly looks like. The stored
+/// <c>JOB_CLASS_NAME</c> is therefore a name no assembly in this process carries, so
+/// <see cref="JobType.TryResolve" /> is genuinely false on the administration side.
+/// </para>
+/// <para>
+/// #3705: <c>RescheduleJob</c> resolved the class and threw <c>JobPersistenceException : Couldn't
+/// replace trigger: Could not load type '...'</c>. Passing <c>false</c> alone would have been worse —
+/// the store would have read a non-concurrent job as concurrent and stored the replacement trigger
+/// <c>WAITING</c> while the job was executing. Both halves are asserted here.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class AdministrationNodeSqliteTest
+{
+    private const string SchedulerName = "administration-node";
+
+    /// <summary>The stored class name of the plain job, which resolves only through the worker's loader.</summary>
+    private const string PlainJobClassName = "Acme.Jobs.NightlyReportJob, Acme.Jobs";
+
+    /// <summary>The stored class name of the job that forbids concurrent execution.</summary>
+    private const string GatedJobClassName = "Acme.Jobs.MessageCleanupJob, Acme.Jobs";
+
+    private static readonly JobKey PlainJob = new("nightly-report", "acme");
+    private static readonly JobKey GatedJob = new("message-cleanup", "acme");
+    private static readonly TriggerKey PlainTrigger = new("nightly-report", "acme");
+    private static readonly TriggerKey GatedTrigger = new("message-cleanup", "acme");
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    private StandaloneSchedulerFactory workerFactory = null!;
+    private StandaloneSchedulerFactory adminFactory = null!;
+
+    /// <summary>The process that owns the job classes and runs them.</summary>
+    private IScheduler worker = null!;
+
+    /// <summary>The process that edits the schedule and cannot load a single job class.</summary>
+    private IScheduler admin = null!;
+
+    [SetUp]
+    public async Task TwoProcessesOverOneStore()
+    {
+        WorkerJobs.Reset();
+
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-admin-node-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+
+        workerFactory = QuartzSchedulerBuilder.Create(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = SchedulerName;
+                options.InstanceId = "worker";
+
+                // The administration node's writes reach this scheduler through the store rather than
+                // through its signaler, so the poll interval is what decides how soon it notices them.
+                options.IdleWaitTime = TimeSpan.FromSeconds(1);
+            });
+
+            q.UseDefaultThreadPool(maxConcurrency: 4);
+
+            // The worker has the assembly; here that is an alias rather than a reference, so that the
+            // stored names are ones the administration node genuinely cannot resolve.
+            q.UseTypeLoader(options => options
+                .Map(PlainJobClassName, typeof(WorkerJobs.NightlyReportJob))
+                .Map(GatedJobClassName, typeof(WorkerJobs.MessageCleanupJob)));
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+        }).Build();
+
+        worker = await workerFactory.GetScheduler();
+
+        await worker.ScheduleJob(
+            JobBuilder.Create()
+                .WithIdentity(PlainJob)
+                .OfType(new Quartz.JobType(PlainJobClassName, _ => typeof(WorkerJobs.NightlyReportJob)))
+                .StoreDurably()
+                .Build(),
+            FarFutureTrigger(PlainTrigger, PlainJob));
+
+        await worker.ScheduleJob(
+            JobBuilder.Create()
+                .WithIdentity(GatedJob)
+                .OfType(new Quartz.JobType(GatedJobClassName, _ => typeof(WorkerJobs.MessageCleanupJob)))
+                .StoreDurably()
+                .Build(),
+            FarFutureTrigger(GatedTrigger, GatedJob));
+
+        adminFactory = QuartzSchedulerBuilder.Create(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = SchedulerName;
+                options.InstanceId = "admin";
+            });
+
+            // Never runs a job, and is never started.
+            q.UseThreadPool<ZeroSizeThreadPool>();
+            q.UseTypeLoader<UnknownJobTypeLoader>();
+
+            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, connectionString));
+        }).Build();
+
+        admin = await adminFactory.GetScheduler();
+    }
+
+    [TearDown]
+    public async Task ShutDownBoth()
+    {
+        // Whatever is held at the gate finishes, so the worker's shutdown is not the thing that waits.
+        WorkerJobs.Release();
+
+        await admin.Shutdown(waitForJobsToComplete: false);
+        await worker.Shutdown(waitForJobsToComplete: true);
+
+        adminFactory.Dispose();
+        workerFactory.Dispose();
+
+        SqliteConnection.ClearAllPools();
+
+        DeleteDatabaseFile();
+    }
+
+    /// <summary>
+    /// Deletes the file, giving the last connection a moment to let go of it.
+    /// </summary>
+    /// <remarks>
+    /// The two schedulers have been shut down and the pools cleared by the time this runs, but on
+    /// Windows a handle that was closed a microsecond ago can still fail the delete, and a fixture that
+    /// leaves a stray temporary file behind is worse than one that waits.
+    /// </remarks>
+    private void DeleteDatabaseFile()
+    {
+        for (int attempt = 0; attempt < 20 && File.Exists(databaseFile); attempt++)
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(50);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The reads, all of which answer on the stored name alone.
+    /// </summary>
+    [Test]
+    public async Task ReadingTheScheduleNeedsNoJobClass()
+    {
+        IJobDetail? detail = await admin.GetJobDetail(GatedJob);
+
+        detail.Should().NotBeNull();
+        detail!.JobType.FullName.Should().Be(GatedJobClassName, "reading a job never rewrites the stored name");
+        detail.JobType.TryResolve(out _).Should().BeFalse(
+            "this process does not have the assembly, which is the arrangement the test is about");
+
+        detail.ConcurrentExecutionDisallowed.Should().BeTrue(
+            "IS_NONCONCURRENT is the record of the attribute, and it is readable without the assembly");
+        detail.PersistJobDataAfterExecution.Should().BeTrue("IS_UPDATE_DATA says the same of the other attribute");
+
+        (await admin.Exists(GatedJob)).Should().BeTrue();
+        (await admin.Exists(GatedTrigger)).Should().BeTrue();
+        (await admin.Exists(new JobKey("no-such-job", "acme"))).Should().BeFalse();
+
+        List<ITrigger> triggers = await admin.GetTriggersOfJob(GatedJob);
+        triggers.Should().ContainSingle().Which.Key.Should().Be(GatedTrigger);
+
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(TriggerState.Normal);
+
+        PagedResult<JobHeader> jobs = await admin.QueryJobs(new JobQuery { Take = PagedQuery.All });
+        jobs.Items.Select(job => job.Key).Should().BeEquivalentTo([PlainJob, GatedJob]);
+        jobs.Items.Single(job => job.Key.Equals(GatedJob)).ConcurrentExecutionDisallowed.Should().BeTrue(
+            "a listing reads the column too, so the dashboard is right about a job it cannot load");
+
+        PagedResult<TriggerHeader> storedTriggers = await admin.QueryTriggers(new TriggerQuery { Take = PagedQuery.All });
+        storedTriggers.Items.Select(trigger => trigger.Key).Should().BeEquivalentTo([PlainTrigger, GatedTrigger]);
+    }
+
+    /// <summary>
+    /// Pausing and resuming, by trigger and by job.
+    /// </summary>
+    [Test]
+    public async Task PausingAndResumingNeedNoJobClass()
+    {
+        (await admin.PauseTrigger(PlainTrigger)).Should().BeTrue();
+        (await admin.GetTriggerState(PlainTrigger)).Should().Be(TriggerState.Paused);
+
+        (await admin.ResumeTrigger(PlainTrigger)).Should().BeTrue();
+        (await admin.GetTriggerState(PlainTrigger)).Should().Be(TriggerState.Normal);
+
+        (await admin.PauseJob(GatedJob)).Should().BeTrue();
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(TriggerState.Paused);
+
+        (await admin.ResumeJob(GatedJob)).Should().BeTrue();
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// The call #3705 reported: rescheduling from a process without the job's assembly.
+    /// </summary>
+    [Test]
+    public async Task ReschedulingNeedsNoJobClass()
+    {
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity(GatedTrigger)
+            .ForJob(GatedJob)
+            .StartAt(DateTimeOffset.UtcNow.AddYears(2))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(2)).RepeatForever())
+            .Build();
+
+        Func<Task> act = async () => await admin.RescheduleJob(GatedTrigger, replacement);
+
+        await act.Should().NotThrowAsync(
+            "the job's key, durability and attribute flags all come from the row, so nothing on this path "
+            + "needs the class - which is what threw JobPersistenceException: Couldn't replace trigger");
+
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(
+            TriggerState.Normal,
+            "nothing is executing, so the replacement is ready to fire");
+        (await StoredTriggerState(GatedTrigger)).Should().Be("WAITING");
+
+        IJobDetail? detail = await admin.GetJobDetail(GatedJob);
+        detail!.ConcurrentExecutionDisallowed.Should().BeTrue("rescheduling did not rewrite the job row");
+    }
+
+    /// <summary>
+    /// Editing a trigger's metadata, which is the other caller that used to resolve the class.
+    /// </summary>
+    [Test]
+    public async Task UpdatingATriggerNeedsNoJobClass()
+    {
+        Func<Task<bool>> act = async () => await admin.UpdateTriggerDetails(
+            PlainTrigger,
+            new TriggerDetailsUpdate().WithDescription("edited from the administration node").WithPriority(9));
+
+        (await act.Should().NotThrowAsync()).Which.Should().BeTrue();
+
+        ITrigger? updated = await admin.GetTrigger(PlainTrigger);
+        updated!.Description.Should().Be("edited from the administration node");
+        updated.Priority.Should().Be(9);
+    }
+
+    /// <summary>
+    /// Editing a job's data map: read the detail, change a value, store it back over the old one.
+    /// </summary>
+    /// <remarks>
+    /// The copy is built from the detail the store handed over, so the two attribute flags travel with
+    /// it as stated values. Were they deduced instead, this write would clear <c>IS_NONCONCURRENT</c> on
+    /// a job whose class this process cannot see — the same silent damage the trigger paths avoid.
+    /// </remarks>
+    [Test]
+    public async Task EditingJobDataNeedsNoJobClassAndKeepsTheFlags()
+    {
+        IJobDetail original = (await admin.GetJobDetail(GatedJob))!;
+
+        IJobDetail edited = original.GetJobBuilder()
+            .UsingJobData("mailbox", "archive")
+            .Build();
+
+        await admin.AddJob(edited, AddJobOptions.Replacing);
+
+        IJobDetail stored = (await admin.GetJobDetail(GatedJob))!;
+
+        stored.JobDataMap.GetString("mailbox").Should().Be("archive", "the edit is what the write was for");
+        stored.JobType.FullName.Should().Be(GatedJobClassName, "and the stored class name is untouched");
+        stored.ConcurrentExecutionDisallowed.Should().BeTrue(
+            "the copy carried the stated flag, so a write from a process without the class cannot turn a "
+            + "non-concurrent job into a concurrent one");
+        stored.PersistJobDataAfterExecution.Should().BeTrue();
+
+        (await StoredJobFlags(GatedJob)).Should().Be((true, true), "which is what the row says as well");
+
+        // And the worker still runs it, reading the data the administration node wrote.
+        await worker.Start();
+        await admin.TriggerJob(GatedJob);
+
+        await WorkerJobs.MessageCleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        WorkerJobs.MessageCleanupMailbox.Should().Be("archive");
+    }
+
+    /// <summary>
+    /// Adding a second trigger to a job that already exists, which is the other half of schedule editing.
+    /// </summary>
+    [Test]
+    public async Task AddingATriggerToAnExistingJobNeedsNoJobClass()
+    {
+        TriggerKey extra = new("message-cleanup-evening", "acme");
+
+        Func<Task> act = async () => await admin.ScheduleJob(FarFutureTrigger(extra, GatedJob));
+
+        await act.Should().NotThrowAsync(
+            "the job the trigger names is read from the row, class and all, so a schedule-editing process "
+            + "can add to a job it cannot load");
+
+        (await admin.Exists(extra)).Should().BeTrue();
+        (await admin.GetTriggerState(extra)).Should().Be(TriggerState.Normal);
+        (await StoredTriggerState(extra)).Should().Be("WAITING", "nothing is executing");
+
+        (await admin.GetTriggersOfJob(GatedJob)).Select(trigger => trigger.Key)
+            .Should().BeEquivalentTo([GatedTrigger, extra]);
+    }
+
+    /// <summary>
+    /// The state that tells the fix apart from simply not resolving the class.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// With the non-concurrent job executing on the worker, everything the administration node stores for
+    /// that job has to be <c>BLOCKED</c> rather than <c>WAITING</c>, and that decision is made from
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" />. A detail whose flags were deduced from a
+    /// class this process cannot load would answer <see langword="false" /> and store both triggers ready
+    /// to run — a concurrent execution of a job that forbids it.
+    /// </para>
+    /// <para>
+    /// <c>QRTZ_TRIGGERS</c> has no non-concurrent column of its own; <c>TRIGGER_STATE</c> is where the
+    /// decision lands, so that is what is read from the table.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task WhatTheAdminStoresWhileTheJobRunsIsBlocked()
+    {
+        await worker.Start();
+        await admin.TriggerJob(GatedJob);
+
+        await WorkerJobs.MessageCleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity(GatedTrigger)
+            .ForJob(GatedJob)
+            .StartAt(DateTimeOffset.UtcNow.AddSeconds(1))
+            .Build();
+
+        await admin.RescheduleJob(GatedTrigger, replacement);
+
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(
+            TriggerState.Blocked,
+            "the job forbids concurrent execution and is executing, so its replacement trigger waits for "
+            + "the run in progress rather than joining it");
+        (await StoredTriggerState(GatedTrigger)).Should().Be("BLOCKED");
+
+        TriggerKey extra = new("message-cleanup-evening", "acme");
+        await admin.ScheduleJob(FarFutureTrigger(extra, GatedJob));
+
+        (await admin.GetTriggerState(extra)).Should().Be(
+            TriggerState.Blocked,
+            "a trigger added while the job runs is blocked for the same reason");
+
+        WorkerJobs.Release();
+
+        await WorkerJobs.MessageCleanupFiredAgain.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // The completion of the run that blocked them is what lets them go, so the replacement fires
+        // rather than being parked in BLOCKED for ever.
+    }
+
+    /// <summary>
+    /// Triggering a job now, from a process that could not construct it.
+    /// </summary>
+    [Test]
+    public async Task TriggeringAJobNeedsNoJobClassOnTheNodeThatAsks()
+    {
+        await worker.Start();
+
+        Func<Task> act = async () => await admin.TriggerJob(PlainJob);
+
+        await act.Should().NotThrowAsync();
+
+        await WorkerJobs.NightlyReportStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// Unscheduling and deleting, which never needed the class and still do not.
+    /// </summary>
+    [Test]
+    public async Task UnschedulingAndDeletingNeedNoJobClass()
+    {
+        (await admin.UnscheduleJob(PlainTrigger)).Should().BeTrue();
+        (await admin.Exists(PlainTrigger)).Should().BeFalse();
+
+        (await admin.DeleteJob(GatedJob)).Should().BeTrue();
+        (await admin.Exists(GatedJob)).Should().BeFalse();
+        (await admin.Exists(GatedTrigger)).Should().BeFalse("a job takes its triggers with it");
+    }
+
+    /// <summary>
+    /// Interruption is answered without the class, and answers <see langword="false" />.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IScheduler.Interrupt(JobKey, CancellationToken)" /> is documented as not cluster aware:
+    /// it cancels the tokens of the executions running in <em>this</em> scheduler, and an administration
+    /// node runs none. So it is safe to call and cannot reach the worker — a limitation of the operation
+    /// rather than of the missing assembly, and the one entry in this matrix that a schedule-editing
+    /// process cannot use to act on another node.
+    /// </remarks>
+    [Test]
+    public async Task InterruptingIsAnsweredWithoutTheJobClassAndReachesNoOtherNode()
+    {
+        await worker.Start();
+        await admin.TriggerJob(GatedJob);
+
+        await WorkerJobs.MessageCleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        (await admin.Interrupt(GatedJob)).Should().BeFalse(
+            "the execution is on the worker, and Interrupt only reaches this scheduler's own firings");
+    }
+
+    private static ITrigger FarFutureTrigger(TriggerKey key, JobKey job)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(key)
+            .ForJob(job)
+            // Far enough out that nothing fires while a test drives the store by hand.
+            .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+    }
+
+    /// <summary>
+    /// <c>TRIGGER_STATE</c> as the table holds it, read without going through the store that wrote it.
+    /// </summary>
+    private async Task<string> StoredTriggerState(TriggerKey key)
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE TRIGGER_NAME = @name AND TRIGGER_GROUP = @group";
+        command.Parameters.AddWithValue("@name", key.Name);
+        command.Parameters.AddWithValue("@group", key.Group);
+
+        return (string) (await command.ExecuteScalarAsync())!;
+    }
+
+    /// <summary>
+    /// The two attribute columns as the job row holds them.
+    /// </summary>
+    private async Task<(bool NonConcurrent, bool UpdateData)> StoredJobFlags(JobKey key)
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT IS_NONCONCURRENT, IS_UPDATE_DATA FROM QRTZ_JOB_DETAILS WHERE JOB_NAME = @name AND JOB_GROUP = @group";
+        command.Parameters.AddWithValue("@name", key.Name);
+        command.Parameters.AddWithValue("@group", key.Group);
+
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+
+        (await reader.ReadAsync()).Should().BeTrue("the job this fixture stored is still there");
+
+        return (reader.GetBoolean(0), reader.GetBoolean(1));
+    }
+
+    /// <summary>
+    /// The administration node's type loader: it knows nothing about the worker's jobs, and says so
+    /// rather than substituting a placeholder.
+    /// </summary>
+    public sealed class UnknownJobTypeLoader : ITypeLoader
+    {
+        public Type? LoadType(string name) => Type.GetType(name, throwOnError: false);
+    }
+
+    /// <summary>
+    /// The jobs as the worker compiles them, and the gates a test drives them with.
+    /// </summary>
+    public static class WorkerJobs
+    {
+        public static TaskCompletionSource NightlyReportStarted { get; private set; } = NewSource();
+
+        public static TaskCompletionSource MessageCleanupStarted { get; private set; } = NewSource();
+
+        public static TaskCompletionSource MessageCleanupFiredAgain { get; private set; } = NewSource();
+
+        public static string? MessageCleanupMailbox { get; private set; }
+
+        private static TaskCompletionSource gate = NewSource();
+
+        public static void Reset()
+        {
+            NightlyReportStarted = NewSource();
+            MessageCleanupStarted = NewSource();
+            MessageCleanupFiredAgain = NewSource();
+            MessageCleanupMailbox = null;
+            gate = NewSource();
+        }
+
+        public static void Release() => gate.TrySetResult();
+
+        internal static async ValueTask EnterMessageCleanup(IJobExecutionContext context, CancellationToken cancellationToken)
+        {
+            MessageCleanupMailbox = context.MergedJobDataMap.GetString("mailbox");
+
+            if (!MessageCleanupStarted.TrySetResult())
+            {
+                // A second firing: the trigger the administration node stored while the first one was
+                // blocked has been let go and run.
+                MessageCleanupFiredAgain.TrySetResult();
+                return;
+            }
+
+            await gate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private static TaskCompletionSource NewSource() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public sealed class NightlyReportJob : IJob
+        {
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                NightlyReportStarted.TrySetResult();
+                return default;
+            }
+        }
+
+        [DisallowConcurrentExecution]
+        [PersistJobDataAfterExecution]
+        public sealed class MessageCleanupJob : IJob
+        {
+            public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+            {
+                return EnterMessageCleanup(context, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
@@ -1,0 +1,216 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The job a trigger belongs to, read by a process that does not have the job's class.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SelectJobForTrigger</c> is the read behind <c>ReplaceTrigger</c> and <c>UpdateTriggerDetails</c>,
+/// and what those two do with the answer is decide whether the trigger they write is <c>WAITING</c> or
+/// <c>BLOCKED</c>. That decision is <see cref="IJobDetail.ConcurrentExecutionDisallowed" />, so the
+/// answer has to be truthful without the class — otherwise a schedule-editing process either throws
+/// (#3705, which is what it did) or, worse, quietly stores a non-concurrent job's trigger as ready to
+/// run while the job is running.
+/// </para>
+/// <para>
+/// The row is written by an ordinary scheduler and read back through the dialect delegate, against a
+/// real SQLite file, so what is asserted is what the store actually stores.
+/// </para>
+/// </remarks>
+public sealed class SelectJobForTriggerFlagsSqliteTest
+{
+    private const string SchedulerName = "select-job-for-trigger";
+
+    /// <summary>
+    /// The stored <c>JOB_CLASS_NAME</c>: a name no assembly in this process carries, which is what an
+    /// administration node sees when the job classes live in a worker it does not reference.
+    /// </summary>
+    private const string StoredJobClassName = "Acme.Jobs.MessageCleanupJob, Acme.Jobs";
+
+    private static readonly JobKey JobKey = new("cleanup", "acme");
+    private static readonly TriggerKey TriggerKey = new("cleanup", "acme");
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-select-job-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task TheAttributeFlagsComeFromTheRowWhenTheClassIsNotLoaded()
+    {
+        await GivenAStoredNonConcurrentJob();
+
+        IJobDetail? detail = await SelectJobForTrigger(new NullTypeLoader(), loadJobType: false);
+
+        detail.Should().NotBeNull();
+
+        detail!.JobType.TryResolve(out _).Should().BeFalse(
+            "the stored class is in an assembly this process does not have, which is the whole arrangement");
+
+        detail.ConcurrentExecutionDisallowed.Should().BeTrue(
+            "IS_NONCONCURRENT is the record of what the attribute said when the job was stored, and it "
+            + "is readable without the assembly the attribute is written in");
+        detail.PersistJobDataAfterExecution.Should().BeTrue(
+            "IS_UPDATE_DATA says the same about the other attribute");
+
+        JobDetailFlags.ConcurrentExecutionDisallowed(detail).Should().BeTrue(
+            "the flag is stated rather than deduced — a deduced one would answer false here, and false "
+            + "is what would store a replacement trigger WAITING while the job is running");
+        JobDetailFlags.PersistJobDataAfterExecution(detail).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Asking for the class is still asking for the class.
+    /// </summary>
+    /// <remarks>
+    /// <c>loadJobType: true</c> is the fire path's read, and it must keep failing loudly rather than
+    /// handing back a detail whose type is <see langword="null" />. What #3705 changed is which callers
+    /// ask for it, not what asking means.
+    /// </remarks>
+    [Test]
+    public async Task AskingForTheClassStillFailsWhenItIsNotThere()
+    {
+        await GivenAStoredNonConcurrentJob();
+
+        Func<Task> act = async () => await SelectJobForTrigger(new SimpleTypeLoader(), loadJobType: true);
+
+        await act.Should().ThrowAsync<TypeLoadException>()
+            .WithMessage($"*{StoredJobClassName}*");
+    }
+
+    /// <summary>
+    /// Writes the job and its trigger through an ordinary scheduler.
+    /// </summary>
+    /// <remarks>
+    /// The detail is built over a <see cref="Quartz.JobType" /> that carries the stored name and resolves to
+    /// the real class, which is what a worker holding the assembly has: the two flags reach the row
+    /// from the attributes, and the row afterwards names a class nothing here can load.
+    /// </remarks>
+    private async Task GivenAStoredNonConcurrentJob()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = SchedulerName;
+                options.InstanceId = "writer";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+        });
+
+        await using ServiceProvider container = services.BuildServiceProvider();
+
+        // Never started: nothing needs to fire for the row to exist.
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create()
+                .WithIdentity(JobKey)
+                .OfType(new Quartz.JobType(StoredJobClassName, _ => typeof(MessageCleanupJob)))
+                .Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(TriggerKey)
+                .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+                .Build());
+
+        await scheduler.Shutdown();
+    }
+
+    private async Task<IJobDetail?> SelectJobForTrigger(ITypeLoader typeLoader, bool loadJobType)
+    {
+        SQLiteDelegate driverDelegate = new();
+        driverDelegate.Initialize(new DriverDelegateContext
+        {
+            TablePrefix = AdoConstants.DefaultTablePrefix,
+            SchedulerName = SchedulerName,
+            InstanceId = "reader",
+            DbProvider = Provider(),
+            TypeLoader = typeLoader,
+            ObjectSerializer = new SystemTextJsonObjectSerializer(),
+        });
+
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+        using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
+
+        return await driverDelegate.SelectJobForTrigger(holder, TriggerKey, typeLoader, loadJobType);
+    }
+
+    private IDbProvider Provider()
+    {
+        DbMetadata metadata = DbMetadataResolver.BuiltIn().ResolveWithoutTypes("SQLite-Microsoft");
+        return new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, connectionString);
+    }
+
+    /// <summary>
+    /// The loader an administration node has: it resolves the types that process knows about, and
+    /// answers nothing for the ones compiled into the worker.
+    /// </summary>
+    private sealed class NullTypeLoader : ITypeLoader
+    {
+        public Type? LoadType(string name) => null;
+    }
+
+    /// <summary>
+    /// The job as the worker compiles it, attributes and all.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    [PersistJobDataAfterExecution]
+    public sealed class MessageCleanupJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerDetailsFamilyTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UpdateTriggerDetailsFamilyTest.cs
@@ -76,7 +76,8 @@ public class UpdateTriggerDetailsFamilyTest
             .Returns(new ValueTask<IOperableTrigger>(stored));
         A.CallTo(() => driverDelegate.SelectTriggerState(conn, TestTrigger, A<CancellationToken>.Ignored))
             .Returns(new ValueTask<StoredTriggerState>(StoredTriggerState.Waiting));
-        A.CallTo(() => driverDelegate.SelectJobForTrigger(conn, TestTrigger, A<ITypeLoader>.Ignored, true, A<CancellationToken>.Ignored))
+        // loadJobType: false — updating a trigger never resolves the job's class (#3705).
+        A.CallTo(() => driverDelegate.SelectJobForTrigger(conn, TestTrigger, A<ITypeLoader>.Ignored, false, A<CancellationToken>.Ignored))
             .Returns(new ValueTask<IJobDetail>(job));
 
         stored.MisfireInstructionCode.Should().Be(MisfireInstruction.SmartPolicy,

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -741,6 +741,139 @@ public class QuartzHostedServiceTests
     }
 
     /// <summary>
+    /// Two stops that overlap are one stop: the second joins the first rather than shutting the same
+    /// schedulers down a second time.
+    /// </summary>
+    /// <remarks>
+    /// The second call arrives while the first is still inside a scheduler's shutdown, which is exactly
+    /// where the generic host puts it — see
+    /// <see cref="StopAsyncWhileRunAsyncIsPending_LeavesTheHostStoppingCleanly" />. Before this was
+    /// serialized, the second call read the list the first had not finished with.
+    /// </remarks>
+    [Test]
+    public async Task StopAsync_CalledConcurrently_ShutsEachSchedulerDownExactlyOnce()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        IScheduler scheduler = SchedulerBlockedInShutdown(entered, release.Task);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(FactoryFor(scheduler));
+
+        await using var provider = services.BuildServiceProvider();
+
+        var hostedService = new SchedulerReadingHostedService(
+            new MockApplicationLifetime(),
+            provider,
+            new StaticOptionsMonitor(new QuartzHostedServiceOptions { AwaitApplicationStarted = false }));
+
+        await hostedService.StartAsync(CancellationToken.None);
+
+        Task first = hostedService.StopAsync(CancellationToken.None);
+
+        await entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Task second = hostedService.StopAsync(CancellationToken.None);
+
+        release.TrySetResult();
+
+        Func<Task> act = async () => await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(10));
+
+        await act.Should().NotThrowAsync(
+            "a second stop that overlaps the first observes the same outcome rather than walking a list "
+            + "the first is still holding");
+
+        // Shutting the same scheduler down twice is what the second stop must not do.
+        A.CallTo(() => scheduler.Shutdown(A<bool>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+
+        hostedService.RunningSchedulers.Should().BeEmpty(
+            "the schedulers were let go of, so nothing is left bound to the repository");
+
+        await hostedService.StopAsync(CancellationToken.None);
+
+        // A stop after the stop has finished is still the same stop, and it calls nothing.
+        A.CallTo(() => scheduler.Shutdown(A<bool>._, A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// The generic host's own double stop, which is what #3701 reported.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>host.StopAsync()</c> while <c>host.RunAsync()</c> is pending raises <c>ApplicationStopping</c>,
+    /// <c>WaitForShutdownAsync</c> wakes on it and calls <c>StopAsync</c> again, and both reach every
+    /// hosted service at once. Twenty hosts, because the race is a race: it reproduced six runs in eight
+    /// on rc.1.
+    /// </para>
+    /// <para>
+    /// <see cref="Host.CreateEmptyApplicationBuilder" /> rather than <c>CreateApplicationBuilder</c>, so
+    /// that the machine's environment variables and the test directory's <c>appsettings.json</c> cannot
+    /// reach this, and a lifetime of its own rather than the console one it would otherwise register,
+    /// which hooks Ctrl+C on the whole test process.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task StopAsyncWhileRunAsyncIsPending_LeavesTheHostStoppingCleanly()
+    {
+        for (int iteration = 0; iteration < 20; iteration++)
+        {
+            HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings());
+            builder.Services.AddSingleton<IHostLifetime, SilentHostLifetime>();
+            builder.Services.AddQuartz(q => q.ConfigureScheduler(
+                options => options.InstanceName = $"stop-race-{iteration}"));
+            builder.Services.AddQuartzHostedService();
+
+            using IHost host = builder.Build();
+
+            IScheduler scheduler = await host.Services.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+            Task run = host.RunAsync();
+
+            Func<Task> act = async () =>
+            {
+                await host.StopAsync();
+                await run;
+            };
+
+            await act.Should().NotThrowAsync(
+                $"iteration {iteration}: stopping the host while its run is pending stops it twice at once, and "
+                + "the schedulers are shut down by whichever stop gets there first");
+
+            scheduler.Status.Should().Be(
+                SchedulerStatus.Shutdown,
+                $"iteration {iteration}: an orderly stop shuts the scheduler down however many stops raced");
+        }
+    }
+
+    /// <summary>
+    /// A host lifetime that neither waits for anything nor installs a console handler.
+    /// </summary>
+    private sealed class SilentHostLifetime : IHostLifetime
+    {
+        public Task WaitForStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The hosted service with its snapshot of running schedulers made readable, which is what says
+    /// whether a stop actually let go of them.
+    /// </summary>
+    private sealed class SchedulerReadingHostedService : QuartzHostedService
+    {
+        public SchedulerReadingHostedService(
+            Lifetime applicationLifetime,
+            IServiceProvider serviceProvider,
+            IOptionsMonitor<QuartzHostedServiceOptions> options)
+            : base(applicationLifetime, serviceProvider, options)
+        {
+        }
+
+        public IReadOnlyList<IScheduler> RunningSchedulers => Schedulers;
+    }
+
+    /// <summary>
     /// A scheduler whose shutdown does not return until the test lets it, so that two of them overlapping
     /// is observable.
     /// </summary>

--- a/src/Quartz/Hosting/QuartzHostedService.cs
+++ b/src/Quartz/Hosting/QuartzHostedService.cs
@@ -41,7 +41,9 @@ public class QuartzHostedService : IHostedLifecycleService
     private readonly Lifetime applicationLifetime;
     private readonly IServiceProvider serviceProvider;
     private readonly IOptionsMonitor<QuartzHostedServiceOptions> options;
-    private readonly List<HostedScheduler> schedulers = [];
+    private List<HostedScheduler> schedulers = [];
+    private readonly Lock stopGate = new();
+    private Task? stopTask;
     internal Task? startupTask;
 
     /// <summary>
@@ -71,7 +73,7 @@ public class QuartzHostedService : IHostedLifecycleService
     /// them down, which makes <see cref="StartedAsync"/> and <see cref="StoppingAsync"/> the two hooks it
     /// is worth reading from.
     /// </remarks>
-    protected IReadOnlyList<IScheduler> Schedulers => schedulers.ConvertAll(static hosted => hosted.Scheduler);
+    protected IReadOnlyList<IScheduler> Schedulers => Volatile.Read(ref schedulers).ConvertAll(static hosted => hosted.Scheduler);
 
     /// <summary>
     /// Runs before any scheduler has been resolved. Does nothing; override it to do something.
@@ -247,13 +249,39 @@ public class QuartzHostedService : IHostedLifecycleService
     /// the repository.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Not overridable, for the reason <see cref="StartAsync" /> is not.
+    /// </para>
+    /// <para>
+    /// Safe to call more than once, and safe to call concurrently, because the generic host does both:
+    /// <c>StopAsync</c> while <c>RunAsync</c> is pending raises <c>ApplicationStopping</c>,
+    /// <c>WaitForShutdownAsync</c> wakes on it and stops the host again, and the two stops reach every
+    /// hosted service at once. Every call after the first joins the stop already under way and observes
+    /// its outcome — the same completion, and the same failure if a shutdown threw.
+    /// </para>
     /// </remarks>
     /// <param name="cancellationToken">The host's shutdown token.</param>
-    public async Task StopAsync(CancellationToken cancellationToken)
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        Task stop;
+        lock (stopGate)
+        {
+            // The second caller's token is deliberately ignored: there is one stop, it runs under the
+            // token of whichever call started it, and a later call waits for that rather than starting
+            // a second shutdown of schedulers the first one is already tearing down.
+            stop = stopTask ??= StopCore(cancellationToken);
+        }
+
+        return stop;
+    }
+
+    /// <summary>
+    /// The stop itself, run exactly once however many callers ask for it.
+    /// </summary>
+    private async Task StopCore(CancellationToken cancellationToken)
     {
         // Stopped without having been started
-        if (schedulers.Count == 0)
+        if (Volatile.Read(ref schedulers).Count == 0)
         {
             return;
         }
@@ -286,19 +314,28 @@ public class QuartzHostedService : IHostedLifecycleService
     /// Shuts every scheduler down, reporting all the failures rather than the first one.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The shutdowns run concurrently, because the host's shutdown budget is one deadline for all of
     /// them rather than one each: shutting down in turn made the host's stop time the sum of the waits
     /// for running jobs, which is what overran <c>HostOptions.ShutdownTimeout</c> with more than
     /// one scheduler registered. Each scheduler owns its own thread pool, job store and scheduler
     /// thread, so there is nothing for them to serialize behind.
+    /// </para>
+    /// <para>
+    /// The list is taken rather than walked in place: emptying it afterwards meant a caller was
+    /// enumerating a list somebody else was clearing, which is the
+    /// <see cref="InvalidOperationException" /> #3701 reported out of <c>RunAsync</c>.
+    /// </para>
     /// </remarks>
     private async ValueTask ShutdownSchedulers(CancellationToken cancellationToken)
     {
+        List<HostedScheduler> toShutDown = Interlocked.Exchange(ref schedulers, []);
+
         // Every shutdown is started before any of them is awaited, so that the waits for running jobs
         // overlap. A scheduler that throws before it yields is captured rather than left to abandon the
         // schedulers after it in the list.
-        List<Task> shutdowns = new List<Task>(schedulers.Count);
-        foreach (HostedScheduler hosted in schedulers)
+        List<Task> shutdowns = new List<Task>(toShutDown.Count);
+        foreach (HostedScheduler hosted in toShutDown)
         {
             try
             {
@@ -323,8 +360,6 @@ public class QuartzHostedService : IHostedLifecycleService
                 exceptions.Add(e);
             }
         }
-
-        schedulers.Clear();
 
         if (exceptions is { Count: > 0 })
         {

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
@@ -511,7 +511,12 @@ internal abstract partial class AdoJobStoreBase
             async () =>
             {
                 // this must be called before we delete the trigger, obviously
-                var job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoader, loadJobType: true, cancellationToken).ConfigureAwait(false);
+                //
+                // The class is not resolved: rescheduling is an editing operation, and an administration
+                // node that cannot load the job's assembly must be able to do it (#3705). What the
+                // replacement needs from the job is its key, its durability and its two attribute flags,
+                // and all four come from the row.
+                var job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoader, loadJobType: false, cancellationToken).ConfigureAwait(false);
 
                 if (job is null)
                 {
@@ -633,7 +638,10 @@ internal abstract partial class AdoJobStoreBase
                 }
 
                 StoredTriggerState state = await Delegate.SelectTriggerState(conn, triggerKey, cancellationToken).ConfigureAwait(false);
-                IJobDetail? job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoader, loadJobType: true, cancellationToken).ConfigureAwait(false);
+                // Not resolved, for the reason ReplaceTrigger does not resolve it: editing a trigger is
+                // something a process without the job's assembly is entitled to do, and the flags the
+                // write needs are columns rather than attributes.
+                IJobDetail? job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoader, loadJobType: false, cancellationToken).ConfigureAwait(false);
 
                 if (job is null)
                 {

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -615,9 +615,13 @@ public interface IDriverDelegate
     /// <param name="triggerKey">The key identifying the trigger.</param>
     /// <param name="typeLoader">The type loader.</param>
     /// <param name="loadJobType">
-    /// Whether to load the job's actual type. Removal does not need it, and in many cases the type no
-    /// longer exists by then, so removal passes <c>false</c> and gets a job detail carrying only the
-    /// recorded type name.
+    /// Whether to resolve the job's type now, which throws when the class is not in this process.
+    /// <c>false</c> gets a job detail whose <see cref="IJobDetail.JobType" /> is the recorded name,
+    /// resolved lazily by whoever comes to run it. It says nothing about the job's two attribute flags:
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" /> and
+    /// <see cref="IJobDetail.PersistJobDataAfterExecution" /> come from <c>IS_NONCONCURRENT</c> and
+    /// <c>IS_UPDATE_DATA</c> either way, so a caller deciding whether a trigger is blocked does not need
+    /// the class to decide it correctly.
     /// </param>
     /// <param name="cancellationToken">The cancellation instruction.</param>
     ValueTask<IJobDetail?> SelectJobForTrigger(ConnectionAndTransactionHolder conn,

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -262,8 +262,19 @@ internal static class StdAdoConstants
     public static readonly string SqlSelectJobExistence =
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobName} = @{SqlParameters.JobName} AND {AdoConstants.ColumnJobGroup} = @{SqlParameters.JobGroup}");
 
+    /// <summary>
+    /// The job a trigger belongs to, as far as the trigger paths need it.
+    /// </summary>
+    /// <remarks>
+    /// <c>IS_NONCONCURRENT</c> and <c>IS_UPDATE_DATA</c> are selected because the two attribute flags
+    /// have to be answerable without the job's CLR type: <c>AdoJobStoreBase.AddTrigger</c> decides
+    /// between <c>WAITING</c> and <c>BLOCKED</c> from
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" />, and a detail built without them falls
+    /// back to reading the attribute off the type — which answers <see langword="false" /> in a process
+    /// that cannot load it (#3705).
+    /// </remarks>
     public static readonly string SqlSelectJobForTrigger =
-        Invariant($"SELECT J.{AdoConstants.ColumnJobName}, J.{AdoConstants.ColumnJobGroup}, J.{AdoConstants.ColumnIsDurable}, J.{AdoConstants.ColumnJobClass}, J.{AdoConstants.ColumnRequestsRecovery} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} T, {TablePrefixSubst}{AdoConstants.TableJobDetails} J WHERE T.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND T.{AdoConstants.ColumnSchedulerName} = J.{AdoConstants.ColumnSchedulerName} AND T.{AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND T.{AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND T.{AdoConstants.ColumnJobName} = J.{AdoConstants.ColumnJobName} AND T.{AdoConstants.ColumnJobGroup} = J.{AdoConstants.ColumnJobGroup}");
+        Invariant($"SELECT J.{AdoConstants.ColumnJobName}, J.{AdoConstants.ColumnJobGroup}, J.{AdoConstants.ColumnIsDurable}, J.{AdoConstants.ColumnJobClass}, J.{AdoConstants.ColumnRequestsRecovery}, J.{AdoConstants.ColumnIsNonConcurrent}, J.{AdoConstants.ColumnIsUpdateData} FROM {TablePrefixSubst}{AdoConstants.TableTriggers} T, {TablePrefixSubst}{AdoConstants.TableJobDetails} J WHERE T.{AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND T.{AdoConstants.ColumnSchedulerName} = J.{AdoConstants.ColumnSchedulerName} AND T.{AdoConstants.ColumnTriggerName} = @{SqlParameters.TriggerName} AND T.{AdoConstants.ColumnTriggerGroup} = @{SqlParameters.TriggerGroup} AND T.{AdoConstants.ColumnJobName} = J.{AdoConstants.ColumnJobName} AND T.{AdoConstants.ColumnJobGroup} = J.{AdoConstants.ColumnJobGroup}");
 
     public static readonly string SqlSelectJobsInGroupLike =
         Invariant($"SELECT {AdoConstants.ColumnJobName}, {AdoConstants.ColumnJobGroup} FROM {TablePrefixSubst}{AdoConstants.TableJobDetails} WHERE {AdoConstants.ColumnSchedulerName} = @{SqlParameters.SchedulerName} AND {AdoConstants.ColumnJobGroup} LIKE @{SqlParameters.JobGroup}{SqlLikeEscapeClause}");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -381,7 +381,13 @@ public partial class StdAdoDelegate
                 .WithIdentity(new JobKey(rs.GetString(AdoConstants.ColumnJobName)!, rs.GetString(AdoConstants.ColumnJobGroup)!))
                 .RequestRecovery(GetBooleanFromDbValue(rs[AdoConstants.ColumnRequestsRecovery]))
                 .OfType(CreateJobType(jobClassName, typeLoader))
-                .StoreDurably(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsDurable]));
+                .StoreDurably(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsDurable]))
+                // Stated from the row rather than deduced from the type, whatever loadJobType says, for
+                // the reason ReadJobDetail states them: the columns are the record of what the
+                // attributes said when the job was stored, and a process that cannot load the class
+                // would otherwise be told a non-concurrent job allows concurrency (#3705).
+                .DisallowConcurrentExecution(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsNonConcurrent]))
+                .PersistJobDataAfterExecution(GetBooleanFromDbValue(rs[AdoConstants.ColumnIsUpdateData]));
 
             if (loadJobType)
             {


### PR DESCRIPTION
The three findings from a real 3.19.1 → 4.0.0-rc.1 production upgrade, plus one comment fix. Four
commits, one per finding.

## `QuartzHostedService.StopAsync` survives the host stopping twice at once (#3701)

`host.StopAsync()` while `host.RunAsync()` is pending makes the generic host stop twice at once:
`StopAsync` raises `ApplicationStopping`, `WaitForShutdownAsync` wakes on it and stops the host again,
and both stops reach every hosted service concurrently. `ShutdownSchedulers` walked the shared list and
`Clear()`ed it at the end, so the second pass enumerated a list the first was emptying.

`StopAsync` now shares one stop task under a lock — every later caller awaits the first call's outcome —
and `ShutdownSchedulers` takes the list with `Interlocked.Exchange` instead of clearing it. The second
caller's token is deliberately ignored: there is one stop, under the token of whichever call started it.
`Schedulers` reads the field through `Volatile.Read`.

**Observed before the fix**, on the third of twenty hosts:

```text
Did not expect any exception ... but found System.InvalidOperationException: Collection was modified;
enumeration operation may not execute.
   at System.Collections.Generic.List`1.Enumerator.MoveNext()
   at Quartz.QuartzHostedService.ShutdownSchedulers(CancellationToken cancellationToken)
   at Quartz.QuartzHostedService.StopAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.Internal.Host.StopAsync(CancellationToken cancellationToken)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.WaitForShutdownAsync(IHost host, CancellationToken token)
   at Microsoft.Extensions.Hosting.HostingAbstractionsHostExtensions.RunAsync(IHost host, CancellationToken token)
```

and on the direct double-stop test, which holds the first call inside a scheduler's shutdown while the
second arrives:

```text
FakeItEasy.ExpectationException :
  Assertion failed for the following call:
    Quartz.IScheduler.Shutdown(waitForJobsToComplete: <Ignored>, cancellationToken: <Ignored>)
  Expected to find it once exactly but found it twice among the calls
```

## An administration node needs no type loader of its own (#3705)

`ReplaceTrigger` and `UpdateTriggerDetails` passed `loadJobType: true`, so `IScheduler.RescheduleJob`
from a process without the job's assembly threw `JobPersistenceException: Couldn't replace trigger:
Could not load type '…'`.

The issue was right that "pass `false`" is not the fix on its own. `SqlSelectJobForTrigger` selected
neither attribute column, so the detail answered `ConcurrentExecutionDisallowed` from the CLR type —
`false` for a type that does not resolve — and `AdoJobStoreBase.AddTrigger` decides between `WAITING`
and `BLOCKED` from exactly that.

So the row is the truth, as `ReadJobDetail` has always treated it:

1. `StdAdoConstants.SqlSelectJobForTrigger` also selects `J.IS_NONCONCURRENT` and `J.IS_UPDATE_DATA`.
   No dialect delegate overrides that member or that SQL.
2. `StdAdoDelegate.SelectJobForTrigger` states both flags on the builder from those columns, whatever
   `loadJobType` says. `IDriverDelegate`'s `<param>` doc now says so; the parameter only decides whether
   the class is resolved now.
3. `ReplaceTrigger` and `UpdateTriggerDetails` pass `false`. `JobType` stays the lazy one, so a worker
   that has the class still resolves it at fire time.

**Forced-resolution sweep** — `git grep -n 'LoadType(\|GetLoadedType()\|JobTypeInformation.GetOrCreate(' src/Quartz/Impl/AdoJobStore src/Quartz/Core`
after the change:

```text
src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Acquisition.cs:258:  JobTypeInformation.GetOrCreate(jobType).ConcurrentExecutionDisallowed  -- firing path
src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs:485:        public Type? LoadType(string name)                                     -- NullJobTypeLoader's declaration; returns null
src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs:349:          resolved = typeLoader.LoadType(name);                                 -- inside CreateJobType's lazy resolver
src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs:394:          jobBuilder.OfType(typeLoader.LoadType(jobClassName)!);                -- the loadJobType branch
src/Quartz/Core/JobTimeoutMiddleware.cs:143:                     JobTypeInformation.GetOrCreate(jobType).Timeout ?? defaultTimeout      -- firing path
```

The other hits, all in `Common/BuiltInDbMetadataFactory.cs`, are a private `LoadType` helper resolving
ADO.NET provider types (`Npgsql.NpgsqlConnection, Npgsql` and friends) rather than job types; they are
excluded above.

**Observed before the fix.** With `loadJobType: true` restored, the two administration operations that
used it:

```text
Did not expect any exception ... but found Quartz.JobPersistenceException: Couldn't replace trigger:
Value cannot be null. (Parameter 'type')
 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'type')
   at Quartz.JobBuilder`1.OfType(Type type)
   at Quartz.Impl.AdoJobStore.StdAdoDelegate.SelectJobForTrigger(...)
   at Quartz.Impl.AdoJobStore.AdoJobStoreBase.<<ReplaceTrigger>b__0>d.MoveNext()

Did not expect any exception, but found Quartz.JobPersistenceException: Couldn't update trigger details
for 'acme.nightly-report': Value cannot be null. (Parameter 'type')
   ... at Quartz.Impl.AdoJobStore.AdoJobStoreBase.<<UpdateTriggerDetails>b__0>d.MoveNext()
```

`ArgumentNullException` rather than the issue's `TypeLoadException` because the fixture's administration
node installs a *fault-tolerant* loader — one that returns `null` — where the issue's application had
the default `SimpleTypeLoader`, which throws. Both are the same arrangement as far as the store is
concerned; the delegate-level fixture pins the `SimpleTypeLoader` form, with the issue's message.

And with only the callers changed and the columns left out — the "pass `false`" option:

```text
Expected (admin.GetTriggerState(GatedTrigger)) to be TriggerState.Blocked {value: 4} because the job
forbids concurrent execution and is executing, so its replacement trigger waits for the run in progress
rather than joining it, but found TriggerState.Normal {value: 0}.
```

**Tests.** `SelectJobForTriggerFlagsSqliteTest` pins the delegate: both flags come back `true` for a
stored class the process cannot load, `JobType.TryResolve` is `false`, `JobDetailFlags` says they were
*stated*; and `loadJobType: true` with `SimpleTypeLoader` still throws `TypeLoadException`.

`AdministrationNodeSqliteTest` is the matrix: two schedulers over one SQLite file, built from two
containers so each has its own repository and its own `ITypeLoader`, same `SchedulerName`, different
instance ids, not clustered. The worker resolves the stored class names through an alias; the
administration node (`ZeroSizeThreadPool`, never started) resolves nothing, and because the stored
`JOB_CLASS_NAME` names an assembly nothing in the process carries, `TryResolve` is genuinely `false`.
Every operation is driven through the administration node: `GetJobDetail`, `Exists`, `GetTriggersOfJob`,
`GetTriggerState`, `QueryJobs`/`QueryTriggers`, `PauseTrigger`/`ResumeTrigger`, `PauseJob`/`ResumeJob`,
`RescheduleJob`, `UpdateTriggerDetails`, `AddJob(replace)` after editing the data map, `ScheduleJob` with
a second trigger `ForJob` an existing job, `TriggerJob` (the worker then fires it), `UnscheduleJob`,
`DeleteJob`, `Interrupt`. Plus the state that tells the fix apart from "pass `false`": with the
non-concurrent job held at a gate on the worker, everything the administration node stores for it is
`BLOCKED`, and releasing the gate lets it fire.

### For a reviewer to decide

* **`Interrupt` is the one operation that cannot act on another node**, and that is a property of the
  operation rather than of the missing assembly: `IScheduler.Interrupt` is documented as not cluster
  aware, so it cancels the tokens of the firings running in the scheduler it is called on, and an
  administration node runs none. It is called and asserted `false` rather than skipped, and the
  migration guide says so.
* **`loadJobType: true` now has no caller in this repository.** The parameter is on the public
  `IDriverDelegate` and stays; the branch keeps its meaning and its test. Worth knowing: with a loader
  that returns `null` rather than throwing, that branch raises `ArgumentNullException("type")` out of
  `JobBuilder.OfType` rather than something that names the type. Pre-existing, now unreachable from
  Quartz's own code, and left alone.
* **`QRTZ_TRIGGERS` has no non-concurrent column of its own**, so "the trigger row's non-concurrent
  column reads true" is asserted as `TRIGGER_STATE = 'BLOCKED'` — which is where that decision actually
  lands.

## Expressions from another six-field dialect (#3706)

Documentation, one compiled sample and a pinning test; nothing in the parser changes.
`cron-expressions.md` gains *If your expressions came from another .NET cron library* beside the Spring
block it already had, stating the day-of-week numbering (Quartz `1-7` from Sunday, Cronos/NCrontab
`0-6`, crontab `0-7`) and the union-versus-intersection rule for the two day fields, with the issue's
table. The migration guide gains *If your expressions came from another cron library* beside the cron
"Before you upgrade" audit — that audit is about expressions 3.x stored happily and cannot catch these,
because they are valid — and a second audit as `#region sample_cron_dialect_audit`, C# rather than SQL
because what it does is split a field and look at the characters in it, and six database dialects spell
that six ways. `CronDialectDivergenceTest` pins the published rows.

## The soak fixture's documented invocation shows its report

`ClusteredSoakTestBase`'s header documented a `dotnet test` line that, at the default console verbosity,
prints nothing of the report the fixture writes to `TestContext.Out`. Comment only.

## Verification

```text
dotnet build Quartz.slnx                 Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit        Passed! Failed: 0, Passed: 5384, Skipped: 36, Total: 5420
dotnet test src/Quartz.Tests.AspNetCore  Passed! Failed: 0, Passed: 630, Skipped: 0, Total: 630
dotnet fallout DocsSnippets              Succeeded
dotnet fallout VerifyDocsSnippets        Documentation snippets are up to date (111 markdown files checked)
dotnet fallout BenchmarkSmoke            Succeeded
npm run docs:check-links                 docs: 223 pages, 1353 internal links, 855 fragments / no dead links or anchors
npm run docs:lint                        Linting: 92 file(s) / Summary: 0 error(s)
```

The new fixtures were run five further times each with no failures. No public API changed: the
`PublicApiTest_*.verified.txt` baselines are untouched. Integration tests were not run locally — the
SQLite fixtures cover the store paths this changes, and CI runs the dialect legs.

Closes #3701
Closes #3705
Closes #3706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm

