### PR TITLE
An F# project can follow the migration guide

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -219,7 +219,7 @@ jobs:
             /d:sonar.cs.opencover.reportsPaths="artifacts/coverage/**/coverage.opencover.xml" \
             /d:sonar.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**,src/Quartz/Impl/AdoJobStore/Schema/**,src/Quartz.Examples.AspNetCore/wwwroot/lib/**" \
             /d:sonar.cpd.exclusions="src/Quartz.Tests.Integration/SchemaBaselines/**,src/Quartz/Impl/AdoJobStore/Schema/**,database/**,docs/.vuepress/configs/**" \
-            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Trimming.Canary/**,src/Quartz.Tests.Integration.Seeder/**,src/Quartz.Examples.Aspire.AppHost/**,src/Quartz.Examples.Aspire.Worker/**,src/Quartz.Examples.Wolverine/**,src/Quartz.Examples/**,src/Quartz.Examples.AspNetCore/**,src/Quartz.Examples.HttpClient/**,src/Quartz.Examples.Worker/**,database/**" \
+            /d:sonar.coverage.exclusions="docs/.vuepress/**,src/Quartz.Trimming.Canary/**,src/Quartz.Tests.Integration.Seeder/**,src/Quartz.Examples.Aspire.AppHost/**,src/Quartz.Examples.Aspire.Worker/**,src/Quartz.Examples.FSharp/**,src/Quartz.Examples.Wolverine/**,src/Quartz.Examples/**,src/Quartz.Examples.AspNetCore/**,src/Quartz.Examples.HttpClient/**,src/Quartz.Examples.Worker/**,database/**" \
             /d:sonar.issue.ignore.multicriteria="generatedOracleGuards,generatedOracleGuardExceptions,repeatedObjectNames,wholeTableByDesign" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.ruleKey="plsql:S1523" \
             /d:sonar.issue.ignore.multicriteria.generatedOracleGuards.resourceKey="database/**/*.sql" \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,13 @@ A few things worth knowing:
 * Some blocks are deliberately left as plain fences: those calling a package this repository does not
   reference, and the `BinaryFormatter` migration sample, which would drag in an unsupported
   compatibility package. Adding a NuGet dependency purely to compile a sample is not worth it.
+* A plain fence that a compiled example *does* back says where it came from. Two pages are in that
+  position: the Wolverine how-to, because the samples project may not reference `WolverineFx`, and
+  the migration guide's "Upgrading an F# project", because the samples project is C# and cannot hold
+  a line of F#. Each fence on them is preceded by an HTML comment reading
+  `Copied from <path>:<line>`, naming `src/Quartz.Examples.Wolverine` or `src/Quartz.Examples.FSharp`,
+  and `WolverineHowToTest` and `FSharpHowToTest` compare the fence with those lines of that file. Add
+  a fence to either page the same way, or the test fails it for being unattributed.
 
 `dotnet fallout VerifyDocsSnippets` is what CI runs. It fails when a page names a snippet that does not
 exist, when a marker was left empty, and when the committed markdown no longer matches the samples.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,6 +28,13 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FakeItEasy" Version="9.0.1" />
     <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.4" />
+    <!--
+      Named here because central package management is on: the F# SDK disables its own implicit
+      FSharp.Core reference when it sees ManagePackageVersionsCentrally, so a project that does not
+      ask for the package builds and then fails at startup with a missing FSharp.Core. Only
+      Quartz.Examples.FSharp references it. Keep it on the version the pinned SDK carries.
+    -->
+    <PackageVersion Include="FSharp.Core" Version="10.1.400" />
     <PackageVersion Include="MELT" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/Quartz.Examples.Aspire.AppHost/Quartz.Examples.Aspire.AppHost.csproj" />
     <Project Path="src/Quartz.Examples.Aspire.Worker/Quartz.Examples.Aspire.Worker.csproj" />
     <Project Path="src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj" />
+    <Project Path="src/Quartz.Examples.FSharp/Quartz.Examples.FSharp.fsproj" />
     <Project Path="src/Quartz.Examples.HttpClient/Quartz.Examples.HttpClient.csproj" />
     <Project Path="src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj" />
     <Project Path="src/Quartz.Examples.Worker/Quartz.Examples.Worker.csproj" />

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -521,6 +521,14 @@ partial class Build : FalloutBuild, ICompile, IPack
     /// run; it walks the catalogue every entry is registered in and exits.
     /// </para>
     /// <para>
+    /// The fourth is <c>Quartz.Examples.FSharp</c>, which needs no marker to wait for because it ends by
+    /// itself: it fires one job on a scheduler built by <c>QuartzSchedulerBuilder</c> and one on a
+    /// scheduler built by a host, and returns non-zero if either firing did not arrive inside its own
+    /// thirty-second bound. It is the compiled half of the migration guide's "Upgrading an F# project",
+    /// and <c>Compile</c> already fails when a call that section teaches stops compiling — what running
+    /// it adds is that the two schedulers an F# caller builds still start, fire and shut down.
+    /// </para>
+    /// <para>
     /// Beside <see cref="BenchmarkSmoke" /> and <see cref="WolverineSmoke" />, after the unit tests, for
     /// the reason those give: all of them want the machine, and a failing test is the one worth reading
     /// first.
@@ -539,6 +547,11 @@ partial class Build : FalloutBuild, ICompile, IPack
                 .SetProjectFile(solution.AllProjects.First(x => x.Name == "Quartz.Examples"))
                 .SetConfiguration(configuration)
                 .SetApplicationArguments("--list")
