### PR TITLE
Sixteen 4.0 fixes ported to 3.x for 3.20.1

### DIFF
--- a/src/Quartz.Jobs/Job/DirectoryScanJobModel.cs
+++ b/src/Quartz.Jobs/Job/DirectoryScanJobModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -70,9 +71,7 @@ internal sealed class DirectoryScanJobModel
             JobDetailJobDataMap = context.JobDetail.JobDataMap,
             DirectoriesToScan = GetDirectoriesToScan(schedCtxt, mergedJobDataMap)
                 .Distinct().ToList(),
-            CurrentFileList = mergedJobDataMap.ContainsKey(DirectoryScanJob.CurrentFileList) ?
-                (List<FileInfo>)mergedJobDataMap.Get(DirectoryScanJob.CurrentFileList)
-                : new List<FileInfo>(),
+            CurrentFileList = ReadFileList(mergedJobDataMap),
             SearchPattern = mergedJobDataMap.ContainsKey(DirectoryScanJob.SearchPattern) ?
                 mergedJobDataMap.GetString(DirectoryScanJob.SearchPattern)! : "*",
             IncludeSubDirectories = mergedJobDataMap.ContainsKey(DirectoryScanJob.IncludeSubDirectories) 
@@ -100,17 +99,63 @@ internal sealed class DirectoryScanJobModel
     /// <summary>
     /// Updates the file list for comparison in next iteration
     /// </summary>
