### PR TITLE
An untagged preview of 3.x sorts above the release it follows

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
-    <VersionPrefix>3.20.0</VersionPrefix>
+    <VersionPrefix>3.21.0</VersionPrefix>
 
     <CLSCompliant>True</CLSCompliant>
     <ComVisible>False</ComVisible>


### PR DESCRIPTION
Every build of `3.x` pushes a preview package to the Feedz feed, and its version comes from `VersionPrefix`. It named `3.20.0` — the version that had already shipped — so a preview built after 3.20.0 sorted at or below it. The prefix names the *next* release, which is the convention `main` follows (it moved to `4.1.0` the day 4.0.0 shipped).

3.20.1 is now released, so the prefix names 3.21.0. Housekeeping only; nothing else changes, and the released version continues to come from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MohXmpUwnvd151ykF5uBwm
