### PR TITLE
Fix body margin

### DIFF
--- a/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
+++ b/src/Quartz.Dashboard/wwwroot/css/quartz-dashboard.css
@@ -131,6 +131,10 @@
     }
 }
 
+body{
+    margin:0;
+}
+
 /* Explicit theme override */
 .qz-dashboard[data-theme="light"] {
     --qz-color-primary: #2563eb;


### PR DESCRIPTION
## Summary

Added body { margin: 0 } to the dashboard css file.

## Details

The dashboard renders inside its own Blazor document and doesn't reset the host document's <body>, so the browser's user-agent default margin (8px) leaks through. This produces an unappealing gap around the edges of every dashboard page.

<img width="1910" height="1202" alt="image" src="https://github.com/user-attachments/assets/26b6d386-f6a8-41ae-b097-2867269ea4f0" />