-    /// <param name="fileList"></param>
+    /// <remarks>
+    /// Stored as a <see cref="Dictionary{TKey,TValue}" /> of full path to last-write ticks, because this
+    /// job is <c>[PersistJobDataAfterExecution]</c> and a job data map is written to
+    /// <c>QRTZ_JOB_DETAILS</c> by whichever serializer is configured. A <c>List&lt;FileInfo&gt;</c> is
+    /// not a value the JSON serializers can read back — System.Text.Json refuses it outright — so the
+    /// job's first firing against a persistent store failed to persist. A string-to-string dictionary is
+    /// a shape both admit, and a path is what the comparison actually uses.
+    /// </remarks>
+    /// <param name="fileList">What this scan saw.</param>
     internal void UpdateFileList(List<FileInfo> fileList)
     {
-        JobDetailJobDataMap.Put(DirectoryScanJob.CurrentFileList, fileList);
+        Dictionary<string, string> stored = new Dictionary<string, string>(fileList.Count, StringComparer.Ordinal);
+        foreach (FileInfo file in fileList)
+        {
+            stored[file.FullName] = file.LastWriteTimeUtc.Ticks.ToString(CultureInfo.InvariantCulture);
+        }
+
+        JobDetailJobDataMap.Put(DirectoryScanJob.CurrentFileList, stored);
+    }
+
+    /// <summary>
+    /// What the previous scan saw, as the paths it recorded.
+    /// </summary>
+    /// <remarks>
+    /// A <c>List&lt;FileInfo&gt;</c> is still read, because a scheduler that has been running since
+    /// before this changed holds one in its in-memory map, and a binary-serialized job store may hold
+    /// one too.
+    /// </remarks>
+    private static List<FileInfo> ReadFileList(JobDataMap mergedJobDataMap)
+    {
+        if (!mergedJobDataMap.TryGetValue(DirectoryScanJob.CurrentFileList, out object? value) || value is null)
+        {
+            return new List<FileInfo>();
+        }
+
+        if (value is Dictionary<string, string> stored)
+        {
+            List<FileInfo> files = new List<FileInfo>(stored.Count);
+            foreach (string path in stored.Keys)
+            {
+                files.Add(new FileInfo(path));
+            }
+
+            return files;
+        }
+
+        return value as List<FileInfo> ?? new List<FileInfo>();
     }
 
 
     private static List<string> GetDirectoriesToScan(SchedulerContext schedCtxt, JobDataMap mergedJobDataMap)
     {
         IDirectoryProvider directoryProvider = new DefaultDirectoryProvider();
-        var explicitDirProviderName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryProviderName);
+
+        // Optional: GetString throws for a key that is not there, and a job data map that names no
+        // provider is the ordinary case, so it is asked for rather than read.
+        mergedJobDataMap.TryGetString(DirectoryScanJob.DirectoryProviderName, out string? explicitDirProviderName);
 
         if (explicitDirProviderName != null)
         {
@@ -126,7 +171,7 @@ internal sealed class DirectoryScanJobModel
 
     private static IDirectoryScanListener GetListener(JobDataMap mergedJobDataMap, SchedulerContext schedCtxt, IServiceProvider? serviceProvider)
     {
-        var listenerName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryScanListenerName);
+        mergedJobDataMap.TryGetString(DirectoryScanJob.DirectoryScanListenerName, out string? listenerName);
 
         if (listenerName == null)
         {

--- a/src/Quartz.Jobs/Job/NativeJob.cs
+++ b/src/Quartz.Jobs/Job/NativeJob.cs
@@ -117,7 +117,7 @@ public class NativeJob : IJob
     /// </para>
     /// </summary>
     /// <param name="context"></param>
-    public virtual Task Execute(IJobExecutionContext context)
+    public virtual async Task Execute(IJobExecutionContext context)
     {
         JobDataMap data = context.MergedJobDataMap;
 
@@ -137,12 +137,24 @@ public class NativeJob : IJob
         }
 
         data.TryGetString(PropertyWorkingDirectory, out var workingDirectory);
-        int exitCode = RunNativeCommand(command, parameters, workingDirectory, wait, consumeStreams);
+        int exitCode = await RunNativeCommand(command, parameters, workingDirectory, wait, consumeStreams, context.CancellationToken).ConfigureAwait(false);
         context.Result = exitCode;
-        return Task.FromResult(true);
     }
 
-    private int RunNativeCommand(string command, string parameters, string? workingDirectory, bool wait, bool consumeStreams)
+    /// <remarks>
+    /// Both streams used to be redirected whatever <paramref name="consumeStreams" /> said, while the
+    /// consumer threads were started only when it was true — so a process that wrote more than a pipe
+    /// buffer holds (about 4 KB) blocked on its own write, and the synchronous <c>WaitForExit</c> below
+    /// held a worker thread for as long as that lasted, which was for ever. Nothing is redirected unless
+    /// somebody is reading it, and the wait is asynchronous.
+    /// </remarks>
+    private async Task<int> RunNativeCommand(
+        string command,
+        string parameters,
+        string? workingDirectory,
+        bool wait,
+        bool consumeStreams,
+        CancellationToken cancellationToken)
     {
         string[] cmd;
         string[] args = new string[2];
@@ -186,39 +198,51 @@ public class NativeJob : IJob
 
             Log.Info($"About to run {cmd[0]} {temp}...");
 
-            Process proc = new Process();
+            using Process proc = new Process();
 
             proc.StartInfo.FileName = cmd[0];
             proc.StartInfo.Arguments = temp;
             proc.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
             proc.StartInfo.CreateNoWindow = true;
             proc.StartInfo.UseShellExecute = false;
-            proc.StartInfo.RedirectStandardError = true;
-            proc.StartInfo.RedirectStandardOutput = true;
+
+            // Redirected only when somebody reads them. A redirected pipe nobody drains fills up and the
+            // process blocks writing to it.
+            proc.StartInfo.RedirectStandardError = consumeStreams;
+            proc.StartInfo.RedirectStandardOutput = consumeStreams;
 
             if (!string.IsNullOrEmpty(workingDirectory))
             {
                 proc.StartInfo.WorkingDirectory = workingDirectory;
             }
 
+            // Subscribed before the start, so that a process that is gone before the wait begins
+            // still completes it.
+            TaskCompletionSource<bool> exited = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (wait)
+            {
+                proc.EnableRaisingEvents = true;
+                proc.Exited += (_, _) => exited.TrySetResult(true);
+            }
+
             proc.Start();
 
-            // Consumes the stdout from the process
-            StreamConsumer stdoutConsumer = new StreamConsumer(this, proc.StandardOutput.BaseStream, StreamTypeStandardOutput);
-            Thread stdoutConsumerThread = new Thread(stdoutConsumer.Run);
-
-            // Consumes the stderr from the process
             if (consumeStreams)
             {
+                // Consumes the stdout and the stderr from the process
+                StreamConsumer stdoutConsumer = new StreamConsumer(this, proc.StandardOutput.BaseStream, StreamTypeStandardOutput);
                 StreamConsumer stderrConsumer = new StreamConsumer(this, proc.StandardError.BaseStream, StreamTypeError);
-                Thread stderrConsumerThread = new Thread(stderrConsumer.Run);
-                stdoutConsumerThread.Start();
-                stderrConsumerThread.Start();
+                new Thread(stdoutConsumer.Run).Start();
+                new Thread(stderrConsumer.Run).Start();
             }
 
             if (wait)
             {
-                proc.WaitForExit();
+                using (cancellationToken.Register(() => exited.TrySetCanceled(cancellationToken)))
+                {
+                    await exited.Task.ConfigureAwait(false);
+                }
+
                 result = proc.ExitCode;
             }
             // any error message?

--- a/src/Quartz.Jobs/Simpl/DefaultDirectoryProvider.cs
+++ b/src/Quartz.Jobs/Simpl/DefaultDirectoryProvider.cs
@@ -16,8 +16,10 @@ internal sealed class DefaultDirectoryProvider : IDirectoryProvider
     public IReadOnlyList<string> GetDirectoriesToScan(JobDataMap mergedJobDataMap)
     {
         List<string> directoriesToScan = new List<string>();
-        var dirName = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryName);
-        var dirNames = mergedJobDataMap.GetString(DirectoryScanJob.DirectoryNames);
+
+        // Either key may be absent, and GetString throws for a key that is not there.
+        mergedJobDataMap.TryGetString(DirectoryScanJob.DirectoryName, out string? dirName);
+        mergedJobDataMap.TryGetString(DirectoryScanJob.DirectoryNames, out string? dirNames);
 
         if (dirName == null && dirNames == null)
         {

--- a/src/Quartz.Serialization.SystemTextJson/Converters/DictionaryConverter.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Converters/DictionaryConverter.cs
@@ -29,6 +29,12 @@ internal sealed class DictionaryConverter : JsonConverter<IDictionary>
         {
             writer.WriteJobDataMapValue(value, options);
         }
+        // A refusal already says which entry it is about and what to do; wrapping it in a second
+        // exception of the same type would only bury that behind "Failed to serialize JobDataMap".
+        catch (JsonSerializationException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             throw new JsonSerializationException("Failed to serialize JobDataMap to json", e);

--- a/src/Quartz.Serialization.SystemTextJson/Converters/JobDataMapConverter.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Converters/JobDataMapConverter.cs
@@ -28,6 +28,12 @@ internal sealed class JobDataMapConverter : JsonConverter<JobDataMap>
         {
             writer.WriteJobDataMapValue(value, options);
         }
+        // A refusal already says which entry it is about and what to do; wrapping it in a second
+        // exception of the same type would only bury that behind "Failed to serialize JobDataMap".
+        catch (JsonSerializationException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             throw new JsonSerializationException("Failed to serialize JobDataMap to json", e);

--- a/src/Quartz.Serialization.SystemTextJson/Simpl/SystemTextJsonObjectSerializer.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Simpl/SystemTextJsonObjectSerializer.cs
@@ -57,7 +57,10 @@ public class SystemTextJsonObjectSerializer : IObjectSerializer
         {
             return JsonSerializer.Deserialize<T?>(data, options);
         }
-        catch (JsonSerializationException e)
+        // Quartz's exception comes from Quartz's own converters; System.Text.Json's comes from the
+        // reader, which rejects a payload whose very first token is malformed before any converter is
+        // reached. Both are the same failure to a caller, and both have to arrive as Quartz's type.
+        catch (Exception e) when (e is JsonSerializationException or JsonException)
         {
             string json = Encoding.UTF8.GetString(data);
             throw new JsonSerializationException($"Could not deserialize JSON: {json}", e);

--- a/src/Quartz.Serialization.SystemTextJson/Util/JobDataValues.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/JobDataValues.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Quartz.Serialization.SystemTextJson;
+
+namespace Quartz.Util;
+
+/// <summary>
+/// What a job data value may be on the way in: what <see cref="Refuse" /> lets past is what
+/// <c>SerializationExtensions.GetJobDataMap</c> can hand back on the way out.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The read side has always been closed — a stored value comes back as a string, a bool, an int, a
+/// long, a double, null or a <c>Dictionary&lt;string, string&gt;</c>, and there is no polymorphic
+/// <see cref="object" /> deserialization. The write side was not closed to match: it wrote whatever
+/// the runtime could serialize, so a <c>List&lt;string&gt;</c> went into the database happily and threw
+/// on the way back out — by which time the blob was already stored, and unreadable, and every later
+/// acquisition of the trigger failed on it (#3495). A writer that consults the same declaration cannot
+/// drift from the reader again.
+/// </para>
+/// <para>
+/// The rule is what the reader cannot hand back, and it is not a list of blessed types: a value is
+/// refused when its JSON is an array, or an object of any shape but the
+/// <c>Dictionary&lt;string, string&gt;</c> the reader produces. A string, a number, a boolean and a null
+/// all come back — as themselves, or as what the <see cref="JobDataMap" /> accessors coerce them into,
+/// which is the store format rather than an oversight. So a <c>short</c>, a <c>byte[]</c>, a
+/// <see cref="Uri" /> and a <see cref="Version" /> are written today and are written still: each is a
+/// number or a string in the column, and a list that named the reader's own types would have refused
+/// them and turned working applications into failing ones over an upgrade.
+/// </para>
+/// <para>
+/// <see cref="Accepted" /> is a fast path over that rule rather than the rule itself. It answers the
+/// types an ordinary job data map is made of without writing anything; everything else is written once,
+/// on its own, and judged by the token that came out — which is the same question the reader will ask
+/// of the stored bytes, asked before there are any.
+/// </para>
+/// <para>
+/// Past that, a value is the application's own choice, and a <see cref="JsonConverter" /> of its own
+/// added to the options — through an override of
+/// <c>SystemTextJsonObjectSerializer.CreateSerializerOptions</c> — is how it declares one. A type an
+/// application has already answered for is a type this refuses nothing about.
+/// </para>
+/// </remarks>
+internal static class JobDataValues
+{
+    /// <summary>
+    /// The types answered without writing anything: every one of them is a string, a number or a
+    /// boolean in the column, so the probe below would only agree at the cost of a serialization.
+    /// </summary>
+    private static readonly HashSet<Type> Accepted = new HashSet<Type>
+    {
+        // Read back as themselves.
+        typeof(string),
+        typeof(bool),
+        typeof(int),
+        typeof(long),
+        typeof(double),
+        typeof(Dictionary<string, string>),
+
+        // Written as a number, and read back as an int, a long or a double.
+        typeof(sbyte),
+        typeof(byte),
+        typeof(short),
+        typeof(ushort),
+        typeof(uint),
+        typeof(ulong),
+        typeof(float),
+        typeof(decimal),
+
+        // Written as a string, and read back as one; the JobDataMap accessors coerce.
+        typeof(char),
+        typeof(DateTime),
+        typeof(DateTimeOffset),
+        typeof(TimeSpan),
+        typeof(Guid),
+        typeof(Uri),
+        typeof(byte[]),
+#if NET6_0_OR_GREATER
+        typeof(DateOnly),
+        typeof(TimeOnly)
+#endif
+    };
+
+    /// <summary>
+    /// Throws unless <paramref name="value" /> is one the reader will hand back.
+    /// </summary>
+    /// <remarks>
+    /// Runs before a single byte reaches the writer, because a blob already in the column is the
+    /// failure this exists to prevent. The scalars are answered by name; anything else is written on
+    /// its own and answered by the token it wrote as.
+    /// </remarks>
+    /// <exception cref="JsonSerializationException">
+    /// The value writes as a JSON array, or as an object of a shape the reader turns into something
+    /// else, and the application has not declared a converter for it.
+    /// </exception>
+    public static void Refuse(string key, object? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        Type type = value.GetType();
+        if (Accepted.Contains(type) || type.IsEnum || HasApplicationConverter(type, options))
+        {
+            return;
+        }
+
+        // A map is answered without the probe. The reader hands an object back as a
+        // Dictionary<string, string> and as nothing else, so a map of anything else cannot come back
+        // whatever it happens to hold today — and writing one to find out would re-enter this check
+        // through Quartz's own map converters, which a map holding itself would do until the stack ran
+        // out. That is also what keeps a JobDataMap out of a JobDataMap.
+        if (value is IDictionary && !IsStringMap(value))
+        {
+            throw Refusal(key, type, innerException: null);
+        }
+
+        JsonTokenType token;
+        try
+        {
+            token = RootTokenOf(value, type, options);
+        }
+        catch (Exception e)
+        {
+            // A value that cannot be written at all is one no reader will ever hand back, and this is
+            // the message that says what to do about it.
+            throw Refusal(key, type, e);
+        }
+
+        switch (token)
+        {
+            case JsonTokenType.String:
+            case JsonTokenType.Number:
+            case JsonTokenType.True:
+            case JsonTokenType.False:
+            case JsonTokenType.Null:
+                return;
+
+            // The one object the reader produces. An object of any other shape comes back as a string
+            // map the job that stored it cannot use, or - once a value in it is not a string - as an
+            // exception on every later read of the trigger.
+            case JsonTokenType.StartObject when IsStringMap(value):
+                return;
+
+            default:
+                throw Refusal(key, type, innerException: null);
+        }
+    }
+
+    /// <summary>
+    /// The token a single value writes as, which is the whole of the question: the reader decides what
+    /// to hand back by the token it reads and by nothing else.
+    /// </summary>
+    private static JsonTokenType RootTokenOf(object value, Type type, JsonSerializerOptions options)
+    {
+        byte[] written = JsonSerializer.SerializeToUtf8Bytes(value, type, options);
+
+        Utf8JsonReader reader = new Utf8JsonReader(written);
+        return reader.Read() ? reader.TokenType : JsonTokenType.None;
+    }
+
+    /// <summary>
+    /// Whether the value is the string-to-string map an object is read back as. The type says so
+    /// rather than the JSON, because a map of strings and an object whose properties are all strings
+    /// are the same bytes and only one of them comes back as what went in.
+    /// </summary>
+    private static bool IsStringMap(object value)
+    {
+        return value is IEnumerable<KeyValuePair<string, string>>;
+    }
+
+    private static JsonSerializationException Refusal(string key, Type type, Exception? innerException)
+    {
+        return new JsonSerializationException(
+            $"Job data entry '{key}' holds a {type.FullName}, which a persistent store cannot read back. " +
+            "A stored value comes back as a string, a number, a boolean, null or a Dictionary<string, string>, " +
+            "so a value written as a JSON array - or as an object of any other shape - is a blob the next read of this job fails on. " +
+            "Serialize it in the job and store the result as a string, or declare a JsonConverter for it by overriding SystemTextJsonObjectSerializer.CreateSerializerOptions.",
+            innerException);
+    }
+
+    /// <summary>
+    /// Whether the application added a converter of its own for the type. Quartz's own converters do
+    /// not count: they answer for a <see cref="JobDataMap" /> because a map is what they write, and a
+    /// map nested inside a map is exactly a value the reader hands back as something else.
+    /// </summary>
+    private static bool HasApplicationConverter(Type type, JsonSerializerOptions options)
+    {
+        foreach (JsonConverter converter in options.Converters)
+        {
+            if (converter.GetType().Assembly != typeof(JobDataValues).Assembly && converter.CanConvert(type))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
+++ b/src/Quartz.Serialization.SystemTextJson/Util/SerializationExtensions.cs
@@ -173,6 +173,13 @@ internal static class Utf8JsonWriterExtensions
 
     public static void WriteJobDataMapValue<T>(this Utf8JsonWriter writer, T jobDataMap, JsonSerializerOptions options) where T : IDictionary
     {
+        // Refused before the first byte is written: a value GetJobDataMap below cannot hand back is a
+        // blob in the database that every later read fails on (#3495).
+        foreach (object? key in jobDataMap.Keys)
+        {
+            JobDataValues.Refuse(key.ToString()!, jobDataMap[key], options);
+        }
+
         writer.WriteStartObject();
 
         foreach (object? key in jobDataMap.Keys)

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
@@ -1,0 +1,595 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Impl;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The administration node the documentation describes: a process that edits the schedule and does not
+/// have the job classes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two schedulers over one SQLite file, sharing a scheduler name because the rows are keyed by it. The
+/// worker resolves the stored class names; the administration node cannot, and it is built twice — once
+/// with a type load helper that answers nothing, which is what a web application that does not reference
+/// the worker's assembly looks like, and once with the placeholder the 3.x documentation tells such an
+/// application to substitute. The placeholder has no attributes, which is the hazard: whether it carried
+/// <see cref="DisallowConcurrentExecutionAttribute" /> used to decide how a replacement trigger was stored
+/// for a job it was standing in for.
+/// </para>
+/// <para>
+/// #3705: <c>RescheduleJob</c> resolved the class and threw <c>JobPersistenceException : Couldn't
+/// replace trigger: Could not load type '...'</c>. Passing <c>false</c> alone would have been worse —
+/// the store would have read a non-concurrent job as concurrent and stored the replacement trigger
+/// <c>WAITING</c> while the job was executing. Both halves are asserted here, under both loaders.
+/// </para>
+/// <para>
+/// Reading a job row still needs a type on 3.x, because <see cref="JobDetailImpl.JobType" /> cannot be
+/// null there; the cases that go through such a read say so, and pin what each loader gets.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+[Category("db-sqlite")]
+[TestFixture(AdminLoader.Unknown)]
+[TestFixture(AdminLoader.Placeholder)]
+public sealed class AdministrationNodeSqliteTest
+{
+    private const string SchedulerName = "administration-node";
+
+    private static readonly JobKey PlainJob = new JobKey("nightly-report", "acme");
+    private static readonly JobKey GatedJob = new JobKey("message-cleanup", "acme");
+    private static readonly TriggerKey PlainTrigger = new TriggerKey("nightly-report", "acme");
+    private static readonly TriggerKey GatedTrigger = new TriggerKey("message-cleanup", "acme");
+
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    private readonly AdminLoader adminLoader;
+
+    private string databaseFile;
+    private string connectionString;
+
+    /// <summary>The process that owns the job classes and runs them.</summary>
+    private IScheduler worker;
+
+    /// <summary>The process that edits the schedule and cannot load a single job class.</summary>
+    private IScheduler admin;
+
+    public AdministrationNodeSqliteTest(AdminLoader adminLoader)
+    {
+        this.adminLoader = adminLoader;
+    }
+
+    [SetUp]
+    public async Task TwoProcessesOverOneStore()
+    {
+        WorkerJobs.Reset();
+
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-admin-node-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+
+        InstallSchemaFromFreshInstallScript();
+
+        SchedulerBuilder workerConfig = SchedulerBuilder.Create("worker", SchedulerName);
+        // The administration node's writes reach this scheduler through the store rather than through
+        // its signaler, so the poll interval is what decides how soon it notices them.
+        workerConfig.SetProperty(StdSchedulerFactory.PropertySchedulerIdleWaitTime, "1000");
+        workerConfig.UseDefaultThreadPool(maxConcurrency: 4);
+        workerConfig.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        worker = await workerConfig.BuildScheduler();
+
+        await worker.ScheduleJob(
+            JobBuilder.Create<WorkerJobs.NightlyReportJob>()
+                .WithIdentity(PlainJob)
+                .StoreDurably()
+                .Build(),
+            FarFutureTrigger(PlainTrigger, PlainJob));
+
+        await worker.ScheduleJob(
+            JobBuilder.Create<WorkerJobs.MessageCleanupJob>()
+                .WithIdentity(GatedJob)
+                .StoreDurably()
+                .Build(),
+            FarFutureTrigger(GatedTrigger, GatedJob));
+
+        // The repository hands out schedulers by name, so the worker steps out of it before the
+        // administration node of the same name is built; each keeps running regardless.
+        SchedulerRepository.Instance.Remove(SchedulerName, "worker");
+
+        SchedulerBuilder adminConfig = SchedulerBuilder.Create("admin", SchedulerName);
+        // Never runs a job, and is never started.
+        adminConfig.UseZeroSizeThreadPool();
+        if (adminLoader == AdminLoader.Unknown)
+        {
+            adminConfig.UseTypeLoader<UnknownJobTypeLoader>();
+        }
+        else
+        {
+            adminConfig.UseTypeLoader<PlaceholderJobTypeLoader>();
+        }
+
+        adminConfig.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        admin = await adminConfig.BuildScheduler();
+    }
+
+    [TearDown]
+    public async Task ShutDownBoth()
+    {
+        // Whatever is held at the gate finishes, so the worker's shutdown is not the thing that waits.
+        WorkerJobs.Release();
+
+        if (admin != null)
+        {
+            await admin.Shutdown(waitForJobsToComplete: false);
+        }
+
+        if (worker != null)
+        {
+            await worker.Shutdown(waitForJobsToComplete: true);
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        DeleteDatabaseFile();
+    }
+
+    /// <summary>
+    /// The call #3705 reported: rescheduling from a process without the job's assembly.
+    /// </summary>
+    [Test]
+    public async Task ReschedulingNeedsNoJobClass()
+    {
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity(GatedTrigger)
+            .ForJob(GatedJob)
+            .StartAt(DateTimeOffset.UtcNow.AddYears(2))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(2)).RepeatForever())
+            .Build();
+
+        Func<Task> act = async () => await admin.RescheduleJob(GatedTrigger, replacement);
+
+        await act.Should().NotThrowAsync(
+            "the job's key, durability and attribute flags all come from the row, so nothing on this path "
+            + "needs the class - which is what threw JobPersistenceException: Couldn't replace trigger");
+
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(
+            TriggerState.Normal,
+            "nothing is executing, so the replacement is ready to fire");
+        StoredTriggerState(GatedTrigger).Should().Be("WAITING");
+
+        StoredJobFlags(GatedJob).Should().Be((true, true), "rescheduling did not rewrite the job row");
+    }
+
+    /// <summary>
+    /// Editing a trigger's metadata, which is the other caller that used to resolve the class.
+    /// </summary>
+    [Test]
+    public async Task UpdatingATriggerNeedsNoJobClass()
+    {
+        Func<Task<bool>> act = async () => await admin.UpdateTriggerDetails(
+            PlainTrigger,
+            new TriggerDetailsUpdate().WithDescription("edited from the administration node").WithPriority(9));
+
+        (await act.Should().NotThrowAsync()).Which.Should().BeTrue();
+
+        ITrigger updated = await admin.GetTrigger(PlainTrigger);
+        updated.Description.Should().Be("edited from the administration node");
+        updated.Priority.Should().Be(9);
+    }
+
+    /// <summary>
+    /// Pausing and resuming, by trigger and by job.
+    /// </summary>
+    [Test]
+    public async Task PausingAndResumingNeedNoJobClass()
+    {
+        await admin.PauseTrigger(PlainTrigger);
+        (await admin.GetTriggerState(PlainTrigger)).Should().Be(TriggerState.Paused);
+
+        await admin.ResumeTrigger(PlainTrigger);
+        (await admin.GetTriggerState(PlainTrigger)).Should().Be(TriggerState.Normal);
+
+        await admin.PauseJob(GatedJob);
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(TriggerState.Paused);
+
+        await admin.ResumeJob(GatedJob);
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(TriggerState.Normal);
+    }
+
+    /// <summary>
+    /// Unscheduling and deleting, which never needed the class and still do not.
+    /// </summary>
+    [Test]
+    public async Task UnschedulingAndDeletingNeedNoJobClass()
+    {
+        (await admin.UnscheduleJob(PlainTrigger)).Should().BeTrue();
+        (await admin.CheckExists(PlainTrigger)).Should().BeFalse();
+
+        (await admin.DeleteJob(GatedJob)).Should().BeTrue();
+        (await admin.CheckExists(GatedJob)).Should().BeFalse();
+        (await admin.CheckExists(GatedTrigger)).Should().BeFalse("a job takes its triggers with it");
+    }
+
+    /// <summary>
+    /// Adding a second trigger to a job that already exists, which reads the job row — and on 3.x a job
+    /// row cannot be read without a type, so this is where the two loaders part company.
+    /// </summary>
+    [Test]
+    public async Task AddingATriggerToAnExistingJobReadsTheJobRow()
+    {
+        TriggerKey extra = new TriggerKey("message-cleanup-evening", "acme");
+
+        Func<Task> act = async () => await admin.ScheduleJob(FarFutureTrigger(extra, GatedJob));
+
+        if (adminLoader == AdminLoader.Unknown)
+        {
+            await act.Should().ThrowAsync<JobPersistenceException>(
+                "storing a trigger for an existing job reads the job's row, and on 3.x a job detail cannot "
+                + "exist without a type - which is why the documentation tells an administration node to "
+                + "substitute a placeholder");
+            return;
+        }
+
+        await act.Should().NotThrowAsync("the placeholder gives the row a type to be read into");
+
+        (await admin.CheckExists(extra)).Should().BeTrue();
+        (await admin.GetTriggerState(extra)).Should().Be(TriggerState.Normal);
+        StoredTriggerState(extra).Should().Be("WAITING", "nothing is executing");
+
+        (await admin.GetTriggersOfJob(GatedJob)).Select(trigger => trigger.Key)
+            .Should().BeEquivalentTo(new[] { GatedTrigger, extra });
+    }
+
+    /// <summary>
+    /// The flags a placeholder reads are the row's, not the placeholder's.
+    /// </summary>
+    [Test]
+    public async Task ReadingAJobThroughAPlaceholderTellsTheTruthAboutItsFlags()
+    {
+        Func<Task<IJobDetail>> act = async () => await admin.GetJobDetail(GatedJob);
+
+        if (adminLoader == AdminLoader.Unknown)
+        {
+            await act.Should().ThrowAsync<JobPersistenceException>(
+                "on 3.x a job detail cannot exist without a type, so a loader that answers nothing cannot read one");
+            return;
+        }
+
+        IJobDetail detail = (await act.Should().NotThrowAsync()).Which;
+
+        detail.JobType.Should().Be<PlaceholderJobTypeLoader.PlaceholderJob>("the loader substituted it");
+        detail.ConcurrentExecutionDisallowed.Should().BeTrue(
+            "IS_NONCONCURRENT is the record of the attribute, and the placeholder - which carries no "
+            + "attribute at all - does not get a say");
+        detail.PersistJobDataAfterExecution.Should().BeTrue("IS_UPDATE_DATA says the same of the other attribute");
+    }
+
+    /// <summary>
+    /// The state that tells the fix apart from simply not resolving the class.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// With the non-concurrent job executing on the worker, everything the administration node stores for
+    /// that job has to be <c>BLOCKED</c> rather than <c>WAITING</c>, and that decision is made from
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" />. A detail whose flags were deduced from a
+    /// class this process cannot load would answer <see langword="false" /> — and so would one deduced
+    /// from the placeholder — and store the replacement ready to run: a concurrent execution of a job
+    /// that forbids it.
+    /// </para>
+    /// <para>
+    /// <c>QRTZ_TRIGGERS</c> has no non-concurrent column of its own; <c>TRIGGER_STATE</c> is where the
+    /// decision lands, so that is what is read from the table.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task WhatTheAdminStoresWhileTheJobRunsIsBlocked()
+    {
+        await worker.Start();
+        await worker.TriggerJob(GatedJob);
+
+        await ShouldObserve(WorkerJobs.MessageCleanupStarted.Task, "the worker runs the job it was told to");
+
+        ITrigger replacement = TriggerBuilder.Create()
+            .WithIdentity(GatedTrigger)
+            .ForJob(GatedJob)
+            .StartAt(DateTimeOffset.UtcNow.AddSeconds(1))
+            .Build();
+
+        await admin.RescheduleJob(GatedTrigger, replacement);
+
+        (await admin.GetTriggerState(GatedTrigger)).Should().Be(
+            TriggerState.Blocked,
+            "the job forbids concurrent execution and is executing, so its replacement trigger waits for "
+            + "the run in progress rather than joining it");
+        StoredTriggerState(GatedTrigger).Should().Be("BLOCKED");
+
+        if (adminLoader == AdminLoader.Placeholder)
+        {
+            TriggerKey extra = new TriggerKey("message-cleanup-evening", "acme");
+            await admin.ScheduleJob(FarFutureTrigger(extra, GatedJob));
+
+            (await admin.GetTriggerState(extra)).Should().Be(
+                TriggerState.Blocked,
+                "a trigger added while the job runs is blocked for the same reason, and the placeholder's "
+                + "missing attribute does not decide otherwise");
+        }
+
+        WorkerJobs.Release();
+
+        // The completion of the run that blocked them is what lets them go, so the replacement fires
+        // rather than being parked in BLOCKED for ever.
+        await ShouldObserve(WorkerJobs.MessageCleanupFiredAgain.Task,
+            "the replacement trigger was let go when the run that blocked it completed");
+    }
+
+    private static ITrigger FarFutureTrigger(TriggerKey key, JobKey job)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(key)
+            .ForJob(job)
+            // Far enough out that nothing fires while a test drives the store by hand.
+            .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// <c>TRIGGER_STATE</c> as the table holds it, read without going through the store that wrote it.
+    /// </summary>
+    private string StoredTriggerState(TriggerKey key)
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE TRIGGER_NAME = @name AND TRIGGER_GROUP = @group";
+                command.Parameters.AddWithValue("@name", key.Name);
+                command.Parameters.AddWithValue("@group", key.Group);
+
+                return (string) command.ExecuteScalar();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The two attribute columns as the job row holds them.
+    /// </summary>
+    private (bool NonConcurrent, bool UpdateData) StoredJobFlags(JobKey key)
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT IS_NONCONCURRENT, IS_UPDATE_DATA FROM QRTZ_JOB_DETAILS WHERE JOB_NAME = @name AND JOB_GROUP = @group";
+                command.Parameters.AddWithValue("@name", key.Name);
+                command.Parameters.AddWithValue("@group", key.Group);
+
+                using (SqliteDataReader reader = command.ExecuteReader())
+                {
+                    reader.Read().Should().BeTrue("the job this fixture stored is still there");
+                    return (reader.GetBoolean(0), reader.GetBoolean(1));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs <c>database/tables/tables_sqlite.sql</c>, the script the documentation tells a reader to
+    /// run, against the empty file. The whole text goes to one command: SQLite's own parser splits it.
+    /// </summary>
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText = File.ReadAllText(ResolveRepositoryFile("database", "tables", "tables_sqlite.sql"));
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A file in the working tree the test assembly was built in, found by walking up from the output
+    /// directory rather than counting directories.
+    /// </summary>
+    private static string ResolveRepositoryFile(params string[] pathSegments)
+    {
+        string relativePath = Path.Combine(pathSegments);
+        DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find '{relativePath}' above '{AppContext.BaseDirectory}'.");
+    }
+
+    /// <summary>
+    /// Deletes the file, giving the last connection a moment to let go of it.
+    /// </summary>
+    private void DeleteDatabaseFile()
+    {
+        for (int attempt = 0; attempt < 20 && File.Exists(databaseFile); attempt++)
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                Thread.Sleep(50);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A type load helper for a process that does not have the worker's assembly. The worker's jobs
+    /// are compiled into this very assembly, so the helper resolves everything the way
+    /// <see cref="SimpleTypeLoadHelper" /> does — the scheduler factory loads its own parts through
+    /// it — and treats the worker's job classes alone as names it cannot answer.
+    /// </summary>
+    public abstract class AdministrationNodeTypeLoader : ITypeLoadHelper
+    {
+        public void Initialize()
+        {
+        }
+
+        public Type LoadType(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            Type type = Type.GetType(name, throwOnError: false);
+            return type != null && type.DeclaringType == typeof(WorkerJobs)
+                ? WithoutTheWorkerAssembly(name)
+                : type;
+        }
+
+        protected abstract Type WithoutTheWorkerAssembly(string name);
+    }
+
+    /// <summary>
+    /// The administration node's type loader when it has no assembly to answer from: it knows nothing
+    /// about the worker's jobs, and says so rather than substituting a placeholder.
+    /// </summary>
+    public sealed class UnknownJobTypeLoader : AdministrationNodeTypeLoader
+    {
+        protected override Type WithoutTheWorkerAssembly(string name) => null;
+    }
+
+    /// <summary>
+    /// The type loader the 3.x documentation tells an administration node to substitute: every stored
+    /// job name it cannot load resolves to one placeholder job, which carries no attribute of any kind.
+    /// </summary>
+    public sealed class PlaceholderJobTypeLoader : AdministrationNodeTypeLoader
+    {
+        protected override Type WithoutTheWorkerAssembly(string name) => typeof(PlaceholderJob);
+
+        public sealed class PlaceholderJob : IJob
+        {
+            public Task Execute(IJobExecutionContext context) => Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// The jobs as the worker compiles them, and the gates a test drives them with.
+    /// </summary>
+    public static class WorkerJobs
+    {
+        public static TaskCompletionSource<bool> MessageCleanupStarted { get; private set; } = NewSource();
+
+        public static TaskCompletionSource<bool> MessageCleanupFiredAgain { get; private set; } = NewSource();
+
+        private static TaskCompletionSource<bool> gate = NewSource();
+
+        public static void Reset()
+        {
+            MessageCleanupStarted = NewSource();
+            MessageCleanupFiredAgain = NewSource();
+            gate = NewSource();
+        }
+
+        public static void Release() => gate.TrySetResult(true);
+
+        private static TaskCompletionSource<bool> NewSource() => new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public sealed class NightlyReportJob : IJob
+        {
+            public Task Execute(IJobExecutionContext context) => Task.CompletedTask;
+        }
+
+        [DisallowConcurrentExecution]
+        [PersistJobDataAfterExecution]
+        public sealed class MessageCleanupJob : IJob
+        {
+            public async Task Execute(IJobExecutionContext context)
+            {
+                if (!MessageCleanupStarted.TrySetResult(true))
+                {
+                    // A second firing: the trigger the administration node stored while the first one
+                    // was blocked has been let go and run.
+                    MessageCleanupFiredAgain.TrySetResult(true);
+                    return;
+                }
+
+                await gate.Task.ConfigureAwait(false);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// What the administration node's type load helper answers for a stored class name it cannot load.
+/// </summary>
+public enum AdminLoader
+{
+    /// <summary>Nothing: the loader returns <see langword="null" />.</summary>
+    Unknown,
+
+    /// <summary>A placeholder job type with no attributes, as the 3.x documentation suggests.</summary>
+    Placeholder,
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
@@ -1,0 +1,183 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Data.Common;
+using System.IO;
+using System.Threading.Tasks;
+using System.Transactions;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Job;
+
+using IsolationLevel = System.Transactions.IsolationLevel;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// Against the one shipped driver that cannot join an ambient transaction, on a real database file.
+/// <c>Microsoft.Data.Sqlite</c> overrides no <see cref="DbConnection.EnlistTransaction" />, so a
+/// connection opened inside a <see cref="TransactionScope" /> never joins it — and until the store
+/// established the enlistment rather than assuming it, the scheduling written through that connection
+/// committed on the spot and survived a scope that was never completed. Reported as
+/// https://github.com/quartznet/quartznet/issues/3666.
+/// </summary>
+/// <remarks>
+/// A file database rather than a fake: the driver's own answer is the whole of what is being pinned,
+/// and it is exactly the part a stand-in cannot supply.
+/// </remarks>
+[Category("db-sqlite")]
+public sealed class EnlistmentRefusalSqliteTest
+{
+    private string databaseFile;
+    private string connectionString;
+    private IScheduler scheduler;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-enlistment-refusal-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+
+        InstallSchemaFromFreshInstallScript();
+    }
+
+    [TearDown]
+    public async Task DeleteDatabase()
+    {
+        if (scheduler != null)
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+            scheduler = null;
+        }
+
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task EnlistingAConnectionInsideATransactionScopeIsRefused()
+    {
+        scheduler = await GetScheduler(nameof(EnlistingAConnectionInsideATransactionScopeIsRefused));
+
+        TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            await connection.OpenAsync();
+
+            Action enlist = () => scheduler.EnlistConnection(connection);
+
+            enlist.Should().Throw<SchedulerException>(
+                    "the scope governs nothing this connection does, so accepting it would commit the scheduling "
+                    + "whatever the application decided")
+                .Which.Message.Should().Contain("Microsoft.Data.Sqlite.SqliteConnection",
+                    "the failure has to name the driver, because that is what the reader has to change or work around")
+                .And.Contain("EnlistTransaction(connection.BeginTransaction())",
+                    "and the form that does work on this very driver");
+        }
+    }
+
+    /// <summary>
+    /// The way out the refusal points at, on the driver that is refused: a transaction of the
+    /// connection's own governs the writes, and rolling it back takes the schedule with it.
+    /// </summary>
+    [Test]
+    public async Task EnlistingTheConnectionsOwnTransactionStillDiscardsTheScheduleOnRollback()
+    {
+        scheduler = await GetScheduler(nameof(EnlistingTheConnectionsOwnTransactionStillDiscardsTheScheduleOnRollback));
+        JobKey jobKey = new JobKey("enlisted", "sqlite");
+
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            await connection.OpenAsync();
+            using (DbTransaction transaction = connection.BeginTransaction())
+            {
+                using (scheduler.EnlistTransaction(transaction))
+                {
+                    await scheduler.ScheduleJob(
+                        JobBuilder.Create<NoOpJob>().WithIdentity(jobKey).StoreDurably().Build(),
+                        TriggerBuilder.Create().WithIdentity(jobKey.Name, jobKey.Group).ForJob(jobKey)
+                            .StartAt(DateTimeOffset.UtcNow.AddHours(1)).Build());
+
+                    (await scheduler.CheckExists(jobKey)).Should().BeTrue("the job store wrote through the enlisted transaction");
+                }
+
+                transaction.Rollback();
+            }
+        }
+
+        (await scheduler.CheckExists(jobKey)).Should().BeFalse(
+            "the schedule belongs to the transaction the application rolled back, which is the guarantee the "
+            + "refusal above exists to keep honest");
+    }
+
+    private Task<IScheduler> GetScheduler(string schedulerName)
+    {
+        SchedulerBuilder config = SchedulerBuilder.Create("one", schedulerName);
+        config.SetProperty("quartz.jobStore.acceptEnlistedTransactions", "true");
+        config.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        return config.BuildScheduler();
+    }
+
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText = File.ReadAllText(ResolveRepositoryFile("database", "tables", "tables_sqlite.sql"));
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private static string ResolveRepositoryFile(params string[] pathSegments)
+    {
+        string relativePath = Path.Combine(pathSegments);
+        DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find '{relativePath}' above '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
@@ -45,6 +45,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// A file database rather than a fake: the driver's own answer is the whole of what is being pinned,
 /// and it is exactly the part a stand-in cannot supply.
 /// </remarks>
+[NonParallelizable]
 [Category("db-sqlite")]
 public sealed class EnlistmentRefusalSqliteTest
 {

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
@@ -50,6 +50,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// real SQLite file, so what is asserted is what the store actually stores.
 /// </para>
 /// </remarks>
+[NonParallelizable]
 [Category("db-sqlite")]
 public sealed class SelectJobForTriggerFlagsSqliteTest
 {

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
@@ -1,0 +1,240 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The job a trigger belongs to, read by a process that does not have the job's class.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SelectJobForTrigger</c> is the read behind <c>ReplaceTrigger</c> and <c>UpdateTriggerDetails</c>,
+/// and what those two do with the answer is decide whether the trigger they write is <c>WAITING</c> or
+/// <c>BLOCKED</c>. That decision is <see cref="IJobDetail.ConcurrentExecutionDisallowed" />, so the
+/// answer has to be truthful without the class — otherwise a schedule-editing process either throws
+/// (#3705, which is what it did) or, worse, quietly stores a non-concurrent job's trigger as ready to
+/// run while the job is running.
+/// </para>
+/// <para>
+/// The row is written by an ordinary scheduler and read back through the dialect delegate, against a
+/// real SQLite file, so what is asserted is what the store actually stores.
+/// </para>
+/// </remarks>
+[Category("db-sqlite")]
+public sealed class SelectJobForTriggerFlagsSqliteTest
+{
+    private const string SchedulerName = "select-job-for-trigger";
+
+    private static readonly JobKey JobKey = new JobKey("cleanup", "acme");
+    private static readonly TriggerKey TriggerKey = new TriggerKey("cleanup", "acme");
+
+    private string databaseFile;
+    private string connectionString;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-select-job-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+
+        InstallSchemaFromFreshInstallScript();
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task TheAttributeFlagsComeFromTheRowWhenTheClassIsNotLoaded()
+    {
+        await GivenAStoredNonConcurrentJob();
+
+        IJobDetail detail = await SelectJobForTrigger(new NullTypeLoader(), loadJobType: false);
+
+        detail.Should().NotBeNull();
+
+        detail.JobType.Should().BeNull("the class was not asked for, and this process is one that could not answer");
+
+        detail.ConcurrentExecutionDisallowed.Should().BeTrue(
+            "IS_NONCONCURRENT is the record of what the attribute said when the job was stored, and it "
+            + "is readable without the assembly the attribute is written in - a deduced flag would answer "
+            + "false here, and false is what would store a replacement trigger WAITING while the job is running");
+        detail.PersistJobDataAfterExecution.Should().BeTrue(
+            "IS_UPDATE_DATA says the same about the other attribute");
+    }
+
+    /// <summary>
+    /// Asking for the class is still asking for the class.
+    /// </summary>
+    /// <remarks>
+    /// <c>loadJobType: true</c> is the fire path's read, and it must keep failing loudly rather than
+    /// handing back a detail whose type is <see langword="null" />. What #3705 changed is which callers
+    /// ask for it, not what asking means.
+    /// </remarks>
+    [Test]
+    public async Task AskingForTheClassStillFailsWhenItIsNotThere()
+    {
+        await GivenAStoredNonConcurrentJob();
+
+        Func<Task> act = async () => await SelectJobForTrigger(new AssemblylessTypeLoader(), loadJobType: true);
+
+        await act.Should().ThrowAsync<TypeLoadException>()
+            .WithMessage($"*{typeof(MessageCleanupJob).FullName}*");
+    }
+
+    /// <summary>
+    /// Writes the job and its trigger through an ordinary scheduler that has the class.
+    /// </summary>
+    private async Task GivenAStoredNonConcurrentJob()
+    {
+        SchedulerBuilder config = SchedulerBuilder.Create("writer", SchedulerName);
+        config.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        // Never started: nothing needs to fire for the row to exist.
+        IScheduler scheduler = await config.BuildScheduler();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<MessageCleanupJob>()
+                .WithIdentity(JobKey)
+                .Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(TriggerKey)
+                .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+                .Build());
+
+        await scheduler.Shutdown();
+    }
+
+    private async Task<IJobDetail> SelectJobForTrigger(ITypeLoadHelper typeLoader, bool loadJobType)
+    {
+        SQLiteDelegate driverDelegate = new SQLiteDelegate();
+        driverDelegate.Initialize(new DelegateInitializationArgs
+        {
+            TablePrefix = "QRTZ_",
+            InstanceName = SchedulerName,
+            InstanceId = "reader",
+            DbProvider = new DbProvider("SQLite-Microsoft", connectionString),
+            TypeLoadHelper = typeLoader,
+            ObjectSerializer = new SystemTextJsonObjectSerializer(),
+        });
+
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            await connection.OpenAsync();
+            using (ConnectionAndTransactionHolder holder = new ConnectionAndTransactionHolder(connection, transaction: null))
+            {
+                return await driverDelegate.SelectJobForTrigger(holder, TriggerKey, typeLoader, loadJobType);
+            }
+        }
+    }
+
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText = File.ReadAllText(ResolveRepositoryFile("database", "tables", "tables_sqlite.sql"));
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private static string ResolveRepositoryFile(params string[] pathSegments)
+    {
+        string relativePath = Path.Combine(pathSegments);
+        DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find '{relativePath}' above '{AppContext.BaseDirectory}'.");
+    }
+
+    /// <summary>
+    /// The loader an administration node has: it resolves the types that process knows about, and
+    /// answers nothing for the ones compiled into the worker.
+    /// </summary>
+    private sealed class NullTypeLoader : ITypeLoadHelper
+    {
+        public void Initialize()
+        {
+        }
+
+        public Type LoadType(string name) => null;
+    }
+
+    /// <summary>
+    /// What <see cref="SimpleTypeLoadHelper" /> does in a process that does not have the assembly: the
+    /// stored name is in this test's own assembly, so the refusal has to be written out.
+    /// </summary>
+    private sealed class AssemblylessTypeLoader : ITypeLoadHelper
+    {
+        public void Initialize()
+        {
+        }
+
+        public Type LoadType(string name) => throw new TypeLoadException($"Could not load type '{name}'");
+    }
+
+    /// <summary>
+    /// The job as the worker compiles it, attributes and all.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    [PersistJobDataAfterExecution]
+    public sealed class MessageCleanupJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context) => Task.CompletedTask;
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
@@ -1,0 +1,222 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+using Microsoft.Data.Sqlite;
+
+using Quartz.Impl.Triggers;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// A repeat interval shorter than a millisecond is refused by a persistent store, loudly, instead of
+/// being written as zero.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>REPEAT_INTERVAL</c> holds whole milliseconds — <c>StdAdoDelegate.GetDbTimeSpanValue</c> casts
+/// <c>TotalMilliseconds</c> to <c>long</c> — so anything shorter used to be stored as <c>0</c>. That is
+/// not merely lossy: the trigger read back has a zero repeat interval, and
+/// <c>SimpleTriggerImpl.GetFireTimeAfter</c> divides by it, so the trigger throws
+/// <see cref="DivideByZeroException" /> on its next firing. <c>JobStoreSupport</c> catches that, logs
+/// it and returns, leaving the row in <c>ACQUIRED</c> for good — a job that stops running and says
+/// nothing (<see href="https://github.com/quartznet/quartznet/issues/3673">#3673</see>).
+/// </para>
+/// <para>
+/// SQLite in a file rather than a container. The rule is <c>StdAdoDelegate</c>'s and therefore every
+/// dialect's; nothing here is SQLite's.
+/// </para>
+/// </remarks>
+[Category("db-sqlite")]
+public sealed class SubMillisecondIntervalSqliteTest
+{
+    /// <summary>Half a millisecond: representable in a <see cref="TimeSpan" />, not in the column.</summary>
+    private static readonly TimeSpan SubMillisecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2);
+
+    private string databaseFile;
+    private string connectionString;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-submilli-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+
+        InstallSchemaFromFreshInstallScript();
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task SchedulingASubMillisecondRepeatIntervalIsRefusedRatherThanRoundedToZero()
+    {
+        IScheduler scheduler = await BuildPersistentScheduler();
+
+        try
+        {
+            Func<Task> act = () => scheduler.ScheduleJob(Job(), Trigger(SubMillisecond));
+
+            (await act.Should().ThrowAsync<Exception>(
+                    "a store that cannot hold the interval has to say so at schedule time; writing zero produces a "
+                    + "trigger that throws DivideByZeroException on its next firing and then sits in ACQUIRED for ever")
+                .WithMessage("*millisecond*"))
+                .WithMessage("*REPEAT_INTERVAL*",
+                    "the message has to name the column, because that is what the caller has to change the value to fit");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// The refusal is the store's, not the trigger's: a whole millisecond is fine, which is what makes
+    /// the message's advice followable.
+    /// </summary>
+    [Test]
+    public async Task AWholeMillisecondIsAccepted()
+    {
+        IScheduler scheduler = await BuildPersistentScheduler();
+
+        try
+        {
+            await scheduler.ScheduleJob(Job(), Trigger(TimeSpan.FromMilliseconds(1)));
+
+            ITrigger stored = await scheduler.GetTrigger(new TriggerKey("fast", "submilli"));
+
+            stored.Should().BeOfType<SimpleTriggerImpl>()
+                .Which.RepeatInterval.Should().Be(TimeSpan.FromMilliseconds(1),
+                    "a millisecond is exactly what the column holds, so it has to round-trip unchanged");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// <c>RAMJobStore</c> keeps whatever it was given, and goes on doing so. The refusal is a property
+    /// of what a database column can hold, and the in-memory store has no column.
+    /// </summary>
+    [Test]
+    public async Task TheInMemoryStoreStillAcceptsIt()
+    {
+        SchedulerBuilder config = SchedulerBuilder.Create("one", "submilli-ram");
+        config.UseInMemoryStore();
+
+        IScheduler scheduler = await config.BuildScheduler();
+
+        try
+        {
+            await scheduler.ScheduleJob(Job(), Trigger(SubMillisecond));
+
+            ITrigger stored = await scheduler.GetTrigger(new TriggerKey("fast", "submilli"));
+
+            stored.Should().BeOfType<SimpleTriggerImpl>()
+                .Which.RepeatInterval.Should().Be(SubMillisecond,
+                    "the in-memory store holds the TimeSpan it was handed; there is no column to round it to");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    private static IJobDetail Job()
+    {
+        return JobBuilder.Create<NoOpIntervalJob>().WithIdentity("fast", "submilli").Build();
+    }
+
+    private static ITrigger Trigger(TimeSpan interval)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity("fast", "submilli")
+            // Far enough out that nothing fires while the test drives the store by hand.
+            .StartAt(DateTimeOffset.UtcNow.AddYears(1))
+            .WithSimpleSchedule(schedule => schedule.WithInterval(interval).RepeatForever())
+            .Build();
+    }
+
+    /// <summary>
+    /// Never started: the trigger is a year out and the test drives the store directly.
+    /// </summary>
+    private Task<IScheduler> BuildPersistentScheduler()
+    {
+        SchedulerBuilder config = SchedulerBuilder.Create("one", "submilli");
+        config.UsePersistentStore(store =>
+        {
+            store.UseMicrosoftSQLite(connectionString);
+            store.UseSystemTextJsonSerializer();
+        });
+
+        return config.BuildScheduler();
+    }
+
+    private void InstallSchemaFromFreshInstallScript()
+    {
+        using (SqliteConnection connection = new SqliteConnection(connectionString))
+        {
+            connection.Open();
+
+            using (SqliteCommand command = connection.CreateCommand())
+            {
+                command.CommandText = File.ReadAllText(ResolveRepositoryFile("database", "tables", "tables_sqlite.sql"));
+                command.ExecuteNonQuery();
+            }
+        }
+    }
+
+    private static string ResolveRepositoryFile(params string[] pathSegments)
+    {
+        string relativePath = Path.Combine(pathSegments);
+        DirectoryInfo current = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (current != null)
+        {
+            string candidate = Path.Combine(current.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find '{relativePath}' above '{AppContext.BaseDirectory}'.");
+    }
+
+    public sealed class NoOpIntervalJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context) => Task.CompletedTask;
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
@@ -48,6 +48,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// dialect's; nothing here is SQLite's.
 /// </para>
 /// </remarks>
+[NonParallelizable]
 [Category("db-sqlite")]
 public sealed class SubMillisecondIntervalSqliteTest
 {

--- a/src/Quartz.Tests.Unit/Core/CompletionWatchingJobStore.cs
+++ b/src/Quartz.Tests.Unit/Core/CompletionWatchingJobStore.cs
@@ -1,0 +1,185 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// A record of the calls one collaborator member has received, which a test can await instead of
+/// poll.
+/// </summary>
+/// <remarks>
+/// This is what keeps the scheduler-loop tests off the wall clock. The assertions are about which
+/// calls the loop made; awaiting a call only decides when it is safe to look at them, so the waits
+/// carry a generous deadline and never a timing expectation.
+/// </remarks>
+public sealed class CallLog<T>
+{
+    private readonly object gate = new object();
+    private readonly List<T> entries = new List<T>();
+    private readonly List<(int Count, TaskCompletionSource<bool> Source)> waiters = new List<(int, TaskCompletionSource<bool>)>();
+
+    /// <summary>
+    /// The calls recorded so far, oldest first.
+    /// </summary>
+    public IReadOnlyList<T> Entries
+    {
+        get
+        {
+            lock (gate)
+            {
+                return entries.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// How many calls have been recorded so far.
+    /// </summary>
+    public int Count
+    {
+        get
+        {
+            lock (gate)
+            {
+                return entries.Count;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records one call, releasing everyone waiting for the count it brings the log to.
+    /// </summary>
+    public void Record(T entry)
+    {
+        List<TaskCompletionSource<bool>> ready = null;
+        lock (gate)
+        {
+            entries.Add(entry);
+            for (int i = waiters.Count - 1; i >= 0; i--)
+            {
+                if (waiters[i].Count <= entries.Count)
+                {
+                    ready ??= new List<TaskCompletionSource<bool>>();
+                    ready.Add(waiters[i].Source);
+                    waiters.RemoveAt(i);
+                }
+            }
+        }
+
+        if (ready is null)
+        {
+            return;
+        }
+
+        // Completed outside the lock: a continuation that records another call would otherwise
+        // re-enter it on this very thread.
+        foreach (TaskCompletionSource<bool> source in ready)
+        {
+            source.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// A task that completes once this member has been called <paramref name="count" /> times.
+    /// </summary>
+    public Task Reaches(int count)
+    {
+        TaskCompletionSource<bool> source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (gate)
+        {
+            if (entries.Count >= count)
+            {
+                return Task.CompletedTask;
+            }
+
+            waiters.Add((count, source));
+        }
+
+        return source.Task;
+    }
+}
+
+/// <summary>
+/// One <see cref="IJobStore.TriggeredJobComplete" /> call, as the scheduler thread made it.
+/// </summary>
+public sealed record CompletedFiring(TriggerKey Trigger, JobKey Job, SchedulerInstruction Instruction);
+
+/// <summary>
+/// Records how each firing was handed back to the store: through <c>TriggeredJobComplete</c>, with which
+/// instruction, or through <c>ReleaseAcquiredTrigger</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The distinction is the one <c>AGENTS.md</c> records: after <c>TriggersFired</c> the scheduler must
+/// complete a firing rather than release it, because releasing does not unblock the sibling triggers of
+/// a <see cref="DisallowConcurrentExecutionAttribute" /> job. Nothing about that is visible from the
+/// scheduler's own surface, so a test watches the store.
+/// </para>
+/// <para>
+/// Both calls are recorded <em>after</em> the wrapped store has acted on them, so a test that waits on a
+/// record and then asks the store a question is looking at a store that has already settled — which is
+/// what keeps these assertions off the clock.
+/// </para>
+/// <para>
+/// <see cref="StdSchedulerFactory" /> builds the store from its type name, so the instance it built is
+/// published through <see cref="LastInstance" /> for the test that asked for it; a fixture using this
+/// store is therefore <c>[NonParallelizable]</c>.
+/// </para>
+/// </remarks>
+public sealed class CompletionWatchingJobStore : RAMJobStore
+{
+    public static CompletionWatchingJobStore LastInstance { get; private set; }
+
+    public CompletionWatchingJobStore()
+    {
+        LastInstance = this;
+    }
+
+    /// <summary>The triggers handed back through <see cref="ReleaseAcquiredTrigger" />.</summary>
+    public CallLog<TriggerKey> Releases { get; } = new CallLog<TriggerKey>();
+
+    /// <summary>The completions the scheduler reported, instruction included.</summary>
+    public CallLog<CompletedFiring> Completions { get; } = new CallLog<CompletedFiring>();
+
+    public override async Task ReleaseAcquiredTrigger(IOperableTrigger trigger, CancellationToken cancellationToken = default)
+    {
+        await base.ReleaseAcquiredTrigger(trigger, cancellationToken).ConfigureAwait(false);
+        Releases.Record(trigger.Key);
+    }
+
+    public override async Task TriggeredJobComplete(
+        IOperableTrigger trigger,
+        IJobDetail jobDetail,
+        SchedulerInstruction triggerInstCode,
+        CancellationToken cancellationToken = default)
+    {
+        await base.TriggeredJobComplete(trigger, jobDetail, triggerInstCode, cancellationToken).ConfigureAwait(false);
+        Completions.Record(new CompletedFiring(trigger.Key, jobDetail.Key, triggerInstCode));
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Core/JobListenerFailureTest.cs
@@ -1,0 +1,446 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Quartz.Core;
+using Quartz.Impl;
+using Quartz.Impl.Matchers;
+using Quartz.Listener;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What a job listener's failure costs the firing it failed on, and what it must not cost anybody else.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A listener can fail in either of two shapes, and until #3502 they were not handled alike. An
+/// <c>async</c> listener hands back a faulted task; a listener whose guard clause throws before it
+/// returns anything fails while the scheduler is still evaluating the call. Only the first was wrapped
+/// in the exception <see cref="JobRunShell" /> catches, so the second escaped the run shell entirely and
+/// the firing was never handed back to the store — leaving a job that forbids concurrent execution
+/// blocked behind a firing that had already been abandoned. Every case here therefore runs twice, once
+/// per shape, and the two shapes must be indistinguishable.
+/// </para>
+/// <para>
+/// The scheduler's own record of what is executing rides along with the same fault: it used to be kept
+/// by the listener loop, so a listener that stopped the loop stopped the bookkeeping too and left the
+/// firing listed as executing for as long as the process lived.
+/// </para>
+/// <para>
+/// Nothing here waits for a length of time or measures one. The store records a firing after it has
+/// acted on it, so a test that waits for a record and then asks a question is asking a store that has
+/// already settled.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class JobListenerFailureTest
+{
+    private const string Group = "job-listener-failure";
+
+    /// <summary>
+    /// How long a test is willing to wait for a firing to reach the store before declaring the
+    /// scheduler stuck. Long enough that a loaded build agent never trips it, and never used as a
+    /// measurement.
+    /// </summary>
+    private static readonly TimeSpan observationDeadline = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The two ways a listener can fail, which the scheduler has to treat as one.
+    /// </summary>
+    public enum FailureShape
+    {
+        /// <summary>Throws before handing anything back, as a guard clause in a method that is not <c>async</c> does.</summary>
+        Synchronous,
+
+        /// <summary>Hands back a faulted task, as an <c>async</c> method does.</summary>
+        Asynchronous,
+    }
+
+    /// <summary>
+    /// Which side of the job the listener fails on.
+    /// </summary>
+    public enum FailureSide
+    {
+        /// <summary><see cref="IJobListener.JobToBeExecuted" />, which stops the job running.</summary>
+        BeforeTheJob,
+
+        /// <summary><see cref="IJobListener.JobWasExecuted" />, which is too late to stop anything.</summary>
+        AfterTheJob,
+    }
+
+    /// <summary>
+    /// The wedge #3502 reported: the firing is abandoned, and the job's other trigger has to be let go
+    /// of anyway — which only happens if the abandoned firing is completed at the store.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous)]
+    [TestCase(FailureShape.Asynchronous)]
+    public async Task AListenerFailingBeforeTheJobStillCompletesTheFiringAndLetsTheSiblingTriggerFire(FailureShape shape)
+    {
+        TriggerKey wedgedKey = new TriggerKey("wedged", Group);
+        CallLog<TriggerKey> runs = new CallLog<TriggerKey>();
+
+        // Fails only for the first trigger's firing, so that the second one running the job is the
+        // scheduler carrying on rather than this listener having lost interest.
+        FailingJobListener listener = new FailingJobListener(shape, FailureSide.BeforeTheJob, context => context.Trigger.Key.Equals(wedgedKey));
+
+        (IScheduler scheduler, CompletionWatchingJobStore store) = await BuildScheduler($"listener-wedge-{shape}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            // Two triggers of one job that forbids concurrent execution, both already due and the
+            // wedged one due first. Committing its firing blocks the sibling, and completing that
+            // firing is the only thing that lets the sibling go again. The scheduler moves a
+            // repeating simple trigger's past start time to "now" as it schedules it, and on a clock
+            // as coarse as .NET Framework's the two can land on the same instant, so the wedged one
+            // also carries the higher priority: what breaks a tie between equal fire times.
+            DateTimeOffset due = DateTimeOffset.UtcNow;
+
+            ITrigger wedged = Repeating(wedgedKey, job, due, priority: 10);
+            ITrigger sibling = Repeating(new TriggerKey("sibling", Group), job, due.AddMilliseconds(1), priority: 5);
+
+            await scheduler.ScheduleJob(job, new[] { wedged, sibling }, replace: false);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "a firing a listener abandoned still has to be reported to the store, or the trigger is never "
+                + "handed back and every trigger of a job that forbids concurrent execution stays blocked behind it");
+
+            store.Completions.Entries[0].Should().Be(
+                new CompletedFiring(wedgedKey, job.Key, SchedulerInstruction.NoInstruction),
+                "a firing that never happened settles nothing about the schedule");
+
+            store.Releases.Entries.Should().BeEmpty(
+                "the firing was already committed, so it is completed rather than released - releasing does "
+                + "not unblock the job's other triggers");
+
+            await ShouldObserve(store.Completions.Reaches(2),
+                "the sibling was blocked by a firing that has now been completed, so it is free to fire");
+
+            store.Completions.Entries[1].Should().Be(
+                new CompletedFiring(sibling.Key, job.Key, SchedulerInstruction.NoInstruction),
+                "the sibling's own firing is an ordinary one");
+
+            runs.Entries.Should().Equal(new[] { sibling.Key },
+                "the job ran exactly once, for the trigger whose firing no listener stopped - which is what "
+                + "says the wedged firing neither ran the job nor kept the job to itself");
+
+            (await scheduler.GetTriggerState(wedgedKey)).Should().Be(TriggerState.Normal,
+                "the wedged trigger has firings ahead of it, and a failed listener does not take them away");
+            (await scheduler.GetTriggerState(sibling.Key)).Should().Be(TriggerState.Normal,
+                "a trigger that has fired and finished is waiting for its next turn, not blocked");
+
+            (await scheduler.GetCurrentlyExecutingJobs()).Should().BeEmpty(
+                "both firings are over, so nothing is executing");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// The phantom entry #3502 reported: the scheduler's record of what it is running is its own, and a
+    /// user listener cannot be what keeps it honest.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Synchronous, FailureSide.AfterTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.AfterTheJob)]
+    public async Task AFailedListenerLeavesNothingListedAsExecuting(FailureShape shape, FailureSide side)
+    {
+        CallLog<TriggerKey> runs = new CallLog<TriggerKey>();
+        FailingJobListener listener = new FailingJobListener(shape, side, _ => true);
+
+        (IScheduler scheduler, CompletionWatchingJobStore store) = await BuildScheduler($"listener-phantom-{shape}-{side}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            TriggerKey triggerKey = new TriggerKey("once", Group);
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the firing has to be over before what is executing means anything");
+
+            runs.Entries.Should().HaveCount(side == FailureSide.BeforeTheJob ? 0 : 1,
+                "a listener that fails on the way in stops the job running, and one that fails afterwards is too late to");
+
+            (await scheduler.GetCurrentlyExecutingJobs()).Should().BeEmpty(
+                "the firing is over, and an operator reading the list of executing jobs must not be shown one "
+                + "that a listener's failure stranded there");
+
+            (await scheduler.GetMetaData()).NumberOfJobsExecuted.Should().Be(1,
+                "the firing was dispatched, which is what this counts - a listener stopping it does not unfire it");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// A trigger with nothing left to fire is finished whether its last firing ran or a listener
+    /// abandoned it, and the scheduler listeners hear so either way.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.BeforeTheJob)]
+    [TestCase(FailureShape.Synchronous, FailureSide.AfterTheJob)]
+    [TestCase(FailureShape.Asynchronous, FailureSide.AfterTheJob)]
+    public async Task AFailedListenerDoesNotSwallowTheTriggersFinalizedNotification(FailureShape shape, FailureSide side)
+    {
+        CallLog<TriggerKey> runs = new CallLog<TriggerKey>();
+        FailingJobListener listener = new FailingJobListener(shape, side, _ => true);
+        FinalizedRecordingSchedulerListener finalized = new FinalizedRecordingSchedulerListener();
+
+        (IScheduler scheduler, _) = await BuildScheduler($"listener-finalized-{shape}-{side}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+            scheduler.ListenerManager.AddSchedulerListener(finalized);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            TriggerKey triggerKey = new TriggerKey("once", Group);
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            await ShouldObserve(finalized.Finalized.Reaches(1),
+                "the trigger had one firing in it and it is spent, so the scheduler listeners have to be told "
+                + "it will never fire again - the listener's failure is not theirs to inherit");
+
+            finalized.Finalized.Entries.Should().Equal(new[] { triggerKey });
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// The leak #3507 reported. The firing is abandoned with no instruction, which settles nothing about
+    /// the schedule — but the trigger was advanced when the firing was committed and had nothing after
+    /// this one, so it is spent, and a store that kept it goes on offering an operator a trigger that
+    /// can never fire.
+    /// </summary>
+    [TestCase(FailureShape.Synchronous)]
+    [TestCase(FailureShape.Asynchronous)]
+    public async Task AListenerFailingOnATriggersLastFiringLeavesNoTriggerBehind(FailureShape shape)
+    {
+        CallLog<TriggerKey> runs = new CallLog<TriggerKey>();
+        FailingJobListener listener = new FailingJobListener(shape, FailureSide.BeforeTheJob, _ => true);
+
+        (IScheduler scheduler, CompletionWatchingJobStore store) = await BuildScheduler($"listener-spent-{shape}");
+
+        try
+        {
+            scheduler.ListenerManager.AddJobListener(listener);
+
+            IJobDetail job = JobBuilder.Create<NonConcurrentRecordingJob>()
+                .WithIdentity("job", Group)
+                .UsingJobData(new JobDataMap { [NonConcurrentRecordingJob.RunLogKey] = runs })
+                .Build();
+
+            TriggerKey triggerKey = new TriggerKey("once", Group);
+            ITrigger trigger = TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartNow()
+                .Build();
+
+            await scheduler.ScheduleJob(job, trigger);
+            await scheduler.Start();
+
+            await ShouldObserve(store.Completions.Reaches(1),
+                "the store has settled the firing by the time it records it, so everything below is asked "
+                + "of a store that has finished with this trigger");
+
+            store.Completions.Entries[0].Should().Be(
+                new CompletedFiring(triggerKey, job.Key, SchedulerInstruction.NoInstruction),
+                "a firing that never happened settles nothing about the schedule - the trigger is removed "
+                + "because it is spent, not because the completion said to remove it");
+
+            (await scheduler.GetTrigger(triggerKey)).Should().BeNull(
+                "the trigger's only firing is over, however badly it went");
+            (await scheduler.GetTriggerState(triggerKey)).Should().Be(TriggerState.None,
+                "a trigger that is gone has no state");
+            (await scheduler.GetTriggerKeys(GroupMatcher<TriggerKey>.AnyGroup())).Should().BeEmpty(
+                "the listing an operator reads must not show a trigger that will never fire again");
+            (await scheduler.GetJobDetail(job.Key)).Should().BeNull(
+                "the job is not durable and its only trigger is gone");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// A scheduler whose in-memory store records every firing it is handed back.
+    /// </summary>
+    private static async Task<(IScheduler Scheduler, CompletionWatchingJobStore Store)> BuildScheduler(string instanceName)
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.scheduler.instanceName"] = instanceName,
+            ["quartz.jobStore.type"] = typeof(CompletionWatchingJobStore).AssemblyQualifiedName,
+            ["quartz.serializer.type"] = TestConstants.DefaultSerializerType,
+        };
+
+        ISchedulerFactory factory = new StdSchedulerFactory(properties);
+        IScheduler scheduler = await factory.GetScheduler();
+        return (scheduler, CompletionWatchingJobStore.LastInstance);
+    }
+
+    private static ITrigger Repeating(TriggerKey key, IJobDetail job, DateTimeOffset startAt, int priority)
+    {
+        return TriggerBuilder.Create()
+            .WithIdentity(key)
+            .ForJob(job)
+            .StartAt(startAt)
+            .WithPriority(priority)
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+    }
+
+    private static async Task ShouldObserve(Task observation, string because)
+    {
+        Func<Task> act = () => observation;
+        await act.Should().CompleteWithinAsync(observationDeadline, because);
+    }
+
+    /// <summary>
+    /// A job that records which trigger fired it, through a log handed to it in its data map so that
+    /// nothing here is static.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class NonConcurrentRecordingJob : IJob
+    {
+        public const string RunLogKey = "run log";
+
+        public Task Execute(IJobExecutionContext context)
+        {
+            ((CallLog<TriggerKey>) context.MergedJobDataMap[RunLogKey]).Record(context.Trigger.Key);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>
+    /// Fails on one side of the job, in whichever of the two shapes it was built for, for the firings it
+    /// was told to fail for and no others.
+    /// </summary>
+    private sealed class FailingJobListener : IJobListener
+    {
+        private readonly FailureShape shape;
+        private readonly FailureSide side;
+        private readonly Func<IJobExecutionContext, bool> failFor;
+
+        public FailingJobListener(FailureShape shape, FailureSide side, Func<IJobExecutionContext, bool> failFor)
+        {
+            this.shape = shape;
+            this.side = side;
+            this.failFor = failFor;
+        }
+
+        public string Name => nameof(FailingJobListener);
+
+        public Task JobToBeExecuted(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return side == FailureSide.BeforeTheJob && failFor(context)
+                ? Fail("the listener could not prepare for this job")
+                : Task.CompletedTask;
+        }
+
+        public Task JobExecutionVetoed(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task JobWasExecuted(
+            IJobExecutionContext context,
+            JobExecutionException jobException,
+            CancellationToken cancellationToken = default)
+        {
+            return side == FailureSide.AfterTheJob && failFor(context)
+                ? Fail("the listener could not record this job")
+                : Task.CompletedTask;
+        }
+
+        private Task Fail(string message)
+        {
+            if (shape == FailureShape.Synchronous)
+            {
+                // What a guard clause in a method that is not async does: the caller is handed an
+                // exception where it expected a Task, before there is anything to await.
+                throw new InvalidOperationException(message);
+            }
+
+            // What an async method does: the exception arrives in the task the caller was handed.
+            return Task.FromException(new InvalidOperationException(message));
+        }
+    }
+
+    private sealed class FinalizedRecordingSchedulerListener : SchedulerListenerSupport
+    {
+        public CallLog<TriggerKey> Finalized { get; } = new CallLog<TriggerKey>();
+
+        public override Task TriggerFinalized(ITrigger trigger, CancellationToken cancellationToken = default)
+        {
+            Finalized.Record(trigger.Key);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections;
+using System.Globalization;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -877,51 +878,140 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
         act.Should().Throw<FormatException>().Which.Message.Should().Contain("too many");
     }
 
-    [Test]
-    public void TestGetTimeBefore()
-    {
-        int year = DateTime.UtcNow.Year;
+    private const long OneDayInMilliseconds = 24 * 60 * 60 * 1000L;
 
-        var tests = new[]
+    /// <summary>
+    /// One expression and the gaps its firings sit at, measured from the first firing after a search
+    /// instant: back to the firing before that one, and on to the firing after it.
+    /// </summary>
+    /// <remarks>
+    /// Both gaps are <see langword="null" /> for an expression pinned to a single year to one side of
+    /// the search instant. Such an expression has firings on one side only, so there is no pair of
+    /// neighbouring firings to measure — what is asserted about it is which side is empty.
+    /// </remarks>
+    private sealed class FiringGaps
+    {
+        public FiringGaps(string expression, long? millisecondsBack, long? millisecondsForward)
         {
-            new object[] { "* * * * * ? *", 1000L },
-            new object[] { "0 * * * * ? *", 60_000L },
-            new object[] { "0/15 * * * * ? *", 15_000L },
-            new object[] { "0 0 5 * * ? *", 24 * 60 * 60 * 1000L },
-            new object[] { "0 0 0 * * ? *", 24 * 60 * 60 * 1000L },
-            new object[] { "0/30 1 2 * * ? *", 24 * 60 * 60 * 1000L - 30_000L, 30_000L },
-            new object[] { $"* * * * * ? {year + 2}" },
-            new object[] { $"* * * * * ? {year - 2}", 24 * 60 * 60 * 1000L - 30_000L, 30_000L }
+            Expression = expression;
+            MillisecondsBack = millisecondsBack;
+            MillisecondsForward = millisecondsForward;
+        }
+
+        public string Expression { get; }
+
+        public long? MillisecondsBack { get; }
+
+        public long? MillisecondsForward { get; }
+    }
+
+    /// <summary>
+    /// The expressions <see cref="TestGetTimeBefore" /> walks, and the gaps they describe. The last two
+    /// are pinned to a year either side of the year the search starts in: the first of them has its
+    /// whole schedule ahead, so the firing found is its very first and nothing precedes it, and the
+    /// second has its whole schedule behind, so there is no firing after the instant at all.
+    /// </summary>
+    private static FiringGaps[] FiringGapsAround(int year) => new[]
+    {
+        new FiringGaps("* * * * * ? *", 1000L, 1000L),
+        new FiringGaps("0 * * * * ? *", 60_000L, 60_000L),
+        new FiringGaps("0/15 * * * * ? *", 15_000L, 15_000L),
+        new FiringGaps("0 0 5 * * ? *", OneDayInMilliseconds, OneDayInMilliseconds),
+        new FiringGaps("0 0 0 * * ? *", OneDayInMilliseconds, OneDayInMilliseconds),
+        new FiringGaps("0/30 1 2 * * ? *", OneDayInMilliseconds - 30_000L, 30_000L),
+        new FiringGaps($"* * * * * ? {year + 2}", null, null),
+        new FiringGaps($"* * * * * ? {year - 2}", null, null)
+    };
+
+    /// <summary>
+    /// The instants <see cref="TestGetTimeBefore" /> searches from: an ordinary one, and one on each
+    /// boundary the search could round differently at.
+    /// </summary>
+    public static IEnumerable TimeBeforeSearchInstants =>
+        new[]
+        {
+            new TestCaseData("mid-minute", new DateTimeOffset(2024, 3, 14, 8, 37, 23, 456, TimeSpan.Zero)),
+            new TestCaseData("second boundary", new DateTimeOffset(2024, 3, 14, 8, 37, 23, 0, TimeSpan.Zero)),
+            new TestCaseData("minute boundary", new DateTimeOffset(2024, 3, 14, 8, 37, 0, 0, TimeSpan.Zero)),
+            new TestCaseData("hour boundary", new DateTimeOffset(2024, 3, 14, 8, 0, 0, 0, TimeSpan.Zero)),
+            new TestCaseData("day boundary", new DateTimeOffset(2024, 3, 14, 0, 0, 0, 0, TimeSpan.Zero)),
+            new TestCaseData("year boundary", new DateTimeOffset(2024, 1, 1, 0, 0, 0, 0, TimeSpan.Zero))
         };
 
-        foreach (var test in tests)
+    /// <summary>
+    /// <see cref="CronExpression.GetTimeBefore" /> walks the schedule backwards to the gap the
+    /// expression describes: from the first firing after a given instant, back to the one before it.
+    /// </summary>
+    /// <remarks>
+    /// The instants are literals because the answer depends on where the search starts, which is what
+    /// made this test flake while it read <c>DateTimeOffset.UtcNow</c>. <c>0/30 1 2 * * ? *</c> fires
+    /// twice a day, at 02:01:00 and at 02:01:30, so the gap back from a firing is 30 s for the second
+    /// of the pair and 23:59:30 for the first. Search from inside the pair and the forward search lands
+    /// on the second of the two, which swaps the row's two figures — for the thirty seconds from
+    /// 02:01:00 to 02:01:29 UTC, and only those, this table was wrong: one run in 2,880.
+    /// </remarks>
+    [TestCaseSource(nameof(TimeBeforeSearchInstants))]
+    public void TestGetTimeBefore(string origin, DateTimeOffset now)
+    {
+        foreach (FiringGaps gaps in FiringGapsAround(now.Year))
         {
-            string expression = (string)test[0];
-            long interval1 = test.Length > 1 ? (long)test[1] : -1;
-            long interval2 = test.Length > 2 ? (long)test[2] : interval1;
-
-            var cron = new CronExpression(expression) { TimeZone = TimeZoneInfo.Utc };
-            var now = DateTimeOffset.UtcNow;
+            CronExpression cron = new CronExpression(gaps.Expression) { TimeZone = TimeZoneInfo.Utc };
+            string searchedFrom = $"the {origin} instant {now.ToString("O", CultureInfo.InvariantCulture)}";
 
             DateTimeOffset? after = cron.GetTimeAfter(now);
-            if (after == null)
+            if (after is null)
             {
-                DateTimeOffset? before = cron.GetTimeBefore(now);
-                Assert.IsNotNull(before, $"expression {expression}");
+                cron.GetTimeBefore(now).Should().NotBeNull(
+                    $"'{gaps.Expression}' fires only in a year already past, so every firing it has is before {searchedFrom}");
+                continue;
             }
-            else if (interval1 < 0)
+
+            DateTimeOffset? before = cron.GetTimeBefore(after.Value);
+            if (gaps.MillisecondsBack is null)
             {
-                DateTimeOffset? before = cron.GetTimeBefore(after.Value);
-                Assert.IsNull(before, $"expression {expression}");
+                before.Should().BeNull(
+                    $"'{gaps.Expression}' fires only in a year still ahead, so the firing after {searchedFrom} is its very first");
+                continue;
             }
-            else
-            {
-                DateTimeOffset? before = cron.GetTimeBefore(after.Value);
-                DateTimeOffset? after2 = cron.GetTimeAfter(after.Value);
-                Assert.AreEqual(interval1, (after.Value - before.Value).TotalMilliseconds, $"expression {expression}");
-                Assert.AreEqual(interval2, (after2.Value - after.Value).TotalMilliseconds, $"expression {expression}");
-            }
+
+            before.Should().NotBeNull(
+                $"'{gaps.Expression}' has firings behind the one that follows {searchedFrom}");
+            (after.Value - before.Value).Should().Be(
+                TimeSpan.FromMilliseconds(gaps.MillisecondsBack.Value),
+                $"'{gaps.Expression}' puts that gap behind the firing that follows {searchedFrom}");
+
+            DateTimeOffset? next = cron.GetTimeAfter(after.Value);
+            next.Should().NotBeNull(
+                $"'{gaps.Expression}' repeats forever, so there is a firing beyond the one that follows {searchedFrom}");
+            (next.Value - after.Value).Should().Be(
+                TimeSpan.FromMilliseconds(gaps.MillisecondsForward.Value),
+                $"'{gaps.Expression}' puts that gap ahead of the firing that follows {searchedFrom}");
         }
+    }
+
+    /// <summary>
+    /// The half-minute that used to break <see cref="TestGetTimeBefore" />, pinned rather than avoided:
+    /// an expression with two firings a day, searched from between them.
+    /// </summary>
+    /// <remarks>
+    /// Nothing was ever wrong with the answer. <c>0/30 1 2 * * ? *</c> genuinely has 30 seconds behind
+    /// the second firing of its pair and 23:59:30 ahead of it; it was the table that assumed the
+    /// forward search always landed on the first of the pair, which it does from everywhere but here.
+    /// </remarks>
+    [Test]
+    public void TestGetTimeBeforeSearchedFromInsideAPairOfFirings()
+    {
+        CronExpression cron = new CronExpression("0/30 1 2 * * ? *") { TimeZone = TimeZoneInfo.Utc };
+        DateTimeOffset insideThePair = new DateTimeOffset(2024, 3, 14, 2, 1, 10, TimeSpan.Zero);
+
+        DateTimeOffset after = cron.GetTimeAfter(insideThePair).Value;
+
+        after.Should().Be(new DateTimeOffset(2024, 3, 14, 2, 1, 30, TimeSpan.Zero),
+            "the day's second firing is still ahead when the search starts ten seconds into the pair");
+        (after - cron.GetTimeBefore(after).Value).Should().Be(TimeSpan.FromSeconds(30),
+            "the firing behind it is the first of that same pair, half a minute earlier");
+        (cron.GetTimeAfter(after).Value - after).Should().Be(TimeSpan.FromHours(24) - TimeSpan.FromSeconds(30),
+            "the firing ahead of it is the first of tomorrow's pair, not another 24 hours away");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AmbientConnectionTest.cs
@@ -391,6 +391,123 @@ public sealed class AmbientConnectionTest
         return scheduler.EnlistTransaction(connection.BeginTransaction());
     }
 
+    /// <summary>
+    /// Being inside a <see cref="TransactionScope" /> is not the same as the connection being in it,
+    /// so the connection is asked to join rather than assumed to have joined. On a driver that
+    /// implements enlistment the ask is a no-op when the connection is already enlisted, and the
+    /// enlistment it wanted when it is not.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_AsksTheConnectionToJoinTheAmbientTransaction()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection();
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            Transaction ambient = Transaction.Current;
+
+            using (CreateScheduler().EnlistConnection(applicationConnection))
+            {
+                applicationConnection.EnlistedIn.Should().BeSameAs(ambient,
+                    "the enlistment is established before the job store writes anything, which is the only moment "
+                    + "a connection that cannot join can still be refused");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The refusal this exists for. <c>Microsoft.Data.Sqlite</c> overrides no
+    /// <see cref="DbConnection.EnlistTransaction" />, so a connection opened inside a scope never joins
+    /// it: the job store would write through the connection, every statement would commit on the spot,
+    /// and a scope that was never completed would leave the schedule behind. Reported as
+    /// https://github.com/quartznet/quartznet/issues/3666.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_OnADriverThatCannotJoinAnAmbientTransaction_IsRefused()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection(new NotSupportedException());
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        {
+            Action enlist = () => CreateScheduler().EnlistConnection(applicationConnection);
+
+            enlist.Should().Throw<SchedulerException>(
+                    "writing through a connection the scope does not govern is the silent failure this refusal replaces")
+                .Which.Message.Should().Contain(nameof(RecordingDbConnection), "the failure has to say which driver it is about")
+                .And.Contain("EnlistTransaction(connection.BeginTransaction())", "and what to do instead");
+        }
+    }
+
+    /// <summary>
+    /// Only "there is no such thing here" is a refusal. A driver that answers anything else has an
+    /// enlistment of its own, which is what was being established — and the ordinary answer is "the
+    /// connection is not open", because an enlisted connection is opened by the job store rather than
+    /// at the moment it is enlisted.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_WhenTheDriverHasAnOpinionOtherThanUnsupported_IsAccepted()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection(new InvalidOperationException("Connection is not open."));
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection,
+                "refusing here would refuse the ordinary case, where the connection is still closed and joins the "
+                + "scope as the job store opens it");
+        }
+    }
+
+    /// <summary>
+    /// And the probe belongs to the ambient form alone. A caller who hands over a transaction is
+    /// governed by that transaction, and asking a connection with an open local transaction to enlist
+    /// is what MySqlConnector and Oracle refuse outright.
+    /// </summary>
+    [Test]
+    public void EnlistConnection_WithATransactionOfItsOwn_DoesNotAskTheConnectionToJoinTheScope()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection(new NotSupportedException());
+        applicationConnection.Open();
+        DbTransaction applicationTransaction = applicationConnection.BeginTransaction();
+
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistConnection(applicationConnection, applicationTransaction))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Transaction.Should().BeSameAs(applicationTransaction,
+                "the caller's own transaction governs the writes, so the scope has nothing to be joined for");
+        }
+    }
+
+    /// <summary>
+    /// The way out the refusal points at has to keep working on the very driver that is refused: a
+    /// transaction of the connection's own is used directly and needs no enlistment at all, ambient
+    /// scope or no ambient scope.
+    /// </summary>
+    [Test]
+    public void EnlistTransaction_OnADriverThatCannotJoinAnAmbientTransaction_IsStillAccepted()
+    {
+        RecordingDbConnection applicationConnection = new RecordingDbConnection(new NotSupportedException());
+        applicationConnection.Open();
+
+        TestJobStore jobStore = CreateJobStore(acceptEnlistedTransactions: true, out _);
+
+        using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+        using (CreateScheduler().EnlistTransaction(applicationConnection.BeginTransaction()))
+        {
+            ConnectionAndTransactionHolder holder = jobStore.CallGetConnection();
+
+            holder.Connection.Should().BeSameAs(applicationConnection);
+            holder.Transaction.Should().NotBeNull("the caller's own transaction governs the writes, and the scope has no say");
+        }
+    }
+
     private static IScheduler CreateScheduler(string name = SchedulerName)
     {
         IScheduler scheduler = A.Fake<IScheduler>();
@@ -425,6 +542,19 @@ public sealed class AmbientConnectionTest
     private sealed class RecordingDbConnection : DbConnection
     {
         private ConnectionState state = ConnectionState.Closed;
+        private readonly Exception enlistmentFailure;
+
+        /// <param name="enlistmentFailure">
+        /// What this connection's driver answers when asked to join an ambient transaction. The default
+        /// is the answer five of the six drivers Quartz ships a delegate for give when the connection is
+        /// already enlisted in it: nothing at all. <see cref="NotSupportedException" /> is what a driver
+        /// that overrides nothing reaches — <c>Microsoft.Data.Sqlite</c> — and anything else is a driver
+        /// with an implementation and an opinion about this particular connection.
+        /// </param>
+        internal RecordingDbConnection(Exception enlistmentFailure = null)
+        {
+            this.enlistmentFailure = enlistmentFailure;
+        }
 
         internal int OpenCount { get; private set; }
 
@@ -435,6 +565,21 @@ public sealed class AmbientConnectionTest
         /// which is how ADO.NET providers behave unless enlistment is suppressed or switched off.
         /// </summary>
         internal System.Transactions.Transaction EnlistedIn { get; private set; }
+
+        /// <summary>
+        /// Recording the transaction is what a provider does when the connection is not enlisted yet;
+        /// when it is already enlisted in this very transaction they all return without doing anything,
+        /// and so does this.
+        /// </summary>
+        public override void EnlistTransaction(System.Transactions.Transaction transaction)
+        {
+            if (enlistmentFailure != null)
+            {
+                throw enlistmentFailure;
+            }
+
+            EnlistedIn ??= transaction;
+        }
 
         public override string ConnectionString { get; set; } = "";
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -1288,6 +1288,104 @@ public class JobStoreSupportTest
         jobStoreSupport.CallIsTransient(new InvalidOperationException("no")).Should().BeFalse();
     }
 
+    /// <summary>
+    /// SQLSTATE class 40 is the standard's own "transaction rollback": the database abandoned the
+    /// transaction for a reason the statements in it did not cause, and the prescribed answer is to run
+    /// it again. It is provider-neutral, which is why it is read at all (#3454).
+    /// </summary>
+    [TestCase("40000", TestName = "IsTransient_RollbackWithNoSubclassIsTransient")]
+    [TestCase("40001", TestName = "IsTransient_SerializationFailureIsTransient")]
+    [TestCase("40003", TestName = "IsTransient_StatementCompletionUnknownIsTransient")]
+    [TestCase("40P01", TestName = "IsTransient_PostgresDeadlockDetectedIsTransient")]
+    public void IsTransient_TransactionRollbackSqlStateIsTransient(string sqlState)
+    {
+        jobStoreSupport.CallIsTransient(new SqlStateException(sqlState)).Should().BeTrue(
+            "SQLSTATE {0} is in class 40, transaction rollback, which is the standard saying to run the transaction again",
+            sqlState);
+    }
+
+    [Test]
+    public void IsTransient_DeferredConstraintViolationIsNotTransient()
+    {
+        jobStoreSupport.CallIsTransient(new SqlStateException("40002")).Should().BeFalse(
+            "40002 is the one member of class 40 that is a real error - an integrity constraint the commit found broken, which every retry will find broken too");
+    }
+
+    [Test]
+    public void IsTransient_UniqueViolationIsNotTransient()
+    {
+        jobStoreSupport.CallIsTransient(new SqlStateException("23505")).Should().BeFalse(
+            "class 23 is an integrity-constraint violation, and only class 40 says anything about retrying");
+    }
+
+    [Test]
+    public void IsTransient_DriverReportingNoSqlStateIsNotTransient()
+    {
+        jobStoreSupport.CallIsTransient(new SqlStateException(null)).Should().BeFalse(
+            "both SqlClients and every SQLite driver leave the state null, and they have to fall through to the checks written for them rather than being caught here");
+    }
+
+    /// <summary>
+    /// Firebird is the reason this check exists, and it is also the driver that puts the state
+    /// somewhere a <c>SqlState</c> property does not reach.
+    /// </summary>
+    [Test]
+    public void IsTransient_FirebirdWriteConflictIsTransient()
+    {
+        FbException writeConflict = new FbException("40001");
+
+        PropertyInfo probe = writeConflict.GetType().GetProperty("IsTransient");
+        (probe?.GetValue(writeConflict) as bool? ?? false).Should().BeFalse(
+            "FbException does not override IsTransient, which is why the driver's own verdict was not enough");
+
+        jobStoreSupport.CallIsTransient(writeConflict).Should().BeTrue(
+            "a write conflict between two Firebird transactions is a serialization failure, the textbook case for retrying");
+    }
+
+    [Test]
+    public void IsTransient_FirebirdConstraintViolationIsNotTransient()
+    {
+        jobStoreSupport.CallIsTransient(new FbException("23000")).Should().BeFalse(
+            "reading Firebird's own spelling of the state must not turn every Firebird failure into a retry");
+    }
+
+    /// <summary>
+    /// Firebird nests the <c>IscException</c> that carries the same property, and it derives from
+    /// <see cref="Exception" /> rather than <see cref="DbException" />. The state is matched on shape,
+    /// the way the SQL Server error numbers are, so it is found at either level.
+    /// </summary>
+    [Test]
+    public void IsTransient_SqlStateIsFoundOnAnyExceptionThatCarriesIt()
+    {
+        jobStoreSupport.CallIsTransient(new IscException("40001")).Should().BeTrue(
+            "the property is what is recognised, not the base class");
+    }
+
+    [Test]
+    public void IsTransient_TransactionRollbackIsFoundThroughAWrapper()
+    {
+        JobPersistenceException wrapped = new JobPersistenceException("couldn't acquire next trigger", new SqlStateException("40001"));
+
+        jobStoreSupport.CallIsTransient(wrapped).Should().BeTrue(
+            "the store wraps what it catches and the retry decision is taken on the wrapper, so a serialization failure has to be visible through it");
+    }
+
+    [Test]
+    public void IsTransient_DeferredConstraintViolationStaysPermanentThroughAWrapper()
+    {
+        JobPersistenceException wrapped = new JobPersistenceException("couldn't store trigger", new SqlStateException("40002"));
+
+        jobStoreSupport.CallIsTransient(wrapped).Should().BeFalse(
+            "walking the chain must not widen class 40 to include the member that is excluded from it");
+    }
+
+    [Test]
+    public void IsTransient_DriverSayingTransientWinsOverAnExcludedSqlState()
+    {
+        jobStoreSupport.CallIsTransient(new SqlStateException("40002") { Transient = true }).Should().BeTrue(
+            "the signals are inclusive - the first one saying transient wins - and a driver that has made up its own mind is believed whatever it reports beside it");
+    }
+
     /// <summary>A driver exception that reports its own verdict and nothing else.</summary>
     public sealed class TransientProviderException : Exception
     {
@@ -1300,6 +1398,51 @@ public class JobStoreSupportTest
     /// <see cref="DbException"/> deliberately, so that on .NET it inherits the <c>IsTransient</c>
     /// that returns false - the property whose answer used to be taken as final.
     /// </summary>
+    /// <summary>
+    /// Stands in for a driver that reports its SQLSTATE through a <c>SqlState</c> property, which is
+    /// what Npgsql's <c>PostgresException</c>, MySqlConnector's and MySql.Data's <c>MySqlException</c>
+    /// all declare, and what <see cref="DbException" /> itself carries from .NET 5 on - so the property
+    /// is an override there and a declaration of the stand-in's own on .NET Framework.
+    /// </summary>
+    public sealed class SqlStateException : DbException
+    {
+        public SqlStateException(string sqlState) => SqlState = sqlState;
+
+        public bool Transient { get; set; }
+
+#if NETCORE
+        public override string SqlState { get; }
+
+        public override bool IsTransient => Transient;
+#else
+        public string SqlState { get; }
+
+        public bool IsTransient => Transient;
+#endif
+    }
+
+    /// <summary>
+    /// Stands in for <c>FirebirdSql.Data.FirebirdClient.FbException</c>, which declares a property
+    /// named <c>SQLSTATE</c> and leaves any inherited <c>SqlState</c> alone.
+    /// </summary>
+    public sealed class FbException : DbException
+    {
+        public FbException(string sqlState) => SQLSTATE = sqlState;
+
+        public string SQLSTATE { get; }
+    }
+
+    /// <summary>
+    /// Stands in for <c>FirebirdSql.Data.Common.IscException</c>, the exception Firebird nests inside
+    /// an <c>FbException</c> and reads the state off. It is not a <see cref="DbException" />.
+    /// </summary>
+    public sealed class IscException : Exception
+    {
+        public IscException(string sqlState) => SQLSTATE = sqlState;
+
+        public string SQLSTATE { get; }
+    }
+
     public sealed class SqlServerLikeException : DbException
     {
         public SqlServerLikeException(params int[] numbers)

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/MySQLDelegateTest.cs
@@ -33,7 +33,10 @@ public class MySQLDelegateTest
 
         var sql = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
 
-        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)",
+            "the sweep filters SCHED_NAME and TRIGGER_STATE by equality and ranges on NEXT_FIRE_TIME, which is "
+            + "the acquisition index's shape; the misfire index's second column is compared with <> and stops the seek (#3608)");
+        sql.Should().NotContain("IDX_{1}T_NFT_ST_MISFIRE");
         sql.Should().Contain("LIMIT 20");
     }
 
@@ -45,7 +48,8 @@ public class MySQLDelegateTest
         var sql = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(-1);
 
         sql.Should().NotContain("LIMIT");
-        sql.Should().NotContain("FORCE INDEX");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)",
+            "the index a statement should read is not a function of how many rows it returns, and the unlimited sweep reads the most");
     }
 
     [Test]
@@ -55,7 +59,9 @@ public class MySQLDelegateTest
 
         var sql = del.GetCountMisfiredTriggersInStateSqlPublic();
 
-        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FORCE INDEX (IDX_{1}T_NFT_ST)",
+            "the count is the sweep's predicate without the ORDER BY, and it is the peek every misfire-handler pass starts with (#3608)");
+        sql.Should().NotContain("IDX_{1}T_NFT_ST_MISFIRE");
     }
 
     [Test]
@@ -92,7 +98,7 @@ public class MySQLDelegateTest
         var template = del.GetSelectNextMisfiredTriggersInStateToAcquireSqlPublic(20);
         var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
 
-        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST)");
         sql.Should().NotContain("IDX_common.");
     }
 
@@ -104,7 +110,7 @@ public class MySQLDelegateTest
         var template = del.GetCountMisfiredTriggersInStateSqlPublic();
         var sql = AdoJobStoreUtil.ReplaceTablePrefix(template, "common.QRTZ_");
 
-        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST_MISFIRE)");
+        sql.Should().Contain("FROM common.QRTZ_TRIGGERS FORCE INDEX (IDX_QRTZ_T_NFT_ST)");
         sql.Should().NotContain("IDX_common.");
     }
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlLikeEscapingTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SqlLikeEscapingTest.cs
@@ -1,0 +1,102 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.Matchers;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// What a group matcher means when the group name contains a character the dialect reads as a
+/// wildcard.
+/// </summary>
+/// <remarks>
+/// Every predicate is a bound parameter with an <c>ESCAPE '!'</c> clause and is scoped by
+/// <c>SCHED_NAME</c>, so this is correctness rather than a boundary: a matcher that matched by character
+/// class would return the wrong rows, not somebody else's.
+/// </remarks>
+public class SqlLikeEscapingTest
+{
+    [Test]
+    public void EveryDialectEscapesTheTwoWildcardsTheStandardHas()
+    {
+        Translate(new PortableDelegate(), GroupMatcher<JobKey>.GroupContains("50%_off"))
+            .Should().Be("%50!%!_off%", "'%' and '_' are wildcards everywhere, and '!' is the escape character");
+
+        Translate(new PortableDelegate(), GroupMatcher<JobKey>.GroupEquals("bang!"))
+            .Should().Be("bang!!", "the escape character escapes itself");
+    }
+
+    /// <summary>
+    /// T-SQL reads <c>[</c> as the start of a character class, so a group matcher containing one matched
+    /// by class on SQL Server and Sybase while matching literally on every other dialect.
+    /// </summary>
+    [Test]
+    public void SqlServerEscapesTheBracketItReadsAsACharacterClass()
+    {
+        Translate(new SqlServerLikeDelegate(), GroupMatcher<JobKey>.GroupContains("[a-z]"))
+            .Should().Be("%![a-z]%",
+                "a group literally named '[a-z]' is found by asking for '[a-z]', and a group named 'b' is not");
+    }
+
+    /// <summary>
+    /// The bracket is not escaped elsewhere, and must not be: the standard says an escape character has
+    /// to be followed by a wildcard or itself, and PostgreSQL enforces that — so <c>![</c> would be an
+    /// error on a dialect where <c>[</c> is not a wildcard.
+    /// </summary>
+    [Test]
+    public void NoOtherDialectEscapesTheBracket()
+    {
+        Translate(new PortableDelegate(), GroupMatcher<JobKey>.GroupContains("[a-z]"))
+            .Should().Be("%[a-z]%");
+    }
+
+    [Test]
+    public void AValueWithNothingToEscapeIsHandedBackAsItIs()
+    {
+        Translate(new SqlServerLikeDelegate(), GroupMatcher<JobKey>.GroupStartsWith("reports")).Should().Be("reports%");
+    }
+
+    private static string Translate(ITranslate translator, GroupMatcher<JobKey> matcher)
+    {
+        return translator.Translate(matcher);
+    }
+
+    private interface ITranslate
+    {
+        string Translate(GroupMatcher<JobKey> matcher);
+    }
+
+    /// <summary>
+    /// Reaches the protected translation every ADO store goes through, for a dialect that adds no
+    /// wildcards of its own.
+    /// </summary>
+    private sealed class PortableDelegate : StdAdoDelegate, ITranslate
+    {
+        public string Translate(GroupMatcher<JobKey> matcher) => ToSqlLikeClause(matcher);
+    }
+
+    /// <inheritdoc cref="PortableDelegate" />
+    private sealed class SqlServerLikeDelegate : SqlServerDelegate, ITranslate
+    {
+        public string Translate(GroupMatcher<JobKey> matcher) => ToSqlLikeClause(matcher);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoConstantsTest.cs
@@ -14,6 +14,51 @@ public class StdAdoConstantsTest
 
         var sql = StdAdoConstants.SqlSelectMisfiredTriggers;
 
-        sql.Should().Be("SELECT * FROM {0}TRIGGERS WHERE SCHED_NAME = @schedulerName AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME < @nextFireTime ORDER BY NEXT_FIRE_TIME ASC, PRIORITY DESC");
+        sql.Should().Be("SELECT * FROM {0}TRIGGERS WHERE SCHED_NAME = @schedulerName AND MISFIRE_INSTR <> -1 AND NEXT_FIRE_TIME <= @nextFireTime ORDER BY NEXT_FIRE_TIME ASC, PRIORITY DESC");
+    }
+
+    /// <summary>
+    /// A waiting trigger belongs to acquisition or to the misfire handler, never to both and never to
+    /// neither: the acquisition statement's <c>@noEarlierThan</c> predicate has to be the exact
+    /// complement of the misfire statements' <c>@nextFireTime</c> one, since both parameters are bound
+    /// to the same <c>now - MisfireThreshold</c>.
+    /// </summary>
+    /// <remarks>
+    /// The comparison is <c>&lt;=</c> because that is what the whole scheduler means by a misfire —
+    /// <c>RAMJobStore.ApplyMisfire</c> and <c>JobStoreSupport.UpdateMisfiredTrigger</c> decline only a
+    /// trigger whose fire time is strictly later — so the threshold instant itself is late (#3462).
+    /// </remarks>
+    [Test]
+    public void TheAcquisitionPredicateShouldBeTheComplementOfTheMisfirePredicate()
+    {
+        StdAdoConstants.SqlCountMisfiredTriggersInStates.Should().Contain("NEXT_FIRE_TIME <= @nextFireTime",
+            "a trigger due at or before now - MisfireThreshold is misfired");
+        StdAdoConstants.SqlSelectHasMisfiredTriggersInState.Should().Contain("NEXT_FIRE_TIME <= @nextFireTime",
+            "the sweep and the count it is peeked at with have to select the same rows");
+        StdAdoConstants.SqlSelectMisfiredTriggersInState.Should().Contain("NEXT_FIRE_TIME <= @nextFireTime");
+        StdAdoConstants.SqlSelectMisfiredTriggersInGroupInState.Should().Contain("NEXT_FIRE_TIME <= @nextFireTime");
+
+        StdAdoConstants.SqlSelectNextTriggerToAcquire.Should().Contain("NEXT_FIRE_TIME > @noEarlierThan",
+            "acquisition takes what is not misfired, so a trigger exactly on the threshold instant is left to the misfire handler rather than fired late without its policy");
+        StdAdoConstants.SqlSelectNextTriggerToAcquireWithExecutionGroup.Should().Contain("NEXT_FIRE_TIME > @noEarlierThan");
+        StdAdoConstants.SqlSelectNextTriggerToAcquireWithPreferredNode.Should().Contain("NEXT_FIRE_TIME > @noEarlierThan");
+        StdAdoConstants.SqlSelectNextTriggerToAcquireWithPreferredNodeOnly.Should().Contain("NEXT_FIRE_TIME > @noEarlierThan");
+
+        foreach (string sql in new[]
+                 {
+                     StdAdoConstants.SqlCountMisfiredTriggersInStates,
+                     StdAdoConstants.SqlSelectHasMisfiredTriggersInState,
+                     StdAdoConstants.SqlSelectMisfiredTriggers,
+                     StdAdoConstants.SqlSelectMisfiredTriggersInState,
+                     StdAdoConstants.SqlSelectMisfiredTriggersInGroupInState,
+                     StdAdoConstants.SqlSelectNextTriggerToAcquire,
+                     StdAdoConstants.SqlSelectNextTriggerToAcquireWithExecutionGroup,
+                     StdAdoConstants.SqlSelectNextTriggerToAcquireWithPreferredNode,
+                     StdAdoConstants.SqlSelectNextTriggerToAcquireWithPreferredNodeOnly
+                 })
+        {
+            sql.Should().NotContain("NEXT_FIRE_TIME < @nextFireTime", "strictly before was the rule the sweep alone had");
+            sql.Should().NotContain("NEXT_FIRE_TIME >= @noEarlierThan", "at or after would overlap the misfire predicate on the threshold instant");
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateSchedulerStateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateSchedulerStateTest.cs
@@ -1,0 +1,257 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+using FakeItEasy;
+
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Simpl;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// The check-in table's reads, and specifically the order their parameters are bound in.
+/// </summary>
+/// <remarks>
+/// Every driver Quartz ships a description for binds by name, so binding order is invisible to all of
+/// them. It is not invisible to a provider a caller describes themselves: a command with
+/// <c>BindByName</c> off takes its parameters positionally, and two adjacent string parameters bound the
+/// wrong way round produce no error at all — just a query for a scheduler named after a node.
+/// </remarks>
+public class StdAdoDelegateSchedulerStateTest
+{
+    private StdAdoDelegate adoDelegate;
+    private RecordingCommand command;
+    private ConnectionAndTransactionHolder conn;
+
+    [SetUp]
+    public void SetUp()
+    {
+        command = new RecordingCommand();
+
+        IDbProvider dbProvider = A.Fake<IDbProvider>();
+        A.CallTo(() => dbProvider.Metadata).Returns(new DbMetadata());
+        A.CallTo(() => dbProvider.CreateCommand()).Returns(command);
+
+        adoDelegate = new StdAdoDelegate();
+        adoDelegate.Initialize(new DelegateInitializationArgs
+        {
+            TablePrefix = "QRTZ_",
+            InstanceName = "TESTSCHED",
+            InstanceId = "node-1",
+            TypeLoadHelper = new SimpleTypeLoadHelper(),
+            DbProvider = dbProvider,
+            ObjectSerializer = new SystemTextJsonObjectSerializer(),
+        });
+
+        conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        command.Dispose();
+        conn.Dispose();
+    }
+
+    [Test]
+    public async Task SelectSchedulerStateRecords_BindsOneNodesParametersInTheOrderTheStatementNamesThem()
+    {
+        InstallEmptyReader();
+
+        await adoDelegate.SelectSchedulerStateRecords(conn, "node-1");
+
+        BoundValues().Should().Equal(new object[] { "TESTSCHED", "node-1" },
+            "SqlSelectSchedulerState names @schedulerName before @instanceName, so a provider that binds "
+            + "positionally would otherwise look for a scheduler called 'node-1' on a node called 'TESTSCHED'");
+    }
+
+    [Test]
+    public async Task SelectSchedulerStateRecords_BindsOnlyTheSchedulerWhenEveryNodeIsAskedFor()
+    {
+        InstallEmptyReader();
+
+        await adoDelegate.SelectSchedulerStateRecords(conn, null);
+
+        BoundValues().Should().Equal(new object[] { "TESTSCHED" },
+            "SqlSelectSchedulerStates has no instance predicate, so binding one would leave the command a parameter over");
+    }
+
+    private List<object> BoundValues()
+    {
+        List<object> values = new List<object>();
+        foreach (DbParameter parameter in command.Parameters)
+        {
+            values.Add(parameter.Value);
+        }
+
+        return values;
+    }
+
+    private void InstallEmptyReader()
+    {
+        DbDataReader reader = A.Fake<DbDataReader>();
+        A.CallTo(() => reader.ReadAsync(A<CancellationToken>._)).Returns(false);
+        command.Reader = reader;
+    }
+
+    /// <summary>
+    /// A command that keeps its parameters in the order they were added, which is all this fixture
+    /// looks at.
+    /// </summary>
+    private sealed class RecordingCommand : DbCommand
+    {
+        /// <summary>
+        /// The result set the next execution hands back. Left unset, executing throws — a command made
+        /// of nothing has nothing to return.
+        /// </summary>
+        public DbDataReader Reader { get; set; }
+
+        public override string CommandText { get; set; } = "";
+
+        public override int CommandTimeout { get; set; }
+
+        public override CommandType CommandType { get; set; }
+
+        public override bool DesignTimeVisible { get; set; }
+
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+
+        protected override DbConnection DbConnection { get; set; }
+
+        protected override DbParameterCollection DbParameterCollection { get; } = new RecordingParameterCollection();
+
+        protected override DbTransaction DbTransaction { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        public override int ExecuteNonQuery() => throw new NotSupportedException();
+
+        public override object ExecuteScalar() => throw new NotSupportedException();
+
+        public override void Prepare()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter() => new RecordingParameter();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            => Reader ?? throw new NotSupportedException();
+    }
+
+    private sealed class RecordingParameterCollection : DbParameterCollection
+    {
+        private readonly List<DbParameter> parameters = new List<DbParameter>();
+
+        public override int Count => parameters.Count;
+
+        public override object SyncRoot { get; } = new object();
+
+#if NETFRAMEWORK
+        public override bool IsFixedSize => false;
+
+        public override bool IsReadOnly => false;
+
+        public override bool IsSynchronized => false;
+#endif
+
+        public override int Add(object value)
+        {
+            parameters.Add((DbParameter) value);
+            return parameters.Count - 1;
+        }
+
+        public override void AddRange(Array values)
+        {
+            foreach (object value in values)
+            {
+                Add(value);
+            }
+        }
+
+        public override void Clear() => parameters.Clear();
+
+        public override bool Contains(object value) => parameters.Contains((DbParameter) value);
+
+        public override bool Contains(string value) => IndexOf(value) >= 0;
+
+        public override void CopyTo(Array array, int index) => ((ICollection) parameters).CopyTo(array, index);
+
+        public override IEnumerator GetEnumerator() => parameters.GetEnumerator();
+
+        public override int IndexOf(object value) => parameters.IndexOf((DbParameter) value);
+
+        public override int IndexOf(string parameterName) => parameters.FindIndex(p => p.ParameterName == parameterName);
+
+        public override void Insert(int index, object value) => parameters.Insert(index, (DbParameter) value);
+
+        public override void Remove(object value) => parameters.Remove((DbParameter) value);
+
+        public override void RemoveAt(int index) => parameters.RemoveAt(index);
+
+        public override void RemoveAt(string parameterName) => RemoveAt(IndexOf(parameterName));
+
+        protected override DbParameter GetParameter(int index) => parameters[index];
+
+        protected override DbParameter GetParameter(string parameterName) => GetParameter(IndexOf(parameterName));
+
+        protected override void SetParameter(int index, DbParameter value) => parameters[index] = value;
+
+        protected override void SetParameter(string parameterName, DbParameter value) => SetParameter(IndexOf(parameterName), value);
+    }
+
+    private sealed class RecordingParameter : DbParameter
+    {
+        public override DbType DbType { get; set; }
+
+        public override ParameterDirection Direction { get; set; }
+
+        public override bool IsNullable { get; set; }
+
+        public override string ParameterName { get; set; } = "";
+
+        public override int Size { get; set; }
+
+        public override string SourceColumn { get; set; } = "";
+
+        public override bool SourceColumnNullMapping { get; set; }
+
+        public override object Value { get; set; }
+
+#if NETFRAMEWORK
+        public override DataRowVersion SourceVersion { get; set; }
+#endif
+
+        public override void ResetDbType()
+        {
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StdAdoDelegateTest.cs
@@ -82,24 +82,28 @@ public class StdAdoDelegateTest
         jdm.Put("key2", null);
         jdm.Put("key3", new NonSerializableTestClass());
 
-        try
+        Action serializeApplicationType = () => del.SerializeJobData(jdm);
+
+        if (binary)
         {
-            del.SerializeJobData(jdm);
-            if (binary)
-            {
-                Assert.Fail("Private types should not be serializable by binary serialization");
-            }
+            serializeApplicationType.Should().Throw<SerializationException>(
+                    "private types should not be serializable by binary serialization")
+                .Which.Message.Should().Contain("key3");
         }
-        catch (SerializationException e)
+        else if (serializer is SystemTextJsonObjectSerializer)
         {
-            if (binary)
-            {
-                Assert.IsTrue(e.Message.IndexOf("key3", StringComparison.Ordinal) >= 0);
-            }
-            else
-            {
-                Assert.Fail($"Private types should be serializable when not using binary serialization: {e}");
-            }
+            // The read side has no polymorphic object deserialization, so a class of the application's
+            // own could never come back as itself. Writing it would put a blob in JOB_DATA that the next
+            // load of this job fails on, which is why the refusal happens here instead (#3495).
+            serializeApplicationType.Should().Throw<Quartz.JsonSerializationException>(
+                    "System.Text.Json refuses at write time a value it could not read back")
+                .Which.Message.Should().Contain("CreateSerializerOptions",
+                    "the failure has to name the way an application declares a type of its own");
+        }
+        else
+        {
+            serializeApplicationType.Should().NotThrow(
+                "with binary serialization out of the picture, a private type is no obstacle to Newtonsoft");
         }
     }
 

--- a/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerEndTimeTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Triggers/DailyTimeIntervalTriggerEndTimeTest.cs
@@ -1,0 +1,149 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Impl.Triggers;
+
+/// <summary>
+/// <see cref="ITrigger.EndTimeUtc" /> is the last instant at which a daily time interval trigger may
+/// fire: nothing past it is produced, wherever in the daily window it falls.
+/// </summary>
+/// <remarks>
+/// The daily half of #3458. The trigger's walk consulted the end time only where it advanced to
+/// another day, so an end time falling between two fire times of the same day let it go on firing
+/// until the daily window closed, and <see cref="ITrigger.FinalFireTimeUtc" /> reported that close
+/// even when it was a day past the end. The inclusive-end alignment of the other trigger types is a
+/// 4.0 change and is deliberately not part of this.
+/// </remarks>
+public class DailyTimeIntervalTriggerEndTimeTest
+{
+    private static readonly DateTimeOffset Start = new DateTimeOffset(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// An end time that falls between two fire times, where "the trigger fires at the end time"
+    /// cannot be what stops the schedule.
+    /// </summary>
+    private static readonly DateTimeOffset MisalignedEnd = Start.AddHours(2).AddMinutes(30);
+
+    [Test]
+    public void NothingFiresPastAnEndTimeThatIsNoFireTime()
+    {
+        IOperableTrigger trigger = Hourly(MisalignedEnd);
+
+        trigger.GetFireTimeAfter(Start.AddHours(2)).Should().BeNull(
+            "the next repeat falls past the end time, and an end time between two fire times ends the schedule at the earlier one");
+
+        TriggerUtils.ComputeFireTimes(trigger, null, 10).Should().Equal(
+            new[] { Start, Start.AddHours(1), Start.AddHours(2) },
+            "an end time is a bound on firing, not merely on how far the schedule is walked");
+
+        trigger.FinalFireTimeUtc.Should().BeOnOrBefore(MisalignedEnd,
+            "a trigger's last fire cannot be past the last instant at which it may fire");
+    }
+
+    /// <summary>
+    /// The daily-time-interval trigger reports the last instant at which it may fire rather than a
+    /// fire time its schedule produces. What it may not report is a time past the end time.
+    /// </summary>
+    [Test]
+    public void FinalFireTimeStopsAtTheEndTimeRatherThanTheDailyWindow()
+    {
+        IOperableTrigger trigger = Hourly(MisalignedEnd);
+
+        trigger.FinalFireTimeUtc.Should().Be(MisalignedEnd,
+            "the daily window closing at 23:59:59 is no reason to report a final fire past the end time");
+    }
+
+    /// <summary>
+    /// The other reading of the same rule: where the daily window closes before the end time, the
+    /// window is the last instant at which the trigger may fire.
+    /// </summary>
+    [Test]
+    public void FinalFireTimeStopsAtTheDailyWindowWhenThatComesFirst()
+    {
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger", "group")
+            .ForJob("job", "group")
+            .StartAt(Start)
+            .EndAt(Start.AddHours(20))
+            .WithDailyTimeIntervalSchedule(schedule => schedule
+                .WithInterval(1, IntervalUnit.Hour)
+                .OnEveryDay()
+                .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(8, 0))
+                .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(17, 0))
+                .InTimeZone(TimeZoneInfo.Utc))
+            .Build();
+
+        trigger.FinalFireTimeUtc.Should().Be(Start.AddHours(17),
+            "the trigger cannot fire between the window closing at 17:00 and the end time three hours later");
+    }
+
+    /// <summary>
+    /// The window's close is a local wall-clock time, so where the end time falls a day later in
+    /// its own zone the window is read on that day and in that zone rather than at the offset the
+    /// end time happens to carry.
+    /// </summary>
+    [Test]
+    public void FinalFireTimeReadsTheDailyWindowInTheTriggersTimeZone()
+    {
+        TimeZoneInfo helsinki = TestTimeZones.Helsinki;
+
+        // 2026-06-01 22:00 UTC is 2026-06-02 01:00 in Helsinki: the end time's local day is the second.
+        DateTimeOffset endTimeUtc = Start.AddHours(22);
+
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger", "group")
+            .ForJob("job", "group")
+            .StartAt(Start)
+            .EndAt(endTimeUtc)
+            .WithDailyTimeIntervalSchedule(schedule => schedule
+                .WithInterval(1, IntervalUnit.Hour)
+                .OnEveryDay()
+                .StartingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 0))
+                .EndingDailyAt(TimeOfDay.HourAndMinuteOfDay(0, 30))
+                .InTimeZone(helsinki))
+            .Build();
+
+        // The window on the end time's local day closes at 00:30 Helsinki, which is 21:30 UTC - before the end time.
+        trigger.FinalFireTimeUtc.Should().Be(new DateTimeOffset(2026, 6, 2, 0, 30, 0, TimeSpan.FromHours(3)),
+            "the window closes on the end time's own local day, half an hour before the end time");
+    }
+
+    private static IOperableTrigger Hourly(DateTimeOffset endTimeUtc)
+    {
+        return (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger", "group")
+            .ForJob("job", "group")
+            .StartAt(Start)
+            .EndAt(endTimeUtc)
+            .WithDailyTimeIntervalSchedule(schedule => schedule
+                .WithInterval(1, IntervalUnit.Hour)
+                .OnEveryDay()
+                .InTimeZone(TimeZoneInfo.Utc))
+            .Build();
+    }
+}

--- a/src/Quartz.Tests.Unit/Job/DirectoryScanJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/DirectoryScanJobTest.cs
@@ -120,6 +120,176 @@ public class DirectoryScanJobTest
         }
     }
 
+    /// <summary>
+    /// The job is <c>[PersistJobDataAfterExecution]</c>, so what it keeps between scans is written to
+    /// the job store by whichever serializer is configured. A <c>List&lt;FileInfo&gt;</c> is not a value
+    /// System.Text.Json can read back — it is refused on write — so the first firing against such a
+    /// store failed to persist; a string map of path to last-write ticks is a shape every serializer
+    /// admits, and it is what the next scan reads back.
+    /// </summary>
+    [Test]
+    public async Task TheScannedFileListIsStoredAsSomethingAJobStoreCanWrite()
+    {
+        string testDirectory = Path.Combine(Path.GetTempPath(), $"QuartzTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(testDirectory);
+        string file = Path.Combine(testDirectory, "seen.txt");
+        File.WriteAllText(file, "seen");
+        // Older than the job's minimum update age, so the first scan counts it as new and records it.
+        File.SetLastWriteTimeUtc(file, DateTime.UtcNow.AddMinutes(-1));
+
+        try
+        {
+            IScheduler scheduler = await SchedulerBuilder.Create()
+                .Build()
+                .GetScheduler();
+
+            TestDirectoryScanListener listener = new TestDirectoryScanListener();
+            scheduler.Context.Put(nameof(TestDirectoryScanListener), listener);
+
+            ExecutionRecordingJobListener executions = new ExecutionRecordingJobListener();
+            scheduler.ListenerManager.AddJobListener(executions);
+
+            IJobDetail jobDetail = JobBuilder.Create<DirectoryScanJob>()
+                .WithIdentity("StoredShape")
+                .UsingJobData(DirectoryScanJob.DirectoryNames, testDirectory)
+                .UsingJobData(DirectoryScanJob.DirectoryScanListenerName, nameof(TestDirectoryScanListener))
+                .StoreDurably()
+                .Build();
+
+            await scheduler.AddJob(jobDetail, false);
+            await scheduler.Start();
+
+            await scheduler.TriggerJob(jobDetail.Key);
+            await executions.Completed(1);
+
+            executions.Failures.Should().BeEmpty("the first scan has a listener to tell and a directory to read");
+
+            // The job listeners hear of the firing before the store writes the job data back, so the
+            // stored map is read once it carries what the scan recorded.
+            JobDataMap stored = await StoredJobDataWith(scheduler, jobDetail.Key, "CURRENT_FILE_LIST");
+
+            stored.Should().ContainKey("CURRENT_FILE_LIST");
+            stored["CURRENT_FILE_LIST"].Should().BeOfType<Dictionary<string, string>>(
+                    "a string map is a value both JSON serializers read back, and a List<FileInfo> is not")
+                .Which.Should().ContainKey(Path.GetFullPath(file), "the path is what the next scan compares");
+
+            SystemTextJsonObjectSerializer serializer = new SystemTextJsonObjectSerializer();
+            serializer.Initialize();
+            Action write = () => serializer.Serialize(stored);
+            write.Should().NotThrow("this is the write a persistent store makes after the firing");
+
+            // The next scan reads the stored shape back, and keeps working.
+            await scheduler.TriggerJob(jobDetail.Key);
+            await executions.Completed(2);
+
+            executions.Failures.Should().BeEmpty("a scan that cannot read what the previous one stored fails the job");
+
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+        finally
+        {
+            if (Directory.Exists(testDirectory))
+            {
+                Directory.Delete(testDirectory, true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The job's stored data map once it carries <paramref name="key" />, or the map as it stands after
+    /// thirty seconds of it not appearing.
+    /// </summary>
+    private static async Task<JobDataMap> StoredJobDataWith(IScheduler scheduler, JobKey jobKey, string key)
+    {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(30);
+        JobDataMap stored = (await scheduler.GetJobDetail(jobKey)).JobDataMap;
+
+        while (!stored.ContainsKey(key) && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(25);
+            stored = (await scheduler.GetJobDetail(jobKey)).JobDataMap;
+        }
+
+        return stored;
+    }
+
+    private sealed class ExecutionRecordingJobListener : IJobListener
+    {
+        private readonly List<Exception> failures = new List<Exception>();
+        private readonly List<(int Count, TaskCompletionSource<bool> Source)> waiters = new List<(int, TaskCompletionSource<bool>)>();
+        private int completed;
+
+        public string Name => nameof(ExecutionRecordingJobListener);
+
+        public IReadOnlyList<Exception> Failures
+        {
+            get
+            {
+                lock (failures)
+                {
+                    return failures.ToArray();
+                }
+            }
+        }
+
+        /// <summary>A task that completes once <paramref name="count" /> firings have been executed.</summary>
+        public Task Completed(int count)
+        {
+            TaskCompletionSource<bool> source = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lock (failures)
+            {
+                if (completed >= count)
+                {
+                    return Task.CompletedTask;
+                }
+
+                waiters.Add((count, source));
+            }
+
+            return Task.WhenAny(source.Task, Task.Delay(TimeSpan.FromSeconds(30))).ContinueWith(t =>
+            {
+                if (!source.Task.IsCompleted)
+                {
+                    throw new TimeoutException($"The job did not complete {count} firings within 30 seconds.");
+                }
+            });
+        }
+
+        public Task JobToBeExecuted(IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task JobExecutionVetoed(IJobExecutionContext context, System.Threading.CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task JobWasExecuted(IJobExecutionContext context, JobExecutionException jobException, System.Threading.CancellationToken cancellationToken = default)
+        {
+            List<TaskCompletionSource<bool>> ready;
+            lock (failures)
+            {
+                if (jobException != null)
+                {
+                    failures.Add(jobException);
+                }
+
+                completed++;
+                ready = new List<TaskCompletionSource<bool>>();
+                for (int i = waiters.Count - 1; i >= 0; i--)
+                {
+                    if (waiters[i].Count <= completed)
+                    {
+                        ready.Add(waiters[i].Source);
+                        waiters.RemoveAt(i);
+                    }
+                }
+            }
+
+            foreach (TaskCompletionSource<bool> source in ready)
+            {
+                source.TrySetResult(true);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
     private class TestDirectoryScanListener : IDirectoryScanListener
     {
         public void FilesUpdatedOrAdded(IReadOnlyCollection<FileInfo> updatedFiles)

--- a/src/Quartz.Tests.Unit/Job/NativeJobTest.cs
+++ b/src/Quartz.Tests.Unit/Job/NativeJobTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 
 using Quartz.Job;
 
@@ -7,14 +9,79 @@ namespace Quartz.Tests.Unit.Job;
 public class NativeJobTest
 {
     [Test]
-    public void TestNativeJob()
+    public async Task TestNativeJob()
     {
         var job = new NativeJob();
         var context = TestUtil.NewJobExecutionContextFor(job);
         context.MergedJobDataMap.Put(NativeJob.PropertyCommand, "Test");
 
-        Action act = () => job.Execute(context);
+        Func<Task> act = async () => await job.Execute(context);
 
-        act.Should().NotThrow<Exception>();
+        await act.Should().NotThrowAsync<Exception>();
+    }
+
+    /// <summary>
+    /// A process that writes more than a pipe buffer holds completes with the defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Both streams used to be redirected whatever <c>consumeStreams</c> said, while the consumer threads
+    /// were started only when it was on — so with the defaults (<c>consumeStreams</c> off,
+    /// <c>waitForProcess</c> on) the child blocked writing to a pipe nobody drained, and the synchronous
+    /// <c>WaitForExit</c> held a Quartz worker thread for as long as that lasted, which was for ever.
+    /// Every branch below writes past any platform's buffer: Windows keeps a few kilobytes, macOS 16 KB
+    /// and Linux 64 KB, and the smallest of these commands writes about 135 KB.
+    /// </para>
+    /// <para>
+    /// The three branches are spelled differently because <c>RunNativeCommand</c> concatenates the
+    /// command and the parameters into one <c>ProcessStartInfo.Arguments</c> string, which is then split
+    /// into argv on whitespace outside quotes. On Windows that string is the command line
+    /// <c>cmd.exe</c> parses for itself, so <c>for /L</c> arrives whole. On Linux a shell is started but
+    /// it is handed an argv, so the whole command has to be a single element and therefore has to carry
+    /// its own quotes: what runs is <c>/bin/sh -c "seq 1 25000"</c>, where a shell command written as
+    /// several words would arrive as <c>-c</c>, its first word, and a list of positional parameters.
+    /// On macOS no shell wraps anything at all — <c>RunNativeCommand</c> tests for Linux by name and
+    /// executes the command directly on every other Unix — so the program and its arguments are named
+    /// separately, and a <c>|</c> would be an argument of <c>seq</c> rather than a pipeline.
+    /// </para>
+    /// <para>
+    /// The deadline is as load-bearing as the assertion: without the fix the wait never returns, so a
+    /// bare <c>await</c> would hang the whole test run rather than fail it. With the deadline it fails
+    /// after a minute, and passes in well under a second.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task AProcessThatFillsThePipeStillCompletesWithTheDefaults()
+    {
+        var job = new NativeJob();
+        var context = TestUtil.NewJobExecutionContextFor(job);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // cmd.exe is handed the command line as written and parses it itself: 2,048 lines of 128
+            // characters, and nothing reading them.
+            const string Line = "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567";
+            context.MergedJobDataMap.Put(NativeJob.PropertyCommand, "for");
+            context.MergedJobDataMap.Put(NativeJob.PropertyParameters, $"/L %i in (1,1,2048) do @echo {Line}");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // The quotes are part of the value: they are what makes the command one argv element by the
+            // time /bin/sh sees it, so what starts is /bin/sh -c "seq 1 25000".
+            context.MergedJobDataMap.Put(NativeJob.PropertyCommand, "\"seq 1 25000\"");
+        }
+        else
+        {
+            // No shell here, so the program and its arguments are named separately: seq 1 25000.
+            context.MergedJobDataMap.Put(NativeJob.PropertyCommand, "seq");
+            context.MergedJobDataMap.Put(NativeJob.PropertyParameters, "1 25000");
+        }
+
+        Func<Task> act = () => job.Execute(context);
+
+        await act.Should().CompleteWithinAsync(TimeSpan.FromSeconds(60),
+            "nothing is redirected unless somebody is reading it, so the child never blocks on a full pipe");
+
+        context.Result.Should().Be(0);
     }
 }

--- a/src/Quartz.Tests.Unit/JobDataMapTest.cs
+++ b/src/Quartz.Tests.Unit/JobDataMapTest.cs
@@ -77,6 +77,50 @@ public class JobDataMapTest : SerializationTestSupport<JobDataMap>
         g.Should().NotBe(Guid.Empty);
     }
 
+    /// <summary>
+    /// A number a comma-decimal culture wrote is rejected by every numeric accessor, never read as a
+    /// different number.
+    /// </summary>
+    /// <remarks>
+    /// The invariant parser's default styles allow a group separator, which would read the comma in
+    /// "3,14" as one and answer 314 — a hundredfold of the value, silently. The floating-point
+    /// accessors therefore parse with styles that allow no group separator at all, so a string a
+    /// comma-decimal culture wrote is unreadable as every numeric type alike, as it always was for
+    /// <see cref="JobDataMap.GetIntValueFromString" />.
+    /// </remarks>
+    [Test]
+    public void ACommaDecimalNumberIsRejectedByEveryNumericAccessor()
+    {
+        JobDataMap map = new JobDataMap();
+        map.Put("pi", "3,14");
+
+        Action readDouble = () => map.GetDoubleValueFromString("pi");
+        readDouble.Should().Throw<FormatException>(
+            "no numeric accessor allows a group separator, so the comma a de-DE machine wrote as a "
+            + "decimal point makes the string unreadable rather than a hundredfold of itself");
+
+        Action readFloat = () => map.GetFloatValueFromString("pi");
+        readFloat.Should().Throw<FormatException>();
+
+        Action readViaCoercingDouble = () => map.GetDoubleValue("pi");
+        readViaCoercingDouble.Should().Throw<FormatException>("the coercing accessor reads a string through the same parser");
+
+        Action readInt = () => map.GetIntValueFromString("pi");
+        readInt.Should().Throw<FormatException>("the integer styles never allowed a group separator");
+    }
+
+    [Test]
+    public void ADecimalPointNumberStillReadsWithTheInvariantCulture()
+    {
+        JobDataMap map = new JobDataMap();
+        map.Put("pi", "3.14");
+        map.Put("big", "-1.5e3");
+
+        map.GetDoubleValueFromString("pi").Should().Be(3.14);
+        map.GetFloatValueFromString("pi").Should().Be(3.14f);
+        map.GetDoubleValueFromString("big").Should().Be(-1500d, "sign, decimal point and exponent are the whole of what a number written for a job may carry");
+    }
+
     [Test]
     public void PutAsString_StoresIntValueAsString()
     {

--- a/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/JobDataMapPortabilityTest.cs
@@ -204,8 +204,164 @@ public class JobDataMapPortabilityTest
             .WithMessage("*inner*", "the failure has to say which entry it is about");
     }
 
+    /// <summary>
+    /// The values System.Text.Json refuses to write, because it could never read them back: a JSON
+    /// array, and an object of any shape but the string map the reader produces. Each of these used to
+    /// serialize without complaint and throw on the way out, by which time the blob was in the database
+    /// and the failure belonged to whoever next ran the job (#3495).
+    /// </summary>
+    private static IEnumerable<TestCaseData> UnreadableValues()
+    {
+        yield return Refused("list", new List<string> { "a", "b" }, "System.Collections.Generic.List");
+        yield return Refused("dictionaryOfObject", new Dictionary<string, object> { ["inner"] = 1 }, "System.Collections.Generic.Dictionary");
+        yield return Refused("nested", new JobDataMap { { "inner", "value" } }, "Quartz.JobDataMap");
+
+        // Written as {"Name":"monthly"}, which is byte for byte a string map - and comes back as one,
+        // never as the object that went in. The shape is not what decides; the value's own type is.
+        yield return Refused("object", new ApplicationJobDataValue { Name = "monthly" }, "ApplicationJobDataValue");
+    }
+
+    private static TestCaseData Refused(string key, object value, string expectedTypeName)
+    {
+        return new TestCaseData(key, value, expectedTypeName).SetName("{m}(" + key + ")");
+    }
+
+    [TestCaseSource(nameof(UnreadableValues))]
+    public void AValueTheReaderCannotAcceptIsRefusedOnWrite(string key, object value, string expectedTypeName)
+    {
+        JobDataMap original = new JobDataMap { { key, value } };
+
+        Action write = () => systemTextJsonSerializer.Serialize(original);
+
+        write.Should().Throw<Quartz.JsonSerializationException>(
+                "a value written now and unreadable later is a blob in the database nobody can load, and the write is the last moment anyone can be told")
+            .Which.Message.Should().Contain(key, "the failure has to say which entry it is about")
+            .And.Contain(expectedTypeName, "and what was in it")
+            .And.Contain("CreateSerializerOptions", "and how an application declares a type of its own");
+    }
+
+    /// <summary>
+    /// The values a store has always taken and still takes, none of which is a type the reader names.
+    /// Each is a number or a string in the column, so each comes back - as an <c>int</c>, or as the
+    /// string the accessors coerce - and refusing them over an upgrade would have made a failing
+    /// application out of a working one.
+    /// </summary>
+    private static IEnumerable<TestCaseData> CoercedValues()
+    {
+        yield return Coerced("short", (short) 7, 7);
+        yield return Coerced("byteArray", new byte[] { 1, 2, 3 }, Convert.ToBase64String(new byte[] { 1, 2, 3 }));
+        yield return Coerced("uri", new Uri("https://www.quartz-scheduler.net/"), "https://www.quartz-scheduler.net/");
+        yield return Coerced("enum", DayOfWeek.Friday, (int) DayOfWeek.Friday);
+    }
+
+    private static TestCaseData Coerced(string key, object value, object expected)
+    {
+        return new TestCaseData(key, value, expected).SetName("{m}(" + key + ")");
+    }
+
+    [TestCaseSource(nameof(CoercedValues))]
+    public void AValueTheReaderCoercesSurvivesTheRoundTrip(string key, object value, object expected)
+    {
+        JobDataMap original = new JobDataMap { { key, value } };
+
+        JobDataMap restored = systemTextJsonSerializer.DeSerialize<JobDataMap>(systemTextJsonSerializer.Serialize(original));
+
+        restored[key].Should().Be(expected,
+            "the refusal is of what the reader cannot hand back at all, not of what it hands back as a number or a string");
+    }
+
+    /// <summary>
+    /// Every value the reader hands back as itself, or as something the accessors coerce, is still
+    /// written: the refusal is of what cannot come back, not of what comes back changed.
+    /// </summary>
+    [Test]
+    public void EveryValueTheAccessorsReadIsStillWritten()
+    {
+        JobDataMap original = new JobDataMap
+        {
+            { "string", "text" },
+            { "bool", true },
+            { "char", 'c' },
+            { "int", 1 },
+            { "long", 2L },
+            { "float", 3.5f },
+            { "double", 4.5d },
+            { "decimal", 5.5m },
+            { "dateTime", new DateTime(2024, 1, 2, 3, 4, 5, DateTimeKind.Utc) },
+            { "dateTimeOffset", new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.FromHours(2)) },
+            { "timeSpan", TimeSpan.FromMinutes(90) },
+            { "guid", Guid.NewGuid() },
+            { "enum", DayOfWeek.Friday },
+            { "stringMap", stringMap },
+            { "null", null }
+        };
+
+        Action write = () => systemTextJsonSerializer.Serialize(original);
+
+        write.Should().NotThrow("each of these is a type JobDataMap has an accessor for, or the one object shape the reader produces");
+    }
+
+    /// <summary>
+    /// Refusing on write must not close the door an application is told to use. A type the
+    /// application declares a converter for - by overriding
+    /// <see cref="SystemTextJsonObjectSerializer.CreateSerializerOptions" /> - is written, and reading it
+    /// back gives what the store format gives for any object: a <c>Dictionary&lt;string, string&gt;</c>.
+    /// </summary>
+    [Test]
+    public void ATypeTheApplicationDeclaredIsWrittenAndRead()
+    {
+        JobDataMap original = new JobDataMap { { "report", new ApplicationJobDataValue { Name = "monthly" } } };
+
+        Action withoutDeclaration = () => systemTextJsonSerializer.Serialize(original);
+        withoutDeclaration.Should().Throw<Quartz.JsonSerializationException>(
+            "an application type Quartz has not been told about is exactly the case the refusal exists for");
+
+        DeclaringSerializer declared = new DeclaringSerializer();
+        declared.Initialize();
+
+        JobDataMap restored = declared.DeSerialize<JobDataMap>(declared.Serialize(original));
+
+        restored["report"].Should().BeEquivalentTo(new Dictionary<string, string> { ["Name"] = "monthly" },
+            "declaring a type is what lets it be written; the store format still hands an object back as a string map");
+    }
+
     private IObjectSerializer SerializerNamed(string name)
     {
         return name == "newtonsoft" ? newtonsoftSerializer : systemTextJsonSerializer;
+    }
+
+    /// <summary>A job data value type of the application's own, which no contract of Quartz's can name.</summary>
+    public sealed class ApplicationJobDataValue
+    {
+        public string Name { get; set; }
+    }
+
+    /// <summary>
+    /// The serializer an application configures when it has a job data value type of its own: the
+    /// converter it adds is its declaration that the type can be written.
+    /// </summary>
+    private sealed class DeclaringSerializer : SystemTextJsonObjectSerializer
+    {
+        protected override System.Text.Json.JsonSerializerOptions CreateSerializerOptions()
+        {
+            System.Text.Json.JsonSerializerOptions options = base.CreateSerializerOptions();
+            options.Converters.Add(new ApplicationJobDataValueConverter());
+            return options;
+        }
+    }
+
+    private sealed class ApplicationJobDataValueConverter : System.Text.Json.Serialization.JsonConverter<ApplicationJobDataValue>
+    {
+        public override ApplicationJobDataValue Read(ref System.Text.Json.Utf8JsonReader reader, Type typeToConvert, System.Text.Json.JsonSerializerOptions options)
+        {
+            throw new NotSupportedException("the store format reads an object back as a string map, never as the type that went in");
+        }
+
+        public override void Write(System.Text.Json.Utf8JsonWriter writer, ApplicationJobDataValue value, System.Text.Json.JsonSerializerOptions options)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("Name", value.Name);
+            writer.WriteEndObject();
+        }
     }
 }

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreMisfireThresholdTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreMisfireThresholdTest.cs
@@ -1,0 +1,105 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Quartz.Job;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// The one rule about a misfire, on the in-memory store: a trigger is late once its fire time is
+/// <em>at or before</em> <c>now - MisfireThreshold</c>, and the threshold instant itself is late.
+/// </summary>
+/// <remarks>
+/// <see cref="StdAdoConstantsTest.TheAcquisitionPredicateShouldBeTheComplementOfTheMisfirePredicate" />
+/// pins the ADO store's spelling of the same rule; the two stores have to agree on the instant, or a
+/// trigger due exactly then is a misfire on one and an ordinary firing on the other (#3462).
+/// </remarks>
+[NonParallelizable]
+public class RAMJobStoreMisfireThresholdTest
+{
+    private static readonly DateTimeOffset Now = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Threshold = TimeSpan.FromMinutes(1);
+
+    private Func<DateTimeOffset> clock;
+
+    [SetUp]
+    public void FreezeTheClock()
+    {
+        clock = SystemTime.UtcNow;
+        SystemTime.UtcNow = () => Now;
+    }
+
+    [TearDown]
+    public void RestoreTheClock()
+    {
+        SystemTime.UtcNow = clock;
+    }
+
+    [Test]
+    public async Task ATriggerDueExactlyAtTheThresholdInstantIsMisfired()
+    {
+        IOperableTrigger acquired = await AcquireTriggerDueAt(Now - Threshold);
+
+        acquired.GetNextFireTimeUtc().Should().Be(Now,
+            "the fire-now misfire policy moved the trigger to the current instant, which is what says the store called it a misfire");
+    }
+
+    [Test]
+    public async Task ATriggerDueOneTickAfterTheThresholdInstantIsNotMisfired()
+    {
+        DateTimeOffset due = (Now - Threshold).AddTicks(1);
+
+        IOperableTrigger acquired = await AcquireTriggerDueAt(due);
+
+        acquired.GetNextFireTimeUtc().Should().Be(due,
+            "a trigger whose fire time is strictly after now - MisfireThreshold is not late, and its fire time is left where it was");
+    }
+
+    private static async Task<IOperableTrigger> AcquireTriggerDueAt(DateTimeOffset due)
+    {
+        RAMJobStore store = new RAMJobStore { MisfireThreshold = Threshold };
+        await store.Initialize(null, new RAMJobStoreTest.SampleSignaler());
+        await store.SchedulerStarted();
+
+        IJobDetail job = JobBuilder.Create<NoOpJob>().WithIdentity("job", "misfire").Build();
+        IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
+            .WithIdentity("trigger", "misfire")
+            .ForJob(job)
+            .StartAt(due)
+            .WithSimpleSchedule(schedule => schedule.WithMisfireHandlingInstructionFireNow())
+            .Build();
+        trigger.ComputeFirstFireTimeUtc(null);
+
+        await store.StoreJobAndTrigger(job, trigger);
+
+        IReadOnlyCollection<IOperableTrigger> acquired = await store.AcquireNextTriggers(Now.AddSeconds(1), 1, TimeSpan.Zero);
+
+        acquired.Should().ContainSingle("the trigger is due either way; what differs is whether its misfire policy was applied on the way");
+        return acquired.Single();
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/SystemTextJsonDeserializationFailureTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/SystemTextJsonDeserializationFailureTest.cs
@@ -1,0 +1,99 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Text;
+
+using Quartz.Impl.Calendar;
+using Quartz.Simpl;
+using Quartz.Spi;
+
+namespace Quartz.Tests.Unit.Simpl;
+
+/// <summary>
+/// A job store blob that <see cref="SystemTextJsonObjectSerializer" /> cannot read has to fail as
+/// <see cref="Quartz.JsonSerializationException" />, carrying the payload that could not be read and
+/// the underlying parse failure, whether the failure came from one of Quartz's converters or from the
+/// reader itself. That is the exception callers catch and the dashboard special-cases.
+/// </summary>
+public class SystemTextJsonDeserializationFailureTest
+{
+    private SystemTextJsonObjectSerializer serializer;
+
+    /// <summary>
+    /// Valid up to the point it stops - the shape a truncated write leaves behind.
+    /// </summary>
+    private const string TruncatedCalendar = "{\"$type\": \"Quartz.Impl.Calendar.AnnualCalendar, Quartz\", \"Description\": \"Test AnnualCalendar";
+
+    /// <summary>
+    /// Parses perfectly and means nothing - the shape a blob written by something else has.
+    /// </summary>
+    private const string WellFormedButNotATrigger = "{\"totally\": \"valid json\", \"just\": [\"not\", \"a\", \"trigger\"]}";
+
+    [SetUp]
+    public void SetUp()
+    {
+        serializer = new SystemTextJsonObjectSerializer();
+        serializer.Initialize();
+    }
+
+    [Test]
+    public void SyntacticallyBrokenPayloadFailsAsQuartzJsonSerializationException()
+    {
+        Action act = () => serializer.DeSerialize<AnnualCalendar>(Encoding.UTF8.GetBytes(TruncatedCalendar));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a parse failure must not escape as the underlying library's own exception type")
+            .Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.Message.Should().Contain(TruncatedCalendar, "the payload that could not be read is the whole diagnostic");
+        thrown.InnerException.Should().NotBeNull("the underlying parse failure is what says where the payload broke");
+    }
+
+    [Test]
+    public void PayloadThatIsNotJsonAtAllFailsAsQuartzJsonSerializationException()
+    {
+        const string NotJson = "this is not json";
+
+        Action act = () => serializer.DeSerialize<AnnualCalendar>(Encoding.UTF8.GetBytes(NotJson));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>(
+                "a payload rejected on its very first token never reaches a converter, and must still fail the same way")
+            .Which;
+
+        thrown.Message.Should().Contain(NotJson);
+        thrown.InnerException.Should().BeOfType<System.Text.Json.JsonException>(
+            "the reader's own refusal is what says where the payload broke");
+    }
+
+    [Test]
+    public void WellFormedButWrongShapePayloadFailsAsQuartzJsonSerializationException()
+    {
+        Action act = () => serializer.DeSerialize<IOperableTrigger>(Encoding.UTF8.GetBytes(WellFormedButNotATrigger));
+
+        Quartz.JsonSerializationException thrown = act.Should().Throw<Quartz.JsonSerializationException>().Which;
+
+        thrown.Should().BeAssignableTo<SchedulerException>();
+        thrown.Message.Should().Contain(WellFormedButNotATrigger);
+        thrown.InnerException.Should().NotBeNull();
+    }
+}

--- a/src/Quartz/Core/ExecutingJobsManager.cs
+++ b/src/Quartz/Core/ExecutingJobsManager.cs
@@ -8,8 +8,18 @@ using Quartz.Spi;
 namespace Quartz.Core;
 
 /// <summary>
-/// ExecutingJobsManager - Job Listener Class.
+/// The scheduler's own record of the firings it is running: what
+/// <see cref="QuartzScheduler.CurrentlyExecutingJobs" /> lists and
+/// <see cref="QuartzScheduler.NumJobsExecuted" /> counts.
 /// </summary>
+/// <remarks>
+/// It is the scheduler's built-in job listener, and it is told about the same two moments a user
+/// listener is — but directly, rather than through the loop that notifies them. A user listener that
+/// throws abandons that loop, and bookkeeping carried along with it would leave a firing listed as
+/// executing for as long as the process lived (#3502). <see cref="FiringStarted" /> and
+/// <see cref="FiringEnded" /> are the members the scheduler calls, and they are synchronous because
+/// there has never been anything in them to await.
+/// </remarks>
 internal sealed class ExecutingJobsManager : IJobListener
 {
     public string Name => GetType()!.FullName!;
@@ -24,12 +34,33 @@ internal sealed class ExecutingJobsManager : IJobListener
 
     private int numJobsFired;
 
+    /// <summary>
+    /// Records that a firing has begun. It is listed as executing, and counted as fired, until
+    /// <see cref="FiringEnded" /> is called for it.
+    /// </summary>
+    public void FiringStarted(IJobExecutionContext context)
+    {
+        Interlocked.Increment(ref numJobsFired);
+        executingJobs[((IOperableTrigger) context.Trigger).FireInstanceId] = context;
+    }
+
+    /// <summary>
+    /// Records that a firing is over, whether the job ran or a listener stopped it on the way in.
+    /// </summary>
+    /// <remarks>
+    /// The count of jobs fired is deliberately not taken back: it counts the firings this scheduler
+    /// dispatched, which a firing a listener then abandoned still is.
+    /// </remarks>
+    public void FiringEnded(IJobExecutionContext context)
+    {
+        executingJobs.TryRemove(((IOperableTrigger) context.Trigger).FireInstanceId, out _);
+    }
+
     public Task JobToBeExecuted(
         IJobExecutionContext context,
         CancellationToken cancellationToken = default)
     {
-        Interlocked.Increment(ref numJobsFired);
-        executingJobs[((IOperableTrigger) context.Trigger).FireInstanceId] = context;
+        FiringStarted(context);
         return Task.CompletedTask;
     }
 
@@ -37,7 +68,7 @@ internal sealed class ExecutingJobsManager : IJobListener
         JobExecutionException? jobException,
         CancellationToken cancellationToken = default)
     {
-        executingJobs.TryRemove(((IOperableTrigger) context.Trigger).FireInstanceId, out _);
+        FiringEnded(context);
         return Task.CompletedTask;
     }
 

--- a/src/Quartz/Core/JobRunShell.cs
+++ b/src/Quartz/Core/JobRunShell.cs
@@ -176,6 +176,7 @@ public class JobRunShell : SchedulerListenerSupport
                 {
                     if (!await NotifyListenersBeginning(jec, cancellationToken).ConfigureAwait(false))
                     {
+                        await NotifyFinalizedIfDone(qs, jec, cancellationToken).ConfigureAwait(false);
                         await qs.NotifyJobStoreJobComplete(trigger, jobDetail, SchedulerInstruction.NoInstruction, cancellationToken).ConfigureAwait(false);
                         break;
                     }
@@ -300,6 +301,7 @@ public class JobRunShell : SchedulerListenerSupport
                 // notify all job listeners
                 if (!await NotifyJobListenersComplete(jec, jobExEx, cancellationToken).ConfigureAwait(false))
                 {
+                    await NotifyFinalizedIfDone(qs, jec, cancellationToken).ConfigureAwait(false);
                     await qs.NotifyJobStoreJobComplete(trigger, jobDetail, instCode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
@@ -307,21 +309,7 @@ public class JobRunShell : SchedulerListenerSupport
                 // notify all trigger listeners
                 if (!await NotifyTriggerListenersComplete(jec, instCode, cancellationToken).ConfigureAwait(false))
                 {
-                    // Ensure finalized notification is still sent when the trigger has no next fire time,
-                    // even if trigger listener notification failed.
-                    try
-                    {
-                        if (jec.Trigger.GetNextFireTimeUtc() == null)
-                        {
-                            await qs.NotifySchedulerListenersFinalized(jec.Trigger, cancellationToken).ConfigureAwait(false);
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        SchedulerException se2 = new SchedulerException("Error notifying scheduler listeners of finalized trigger.", e);
-                        await qs.NotifySchedulerListenersError("Error notifying scheduler listeners of finalized trigger.", se2, cancellationToken).ConfigureAwait(false);
-                    }
-
+                    await NotifyFinalizedIfDone(qs, jec, cancellationToken).ConfigureAwait(false);
                     await qs.NotifyJobStoreJobComplete(trigger, jobDetail, instCode, cancellationToken).ConfigureAwait(false);
                     break;
                 }
@@ -390,6 +378,37 @@ public class JobRunShell : SchedulerListenerSupport
     {
         jec = null;
         qs = null;
+    }
+
+    /// <summary>
+    /// Announces that the trigger has fired for the last time, when it has.
+    /// </summary>
+    /// <remarks>
+    /// Every way out of a firing has to do this, the ones a failed listener cut short included: a
+    /// trigger whose last firing was abandoned is as finished as one whose last firing ran, and a
+    /// scheduler listener told only about the tidy paths would go on believing the trigger is still
+    /// there. The veto path says it in its own words, because the message it reports a failure with
+    /// names the veto.
+    /// </remarks>
+    private static async Task NotifyFinalizedIfDone(
+        QuartzScheduler qs,
+        IJobExecutionContext ctx,
+        CancellationToken cancellationToken)
+    {
+        if (ctx.Trigger.GetNextFireTimeUtc() != null)
+        {
+            return;
+        }
+
+        try
+        {
+            await qs.NotifySchedulerListenersFinalized(ctx.Trigger, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            SchedulerException se = new SchedulerException("Error notifying scheduler listeners of finalized trigger.", e);
+            await qs.NotifySchedulerListenersError("Error notifying scheduler listeners of finalized trigger.", se, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     private async Task<bool> NotifyListenersBeginning(

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -287,8 +287,9 @@ public class QuartzScheduler :
             schedThread.IdleWaitTime = idleWaitTime;
         }
 
+        // Not registered as an internal listener: the scheduler tells it about both ends of a firing
+        // directly, outside the loop a failing user listener abandons (#3502).
         jobMgr = new ExecutingJobsManager();
-        AddInternalJobListener(jobMgr);
         var errLogger = new ErrorLogger();
         AddInternalSchedulerListener(errLogger);
 
@@ -1710,12 +1711,22 @@ public class QuartzScheduler :
         var listeners = ListenerManager.GetJobListeners();
         var internalListeners = internalJobListeners.Values;
 
-        if (listeners.Count == 0 && internalListeners.Count == 1)
+        if (listeners.Count == 0)
         {
-            // default case is that we only have our internal one
-            using var enumerator = internalListeners.GetEnumerator();
-            enumerator.MoveNext();
-            return (enumerator.Current, null);
+            if (internalListeners.Count == 0)
+            {
+                // default case is that there is nobody to tell; the scheduler's own record of the
+                // firing is kept by ExecutingJobsManager, which is not in this list
+                return (null, null);
+            }
+
+            if (internalListeners.Count == 1)
+            {
+                // a job store that listens to its own firings
+                using var enumerator = internalListeners.GetEnumerator();
+                enumerator.MoveNext();
+                return (enumerator.Current, null);
+            }
         }
 
         return (null, listeners.Concat(internalListeners));
@@ -1878,7 +1889,46 @@ public class QuartzScheduler :
         IJobExecutionContext jec,
         CancellationToken cancellationToken = default)
     {
-        return NotifyJobListeners(jl => jl.JobToBeExecuted(jec, cancellationToken), jec, null);
+        // The scheduler's own record of the firing is kept outside the listener loop below, because a
+        // listener that throws abandons that loop. JobRunShell then completes the firing without the
+        // job having run and without anyone being told it was executed, so a record kept inside the
+        // loop would list the firing as executing for as long as the process lived (#3502).
+        jobMgr.FiringStarted(jec);
+
+        Task notification;
+        try
+        {
+            notification = NotifyJobListeners(jl => jl.JobToBeExecuted(jec, cancellationToken), jec, null);
+        }
+        catch
+        {
+            // The single-listener path wraps a listener that threw before handing back a task and
+            // throws the wrapper itself, before there is a task to await.
+            jobMgr.FiringEnded(jec);
+            throw;
+        }
+
+        return notification.IsCompletedSuccessfully()
+            ? Task.CompletedTask
+            : EndFiringIfNotificationFails(notification, jobMgr, jec);
+
+        static async Task EndFiringIfNotificationFails(
+            Task notification,
+            ExecutingJobsManager jobMgr,
+            IJobExecutionContext jec)
+        {
+            try
+            {
+                await notification.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Nothing further will be notified for this firing, so this is the only place the
+                // record of it can be taken back out.
+                jobMgr.FiringEnded(jec);
+                throw;
+            }
+        }
     }
 
     /// <summary>
@@ -1904,6 +1954,10 @@ public class QuartzScheduler :
         JobExecutionException? je,
         CancellationToken cancellationToken = default)
     {
+        // Taken out of the record before the listeners are told, and not by one of them: a listener
+        // that throws here must not leave the firing showing as executing (#3502).
+        jobMgr.FiringEnded(jec);
+
         return NotifyJobListeners(jl => jl.JobWasExecuted(jec, je, cancellationToken), jec, je);
     }
 
@@ -1943,7 +1997,19 @@ public class QuartzScheduler :
                     continue;
                 }
 
-                await NotifySingle(notifyAction(jl), jl, jec).ConfigureAwait(false);
+                // The call to the listener is inside the guard, not an argument to it, so a listener
+                // that throws before it hands anything back — a guard clause in a method that is not
+                // async — is wrapped in the same exception as one that hands back a faulted task.
+                // JobRunShell catches SchedulerException, and a raw exception escaping it left the
+                // firing stranded and the job's other triggers blocked behind it (#3502).
+                try
+                {
+                    await notifyAction(jl).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    throw new JobExecutionProcessException(jl, jec, e);
+                }
             }
         }
 

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreUtil.cs
@@ -62,4 +62,42 @@ public static class AdoJobStoreUtil
         var unqualifiedPrefix = lastDot >= 0 ? tablePrefix.Substring(lastDot + 1) : tablePrefix;
         return string.Format(CultureInfo.InvariantCulture, query, tablePrefix, unqualifiedPrefix);
     }
+
+    /// <summary>
+    /// Refuses a duration the schema cannot hold exactly, naming the trigger and the column it was
+    /// going into.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Duration columns hold whole milliseconds - see <c>StdAdoDelegate.GetDbTimeSpanValue</c>, which
+    /// casts <c>TotalMilliseconds</c> to <c>long</c> - so a shorter interval used to be written as
+    /// <c>0</c>. For a simple trigger that is not merely lossy: the trigger read back has a zero
+    /// repeat interval, <c>SimpleTriggerImpl.GetFireTimeAfter</c> divides by it, and the resulting
+    /// <see cref="DivideByZeroException" /> is caught and logged by the store - leaving the row in
+    /// <c>ACQUIRED</c> for good, which is a job that stops running and says nothing (#3673).
+    /// </para>
+    /// <para>
+    /// Refused here rather than rounded, because rounding half a millisecond to zero and rounding it
+    /// to one are both schedules the caller did not ask for. The message names the column so that
+    /// what to change the value to is not a guess.
+    /// </para>
+    /// </remarks>
+    /// <param name="value">The duration about to be persisted.</param>
+    /// <param name="column">The column it is going into, as the schema spells it.</param>
+    /// <param name="triggerKey">The trigger that carries it.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="value" /> carries ticks below a whole millisecond.
+    /// </exception>
+    internal static void RequireStorableDuration(TimeSpan value, string column, TriggerKey triggerKey)
+    {
+        if (value.Ticks % TimeSpan.TicksPerMillisecond == 0)
+        {
+            return;
+        }
+
+        string message = FormattableString.Invariant(
+            $"Trigger '{triggerKey}' has an interval of {value:c}, which a persistent job store cannot hold: {column} keeps whole milliseconds, so it would be stored as {(long) value.TotalMilliseconds} ms and read back as a different schedule. Round the interval to a whole number of milliseconds, or keep this trigger in the in-memory store.");
+
+        throw new ArgumentException(message, nameof(value));
+    }
 }

--- a/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/IDriverDelegate.cs
@@ -535,9 +535,22 @@ public interface IDriverDelegate
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Select the job to which the trigger is associated. Allow option to load actual job class or not. When case of
-    /// remove, we do not need to load the type, which in many cases, it's no longer exists.
+    /// Select the job to which the trigger is associated. Allow option to load actual job class or not.
     /// </summary>
+    /// <param name="conn">The DB Connection</param>
+    /// <param name="triggerKey">The key identifying the trigger.</param>
+    /// <param name="loadHelper">The type load helper.</param>
+    /// <param name="loadJobType">
+    /// Whether to resolve the job's type now, which throws when the class is not in this process.
+    /// <c>false</c> gets a job detail with no <see cref="IJobDetail.JobType" /> at all, which removal
+    /// passes because the type often no longer exists by then, and which the trigger edits pass because
+    /// an administration node without the job's assembly must be able to make them. It says nothing
+    /// about the job's two attribute flags: <see cref="IJobDetail.ConcurrentExecutionDisallowed" />
+    /// and <see cref="IJobDetail.PersistJobDataAfterExecution" /> come from <c>IS_NONCONCURRENT</c> and
+    /// <c>IS_UPDATE_DATA</c> either way, so a caller deciding whether a trigger is blocked does not need
+    /// the class to decide it correctly (#3705).
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
     Task<IJobDetail?> SelectJobForTrigger(ConnectionAndTransactionHolder conn,
         TriggerKey triggerKey,
         ITypeLoadHelper loadHelper,

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -21,12 +21,14 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -5333,6 +5335,18 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
 
         try
         {
+            if (IsTransactionRollback(ex))
+            {
+                return true;
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+
+        try
+        {
             if (InspectSqlException(ex))
             {
                 return true;
@@ -5357,6 +5371,87 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
 
         return ex is TimeoutException;
     }
+
+    /// <summary>
+    /// Whether the exception, or one it wraps, reports a SQLSTATE in class <c>40</c> — the standard's
+    /// own "transaction rollback" class, which is its way of saying the database abandoned the
+    /// transaction for a reason that has nothing to do with the statements in it, so running it again
+    /// is the prescribed answer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// SQLSTATE is provider-neutral, which is why it is worth reading. <c>40001</c>, the serialization
+    /// failure, is what Firebird reports for a write conflict between two transactions, what MySQL
+    /// reports for its <c>1213</c> deadlock, and what PostgreSQL reports beside its own extension
+    /// <c>40P01</c>, deadlock detected. Npgsql and MySqlConnector already say as much through their
+    /// <c>IsTransient</c>, so for those two this is belt and braces. Firebird and MySql.Data do not:
+    /// <c>FbException</c> reports <c>IsTransient: false</c> for a serialization failure, so the store
+    /// treated the one condition retrying exists for as fatal, wrapped it in a
+    /// <see cref="JobPersistenceException" /> and gave up (#3454).
+    /// </para>
+    /// <para>
+    /// <c>40002</c> is the single member of the class that is excluded. It is an integrity-constraint
+    /// violation the database deferred to commit time — a real error, which will fail in exactly the
+    /// same way on the next attempt. The rest of the class is transient: <c>40000</c> (rollback with no
+    /// subclass), <c>40001</c>, <c>40003</c> (statement completion unknown) and <c>40P01</c>.
+    /// </para>
+    /// <para>
+    /// This leaves the SQL Server path alone. Both SqlClients report no SQLSTATE, so 1205 and its
+    /// neighbours still arrive the way they always did, through <see cref="InspectSqlException" />.
+    /// </para>
+    /// </remarks>
+    private static bool IsTransactionRollback(Exception ex)
+    {
+        for (Exception? candidate = ex; candidate != null; candidate = candidate.InnerException)
+        {
+            string? sqlState = GetSqlState(candidate);
+
+            // The class is the first two characters and the subclass is the rest, so the whole class is
+            // a prefix match with the one exception carved out by name.
+            if (sqlState != null
+                && sqlState.StartsWith("40", StringComparison.Ordinal)
+                && sqlState != "40002")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// The exception's SQLSTATE, read from whichever property the driver chose to spell it with, or
+    /// <see langword="null" /> if it reports none.
+    /// </summary>
+    /// <remarks>
+    /// <c>DbException.SqlState</c> is the property to ask, and Npgsql, MySqlConnector and MySql.Data
+    /// all declare it on every framework; the base class only has it from .NET 5 on, which is why it is
+    /// read by name here rather than through the type. Firebird does not use it: <c>FbException</c>
+    /// declares a <c>SQLSTATE</c> of its own, so the state that prompted all this is reachable only by
+    /// that name. Read by reflection for the reason the SQL Server error numbers are — Quartz references
+    /// no driver — and matched on shape rather than on a base class, so the <c>IscException</c> Firebird
+    /// nests inside, which carries the same property, answers too.
+    /// </remarks>
+    private static string? GetSqlState(Exception ex)
+    {
+        PropertyInfo?[] properties = sqlStateProperties.GetOrAdd(ex.GetType(), static type => new[]
+        {
+            type.GetProperty("SqlState", BindingFlags.Instance | BindingFlags.Public),
+            type.GetProperty("SQLSTATE", BindingFlags.Instance | BindingFlags.Public)
+        });
+
+        foreach (PropertyInfo? property in properties)
+        {
+            if (property != null && property.PropertyType == typeof(string) && property.GetValue(ex) is string { Length: > 0 } sqlState)
+            {
+                return sqlState;
+            }
+        }
+
+        return null;
+    }
+
+    private static readonly ConcurrentDictionary<Type, PropertyInfo?[]> sqlStateProperties = new ConcurrentDictionary<Type, PropertyInfo?[]>();
 
     private static bool InspectSqlException(Exception ex)
     {

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2324,7 +2324,12 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         try
         {
             // this must be called before we delete the trigger, obviously
-            var job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoadHelper, cancellationToken).ConfigureAwait(false);
+            //
+            // The class is not resolved: rescheduling is an editing operation, and an administration
+            // node that cannot load the job's assembly must be able to do it (#3705). What the
+            // replacement needs from the job is its key, its durability and its two attribute flags,
+            // and all four come from the row.
+            var job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoadHelper, loadJobType: false, cancellationToken).ConfigureAwait(false);
 
             if (job == null)
             {
@@ -2454,7 +2459,10 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             }
 
             string state = await Delegate.SelectTriggerState(conn, triggerKey, cancellationToken).ConfigureAwait(false);
-            IJobDetail? job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoadHelper, cancellationToken).ConfigureAwait(false);
+            // Not resolved, for the reason ReplaceTrigger does not resolve it: editing a trigger is
+            // something a process without the job's assembly is entitled to do, and the flags the
+            // write needs are columns rather than attributes.
+            IJobDetail? job = await Delegate.SelectJobForTrigger(conn, triggerKey, TypeLoadHelper, loadJobType: false, cancellationToken).ConfigureAwait(false);
 
             if (job is null)
             {

--- a/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/MySQLDelegate.cs
@@ -58,20 +58,49 @@ public class MySQLDelegate : StdAdoDelegate
             + " LIMIT " + maxCount;
     }
 
+    /// <summary>
+    /// The misfire sweep carries a FORCE INDEX hint pointing at IDX_*_T_NFT_ST — the acquisition
+    /// index, not IDX_*_T_NFT_ST_MISFIRE.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It named the misfire index until <see href="https://github.com/quartznet/quartznet/issues/3608">#3608</see>
+    /// measured what that costs. The sweep filters on SCHED_NAME and TRIGGER_STATE by equality, ranges
+    /// on NEXT_FIRE_TIME and keeps MISFIRE_INSTR as a residual — which is exactly the shape of
+    /// <c>IDX_QRTZ_T_NFT_ST (SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME)</c>, and nothing like
+    /// <c>(SCHED_NAME, MISFIRE_INSTR, NEXT_FIRE_TIME, TRIGGER_STATE)</c>, whose second column is compared
+    /// with <c>&lt;&gt;</c> and so stops the seek dead. Every other dialect's optimizer works this out
+    /// on its own; MySQL is the one that cannot, because this hint tells it not to. Measured on a
+    /// 100,000-trigger table with a 5,000-row backlog: 15,561 buffer pool reads and 66 ms became
+    /// 129 reads and 0.7 ms.
+    /// </para>
+    /// <para>
+    /// Applied whatever the batch size, including an unlimited sweep. It used to be skipped for the
+    /// unlimited one, which was an artefact of the row limit and the hint sharing an early return
+    /// rather than a decision: the index a statement should read is not a function of how many rows
+    /// it returns, and an unlimited sweep is the case that reads the most.
+    /// </para>
+    /// </remarks>
     protected override string GetSelectNextMisfiredTriggersInStateToAcquireSql(int count)
     {
-        if (count != -1)
-        {
-            return SqlSelectHasMisfiredTriggersInState
-                .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE")
-                + " LIMIT " + count;
-        }
-        return base.GetSelectNextMisfiredTriggersInStateToAcquireSql(count);
+        string sql = SqlSelectHasMisfiredTriggersInState
+            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST) WHERE");
+
+        return count != -1 ? sql + " LIMIT " + count : sql;
     }
 
+    /// <summary>
+    /// The counting form of the misfire scan carries the same FORCE INDEX hint.
+    /// </summary>
+    /// <remarks>
+    /// Its predicate is the sweep's without the ORDER BY, so it wants the same index for the same
+    /// reason — and it is the cheap peek every misfire-handler pass starts with, so it runs far more
+    /// often than the sweep it guards. Measured on the same table with nothing misfired at all:
+    /// 4,594 buffer pool reads and 111 ms became 8 reads and 0.7 ms.
+    /// </remarks>
     protected override string GetCountMisfiredTriggersInStateSql()
     {
         return SqlCountMisfiredTriggersInStates
-            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST_MISFIRE) WHERE");
+            .Replace("{0}TRIGGERS WHERE", "{0}TRIGGERS FORCE INDEX (IDX_{1}T_NFT_ST) WHERE");
     }
 }

--- a/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SimpleTriggerPersistenceDelegate.cs
@@ -82,6 +82,7 @@ public class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         CancellationToken cancellationToken = default)
     {
         ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
+        AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, AdoConstants.ColumnRepeatInterval, trigger.Key);
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlInsertSimpleTrigger, TablePrefix));
         DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);
@@ -137,6 +138,7 @@ public class SimpleTriggerPersistenceDelegate : ITriggerPersistenceDelegate
         CancellationToken cancellationToken = default)
     {
         ISimpleTrigger simpleTrigger = (ISimpleTrigger) trigger;
+        AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, AdoConstants.ColumnRepeatInterval, trigger.Key);
 
         using var cmd = DbAccessor.PrepareCommand(conn, AdoJobStoreUtil.ReplaceTablePrefix(StdAdoConstants.SqlUpdateSimpleTrigger, TablePrefix));
         DbAccessor.AddCommandParameter(cmd, "schedulerName", SchedName);

--- a/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/SqlServerDelegate.cs
@@ -31,6 +31,13 @@ namespace Quartz.Impl.AdoJobStore;
 public class SqlServerDelegate : StdAdoDelegate
 {
     /// <summary>
+    /// T-SQL reads <c>[</c> as the start of a character class in a <c>LIKE</c> pattern, so a group
+    /// matcher asking for a name containing <c>[a-z]</c> would match by class here and literally
+    /// everywhere else.
+    /// </summary>
+    internal override string AdditionalLikeWildcards => "[";
+
+    /// <summary>
     /// Gets the select next trigger to acquire SQL clause.
     /// SQL Server specific version with TOP functionality
     /// </summary>

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -228,19 +228,19 @@ public class StdAdoConstants : AdoConstants
         Invariant($"SELECT {ColumnJobName}, {ColumnJobGroup} FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobGroup} = @jobGroup");
 
     public static readonly string SqlSelectMisfiredTriggers =
-        Invariant($"SELECT * FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
+        Invariant($"SELECT * FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} <= @nextFireTime ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
     public static readonly string SqlSelectMisfiredTriggersInGroupInState =
-        Invariant($"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
+        Invariant($"SELECT {ColumnTriggerName} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} <= @nextFireTime AND {ColumnTriggerGroup} = @triggerGroup AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
     public static readonly string SqlSelectMisfiredTriggersInState =
-        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
+        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} <= @nextFireTime AND {ColumnTriggerState} = @state ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
     public static readonly string SqlCountMisfiredTriggersInStates =
-        Invariant($"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1");
+        Invariant($"SELECT COUNT({ColumnTriggerName}) FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} <= @nextFireTime AND {ColumnTriggerState} = @state1");
 
     public static readonly string SqlSelectHasMisfiredTriggersInState =
-        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} < @nextFireTime AND {ColumnTriggerState} = @state1 ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
+        Invariant($"SELECT {ColumnTriggerName}, {ColumnTriggerGroup} FROM {TablePrefixSubst}{TableTriggers} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnMifireInstruction} <> {MisfireInstruction.IgnoreMisfirePolicy} AND {ColumnNextFireTime} <= @nextFireTime AND {ColumnTriggerState} = @state1 ORDER BY {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
     public static readonly string SqlSelectNextTriggerToAcquire =
         Invariant($@"SELECT
@@ -250,7 +250,7 @@ public class StdAdoConstants : AdoConstants
               JOIN
                 {TablePrefixSubst}{TableJobDetails} jd ON (jd.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND  jd.{ColumnJobGroup} = t.{ColumnJobGroup} AND jd.{ColumnJobName} = t.{ColumnJobName}) 
               WHERE
-                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} >= @noEarlierThan))
+                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} > @noEarlierThan))
               ORDER BY 
                 {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
@@ -465,7 +465,7 @@ public class StdAdoConstants : AdoConstants
               JOIN
                 {TablePrefixSubst}{TableJobDetails} jd ON (jd.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND  jd.{ColumnJobGroup} = t.{ColumnJobGroup} AND jd.{ColumnJobName} = t.{ColumnJobName})
               WHERE
-                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} >= @noEarlierThan))
+                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} > @noEarlierThan))
               ORDER BY
                 {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
 
@@ -541,7 +541,7 @@ public class StdAdoConstants : AdoConstants
               JOIN
                 {TablePrefixSubst}{TableJobDetails} jd ON (jd.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND  jd.{ColumnJobGroup} = t.{ColumnJobGroup} AND jd.{ColumnJobName} = t.{ColumnJobName})
               WHERE
-                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} >= @noEarlierThan))
+                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} > @noEarlierThan))
                 {PreferredNodeWhereClause}
               ORDER BY
                 {ColumnNextFireTime} ASC, {ColumnPriority} DESC");
@@ -554,7 +554,7 @@ public class StdAdoConstants : AdoConstants
               JOIN
                 {TablePrefixSubst}{TableJobDetails} jd ON (jd.{ColumnSchedulerName} = t.{ColumnSchedulerName} AND  jd.{ColumnJobGroup} = t.{ColumnJobGroup} AND jd.{ColumnJobName} = t.{ColumnJobName})
               WHERE
-                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} >= @noEarlierThan))
+                t.{ColumnSchedulerName} = @schedulerName AND {ColumnTriggerState} = @state AND {ColumnNextFireTime} <= @noLaterThan AND ({ColumnMifireInstruction} = -1 OR ({ColumnMifireInstruction} <> -1 AND {ColumnNextFireTime} > @noEarlierThan))
                 {PreferredNodeWhereClause}
               ORDER BY
                 {ColumnNextFireTime} ASC, {ColumnPriority} DESC");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoConstants.cs
@@ -204,8 +204,19 @@ public class StdAdoConstants : AdoConstants
     public static readonly string SqlSelectJobExistence =
         Invariant($"SELECT 1 FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName AND {ColumnJobName} = @jobName AND {ColumnJobGroup} = @jobGroup");
 
+    /// <summary>
+    /// The job a trigger belongs to, as far as the trigger paths need it.
+    /// </summary>
+    /// <remarks>
+    /// <c>IS_NONCONCURRENT</c> and <c>IS_UPDATE_DATA</c> are selected because the two attribute flags
+    /// have to be answerable without the job's CLR type: <c>JobStoreSupport.StoreTrigger</c> decides
+    /// between <c>WAITING</c> and <c>BLOCKED</c> from
+    /// <see cref="IJobDetail.ConcurrentExecutionDisallowed" />, and a detail built without them falls
+    /// back to reading the attribute off the type — which answers <see langword="false" /> in a process
+    /// that cannot load it, or off whatever placeholder its type loader substituted (#3705).
+    /// </remarks>
     public static readonly string SqlSelectJobForTrigger =
-        Invariant($"SELECT J.{ColumnJobName}, J.{ColumnJobGroup}, J.{ColumnIsDurable}, J.{ColumnJobClass}, J.{ColumnRequestsRecovery} FROM {TablePrefixSubst}{TableTriggers} T, {TablePrefixSubst}{TableJobDetails} J WHERE T.{ColumnSchedulerName} = @schedulerName AND T.{ColumnSchedulerName} = J.{ColumnSchedulerName} AND T.{ColumnTriggerName} = @triggerName AND T.{ColumnTriggerGroup} = @triggerGroup AND T.{ColumnJobName} = J.{ColumnJobName} AND T.{ColumnJobGroup} = J.{ColumnJobGroup}");
+        Invariant($"SELECT J.{ColumnJobName}, J.{ColumnJobGroup}, J.{ColumnIsDurable}, J.{ColumnJobClass}, J.{ColumnRequestsRecovery}, J.{ColumnIsNonConcurrent}, J.{ColumnIsUpdateData} FROM {TablePrefixSubst}{TableTriggers} T, {TablePrefixSubst}{TableJobDetails} J WHERE T.{ColumnSchedulerName} = @schedulerName AND T.{ColumnSchedulerName} = J.{ColumnSchedulerName} AND T.{ColumnTriggerName} = @triggerName AND T.{ColumnTriggerGroup} = @triggerGroup AND T.{ColumnJobName} = J.{ColumnJobName} AND T.{ColumnJobGroup} = J.{ColumnJobGroup}");
 
     public static readonly string SqlSelectJobGroups =
         Invariant($"SELECT DISTINCT({ColumnJobGroup}) FROM {TablePrefixSubst}{TableJobDetails} WHERE {ColumnSchedulerName} = @schedulerName");

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Jobs.cs
@@ -236,6 +236,14 @@ public partial class StdAdoDelegate
 
             job.RequestsRecovery = GetBooleanFromDbValue(rs[ColumnRequestsRecovery]);
 
+            // Stated from the row rather than deduced from the type, whatever loadJobType says, for
+            // the reason SelectJobDetail states them: the columns are the record of what the
+            // attributes said when the job was stored, and a process that cannot load the class
+            // would otherwise be told a non-concurrent job allows concurrency (#3705).
+            job.StateAttributeFlags(
+                concurrentExecutionDisallowed: GetBooleanFromDbValue(rs[ColumnIsNonConcurrent]),
+                persistJobDataAfterExecution: GetBooleanFromDbValue(rs[ColumnIsUpdateData]));
+
             return job;
         }
 

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Schedulers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Schedulers.cs
@@ -64,17 +64,19 @@ public partial class StdAdoDelegate
         DbCommand cmd;
         List<SchedulerStateRecord> list = new List<SchedulerStateRecord>();
 
+        // Bound in the order the statements name them - SCHED_NAME first, INSTANCE_NAME second - for a
+        // provider that binds positionally rather than by name.
         if (instanceName != null)
         {
             cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectSchedulerState));
+            AddCommandParameter(cmd, "schedulerName", schedName);
             AddCommandParameter(cmd, "instanceName", instanceName);
         }
         else
         {
             cmd = PrepareCommand(conn, ReplaceTablePrefix(SqlSelectSchedulerStates));
+            AddCommandParameter(cmd, "schedulerName", schedName);
         }
-
-        AddCommandParameter(cmd, "schedulerName", schedName);
 
         using var rs = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await rs.ReadAsync(cancellationToken).ConfigureAwait(false))

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.Triggers.cs
@@ -2176,6 +2176,8 @@ public partial class StdAdoDelegate
         // do not change extended properties during misfire.
         if (trigger is ISimpleTrigger simpleTrigger && FindTriggerPersistenceDelegate(trigger) is not null)
         {
+            AdoJobStoreUtil.RequireStorableDuration(simpleTrigger.RepeatInterval, ColumnRepeatInterval, trigger.Key);
+
             using var cmd2 = PrepareCommand(conn, ReplaceTablePrefix(SqlUpdateSimpleTrigger));
             AddCommandParameter(cmd2, "schedulerName", schedName);
             AddCommandParameter(cmd2, "triggerRepeatCount", simpleTrigger.RepeatCount);

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -444,7 +444,7 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
             return "%";
         }
 
-        string value = EscapeSqlLikeWildcards(matcher.CompareToValue);
+        string value = EscapeSqlLikeWildcards(matcher.CompareToValue, AdditionalLikeWildcards);
 
         if (StringOperator.Equality.Equals(matcher.CompareWithOperator))
         {
@@ -470,13 +470,40 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
     }
 
     /// <summary>
+    /// The characters this dialect treats as <c>LIKE</c> wildcards beyond <c>%</c> and <c>_</c>, which
+    /// every dialect has. Empty for all but the T-SQL family.
+    /// </summary>
+    /// <remarks>
+    /// SQL Server and Sybase read <c>[</c> as the start of a character class, so a group matcher value
+    /// containing one matches by class there and literally everywhere else. It cannot be escaped
+    /// unconditionally: the standard says an escape character must be followed by a wildcard or
+    /// itself, and PostgreSQL enforces that, so <c>![</c> is an error on a dialect where <c>[</c> is not
+    /// a wildcard. Internal on 3.x so that the public surface stays where it is.
+    /// </remarks>
+    internal virtual string AdditionalLikeWildcards => "";
+
+    /// <summary>
     /// Escapes the LIKE wildcards '%' and '_', and
     /// <see cref="StdAdoConstants.SqlLikeEscapeCharacter" /> itself, so that the value matches
     /// literally.
     /// </summary>
     protected static string EscapeSqlLikeWildcards(string value)
     {
-        if (value.IndexOfAny(SqlLikeWildcardCharacters) < 0)
+        return EscapeSqlLikeWildcards(value, additionalWildcards: "");
+    }
+
+    /// <summary>
+    /// Escapes the LIKE wildcards '%' and '_', the escape character '!' itself, and any character of
+    /// <paramref name="additionalWildcards" />, so that the value matches literally.
+    /// </summary>
+    /// <param name="value">The text to match literally.</param>
+    /// <param name="additionalWildcards">
+    /// What else the dialect reads as a wildcard — see <see cref="AdditionalLikeWildcards" />.
+    /// </param>
+    internal static string EscapeSqlLikeWildcards(string value, string additionalWildcards)
+    {
+        if (value.IndexOfAny(SqlLikeWildcardCharacters) < 0
+            && (additionalWildcards.Length == 0 || value.IndexOfAny(additionalWildcards.ToCharArray()) < 0))
         {
             return value;
         }
@@ -484,7 +511,7 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
         var builder = new StringBuilder(value.Length + 8);
         foreach (char c in value)
         {
-            if (c == SqlLikeEscapeCharacter || c == '%' || c == '_')
+            if (c == SqlLikeEscapeCharacter || c == '%' || c == '_' || additionalWildcards.IndexOf(c) >= 0)
             {
                 builder.Append(SqlLikeEscapeCharacter);
             }

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -262,6 +262,18 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
     /// <returns></returns>
     public virtual object? GetDbTimeSpanValue(TimeSpan? timeSpanValue)
     {
+        // Whole milliseconds is the whole of the format, so a value carrying anything finer is a value
+        // this cannot store. Refused rather than truncated: the callers that know which trigger and
+        // which column it belongs to check first and say so (AdoJobStoreUtil.RequireStorableDuration),
+        // and this catches whatever they do not cover (#3673).
+        if (timeSpanValue is { } value && value.Ticks % TimeSpan.TicksPerMillisecond != 0)
+        {
+            string message = FormattableString.Invariant(
+                $"{value:c} cannot be stored: this store keeps durations as whole milliseconds, so it would be written as {(long) value.TotalMilliseconds} ms and read back as a different value.");
+
+            throw new ArgumentException(message, nameof(timeSpanValue));
+        }
+
         return timeSpanValue != null ? (long?) timeSpanValue.Value.TotalMilliseconds : null;
     }
 

--- a/src/Quartz/Impl/JobDetailImpl.cs
+++ b/src/Quartz/Impl/JobDetailImpl.cs
@@ -383,7 +383,14 @@ public class JobDetailImpl : IJobDetail
         {
             if (!persistJobDataAfterExecution.HasValue)
             {
-                persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(JobType).PersistJobDataAfterExecution;
+                if (jobType == null)
+                {
+                    // Nothing stated and nothing to deduce it from: a detail a driver delegate built
+                    // without resolving the class and without stating the flags.
+                    return false;
+                }
+
+                persistJobDataAfterExecution = JobTypeInformation.GetOrCreate(jobType).PersistJobDataAfterExecution;
             }
 
             return persistJobDataAfterExecution.GetValueOrDefault();
@@ -403,11 +410,36 @@ public class JobDetailImpl : IJobDetail
         {
             if (!disallowConcurrentExecution.HasValue)
             {
-                disallowConcurrentExecution = JobTypeInformation.GetOrCreate(JobType).ConcurrentExecutionDisallowed;
+                if (jobType == null)
+                {
+                    // Nothing stated and nothing to deduce it from: a detail a driver delegate built
+                    // without resolving the class and without stating the flags.
+                    return false;
+                }
+
+                disallowConcurrentExecution = JobTypeInformation.GetOrCreate(jobType).ConcurrentExecutionDisallowed;
             }
 
             return disallowConcurrentExecution.GetValueOrDefault();
         }
+    }
+
+    /// <summary>
+    /// States the two attribute flags from what a job store recorded, so that they answer without
+    /// the job's CLR type being loaded.
+    /// </summary>
+    /// <remarks>
+    /// <c>IS_NONCONCURRENT</c> and <c>IS_UPDATE_DATA</c> are the record of what the attributes said
+    /// when the job was stored. A process that cannot load the class — or that substitutes a
+    /// placeholder for it through its <see cref="Spi.ITypeLoadHelper" /> — would otherwise deduce
+    /// them from a type that is not the job's, and store a non-concurrent job's trigger as ready to
+    /// run while the job is running (#3705). Writes the existing fields, so a serialized detail is
+    /// unchanged in shape.
+    /// </remarks>
+    internal void StateAttributeFlags(bool concurrentExecutionDisallowed, bool persistJobDataAfterExecution)
+    {
+        disallowConcurrentExecution = concurrentExecutionDisallowed;
+        this.persistJobDataAfterExecution = persistJobDataAfterExecution;
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
+++ b/src/Quartz/Impl/Triggers/DailyTimeIntervalTriggerImpl.cs
@@ -623,9 +623,34 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
     /// fire, after the given time. If the trigger will not fire after the given
     /// time, <see langword="null" /> will be returned.
     /// </summary>
+    /// <remarks>
+    /// Never past <see cref="EndTimeUtc" />: the end time is where the trigger's firing stops, wherever
+    /// in the daily window it falls.
+    /// </remarks>
     /// <param name="afterTime"></param>
     /// <returns></returns>
     public override DateTimeOffset? GetFireTimeAfter(DateTimeOffset? afterTime)
+    {
+        DateTimeOffset? fireTime = ComputeFireTimeAfter(afterTime);
+        DateTimeOffset? endTime = EndTimeUtc;
+
+        // The walk below consults the end time only where it has to advance to another day, so a
+        // fire time reached by stepping the interval within one day is bounded here instead.
+        // Without this the trigger goes on firing past its end time until the daily window closes
+        // (#3458).
+        if (fireTime != null && endTime != null && fireTime.Value > endTime.Value)
+        {
+            return null;
+        }
+
+        return fireTime;
+    }
+
+    /// <summary>
+    /// The schedule walk behind <see cref="GetFireTimeAfter" />, which bounds what this returns by
+    /// <see cref="EndTimeUtc" />.
+    /// </summary>
+    private DateTimeOffset? ComputeFireTimeAfter(DateTimeOffset? afterTime)
     {
         // Check if trigger has completed or not.
         if (complete)
@@ -887,25 +912,39 @@ public class DailyTimeIntervalTriggerImpl : AbstractTrigger, IDailyTimeIntervalT
     /// Returns the final time at which the <see cref="IDailyTimeIntervalTrigger" /> will
     /// fire, if there is no end time set, null will be returned.
     /// </summary>
-    /// <remarks>Note that the return time may be in the past.</remarks>
+    /// <remarks>
+    /// <para>Note that the return time may be in the past.</para>
+    /// <para>
+    /// Unlike the other shipped trigger types this is the last instant at which the trigger may
+    /// fire rather than a fire time its schedule produces: neither <see cref="EndTimeUtc" /> nor
+    /// <see cref="EndTimeOfDay" /> has to land on a repeat of the interval. It is never past
+    /// <see cref="EndTimeUtc" />, which is where every trigger's firing stops (#3458).
+    /// </para>
+    /// </remarks>
     /// <returns></returns>
     public override DateTimeOffset? FinalFireTimeUtc
     {
         get
         {
-            if (complete || EndTimeUtc == null)
+            DateTimeOffset? endTime = EndTimeUtc;
+
+            if (complete || endTime == null)
             {
                 return null;
             }
 
-            // We have an endTime, we still need to check to see if there is a endTimeOfDay if that's applicable.
-            DateTimeOffset? endTime = EndTimeUtc;
-            DateTimeOffset? endTimeOfDayDate = endTimeOfDay?.GetTimeOfDayForDate(endTime);
-            if (endTime < endTimeOfDayDate)
+            if (endTimeOfDay == null)
             {
-                endTime = endTimeOfDayDate;
+                return endTime;
             }
-            return endTime;
+
+            // The daily window closes on the end time's own local day, which comes first whenever
+            // the end time falls after it. Resolved through the trigger's time zone rather than the
+            // end time's offset, which is the offset the window would be read in otherwise.
+            DateTimeOffset endTimeLocal = TimeZoneUtil.ConvertTime(endTime.Value, TimeZone);
+            DateTimeOffset endOfWindow = TimeZoneUtil.ResolveLocal(endTimeOfDay.GetTimeOfDayForDate(endTimeLocal).DateTime, TimeZone);
+
+            return endTime.Value < endOfWindow ? endTime.Value : endOfWindow;
         }
     }
 

--- a/src/Quartz/JobDataMap.cs
+++ b/src/Quartz/JobDataMap.cs
@@ -301,7 +301,11 @@ public class JobDataMap : StringKeyDirtyFlagMap
     public virtual double GetDoubleValueFromString(string key)
     {
         object obj = Get(key);
-        return double.Parse((string) obj, CultureInfo.InvariantCulture);
+
+        // NumberStyles.Float rather than the default: the default admits a thousands separator, and the
+        // invariant culture's is the comma, so "3,14" read as three hundred and fourteen. A decimal comma
+        // is now a FormatException, which is what GetIntValueFromString always said of it.
+        return double.Parse((string) obj, NumberStyles.Float, CultureInfo.InvariantCulture);
     }
 
     /// <summary>
@@ -325,7 +329,10 @@ public class JobDataMap : StringKeyDirtyFlagMap
     public virtual float GetFloatValueFromString(string key)
     {
         object obj = Get(key);
-        return float.Parse((string) obj, CultureInfo.InvariantCulture);
+
+        // See GetDoubleValueFromString: no thousands separator, so a decimal comma is refused rather
+        // than read as a hundredfold.
+        return float.Parse((string) obj, NumberStyles.Float, CultureInfo.InvariantCulture);
     }
 
     /// <summary>

--- a/src/Quartz/SchedulerEnlistmentExtensions.cs
+++ b/src/Quartz/SchedulerEnlistmentExtensions.cs
@@ -164,13 +164,71 @@ public static class SchedulerEnlistmentExtensions
 
         EnsureEnlistmentAccepted(scheduler, connection);
 
-        // Remembered so a later operation can tell that the scope has since ended, instead of
-        // quietly running with no transaction at all.
-        return AmbientConnection.Enlist(
-            scheduler.SchedulerName,
-            connection,
-            transaction,
-            transaction is null ? System.Transactions.Transaction.Current : null);
+        System.Transactions.Transaction? ambient = transaction is null ? System.Transactions.Transaction.Current : null;
+        if (ambient is not null)
+        {
+            JoinAmbientTransaction(scheduler, connection, ambient);
+        }
+
+        // The ambient transaction is remembered so a later operation can tell that the scope has since
+        // ended, instead of quietly running with no transaction at all.
+        return AmbientConnection.Enlist(scheduler.SchedulerName, connection, transaction, ambient);
+    }
+
+    /// <summary>
+    /// Establishes that the connection really does take part in the ambient transaction, rather than
+    /// assuming it does because there is one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A connection opened inside a <see cref="System.Transactions.TransactionScope" /> joins it as it
+    /// opens — unless its driver implements no enlistment at all, in which case nothing happens and
+    /// nothing says so. <c>Microsoft.Data.Sqlite</c> is such a driver: its connection overrides no
+    /// <see cref="DbConnection.EnlistTransaction" />, so a call reaches the base implementation, which
+    /// throws <see cref="NotSupportedException" />. Accepting that connection would have the job store
+    /// write through it with every statement committing on the spot, and a scope that was never
+    /// completed would leave the schedule behind — which looks exactly like a working enlistment right
+    /// up to the first rollback.
+    /// </para>
+    /// <para>
+    /// Asking the connection to join the transaction it is supposed to be in already is what tells the
+    /// two apart, and every driver Quartz ships a delegate for treats that as a no-op: SqlClient and
+    /// Npgsql return early when their enlisted transaction equals this one, MySqlConnector and Firebird
+    /// on the same comparison, and Oracle re-records the transaction and traces "already enlisted" when
+    /// the local identifier matches. A connection that is <em>not</em> yet enlisted — opened before the
+    /// scope, or with enlistment switched off in its connection string — is enlisted by the call, which
+    /// is what the caller was asking for either way.
+    /// </para>
+    /// <para>
+    /// Only <see cref="NotSupportedException" /> is a refusal. Anything else a driver answers means it
+    /// has an enlistment implementation and an opinion about this particular connection — "the
+    /// connection is not open" is the ordinary one, since an enlisted connection is opened by the job
+    /// store rather than here — and having an implementation at all is the whole of what this asks.
+    /// </para>
+    /// </remarks>
+    private static void JoinAmbientTransaction(IScheduler scheduler, DbConnection connection, System.Transactions.Transaction ambient)
+    {
+        try
+        {
+            connection.EnlistTransaction(ambient);
+        }
+        catch (NotSupportedException e)
+        {
+            throw new SchedulerException(
+                $"Scheduler '{scheduler.SchedulerName}' cannot take part in the ambient transaction through a "
+                + $"{connection.GetType().FullName} ({connection.GetType().Assembly.GetName().Name}): the driver implements no "
+                + "DbConnection.EnlistTransaction, so the connection never joined the TransactionScope and every statement the "
+                + "job store issued on it would commit on the spot - a scope that rolled back would leave the schedule behind. "
+                + "Begin a transaction on the connection and enlist that instead: "
+                + "scheduler.EnlistTransaction(connection.BeginTransaction()).",
+                e);
+        }
+        catch (Exception)
+        {
+            // See the remarks: a driver that answers anything but "not supported" has an enlistment of
+            // its own, which is what was being established. Letting its answer out would refuse the
+            // ordinary case, where the connection is still closed because the job store opens it.
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Sixteen fixes from the 4.0 line, ported to `3.x` for 3.20.1. One commit per item, in the audit's order of value; no public signature moves (`PublicApiTest` baselines unchanged), `netstandard2.0` still builds, no `[Serializable]` type gains a field, and every port carries the 4.x test's pin adapted to this branch.

## Per commit

1. **A job listener that throws before it returns loses the firing, not the schedule** — port of 4.x `6442748412` + `629c3436b0` (#3502). The listener call was an argument to the guarded region rather than a statement inside it, so a synchronous throw escaped raw, `JobRunShell` never reached `TriggeredJobComplete`, and a `[DisallowConcurrentExecution]` job's siblings stayed blocked for good; the firing also stayed listed as executing. `ExecutingJobsManager` is no longer an internal listener — the scheduler tells it about both ends of a firing directly — and every abandoned firing announces a finished trigger. Test: `JobListenerFailureTest` (12 cases; 10 fail without the fix). *3.x note:* the port of the wedge test gives the wedged trigger a higher priority, because 3.x's `AdjustSimpleTriggerStartTimeIfInPast` moves both triggers' past start times to "now" and on .NET Framework's clock they can land on the same tick, where the key would otherwise decide the order.
2. **MySQL's misfire sweep reads the index that has the shape it needs** — port of `5f9a56990c` (#3608). Both misfire hints now name `IDX_{1}T_NFT_ST` (`(SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME)` on every 3.x MySQL schema) instead of the misfire index whose second column is compared with `<>`. Measured on 4.x: count 111 ms → 0.7 ms, sweep 66 ms → 0.7 ms. No schema change. *Beyond the brief:* the sweep hint is applied to the unlimited (`-1`) sweep too, which the original #2894 early return had skipped by accident — same reasoning as 4.x. Test: `MySQLDelegateTest`.
3. **An administration node edits the schedule without the job classes** — port of `f3b071c303` (#3705). `SqlSelectJobForTrigger` selects `IS_NONCONCURRENT`/`IS_UPDATE_DATA`, `SelectJobForTrigger` states both flags through an `internal` setter onto the private fields `JobDetailImpl` already had, and `ReplaceTrigger`/`UpdateTriggerDetails` pass `loadJobType: false`. The lazy getters answer `false` rather than throwing for a detail with neither a type nor stated flags. *3.x difference:* a `JobDetailImpl` cannot exist without a `Type` here, so reading a job row still needs the documented placeholder loader; the fixture runs the admin node under both a null-answering loader and the placeholder, and pins what each can do — the trigger edits work under both, and the placeholder's missing attribute no longer decides whether a replacement trigger is stored `WAITING` while the job runs (the hazard the audit named). Tests: `AdministrationNodeSqliteTest` (two fixtures × 7), `SelectJobForTriggerFlagsSqliteTest`; 5 cases fail without the fix, including BLOCKED-vs-WAITING under the placeholder.
4. **A transaction the database rolled back is retried whatever the driver calls it** — port of `5b12c84bca` (#3454). SQLSTATE class 40 (`40002` excepted) is transient, read reflectively from `SqlState` or Firebird's `SQLSTATE` over the exception chain — there is no `DbException.SqlState` on `netstandard2.0`. Tests: 13 new `IsTransient` cases in `JobStoreSupportTest` (7 fail without the fix). **Behavior change worth noting:** Firebird write conflicts and `MySql.Data` 1213 deadlocks are retried where they were treated as permanent.
5. **A store refuses a duration it cannot hold, instead of writing zero** — port of `5c7cd5fb18` (#3673). `AdoJobStoreUtil.RequireStorableDuration` (`internal` here — `AdoJobStoreUtil` is public on 3.x) at the three `REPEAT_INTERVAL` write sites plus the `GetDbTimeSpanValue` backstop; `RAMJobStore` keeps accepting the interval. Test: `SubMillisecondIntervalSqliteTest` (fails without the fix). **Behavior change worth noting:** a sub-millisecond simple-trigger interval is an `ArgumentException` at schedule time where it used to be stored as `0` and wedge the trigger in `ACQUIRED`.
6. **System.Text.Json refuses a job data value it cannot read back** — port of `3e191f503a` (#3495). `JobDataValues.Refuse` runs before the first byte is written, naming entry and type. Accepted: the `JobDataMap` accessor types, enums, `Dictionary<string, string>`, and any type the application added a `JsonConverter` for by overriding `SystemTextJsonObjectSerializer.CreateSerializerOptions` — this branch's shape of 4.x's `AddTypeInfoResolver` escape hatch. Quartz's own converters do not count as a declaration, or a nested `JobDataMap` would slip through. Tests: `JobDataMapPortabilityTest` negative cases + escape hatch; `StdAdoDelegateTest.TestSerializeJobData` updated for the STJ fixture. **Behavior change worth noting:** a `List<string>` or nested map in job data is a `JsonSerializationException` at write time instead of a blob every later read fails on.
7. **A daily time interval trigger stops at its end time** — port of the daily half of `e7e28a69c3` (#3458). `GetFireTimeAfter` bounds every fire time by `EndTimeUtc`; `FinalFireTimeUtc` is the earlier of the end time and the daily window's close on the end time's local day, resolved through the trigger's zone. The `<=`→`<` alignment for `SimpleTrigger`/`CalendarIntervalTrigger` is deliberately left out. Test: `DailyTimeIntervalTriggerEndTimeTest` (4 cases, all fail without the fix). **Behavior change worth noting:** a trigger whose end time fell mid-window fires fewer times than on 3.20.
8. **NativeJob no longer deadlocks a child that writes more than a pipe buffer** — port of the NativeJob half of `b1122ba153` (rc.1 A25). Nothing is redirected unless consumed, the process is disposed, and the wait is asynchronous via an `Exited` subscription taken before the start (no `WaitForExitAsync` on `netstandard2.0`/`net462`), cancelled through the job's token. Test: `NativeJobTest.AProcessThatFillsThePipeStillCompletesWithTheDefaults` (256 KB of output; without the fix it hangs, which I confirmed and killed).
9. **A connection that cannot join the ambient transaction is refused** — port of `1e6af15e1e` (#3666). `EnlistConnection` inside a `TransactionScope` asks the connection to enlist; only `NotSupportedException` is a refusal, wrapped as a `SchedulerException` naming the driver and `EnlistTransaction(connection.BeginTransaction())`. Tests: 5 new cases in `AmbientConnectionTest`, `EnlistmentRefusalSqliteTest` against the real driver.
10. **A trigger due at the threshold instant is late on every store** — port of `f89783a86a` (#3462), **whole**. The ADO sweep/count predicates moved `<`→`<=` and acquisition `>=`→`>`. *On the RAM side there was nothing to port:* `RAMJobStore.ApplyMisfire` (`RAMJobStore.cs:1670`, `tnft.Value > misfireTime` → not misfired) and `JobStoreSupport.UpdateMisfiredTrigger` (`:1517`) already applied the at-or-before rule; the commit pins them as they stand. Tests: `StdAdoConstantsTest` (complement pin), `RAMJobStoreMisfireThresholdTest` (frozen clock, one tick either side). **Behavior change worth noting:** a trigger due exactly at `now - MisfireThreshold` goes to the misfire handler where the sweep used to leave it to acquisition.
11. **A job-data number written with a decimal comma is unreadable, not a hundredfold of itself** — port of `0a67c0e6f2`. `NumberStyles.Float` for the floating-point string accessors. Test: `JobDataMapTest`. **Behavior change worth noting:** `"3,14"` is a `FormatException` from `GetDoubleValueFromString`/`GetFloatValueFromString` where it read as 314.
12. **A group matcher containing a bracket matches literally on SQL Server** — port of `f43772ecae` (rc.1 G5-11). `internal virtual AdditionalLikeWildcards` on `StdAdoDelegate`, `"["` on `SqlServerDelegate`; the `protected static` one-argument helper keeps its signature. Test: `SqlLikeEscapingTest`.
13. **DirectoryScanJob stores its previous scan as something a job store can write** — port of the DirectoryScanJob half of `b1122ba153` (rc.1 A24): a `Dictionary<string, string>` of path → last-write ticks, legacy `List<FileInfo>` still read; the 4.x listener-resolution rewrite is deliberately not ported. **Found on the way, fixed in the same commit:** on 3.x `JobDataMap.GetString` throws `KeyNotFoundException` for a missing key, and `DirectoryScanJobModel` read the optional `DIRECTORY_PROVIDER_NAME` with it (as `DefaultDirectoryProvider` did `DIRECTORY_NAME`/`DIRECTORY_NAMES`, one of which is always absent) — so every firing threw before scanning anything, and the existing tests did not notice because they only asserted that `TriggerJob` did not throw. The optional keys are `TryGetString` now. Test: `DirectoryScanJobTest.TheScannedFileListIsStoredAsSomethingAJobStoreCanWrite`, which asserts the firing succeeded before looking at what was stored.
14. **The scheduler-state select binds its parameters in the order its statement names them** — port of `7878e95f82`. Test: `StdAdoDelegateSchedulerStateTest` with a recording command double.
15. **TestGetTimeBefore searches from fixed instants, not from the clock** — port of `31855e5074`. Test only; the half-minute the old table got wrong is pinned by its own test.
16. **A payload System.Text.Json rejects on its first token fails as Quartz's exception** — port of the STJ half of `749ee7bddb` (#3260). The Newtonsoft half does not apply on 3.x. Test: `SystemTextJsonDeserializationFailureTest` (the first-token case fails without the fix).

Plus one hygiene commit: **The SQLite fixtures tear down one at a time** — the integration project runs fixtures in parallel and every SQLite fixture empties the global connection pool on teardown; three of the new fixtures needed the `[NonParallelizable]` that `SchemaValidationTest` already carries, or the whole `db-sqlite` category failed differently on each run.

## Not in this PR (the audit's second tier, 3.21 material)

`RAMJobStore` notifying listeners under its monitor (#3472), `RedisSemaphore` multiplexer disposal (#3639, needs a public interface implementation), timer-ceiling validation (#3577), and the `ResumeAll` triggerless-paused-group row (`f76b04a468`).

## Left for a follow-up

Nothing was dropped; all sixteen items are in.

## For the reviewer to decide

- Item 2 also hints the unlimited misfire sweep (the `-1` case), which 3.x had skipped by accident of the #2894 early return; 4.x does the same. Revert that hunk if you want the port to be hint-target-only.
- Item 13's `GetString`→`TryGetString` fix means `DirectoryScanJob` works on 3.x at all; it is a separate defect from the port and could be its own release-notes line.
- Item 1 removes `ExecutingJobsManager` from `QuartzScheduler.InternalJobListeners` (the public list no longer shows it). No code in the repository reads that list; a user enumerating it would see one fewer entry.

## Verification (actual output)

```
dotnet build Quartz.slnx                      0 Warning(s), 0 Error(s)
Quartz.Tests.Unit  net10.0                    Passed! Failed: 0, Passed: 1979, Skipped: 4, Total: 1983
Quartz.Tests.Unit  net472                     Passed! Failed: 0, Passed: 1968, Skipped: 5, Total: 1973
Quartz.Tests.Integration db-sqlite net10.0    Passed! Failed: 0, Passed: 48, Total: 48   (twice)
Quartz.Tests.Integration db-sqlite net472     Passed! Failed: 0, Passed: 47, Total: 47
PublicApiTest                                 rides in the unit suite; no *.received.txt emitted, Verify/ unchanged
```

Each new fixture was run three times per framework. The Docker-backed integration legs (postgres, sqlserver, mysql, oracle, firebird, redis) were not run locally; CI runs them. One `AdministrationNodeSqliteTest` net472 run hung at process exit early on, while another repository's test run was hammering the box; six subsequent runs (three with `--blame-hang`) were clean and I could not reproduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
