### PR TITLE
The 3.x line's untagged builds say 3.20

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
-    <VersionPrefix>3.19.0</VersionPrefix>
+    <VersionPrefix>3.20.0</VersionPrefix>
 
     <CLSCompliant>True</CLSCompliant>
     <ComVisible>False</ComVisible>


### PR DESCRIPTION
`VersionPrefix` on this branch still read `3.19.0` after 3.20.0 shipped on 2026-08-27, so an untagged build sorted below the release it follows. Housekeeping from the 4.0.0 release-day list; nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