+            );
+
+            DotNetRun(s => s
+                .SetProjectFile(solution.AllProjects.First(x => x.Name == "Quartz.Examples.FSharp"))
+                .SetConfiguration(configuration)
             );
 
             RunExampleUntilItSays(

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -3543,8 +3543,8 @@ let scheduleOne (scheduler: IScheduler) (job: IJobDetail) (trigger: ITrigger) : 
 ```
 
 Nothing about this is particular to `ScheduleJob`. Every asynchronous member on `IScheduler` ends with
-two optional parameters, so any of them that is overloaded resolves the same way, and any inferred value
-handed to one wants the same annotation.
+at least one optional parameter, so any of the overloaded ones resolves the same way, and any inferred
+value handed to one wants the same annotation.
 
 ### `FS0041` — `Async.AwaitTask` has no `ValueTask` overload
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -24,7 +24,8 @@ is the reading order: six passes over the API, each with a theme, with the rest 
 by topic underneath. The compiler finds most of the work for you; the passes are for knowing why a name
 moved and what to reach for instead. Start with [Package Changes](#package-changes) — the first error
 a mixed 3.x/4.x project produces is a package problem rather than a code one, and it is described
-there.
+there. If that application is F#, read [Upgrading an F# project](#upgrading-an-f-project) first: the
+upgrade is the same one, but F# reports it as a longer list of errors than it has causes.
 
 **Is it neither, because you are starting something new?** None of this applies. Go to the
 [quick start](quick-start.md) and then [the tutorial](tutorial/).
@@ -3441,6 +3442,212 @@ If you need `Task` semantics (e.g., to await multiple times), call `.AsTask()` o
 :::
 
 For more information on `ValueTask` please see [Microsoft docs](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask-1).
+
+## Upgrading an F# project
+
+Every 4.0 signature is reachable from F#, and F# honours a C# optional parameter at a call site, so
+`scheduler.Start()` and `scheduler.ScheduleJob(job, trigger)` are written the way this guide writes
+them. Four things still go differently, and the first build of an upgraded F# project reports many more
+errors than it has causes: F# infers the types of function parameters, so one signature it cannot match
+leaves everything downstream of it untyped, and each of those becomes an error of its own.
+[ForNeVeR/nightwatch#68](https://github.com/ForNeVeR/nightwatch/pull/68) — the upgrade this section was
+written from — reported thirteen errors for four causes. Fix them from the top of the file down, and
+rebuild after each one.
+
+::: tip A working copy of all of this
+[`src/Quartz.Examples.FSharp`](https://github.com/quartznet/quartznet/tree/main/src/Quartz.Examples.FSharp)
+is this section as one console application: a job, a scheduler built by `QuartzSchedulerBuilder`, the
+same scheduler built by a host, and one firing of each on the in-memory store. It is in the solution, so
+a call below that stops compiling fails the build, every `fsharp` block below is compared against it line
+for line, and the `ExamplesSmoke` target runs it on every pull request.
+:::
+
+### `FS0856` — a job is implemented with both parameters
+
+```text
+error FS0856: This override takes a different number of arguments to the corresponding abstract member. The following abstract members were found:
+   IJob.Execute(context: IJobExecutionContext, ?cancellationToken: System.Threading.CancellationToken) : ValueTask
+```
+
+`?cancellationToken` is how F# displays a C# optional parameter. It means what it says at a call site
+and nothing at all at an implementation, where the whole signature has to be written out. C# is no
+different — `Execute` gaining the token is a break for both languages, and
+[Jobs take a CancellationToken](#jobs-take-a-cancellationtoken) is why the parameter is there. What is
+F#-specific is the shape of the diagnostic: it reports the arity and not the parameter, and the reading
+of `?cancellationToken` it invites — declaring the parameter optional in F#'s own sense, with a leading
+`?` — trades FS0856 for `FS0001: This expression was expected to have type 'CancellationToken' but here
+has type 'CancellationToken option'`, because that syntax means an `option` rather than a defaulted
+argument.
+
+Write both parameters, and annotate them. Until the override matches there is nothing for F# to infer
+`context` from, which is where the `FS0072` and `FS0008` errors further down the file come from; they
+go away with this one.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/GreetJob.fs:27 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+member _.Execute(context: IJobExecutionContext, cancellationToken: CancellationToken) : ValueTask =
+    ValueTask(
+        task {
+            do! Task.Delay(TimeSpan.FromMilliseconds 1.0, cancellationToken)
+            printfn "GreetJob fired at %O" context.FireTimeUtc
+            Firings.record ()
+        }
+    )
+```
+
+FSharp.Core has no `valueTask { }` builder, so a `task { }` handed to `ValueTask`'s constructor is the
+idiom. A 3.x job written as `upcast task { … }` cannot be repaired by leaving the `upcast` in place:
+`ValueTask` is a struct and no supertype of `Task`, and what that produces is
+`FS0013: The static coercion from type Task<unit> to 'a ... involves an indeterminate type`.
+
+### `FS0041` — `ScheduleJob` has to know what it is being handed
+
+```text
+error FS0041: A unique overload for method 'ScheduleJob' could not be determined based on type information prior to this program point. A type annotation may be needed.
+
+Known types of arguments: IJobDetail * 'a
+
+Candidates:
+ - (extension) SchedulerJobExtensions.ScheduleJob<'TJob,'TInput when 'TJob :> IJob<'TInput>>(input: 'TInput, at: System.DateTimeOffset, ?options: OneOffJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<ScheduledOneOffJob>
+ - (extension) SchedulerJobExtensions.ScheduleJob<'TJob,'TInput when 'TJob :> IJob<'TInput>>(input: 'TInput, delay: System.TimeSpan, ?options: OneOffJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<ScheduledOneOffJob>
+ - IScheduler.ScheduleJob(jobDetail: IJobDetail, trigger: ITrigger, ?options: ScheduleJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<System.DateTimeOffset>
+ - IScheduler.ScheduleJob(jobDetail: IJobDetail, triggersForJob: System.Collections.Generic.IReadOnlyCollection<ITrigger>, ?options: ScheduleJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask
+```
+
+The `'a` in *Known types of arguments* is the whole of it: the trigger arrived as an inferred function
+parameter, so at that point F# does not yet know what it is, and it will not pick an overload it cannot
+distinguish. C# never reaches this position, because a C# parameter has a declared type — which is why
+this is an F#-only error rather than an ambiguity in the API.
+
+4.0 widened the candidate set in two ways, both deliberate and both harmless in C#: `options` gained a
+default so that `ScheduleJob(job, trigger)` keeps compiling
+([the surviving overloads](#the-builder-surface-says-each-thing-once)), which makes every candidate a
+match for two arguments; and `SchedulerJobExtensions` adds the two typed-input overloads
+([a typed job can be scheduled in one call](#a-typed-job-can-be-scheduled-in-one-call)), which F#
+considers beside the interface's own.
+
+Annotate the value — as a parameter here, but a `let` binding or the call itself does just as well:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/Standalone.fs:39 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+let scheduleOne (scheduler: IScheduler) (job: IJobDetail) (trigger: ITrigger) : Task<DateTimeOffset> =
+    task {
+        return! scheduler.ScheduleJob(job, trigger)
+    }
+```
+
+Nothing about this is particular to `ScheduleJob`. Every asynchronous member on `IScheduler` ends with
+two optional parameters, so any of them that is overloaded resolves the same way, and any inferred value
+handed to one wants the same annotation.
+
+### `FS0041` — `Async.AwaitTask` has no `ValueTask` overload
+
+```text
+error FS0041: No overloads match for method 'AwaitTask'.
+
+Known type of argument: ValueTask
+
+Available overloads:
+ - static member Async.AwaitTask: task: Task -> Async<unit> // Argument 'task' doesn't match
+ - static member Async.AwaitTask: task: Task<'T> -> Async<'T> // Argument 'task' doesn't match
+```
+
+`Task` became `ValueTask` on nearly every member, so every `Async.AwaitTask(scheduler.…)` in a 3.x F#
+project reports this at once. Which answer you want depends on the computation expression you are in.
+
+Inside `task { }` there is nothing to convert: the builder binds anything awaitable, `ValueTask`
+included.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/Standalone.fs:45 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+let start (scheduler: IScheduler) : Task<unit> =
+    task {
+        do! scheduler.Start()
+    }
+```
+
+Inside `async { }`, ask the `ValueTask` for a `Task` and await that. `AsTask` may be called once and
+only once, which the warning above says and which an `async` block makes easy to honour: bind the result
+rather than the call.
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/Standalone.fs:52 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+let stop (scheduler: IScheduler) : Async<unit> =
+    async {
+        do! scheduler.Shutdown(waitForJobsToComplete = true).AsTask() |> Async.AwaitTask
+    }
+```
+
+`task { }` is the one to reach for in new code: `AsTask()` allocates the object the `ValueTask` existed
+to avoid, once per call. An existing `Async`-based codebase does not have to be converted to get that —
+`Async.StartAsTask` goes the other way, so an `Async<unit>` such as `stop` is reached from inside a
+`task { }` with `do! Async.StartAsTask(stop scheduler)`.
+
+### `FS0039` — `StdSchedulerFactory` is gone, and its replacement is not constructed
+
+```text
+error FS0039: The value or constructor 'StdSchedulerFactory' is not defined. Maybe you want one of the following:
+   StandaloneSchedulerFactory
+   ISchedulerFactory
+```
+
+`StandaloneSchedulerFactory` is the type you end up holding, so the suggestion points at the right
+name — but it is not a drop-in for `StdSchedulerFactory()`, because its constructor is internal: the
+factory owns a service provider, and something has to have built one. Taking the suggestion literally
+trades FS0039 for `FS0801: This type has no accessible object constructors`.
+[`StdSchedulerFactory` is gone](#stdschedulerfactory-is-gone) is the C# form of this, and
+`QuartzSchedulerBuilder` is what builds the factory:
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/Standalone.fs:10 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+let buildFactory () : StandaloneSchedulerFactory =
+    QuartzSchedulerBuilder
+        .Create(fun q ->
+            q
+                .ConfigureScheduler(fun options -> options.InstanceName <- "fsharp-example")
+                .UseInMemoryStore()
+            |> ignore)
+        .Build()
+```
+
+An F# lambda becomes the `Action<IQuartzBuilder>` the overload asks for with no ceremony, and each
+fluent call is piped into `ignore` because F# discards nothing for you. F# has no `await using`, so the
+factory — which owns that provider — is disposed where you are done with it, `do! factory.DisposeAsync()`
+inside a `task { }`.
+
+An application that already has a container uses the same callback through `AddQuartz`, exactly as C#
+does ([the standalone builder is the same builder](#the-standalone-builder-is-the-same-builder)):
+
+<!-- Not a compiled sample: `Quartz.Documentation.Samples` is a C# project.
+     Copied from src/Quartz.Examples.FSharp/Hosting.fs:21 — FSharpHowToTest fails when the two stop
+     matching. -->
+
+```fsharp
+builder.Services
+    .AddQuartz(fun q ->
+        q
+            .UseInMemoryStore()
+            .ScheduleJob<GreetJob>(fun trigger ->
+                trigger.WithIdentity("greet-hosted", "fsharp").StartNow() |> ignore)
+        |> ignore)
+    .AddQuartzHostedService(fun options -> options.WaitForJobsToComplete <- true)
+|> ignore
+```
 
 ## SystemTime Replaced with TimeProvider
 

--- a/src/Quartz.Examples.FSharp/GreetJob.fs
+++ b/src/Quartz.Examples.FSharp/GreetJob.fs
@@ -1,0 +1,34 @@
+namespace Quartz.Examples.FSharp
+
+open System
+open System.Threading
+open System.Threading.Tasks
+
+open Quartz
+
+/// Every firing of GreetJob, counted, so the program can wait for one and then shut down.
+module Firings =
+
+    let private signal = new SemaphoreSlim(0)
+
+    /// Recorded by the job on each run.
+    let record () = signal.Release() |> ignore
+
+    /// Waits for one firing. False means none arrived inside the timeout.
+    let waitForOne (timeout: TimeSpan) : Task<bool> = signal.WaitAsync timeout
+
+/// A job, written the way F# has to write it. C# may leave the trailing cancellation token off an
+/// implementation because it has a default; F# counts a C# optional parameter as part of the arity of
+/// the member being implemented, so both parameters are spelled out or the override does not match.
+type GreetJob() =
+
+    interface IJob with
+
+        member _.Execute(context: IJobExecutionContext, cancellationToken: CancellationToken) : ValueTask =
+            ValueTask(
+                task {
+                    do! Task.Delay(TimeSpan.FromMilliseconds 1.0, cancellationToken)
+                    printfn "GreetJob fired at %O" context.FireTimeUtc
+                    Firings.record ()
+                }
+            )

--- a/src/Quartz.Examples.FSharp/Hosting.fs
+++ b/src/Quartz.Examples.FSharp/Hosting.fs
@@ -1,0 +1,38 @@
+module Quartz.Examples.FSharp.Hosting
+
+open System
+open System.Threading.Tasks
+
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
+
+open Quartz
+
+/// The same scheduler with a container behind it: AddQuartz registers its object graph and
+/// AddQuartzHostedService starts and stops it with the host. Each F# lambda becomes the Action<'T>
+/// the C# overload asks for, and each fluent call is piped into ignore because F# does not discard a
+/// return value for you.
+let runGreeting () : Task<bool> =
+    task {
+        let builder = Host.CreateApplicationBuilder()
+        builder.Logging.SetMinimumLevel LogLevel.Warning |> ignore
+
+        builder.Services
+            .AddQuartz(fun q ->
+                q
+                    .UseInMemoryStore()
+                    .ScheduleJob<GreetJob>(fun trigger ->
+                        trigger.WithIdentity("greet-hosted", "fsharp").StartNow() |> ignore)
+                |> ignore)
+            .AddQuartzHostedService(fun options -> options.WaitForJobsToComplete <- true)
+        |> ignore
+
+        use host = builder.Build()
+        do! host.StartAsync()
+
+        let! fired = Firings.waitForOne (TimeSpan.FromSeconds 30.0)
+
+        do! host.StopAsync()
+        return fired
+    }

--- a/src/Quartz.Examples.FSharp/Program.fs
+++ b/src/Quartz.Examples.FSharp/Program.fs
@@ -1,0 +1,20 @@
+module Quartz.Examples.FSharp.Program
+
+open System.Threading.Tasks
+
+/// Runs both schedulers and waits for each to fire the job once.
+let private run () : Task<bool> =
+    task {
+        let! standalone = Standalone.runGreeting ()
+        let! hosted = Hosting.runGreeting ()
+        return standalone && hosted
+    }
+
+[<EntryPoint>]
+let main _ =
+    if run().GetAwaiter().GetResult() then
+        printfn "Both schedulers fired the job."
+        0
+    else
+        eprintfn "A scheduler did not fire the job inside the timeout."
+        1

--- a/src/Quartz.Examples.FSharp/Quartz.Examples.FSharp.fsproj
+++ b/src/Quartz.Examples.FSharp/Quartz.Examples.FSharp.fsproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Quartz.NET from F#, as one runnable console application.
+
+    An F# project upgrading from 3.x hits four compiler errors no C# project sees, because F# reads a
+    C# optional parameter as part of a member's arity and resolves overloads differently
+    (ForNeVeR/nightwatch#68). The section "Upgrading an F# project" in
+    docs/documentation/quartz-4.x/migration-guide.md is written against this project, and
+    FSharpHowToTest compares every fsharp fence on that page with the file and line it says it came
+    from. It is in Quartz.slnx so that `Compile` fails the moment one of those calls stops compiling,
+    which is the only reason an example project exists.
+
+    Nothing external is needed: the in-memory store, one job, one firing, twice over — once from
+    QuartzSchedulerBuilder and once from a host. Running this project exits 0 when both fired, and
+    the ExamplesSmoke target runs exactly that.
+  -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <!--
+    Compilation order is significant in F#: a file may only use what the files above it declare.
+  -->
+  <ItemGroup>
+    <Compile Include="GreetJob.fs" />
+    <Compile Include="Standalone.fs" />
+    <Compile Include="Hosting.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      Named rather than implicit. The F# SDK adds FSharp.Core itself, but only when central package
+      management is off; with it on it sets DisableImplicitFSharpCoreReference and leaves the
+      reference to the project, which otherwise compiles and then fails at startup with
+      "Could not load file or assembly 'FSharp.Core'".
+    -->
+    <PackageReference Include="FSharp.Core" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Examples.FSharp/Standalone.fs
+++ b/src/Quartz.Examples.FSharp/Standalone.fs
@@ -1,0 +1,74 @@
+module Quartz.Examples.FSharp.Standalone
+
+open System
+open System.Threading.Tasks
+
+open Quartz
+
+/// A scheduler with no application container: QuartzSchedulerBuilder creates one, and the factory it
+/// hands back owns it. This is what a 3.x StdSchedulerFactory() becomes.
+let buildFactory () : StandaloneSchedulerFactory =
+    QuartzSchedulerBuilder
+        .Create(fun q ->
+            q
+                .ConfigureScheduler(fun options -> options.InstanceName <- "fsharp-example")
+                .UseInMemoryStore()
+            |> ignore)
+        .Build()
+
+/// The job and the trigger that fires it once, straight away.
+let describeGreeting () : IJobDetail * ITrigger =
+    let job =
+        JobBuilder
+            .Create<GreetJob>()
+            .WithIdentity("greet", "fsharp")
+            .Build()
+
+    let trigger =
+        TriggerBuilder
+            .Create()
+            .WithIdentity("greet-now", "fsharp")
+            .StartNow()
+            .Build()
+
+    job, trigger
+
+/// ScheduleJob is an overload set F# will not resolve from an unannotated argument, because every
+/// candidate's trailing parameters are optional and so every candidate matches two arguments.
+/// Annotating the trigger is the whole fix.
+let scheduleOne (scheduler: IScheduler) (job: IJobDetail) (trigger: ITrigger) : Task<DateTimeOffset> =
+    task {
+        return! scheduler.ScheduleJob(job, trigger)
+    }
+
+/// A ValueTask inside task { }: awaited like any other awaitable, with nothing to convert.
+let start (scheduler: IScheduler) : Task<unit> =
+    task {
+        do! scheduler.Start()
+    }
+
+/// The same ValueTask from async { }: Async.AwaitTask has no ValueTask overload, so ask the ValueTask
+/// for a Task first — once, which is all a ValueTask allows.
+let stop (scheduler: IScheduler) : Async<unit> =
+    async {
+        do! scheduler.Shutdown(waitForJobsToComplete = true).AsTask() |> Async.AwaitTask
+    }
+
+/// Everything above in order: build, schedule, start, wait for one firing, shut down. F# has no
+/// `await using`, so the factory that owns the container is disposed by hand.
+let runGreeting () : Task<bool> =
+    task {
+        let factory = buildFactory ()
+        let! scheduler = factory.GetScheduler()
+
+        let job, trigger = describeGreeting ()
+        let! firstFireTime = scheduleOne scheduler job trigger
+        printfn "greet is scheduled for %O" firstFireTime
+
+        do! start scheduler
+        let! fired = Firings.waitForOne (TimeSpan.FromSeconds 30.0)
+        do! Async.StartAsTask(stop scheduler)
+        do! factory.DisposeAsync()
+
+        return fired
+    }

--- a/src/Quartz.Tests.Unit/AttributedSamples.cs
+++ b/src/Quartz.Tests.Unit/AttributedSamples.cs
@@ -1,0 +1,148 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The check behind <see cref="WolverineHowToTest" /> and <see cref="FSharpHowToTest" />: a page whose
+/// fenced samples are hand-written, held to the example project each one says it was copied from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every other page's samples are generated: they live as <c>#region sample_*</c> blocks in
+/// <c>Quartz.Documentation.Samples</c> and <c>VerifyDocsSnippets</c> fails a page that has drifted from
+/// them. Two pages cannot use that machinery — <c>DocsSnippets</c> reads that one project, and it may
+/// neither take a <c>WolverineFx</c> dependency for the sake of a sample nor hold a line of F#, it being
+/// a C# project. This is what <c>VerifyDocsSnippets</c> would otherwise have been for them: each fence
+/// names the example file and line it was copied from, and the two are compared verbatim.
+/// </para>
+/// <para>
+/// It is deliberately not the anti-pattern <see cref="Configuration.DocumentedConfigurationTest" />'s
+/// remarks describe — that was a test holding its own transcription of a page, so that the page and the
+/// test were two copies with nothing comparing them. Here the compiled example is the only copy, and
+/// the page is checked against it.
+/// </para>
+/// </remarks>
+internal static class AttributedSamples
+{
+    /// <summary>
+    /// The provenance comment and the fence it introduces — <c>Copied from &lt;path&gt;:&lt;line&gt;</c>
+    /// anywhere inside an HTML comment, then a fence in the page's sample language.
+    /// </summary>
+    private static Regex AttributedFence(string exampleDirectory, string language) => new(
+        $@"<!--(?:(?!-->).)*?Copied from (?<path>{Regex.Escape(exampleDirectory)}/[^\s:]+):(?<line>\d+)(?:(?!-->).)*?-->\s*\r?\n```{Regex.Escape(language)}\r?\n(?<code>.*?)\r?\n```",
+        RegexOptions.Singleline,
+        TimeSpan.FromSeconds(10));
+
+    /// <summary>
+    /// Every fenced block on the page in that language, attributed or not.
+    /// </summary>
+    private static Regex AnyFence(string language) => new(
+        $@"^```{Regex.Escape(language)}\r?$",
+        RegexOptions.Multiline,
+        TimeSpan.FromSeconds(10));
+
+    /// <summary>
+    /// Asserts that each attributed fence on the page is, line for line, what the example file holds at
+    /// the line the page names.
+    /// </summary>
+    /// <param name="pagePath">The page, relative to the repository root, with forward slashes.</param>
+    /// <param name="exampleDirectory">The example project the page quotes, in the same form.</param>
+    /// <param name="language">The fence's language tag, which is the example project's language.</param>
+    /// <param name="leastExpectedFences">
+    /// How many fences the page is expected to carry, so that deleting them all cannot make the check
+    /// pass by having nothing left to compare.
+    /// </param>
+    public static void EachFenceAppearsVerbatimInTheExample(
+        string pagePath,
+        string exampleDirectory,
+        string language,
+        int leastExpectedFences)
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+        string page = ReadPage(root, pagePath);
+
+        MatchCollection matches = AttributedFence(exampleDirectory, language).Matches(page);
+        matches.Count.Should().BeGreaterThanOrEqualTo(leastExpectedFences,
+            $"{pagePath} teaches {exampleDirectory}, and a page that has stopped quoting it is a page nobody is checking");
+
+        foreach (Match match in matches)
+        {
+            string relative = match.Groups["path"].Value;
+            int firstLine = int.Parse(match.Groups["line"].Value, CultureInfo.InvariantCulture);
+
+            FileInfo source = new(Path.Combine(root.FullName, relative.Replace('/', Path.DirectorySeparatorChar)));
+            source.Exists.Should().BeTrue($"{pagePath} says it copied a sample from {relative}");
+
+            string[] sourceLines = File.ReadAllLines(source.FullName);
+            string[] pageLines = Dedent(match.Groups["code"].Value.Replace("\r\n", "\n").Split('\n'));
+
+            (firstLine + pageLines.Length - 1).Should().BeLessThanOrEqualTo(sourceLines.Length,
+                $"{relative} is shorter than the block {pagePath} says starts at line {firstLine}");
+
+            string[] candidate = Dedent(sourceLines.Skip(firstLine - 1).Take(pageLines.Length).ToArray());
+
+            for (int i = 0; i < pageLines.Length; i++)
+            {
+                candidate[i].Should().Be(pageLines[i],
+                    $"{pagePath} quotes {relative}:{firstLine + i}. Copy the block again from the example, and correct the line number in the page's provenance comment if it moved: {Locate(sourceLines, pageLines)}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asserts that the page carries no fence in that language without a provenance comment, since an
+    /// unattributed one is a sample nothing compares against anything.
+    /// </summary>
+    public static void EachFenceSaysWhereItCameFrom(string pagePath, string exampleDirectory, string language)
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+        string page = ReadPage(root, pagePath);
+
+        AnyFence(language).Matches(page).Count.Should().Be(AttributedFence(exampleDirectory, language).Matches(page).Count,
+            $"every {language} fence on {pagePath} is hand-written, so each one needs the comment naming the {exampleDirectory} file and line it was copied from — otherwise nothing keeps it honest");
+    }
+
+    private static string ReadPage(DirectoryInfo root, string pagePath)
+    {
+        FileInfo file = new(Path.Combine(root.FullName, pagePath.Replace('/', Path.DirectorySeparatorChar)));
+        file.Exists.Should().BeTrue($"{pagePath} is the page this test exists for");
+
+        return File.ReadAllText(file.FullName);
+    }
+
+    /// <summary>
+    /// Removes the indentation the block carries as a whole, so a method body reads on the page the way
+    /// a generated snippet would.
+    /// </summary>
+    private static string[] Dedent(string[] lines)
+    {
+        string[] trimmed = lines.Select(x => x.TrimEnd()).ToArray();
+
+        int indent = trimmed
+            .Where(x => x.Length > 0)
+            .Select(x => x.Length - x.TrimStart().Length)
+            .DefaultIfEmpty(0)
+            .Min();
+
+        return trimmed.Select(x => x.Length == 0 ? x : x[indent..]).ToArray();
+    }
+
+    /// <summary>
+    /// Where the quoted block really begins, so a failure names the line to write rather than only the
+    /// line that is wrong.
+    /// </summary>
+    private static string Locate(string[] sourceLines, string[] pageLines)
+    {
+        for (int start = 0; start + pageLines.Length <= sourceLines.Length; start++)
+        {
+            string[] candidate = Dedent(sourceLines.Skip(start).Take(pageLines.Length).ToArray());
+            if (candidate.SequenceEqual(pageLines, StringComparer.Ordinal))
+            {
+                return $"the block now starts at line {start + 1}";
+            }
+        }
+
+        return "the block is no longer in that file at all";
+    }
+}

--- a/src/Quartz.Tests.Unit/FSharpHowToTest.cs
+++ b/src/Quartz.Tests.Unit/FSharpHowToTest.cs
@@ -1,0 +1,37 @@
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// The F# in the migration guide's "Upgrading an F# project" is the F# in
+/// <c>src/Quartz.Examples.FSharp</c>.
+/// </summary>
+/// <remarks>
+/// That section carries plain fences rather than generated snippets, because <c>DocsSnippets</c> reads
+/// <c>Quartz.Documentation.Samples</c>, which is a C# project and so can hold no F# at all — the same
+/// bind the Wolverine how-to is in for a different reason, and the arrangement both use is described on
+/// <see cref="AttributedSamples" />. Everything else on the page is C#, so this test looks at
+/// <c>fsharp</c> fences alone.
+/// </remarks>
+public class FSharpHowToTest
+{
+    private const string PagePath = "docs/documentation/quartz-4.x/migration-guide.md";
+
+    private const string ExampleDirectory = "src/Quartz.Examples.FSharp";
+
+    /// <summary>
+    /// One fence per error the section answers, plus the job, plus the hosted registration: six, which
+    /// is the fewest the section can carry and still be the section this test exists for.
+    /// </summary>
+    private const int LeastExpectedFences = 6;
+
+    [Test]
+    public void EveryFencedSampleAppearsVerbatimInTheExample()
+    {
+        AttributedSamples.EachFenceAppearsVerbatimInTheExample(PagePath, ExampleDirectory, "fsharp", LeastExpectedFences);
+    }
+
+    [Test]
+    public void EveryFencedSampleSaysWhereItCameFrom()
+    {
+        AttributedSamples.EachFenceSaysWhereItCameFrom(PagePath, ExampleDirectory, "fsharp");
+    }
+}

--- a/src/Quartz.Tests.Unit/WolverineHowToTest.cs
+++ b/src/Quartz.Tests.Unit/WolverineHowToTest.cs
@@ -1,27 +1,15 @@
-using System.Text.RegularExpressions;
-
 namespace Quartz.Tests.Unit;
 
 /// <summary>
 /// The C# on the Wolverine how-to page is the C# in <c>src/Quartz.Examples.Wolverine</c>.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Every other page's samples are generated: they live as <c>#region sample_*</c> blocks in
-/// <c>Quartz.Documentation.Samples</c> and <c>VerifyDocsSnippets</c> fails a page that has drifted from
-/// them. That machinery is not available here, because <c>DocsSnippets</c> reads that one project and
-/// that project may not take a <c>WolverineFx</c> dependency for the sake of a sample — the rule
-/// <c>CONTRIBUTING.md</c> states under "Code samples in the documentation", and the reason the Aspire
-/// how-to's AppHost blocks are hand-written too.
-/// </para>
-/// <para>
-/// So the page carries plain fences, and this test is what <c>VerifyDocsSnippets</c> would otherwise
-/// have been: each fence names the example file and line it was copied from, and the two are compared
-/// verbatim. It is deliberately not the anti-pattern
-/// <see cref="Configuration.DocumentedConfigurationTest" />'s remarks describe — that was a test
-/// holding its own transcription of a page, so that the page and the test were two copies with nothing
-/// comparing them. Here the compiled example is the only copy, and the page is checked against it.
-/// </para>
+/// The page carries plain fences rather than generated snippets, because <c>DocsSnippets</c> reads
+/// <c>Quartz.Documentation.Samples</c> and that project may not take a <c>WolverineFx</c> dependency for
+/// the sake of a sample — the rule <c>CONTRIBUTING.md</c> states under "Code samples in the
+/// documentation", and the reason the Aspire how-to's AppHost blocks are hand-written too.
+/// <see cref="AttributedSamples" /> is what stands in for <c>VerifyDocsSnippets</c> here, and explains
+/// the arrangement.
 /// </remarks>
 public class WolverineHowToTest
 {
@@ -30,112 +18,20 @@ public class WolverineHowToTest
     private const string ExampleDirectory = "src/Quartz.Examples.Wolverine";
 
     /// <summary>
-    /// How many fences the page is expected to carry, so that deleting them all cannot make this test
-    /// pass by having nothing to check.
+    /// The page teaches six parts of the example, so six is the fewest fences it can carry and still be
+    /// the page this test exists for.
     /// </summary>
     private const int LeastExpectedFences = 6;
-
-    /// <summary>
-    /// The provenance comment and the fence it introduces — <c>Copied from &lt;path&gt;:&lt;line&gt;</c>
-    /// anywhere inside an HTML comment, then a <c>csharp</c> fence.
-    /// </summary>
-    private static readonly Regex AttributedFence = new(
-        @"<!--(?<comment>(?:(?!-->).)*?)Copied from (?<path>src/Quartz\.Examples\.Wolverine/[^\s:]+):(?<line>\d+)(?:(?!-->).)*?-->\s*\r?\n```csharp\r?\n(?<code>.*?)\r?\n```",
-        RegexOptions.Singleline,
-        TimeSpan.FromSeconds(10));
-
-    /// <summary>
-    /// Every fenced C# block on the page, attributed or not.
-    /// </summary>
-    private static readonly Regex CsharpFence = new(
-        @"^```csharp\r?$",
-        RegexOptions.Multiline,
-        TimeSpan.FromSeconds(10));
 
     [Test]
     public void EveryFencedSampleAppearsVerbatimInTheExample()
     {
-        DirectoryInfo root = RepositoryRoot.Find();
-        string page = ReadPage(root);
-
-        MatchCollection matches = AttributedFence.Matches(page);
-        matches.Count.Should().BeGreaterThanOrEqualTo(LeastExpectedFences,
-            $"{PagePath} teaches the six parts of {ExampleDirectory}, and a page that has stopped quoting them is a page nobody is checking");
-
-        foreach (Match match in matches)
-        {
-            string relative = match.Groups["path"].Value;
-            int firstLine = int.Parse(match.Groups["line"].Value, System.Globalization.CultureInfo.InvariantCulture);
-
-            FileInfo source = new(Path.Combine(root.FullName, relative.Replace('/', Path.DirectorySeparatorChar)));
-            source.Exists.Should().BeTrue($"{PagePath} says it copied a sample from {relative}");
-
-            string[] sourceLines = File.ReadAllLines(source.FullName);
-            string[] pageLines = Dedent(match.Groups["code"].Value.Replace("\r\n", "\n").Split('\n'));
-
-            (firstLine + pageLines.Length - 1).Should().BeLessThanOrEqualTo(sourceLines.Length,
-                $"{relative} is shorter than the block {PagePath} says starts at line {firstLine}");
-
-            string[] candidate = Dedent(sourceLines.Skip(firstLine - 1).Take(pageLines.Length).ToArray());
-
-            for (int i = 0; i < pageLines.Length; i++)
-            {
-                candidate[i].Should().Be(pageLines[i],
-                    $"{PagePath} quotes {relative}:{firstLine + i}. Copy the block again from the example, and correct the line number in the page's provenance comment if it moved: {Locate(sourceLines, pageLines)}");
-            }
-        }
+        AttributedSamples.EachFenceAppearsVerbatimInTheExample(PagePath, ExampleDirectory, "csharp", LeastExpectedFences);
     }
 
     [Test]
     public void EveryFencedSampleSaysWhereItCameFrom()
     {
-        DirectoryInfo root = RepositoryRoot.Find();
-        string page = ReadPage(root);
-
-        CsharpFence.Matches(page).Count.Should().Be(AttributedFence.Matches(page).Count,
-            $"every csharp fence on {PagePath} is hand-written, so each one needs the comment naming the {ExampleDirectory} file and line it was copied from — otherwise nothing keeps it honest");
-    }
-
-    private static string ReadPage(DirectoryInfo root)
-    {
-        FileInfo file = new(Path.Combine(root.FullName, PagePath.Replace('/', Path.DirectorySeparatorChar)));
-        file.Exists.Should().BeTrue($"{PagePath} is the page this test exists for");
-
-        return File.ReadAllText(file.FullName);
-    }
-
-    /// <summary>
-    /// Removes the indentation the block carries as a whole, so a method body reads on the page the way
-    /// a generated snippet would.
-    /// </summary>
-    private static string[] Dedent(string[] lines)
-    {
-        string[] trimmed = lines.Select(x => x.TrimEnd()).ToArray();
-
-        int indent = trimmed
-            .Where(x => x.Length > 0)
-            .Select(x => x.Length - x.TrimStart().Length)
-            .DefaultIfEmpty(0)
-            .Min();
-
-        return trimmed.Select(x => x.Length == 0 ? x : x[indent..]).ToArray();
-    }
-
-    /// <summary>
-    /// Where the quoted block really begins, so a failure names the line to write rather than only the
-    /// line that is wrong.
-    /// </summary>
-    private static string Locate(string[] sourceLines, string[] pageLines)
-    {
-        for (int start = 0; start + pageLines.Length <= sourceLines.Length; start++)
-        {
-            string[] candidate = Dedent(sourceLines.Skip(start).Take(pageLines.Length).ToArray());
-            if (candidate.SequenceEqual(pageLines, StringComparer.Ordinal))
-            {
-                return $"the block now starts at line {start + 1}";
-            }
-        }
-
-        return "the block is no longer in that file at all";
+        AttributedSamples.EachFenceSaysWhereItCameFrom(PagePath, ExampleDirectory, "csharp");
     }
 }


### PR DESCRIPTION
An F# project upgrading to 4.0 gets a build log that reads much worse than the upgrade is:
[ForNeVeR/nightwatch#68](https://github.com/ForNeVeR/nightwatch/pull/68) reported thirteen errors for
four causes, and the migration guide had nothing for any of them. This adds the section, an example
project that compiles and runs, and a test that holds the two together.

Docs and an example only — **no product code changes**.

## The four errors, and what each one is

Reproduced against the .NET 10 SDK (10.0.400) by writing the example the naive 3.x way first; every
message below is what that build printed, and matches the nightwatch log line for line.

**1. `FS0856` — a job is implemented with both parameters**

```text
error FS0856: This override takes a different number of arguments to the corresponding abstract member. The following abstract members were found:
   IJob.Execute(context: IJobExecutionContext, ?cancellationToken: System.Threading.CancellationToken) : ValueTask
```

Write `member _.Execute(context: IJobExecutionContext, cancellationToken: CancellationToken) : ValueTask`.
`?cancellationToken` is how F# *displays* a C# optional parameter; it means what it says at a call
site and nothing at an implementation. **C# is the same in this respect** — the issue frames the
arity rule as an F#/C# difference and it is not one; `Execute` gaining the token is a break for both
languages. What is F#-specific is that the diagnostic reports arity rather than the parameter, that
the obvious repair (`?cancellationToken`, F#'s own optional syntax) trades FS0856 for
`FS0001: … 'CancellationToken' but here has type 'CancellationToken option'`, and that until the
override matches, `context` is untyped and every use of it downstream is a further error. That is
where nine of nightwatch's thirteen came from.

**2. `FS0041` — `ScheduleJob` cannot be resolved from an inferred argument**

```text
error FS0041: A unique overload for method 'ScheduleJob' could not be determined based on type information prior to this program point. A type annotation may be needed.

Known types of arguments: IJobDetail * 'a

Candidates:
 - (extension) SchedulerJobExtensions.ScheduleJob<'TJob,'TInput when 'TJob :> IJob<'TInput>>(input: 'TInput, at: System.DateTimeOffset, ?options: OneOffJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<ScheduledOneOffJob>
 - (extension) SchedulerJobExtensions.ScheduleJob<'TJob,'TInput when 'TJob :> IJob<'TInput>>(input: 'TInput, delay: System.TimeSpan, ?options: OneOffJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<ScheduledOneOffJob>
 - IScheduler.ScheduleJob(jobDetail: IJobDetail, trigger: ITrigger, ?options: ScheduleJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask<System.DateTimeOffset>
 - IScheduler.ScheduleJob(jobDetail: IJobDetail, triggersForJob: System.Collections.Generic.IReadOnlyCollection<ITrigger>, ?options: ScheduleJobOptions, ?cancellationToken: System.Threading.CancellationToken) : ValueTask
```

Annotate the trigger: `let scheduleOne (scheduler: IScheduler) (job: IJobDetail) (trigger: ITrigger) = …`.
The `'a` is the whole cause — the trigger arrived as an inferred function parameter. C# never reaches
this position, so this one *is* F#-only. `options` gaining a default and `SchedulerJobExtensions`
adding two typed-input overloads are what widened the candidate set; both are deliberate and both are
invisible in C#.

**3. `FS0041` — `Async.AwaitTask` has no `ValueTask` overload**

```text
error FS0041: No overloads match for method 'AwaitTask'.

Known type of argument: ValueTask

Available overloads:
 - static member Async.AwaitTask: task: Task -> Async<unit> // Argument 'task' doesn't match
 - static member Async.AwaitTask: task: Task<'T> -> Async<'T> // Argument 'task' doesn't match
```

Inside `task { }`, `do! scheduler.Start()` — the builder binds any awaitable. Inside `async { }`,
`do! scheduler.Shutdown(waitForJobsToComplete = true).AsTask() |> Async.AwaitTask`. The section says
which to prefer and shows `Async.StartAsTask` going the other way.

**4. `FS0039` — `StdSchedulerFactory` is gone**

```text
error FS0039: The value or constructor 'StdSchedulerFactory' is not defined. Maybe you want one of the following:
   StandaloneSchedulerFactory
   ISchedulerFactory
```

The suggestion names the right type and **is not a drop-in**: `StandaloneSchedulerFactory`'s
constructor is internal, so `StandaloneSchedulerFactory()` trades FS0039 for
`FS0801: This type has no accessible object constructors` (verified, not inferred). The guide says so
and points at `QuartzSchedulerBuilder.Create(…).Build()`. The issue records the suggestion as "right",
which it is only as a name.

## What is in the PR

* **`src/Quartz.Examples.FSharp`** — an `.fsproj` in `Quartz.slnx`, so `Compile` builds it on all three
  CI operating systems. Four files: `GreetJob.fs` (the two-argument `Execute` returning `ValueTask`),
  `Standalone.fs` (`QuartzSchedulerBuilder`, the annotated `ScheduleJob`, a `ValueTask` awaited from
  `task { }` and from `async { }`), `Hosting.fs` (`AddQuartz` + `AddQuartzHostedService` on a host) and
  `Program.fs`. It fires one job on each of the two schedulers over the in-memory store, waits for each
  firing with a thirty-second bound, shuts down, and exits 0 — or 1 if a firing did not arrive.
  `dotnet run --project src/Quartz.Examples.FSharp` takes about three seconds.
* **`ExamplesSmoke` runs it.** No marker to wait for, because it ends by itself, so it is a plain
  `DotNetRun` beside the `Quartz.Examples --list` one. That target is in the `pr-tests-unit` workflow
  already.
* **`FSharp.Core` is named in `Directory.Packages.props`.** The F# SDK sets
  `DisableImplicitFSharpCoreReference` when `ManagePackageVersionsCentrally` is on, so without this the
  project builds cleanly and then dies at startup with
  `Could not load file or assembly 'FSharp.Core'`. Pinned to `10.1.400`, the version the SDK carries.
* **The guide section** goes after the `ValueTask` group (`## Tasks Changed to ValueTask`) and before
  `## SystemTime Replaced with TimeProvider`, with a one-sentence signpost from *Start here*. Its
  `fsharp` fences are hand-written, because `Quartz.Documentation.Samples` is a C# project.
* **`FSharpHowToTest`** checks each fence against the example file and line its provenance comment
  names, and that no `fsharp` fence lacks one. The machinery is now `AttributedSamples`, shared with
  `WolverineHowToTest`, which had the only copy of it — that test keeps its two test names and its
  reasoning, and passes unchanged.
* **`CONTRIBUTING.md`** gains a bullet under *Code samples in the documentation* for the
  attributed-fence rule and the two pages it applies to.
* **`sonar.yml`** adds the new example to `sonar.coverage.exclusions`, beside every other example.

## Verification

```
dotnet build Quartz.slnx                                   0 Warning(s), 0 Error(s)
dotnet test src/Quartz.Tests.Unit                          Failed: 0, Passed: 5386, Skipped: 36
dotnet test src/Quartz.Tests.AspNetCore                    Failed: 0, Passed: 630
dotnet fallout ExamplesSmoke                               Succeeded (F# example ran, exit 0)
dotnet fallout DocsSnippets                                up to date, git status clean afterwards
dotnet fallout VerifyDocsSnippets                          Succeeded (111 markdown files)
npm run docs:check-links     224 pages, 1405 internal links, 863 fragments, no dead links or anchors
npm run docs:lint                                          92 files, 0 error(s)
```

`FSharpHowToTest` was also confirmed to fail on a one-character edit to a fence
(`scheduler.Start()` → `scheduler.Start ()`), which was then reverted.

`Quartz.Tests.Integration` was not run: no product code changed, and it needs a Docker daemon.
`BenchmarkSmoke` was not run for the same reason — nothing here touches a type `Quartz.Benchmark` uses.

Closes #3718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
