### PR TITLE
The published-rc.2 check's two documentation corrections

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5669,15 +5669,35 @@ ways:
 // What this lists is the expressions worth reading again if they were carried over from a
 // crontab-derived library such as Cronos or NCrontab.
 await using DbCommand command = connection.CreateCommand();
-command.CommandText = "SELECT TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION FROM QRTZ_CRON_TRIGGERS";
+
+// A schema shared by several schedulers holds all of their rows in these tables, told apart
+// by SCHED_NAME — the scheduler's InstanceName — alone. The audit therefore filters on it and
+// lists it, because a line naming only the trigger's group and name would not say whose
+// trigger it is. Run it for every scheduler before upgrading, and substitute your own table
+// prefix for QRTZ_.
+command.CommandText =
+    """
+    SELECT SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION
+    FROM   QRTZ_CRON_TRIGGERS
+    WHERE  SCHED_NAME = @schedulerName
+    """;
+
+// The name is bound, never written into the text. '@' is the marker this sample spells; a
+// provider that spells it otherwise — ':' on Oracle — needs that one character changed, which
+// is what DbMetadata.ParameterNamePrefix carries for Quartz's own statements.
+DbParameter schedulerNameParameter = command.CreateParameter();
+schedulerNameParameter.ParameterName = "@schedulerName";
+schedulerNameParameter.Value = schedulerName;
+command.Parameters.Add(schedulerNameParameter);
 
 await using DbDataReader reader = await command.ExecuteReaderAsync();
 
 while (await reader.ReadAsync())
 {
-    string name = reader.GetString(0);
-    string group = reader.GetString(1);
-    string expression = reader.GetString(2);
+    string scheduler = reader.GetString(0);
+    string name = reader.GetString(1);
+    string group = reader.GetString(2);
+    string expression = reader.GetString(3);
 
     // A stored expression is always the canonical six-field Quartz form: seconds, minutes,
     // hours, day-of-month, month, day-of-week, and optionally a year.
@@ -5695,13 +5715,13 @@ while (await reader.ReadAsync())
     // form that carries one: '1', '1-5', '*/2', and the '6#3' and '6L' forms with it.
     if (IsNumericDay(dayOfWeek))
     {
-        Console.WriteLine($"{group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
+        Console.WriteLine($"{scheduler}: {group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
     }
 
     // Quartz fires on the union of the two day fields, as crontab does; Cronos intersects them.
     if (!IsUnrestricted(dayOfMonth) && !IsUnrestricted(dayOfWeek))
     {
-        Console.WriteLine($"{group}.{name}: both day fields restricted — this fires on their union");
+        Console.WriteLine($"{scheduler}: {group}.{name}: both day fields restricted — this fires on their union");
     }
 }
 

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -810,7 +810,7 @@ did: nothing `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS` empty, no unexpected
 unobserved task exception, and a live heap of 4–5 MB behind 619–640 handles from the first minute to
 the thirtieth.
 
-**SQL Server was then run on the tagged commit itself** — 30 minutes on `97505ecce`, on 2026-09-03 —
+**SQL Server was then run on the rc.1 commit** — 30 minutes on `97505ecce`, on 2026-09-03 —
 because this is the dialect whose schema moved: rc.1 drops `IDX_QRTZ_T_NFT_ST_MISFIRE`, so the run
 provisioned a `tables_sqlServer.sql` the beta.1 run never saw, and the build under it also carries
 the rc.1 store changes — the paused-job-group probe every trigger store now makes, and the
@@ -823,7 +823,15 @@ replaying the killed node's one interrupted firing in the same second as the kil
 others did: nothing `ACQUIRED` or `BLOCKED`, `QRTZ_FIRED_TRIGGERS` empty and the killed node's
 `EXECUTING` row gone with it, no unexpected scheduler error, no unobserved task exception, and a live
 heap of 4–5 MB behind 706–756 handles across all thirty samples. No tolerance was widened for either
-run; the fixture is the one in the tag.
+run; the fixture's assertions are the ones the release carries.
+
+4.0.0 is a later commit than `97505ecce`, and two commits have touched `Quartz` in between. The store's
+share of them is one statement: `SelectJobForTrigger` now selects `IS_NONCONCURRENT` and
+`IS_UPDATE_DATA`, so that a process without the job's class still reads the job's attribute flags
+(#3705). Rescheduling, editing and deleting a trigger are what reach it, and the soak's workload does
+none of the three — it schedules its triggers once and then runs. The other commit is
+`QuartzHostedService`'s stop path, which the fixture never enters, because it builds each node from
+`QuartzSchedulerBuilder` rather than from a host. The figures above therefore stand for the release.
 
 The harness is `ClusteredSoakTestBase` in `Quartz.Tests.Integration`; it is opt-in
 (`[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`) and is run before a tag rather than in CI.

--- a/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
+++ b/src/Quartz.Documentation.Samples/MigrationGuideSamples.cs
@@ -122,7 +122,7 @@ public static class MigrationGuideSamples
     /// six database dialects spell that six ways. This one runs anywhere the application's own
     /// connection does.
     /// </remarks>
-    public static async Task AuditCronDialect(DbConnection connection)
+    public static async Task AuditCronDialect(DbConnection connection, string schedulerName)
     {
         #region sample_cron_dialect_audit
 
@@ -130,15 +130,35 @@ public static class MigrationGuideSamples
         // What this lists is the expressions worth reading again if they were carried over from a
         // crontab-derived library such as Cronos or NCrontab.
         await using DbCommand command = connection.CreateCommand();
-        command.CommandText = "SELECT TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION FROM QRTZ_CRON_TRIGGERS";
+
+        // A schema shared by several schedulers holds all of their rows in these tables, told apart
+        // by SCHED_NAME — the scheduler's InstanceName — alone. The audit therefore filters on it and
+        // lists it, because a line naming only the trigger's group and name would not say whose
+        // trigger it is. Run it for every scheduler before upgrading, and substitute your own table
+        // prefix for QRTZ_.
+        command.CommandText =
+            """
+            SELECT SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION
+            FROM   QRTZ_CRON_TRIGGERS
+            WHERE  SCHED_NAME = @schedulerName
+            """;
+
+        // The name is bound, never written into the text. '@' is the marker this sample spells; a
+        // provider that spells it otherwise — ':' on Oracle — needs that one character changed, which
+        // is what DbMetadata.ParameterNamePrefix carries for Quartz's own statements.
+        DbParameter schedulerNameParameter = command.CreateParameter();
+        schedulerNameParameter.ParameterName = "@schedulerName";
+        schedulerNameParameter.Value = schedulerName;
+        command.Parameters.Add(schedulerNameParameter);
 
         await using DbDataReader reader = await command.ExecuteReaderAsync();
 
         while (await reader.ReadAsync())
         {
-            string name = reader.GetString(0);
-            string group = reader.GetString(1);
-            string expression = reader.GetString(2);
+            string scheduler = reader.GetString(0);
+            string name = reader.GetString(1);
+            string group = reader.GetString(2);
+            string expression = reader.GetString(3);
 
             // A stored expression is always the canonical six-field Quartz form: seconds, minutes,
             // hours, day-of-month, month, day-of-week, and optionally a year.
@@ -156,13 +176,13 @@ public static class MigrationGuideSamples
             // form that carries one: '1', '1-5', '*/2', and the '6#3' and '6L' forms with it.
             if (IsNumericDay(dayOfWeek))
             {
-                Console.WriteLine($"{group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
+                Console.WriteLine($"{scheduler}: {group}.{name}: numeric day-of-week '{dayOfWeek}' — write it as a name");
             }
 
             // Quartz fires on the union of the two day fields, as crontab does; Cronos intersects them.
             if (!IsUnrestricted(dayOfMonth) && !IsUnrestricted(dayOfWeek))
             {
-                Console.WriteLine($"{group}.{name}: both day fields restricted — this fires on their union");
+                Console.WriteLine($"{scheduler}: {group}.{name}: both day fields restricted — this fires on their union");
             }
         }
 


### PR DESCRIPTION
Two corrections the published-rc.2 check turned up. Both are class 1 under the 4.0 release rule — a
documentation page and a documentation sample, no product code — so `v4.0.0` stays on the rc.2 commit.

## The cron-dialect audit says which scheduler's rows it read

`sample_cron_dialect_audit`, rendered into the migration guide under *If your expressions came from
another cron library*, selected `TRIGGER_NAME, TRIGGER_GROUP, CRON_EXPRESSION` and printed
`group.name`. The SQL audit a few lines above it on the same page selects `SCHED_NAME`, because a
schema shared by several schedulers holds all of their rows in one set of tables and nothing else
tells them apart — so on such a schema the C# audit's listing named a trigger that could have belonged
to any scheduler there.

The sample now takes the scheduler name as a method parameter, binds it to the command as a
`DbParameter` (nothing is interpolated into the statement), selects `SCHED_NAME` back and prints it as
part of every line. `QRTZ_` stays the sample's assumption, with the SQL audit's own instruction beside
it: substitute your table prefix. The markdown is the regenerated one — `dotnet fallout DocsSnippets`,
not typed.

## The SQL Server soak is dated by the commit it actually ran on

`operations.md` said the SQL Server soak was run **on the tagged commit itself** — `97505ecce`. That
sha is rc.1's, and 4.0.0 is the rc.2 commit, so the sentence now names a build the soak never saw. It
says rc.1 instead, and then answers the question it was really making: two commits have touched
`Quartz` since, and neither is in the soak's path. `SelectJobForTrigger` now selects
`IS_NONCONCURRENT` and `IS_UPDATE_DATA` (#3705), which only rescheduling, editing and deleting a
trigger reach — the workload does none of the three — and `QuartzHostedService`'s stop path, which
`ClusteredSoakTestBase` never enters, because it builds each node from `QuartzSchedulerBuilder` rather
than from a host. No number was changed and nothing was re-run.

## For a reviewer to decide

* The closing clause of that paragraph read *"the fixture is the one in the tag"*. The fixture's code
  is unchanged since the run, but its XML doc comment moved in 823d1ba69, so at the rc.2 tag the file
  is not byte-identical to the one that ran. It now reads *"the fixture's assertions are the ones the
  release carries"*, which is the claim that was meant. Say the word if you would rather have the
  original sentence back.
* The SQL audit above the sample **selects** `SCHED_NAME` but does not filter on it; its comment says
  to run the query against every scheduler's tables. That is coherent as written — a DBA running it by
  hand sees the column — so it was left alone. The C# sample cannot do the same, because it prints
  rather than returns a result set.
* The sample now spells its parameter marker `@`, with a comment that Oracle spells it `:` and that
  `DbMetadata.ParameterNamePrefix` is where Quartz's own statements take it from. That is the one
  provider-specific character in a sample the page describes as running anywhere the application's own
  connection does.

## Verification

```text
$ dotnet fallout VerifyDocsSnippets
Documentation snippets are up to date (111 markdown files checked)
VerifyDocsSnippets    Succeeded     < 1sec

$ npm run docs:check-links
docs: 223 pages, 1353 internal links, 855 fragments
no dead links or anchors

$ npm run docs:lint
Linting: 92 file(s)
Summary: 0 error(s)

$ dotnet build src/Quartz.Documentation.Samples/Quartz.Documentation.Samples.csproj
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet build Quartz.slnx
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
Passed!  - Failed:     0, Passed:  5384, Skipped:    36, Total:  5420, Duration: 50 s - Quartz.Tests.Unit.dll (net10.0)
```

Integration tests were not run: this change touches a documentation page and a documentation sample,
neither of which is compiled into a shipping assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
