### PR TITLE
The 4.0 upgrade restores, and the four folded ids no longer anchor a grouped update to 3.20.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,45 @@ updates:
       # every run would propose "upgrading" back to the dead 11.0.18.
       - dependency-name: "Fallout.*"
         versions: ["11.*"]
+      # The dependency floors, which are the versions a consumer inherits from a shipped nuspec rather
+      # than versions this repository runs on. Directory.Packages.props, "The floors a consumer
+      # inherits", says the whole of why: 4.0.0 floored six framework extensions at whatever
+      # Dependabot had most recently proposed, and an application pinning one of them a patch lower
+      # could not restore at all (#3717). A weekly minor or patch here is exactly the change that
+      # caused that, so it is not offered; a major still is, because a major is a decision.
+      #
+      # Raise one of these by hand, for a security advisory, to the version that fixed it.
+      # PackageDependencyTest fails a Microsoft.* floor that is not x.0.0 either way.
+      - dependency-name: "Microsoft.AspNetCore.SignalR.Client"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Configuration.Binder"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Configuration.EnvironmentVariables"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.DependencyInjection"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Diagnostics.HealthChecks"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Hosting"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Hosting.Abstractions"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Http"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Logging"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Logging.Console"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Options.ConfigurationExtensions"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Newtonsoft.Json"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "OpenTelemetry.Extensions.Hosting"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "StackExchange.Redis"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "TimeZoneConverter"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     # Dependencies are matched against groups in the order they are declared here,
     # and each dependency ends up in the first group it matches.
     groups:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,29 +30,19 @@
     <PackageVersion Include="FirebirdSql.Data.FirebirdClient" Version="10.3.4" />
     <PackageVersion Include="MELT" Version="1.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <!--
-      The stable 10.x line, aligned with the Microsoft.Extensions.* versions above. It spent a while on
-      11.0.0-preview.* - it was moved there while .NET 10 was itself in preview and Dependabot kept it
-      walking that line - which no shipped package took, because only the tests, the examples and the
-      trim canary reference it. PackageDependencyTest is what keeps that true.
+      The stable 10.x line. It spent a while on 11.0.0-preview.* - it was moved there while .NET 10 was
+      itself in preview and Dependabot kept it walking that line - which no shipped package took,
+      because only the tests, the examples and the trim canary reference it. PackageDependencyTest is
+      what keeps that true, and it is also why this stays current rather than joining the floors below:
+      nothing inherits it.
     -->
     <PackageVersion Include="Microsoft.Data.SQLite" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="MySqlConnector" Version="2.6.2" />
@@ -62,12 +52,10 @@
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Npgsql" Version="10.0.3" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
@@ -90,13 +78,74 @@
     <PackageVersion Include="Testcontainers.Oracle" Version="4.14.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
-    <PackageVersion Include="StackExchange.Redis" Version="3.1.31" />
-    <PackageVersion Include="TimeZoneConverter" Version="7.2.0" />
     <PackageVersion Include="Verify.NUnit" Version="32.0.0" />
     <PackageVersion Include="WolverineFx" Version="6.33.0" />
     <PackageVersion Include="WolverineFx.Postgresql" Version="6.33.0" />
     <PackageVersion Include="WolverineFx.RuntimeCompilation" Version="6.33.0" />
   </ItemGroup>
+
+  <!--
+    The floors a consumer inherits. Every version below is copied verbatim into a shipped package's
+    nuspec as a minimum, and NuGet resolves a minimum by raising everything else to meet it: an
+    application pinning Microsoft.Extensions.Options at 10.0.10 and referencing Quartz 4.0.0 was told
+    "detected package downgrade" and stopped restoring, because 4.0.0 floored six framework extensions
+    at 10.0.11 — the central version on the day it was built, not a version anything in Quartz needs
+    (#3717). A floor is a demand made of every consumer, so it is the lowest version of its major that
+    still has the API used here rather than the newest one available.
+
+    The library therefore compiles against the floor on purpose, and so do the tests, the examples and
+    the benchmarks — one central version per id is what makes "it builds" mean "the floor is real".
+    Raise one only for a security advisory, and then to the fixed version rather than to the newest.
+    Everything else in this file is used only by tests, examples or the build, ships nowhere, and stays
+    current; a test project that genuinely needs a newer one of these ids says so with VersionOverride
+    on its own PackageReference rather than moving the floor.
+
+    Two of the ids here are not floors themselves. Microsoft.Extensions.Hosting and
+    Microsoft.Extensions.Logging.Console ship in nothing and are referenced only by tests and examples,
+    but dotnet/runtime versions the family in lockstep: 10.0.11 of either demands 10.0.11 of a floored
+    id, and CentralPackageTransitivePinningEnabled has already pinned that at the floor, so restore
+    fails. They sit with the floors so the family stays one line rather than two that disagree.
+
+    That pinning is also why several of these ids reach a nuspec no shipped project names them in —
+    Quartz.Jobs references nothing but Quartz, and inherits all six of Quartz's framework extensions as
+    dependencies of its own. A floor is therefore a demand made by every package here, not only by the
+    one that wrote the reference, which is what makes lowering them worth the trouble.
+
+    .github/dependabot.yml carries an ignore entry for each of these ids so a weekly minor or patch is
+    not offered, and PackageDependencyTest fails a Microsoft.* floor that is not x.0.0, so a bump that
+    gets past both still has to argue with a unit test that names this comment.
+  -->
+  <ItemGroup Label="Dependency floors">
+    <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <!--
+      13.0.2 rather than 13.0.1, which is where the advisory-free 13.x line starts: TimeOnly and
+      DateOnly are reflected over member by member before it, so a job data map holding a TimeOnly
+      round-trips through the Json.NET serializer having quietly lost its seconds.
+      JobDataMapPortabilityTest is what says so, and it said so the first time this floor was set to
+      13.0.1.
+    -->
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.2" />
+    <!--
+      1.15.3 rather than the 1.9.0 the code compiles against: every earlier 1.x drags in an
+      OpenTelemetry.Api with GHSA-g94r-2vxg-569j, and 1.15.3 is the version that fixed it. This is the
+      "raise it for an advisory, to the fixed version" case, written down at the floor rather than
+      discovered by the next person who tries to lower it.
+    -->
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="StackExchange.Redis" Version="3.0.0" />
+    <PackageVersion Include="TimeZoneConverter" Version="7.0.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <GlobalPackageReference Include="GitHubActionsTestLogger" Version="3.0.5" />
     <GlobalPackageReference Include="Meziantou.Analyzer" Version="3.0.205" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,12 +93,16 @@
     (#3717). A floor is a demand made of every consumer, so it is the lowest version of its major that
     still has the API used here rather than the newest one available.
 
-    The library therefore compiles against the floor on purpose, and so do the tests, the examples and
-    the benchmarks — one central version per id is what makes "it builds" mean "the floor is real".
-    Raise one only for a security advisory, and then to the fixed version rather than to the newest.
-    Everything else in this file is used only by tests, examples or the build, ships nowhere, and stays
-    current; a test project that genuinely needs a newer one of these ids says so with VersionOverride
-    on its own PackageReference rather than moving the floor.
+    Everything here therefore compiles against the floor on purpose — one central version per id is what
+    makes "it builds" mean "the floor is real". Raise one only for a security advisory, and then to the
+    fixed version rather than to the newest. Everything else in this file is used only by tests, examples
+    or the build, ships nowhere, and stays current.
+
+    Five projects that ship nothing step over a floor with VersionOverride on their own PackageReference,
+    because Aspire, bunit, Microsoft.AspNetCore.Mvc.Testing, NSwag and the released Quartz.Serialization.Json
+    3.20.0 each ask for a newer patch than Quartz should demand of anybody. That is the only way to say it:
+    moving the floor instead would hand the demand to every consumer. Nothing that ships may do it, which
+    PackageDependencyTest holds.
 
     Two of the ids here are not floors themselves. Microsoft.Extensions.Hosting and
     Microsoft.Extensions.Logging.Console ship in nothing and are referenced only by tests and examples,
@@ -106,10 +110,10 @@
     id, and CentralPackageTransitivePinningEnabled has already pinned that at the floor, so restore
     fails. They sit with the floors so the family stays one line rather than two that disagree.
 
-    That pinning is also why several of these ids reach a nuspec no shipped project names them in —
-    Quartz.Jobs references nothing but Quartz, and inherits all six of Quartz's framework extensions as
-    dependencies of its own. A floor is therefore a demand made by every package here, not only by the
-    one that wrote the reference, which is what makes lowering them worth the trouble.
+    That pinning is also why several of these ids reach nuspecs that name none of them: Quartz.Jobs
+    references nothing but Quartz, and carries all six of Quartz's framework extensions as dependencies of
+    its own. A floor is therefore a demand made by every shipped package rather than only by the one that
+    wrote the reference, which is what makes lowering them worth the trouble.
 
     .github/dependabot.yml carries an ignore entry for each of these ids so a weekly minor or patch is
     not offered, and PackageDependencyTest fails a Microsoft.* floor that is not x.0.0, so a bump that

--- a/Quartz.slnx
+++ b/Quartz.slnx
@@ -37,6 +37,19 @@
   <Project Path="build/_build.csproj">
     <Build Project="false" />
   </Project>
+  <!--
+    The four empty packages published under the ids 4.0 folded away, so a grouped dependency update can
+    resolve to 4.x rather than re-anchoring on 3.20.1. src/QuartzShimPackage.props explains them; they are
+    in the solution because Pack packs it and Publish pushes what Pack produced, and in a folder of their
+    own because there is nothing to read in any of them.
+  -->
+  <Folder Name="/Shims/">
+    <File Path="src/QuartzShimPackage.props" />
+    <Project Path="src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj" />
+    <Project Path="src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj" />
+    <Project Path="src/Quartz.Serialization.Json/Quartz.Serialization.Json.csproj" />
+    <Project Path="src/Quartz.Serialization.SystemTextJson/Quartz.Serialization.SystemTextJson.csproj" />
+  </Folder>
   <Project Path="src/Quartz.Aspire/Quartz.Aspire.csproj" />
   <Project Path="src/Quartz.AspNetCore/Quartz.AspNetCore.csproj" />
   <Project Path="src/Quartz.Dashboard/Quartz.Dashboard.csproj" />

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -183,9 +183,11 @@ pull request is the one that stays open, and the reference is yours to delete in
 Because they carry no assembly they cannot cause the `CS0433` above. A 3.x one still can, so an upgrade
 that leaves an old version pinned is not made safe by their existence.
 
-`Quartz.OpenTracing` and `OpenTelemetry.Instrumentation.Quartz` deliberately have no such package. Neither
-has a 4.x replacement to depend on, and an empty package would hide that rather than say it — the two
-sections below are what they need instead.
+The two 3.x packages that are *not* published this way are `Quartz.OpenTracing` and
+`Quartz.OpenTelemetry.Instrumentation`. Neither has a 4.x package to depend on, so there is nothing an empty
+one could point at, and publishing it would say "you are up to date" to a reference that has to go. What
+replaces both is Quartz's own activity source and meter — see
+[OpenTelemetry Integration](packages/opentelemetry-integration.md) and the two sections below.
 
 `Quartz.OpenTracing` is **dropped** and has no 4.x release. It consumed the `DiagnosticSource` events that
 4.x replaced with `System.Diagnostics.Activity`, and the OpenTracing project itself is archived. Remove the

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -167,6 +167,26 @@ If you use Newtonsoft.Json serialization, reference `Quartz.Serialization.Newton
 Configuration that names a type from one of the merged assemblies as a string keeps working: a name that fails to
 resolve is retried against `Quartz`, with a warning naming both spellings.
 
+### Empty packages under the four old ids
+
+From 4.0.1 those four ids — `Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`,
+`Quartz.Serialization.Json` and `Quartz.Serialization.SystemTextJson` — are published at every 4.x version
+as **empty packages**: a dependency on the package that replaced them, a readme, and no assembly at all.
+
+**You still remove them.** They exist for one thing you cannot do by hand, which is let a dependency bot
+get to 4.x. A bot that updates Quartz together with any of these as one group resolves that group to the
+newest version *every* member has, and until 4.0.1 that was 3.20.1 — so the bot closed the 4.0.0 pull
+request it had already opened as superseded and landed 3.20.1 with green checks, and the consumer's only
+signal that 4.0 existed disappeared. With the empty packages there, the group resolves to 4.x, the upgrade
+pull request is the one that stays open, and the reference is yours to delete in it.
+
+Because they carry no assembly they cannot cause the `CS0433` above. A 3.x one still can, so an upgrade
+that leaves an old version pinned is not made safe by their existence.
+
+`Quartz.OpenTracing` and `OpenTelemetry.Instrumentation.Quartz` deliberately have no such package. Neither
+has a 4.x replacement to depend on, and an empty package would hide that rather than say it — the two
+sections below are what they need instead.
+
 `Quartz.OpenTracing` is **dropped** and has no 4.x release. It consumed the `DiagnosticSource` events that
 4.x replaced with `System.Diagnostics.Activity`, and the OpenTracing project itself is archived. Remove the
 package reference and the `AddQuartzOpenTracing` call, and subscribe to Quartz's activity source and meter

--- a/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
+++ b/src/Quartz.Examples.AspNetCore/Quartz.Examples.AspNetCore.csproj
@@ -38,6 +38,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <!--
+      NSwag 14.7.1 asks for Newtonsoft.Json 13.0.3, above the 13.0.1 floor Quartz.Serialization.Newtonsoft
+      ships. This example ships nothing, so it raises the version for itself rather than moving a floor
+      every consumer of that package would inherit.
+    -->
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />
     <PackageReference Include="NSwag.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/src/Quartz.Examples.Aspire.AppHost/Quartz.Examples.Aspire.AppHost.csproj
+++ b/src/Quartz.Examples.Aspire.AppHost/Quartz.Examples.Aspire.AppHost.csproj
@@ -44,6 +44,27 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--
+      Aspire 13.5.3 is built against the newest framework extensions and Newtonsoft.Json and asks for
+      them by exact patch, which is above the floors Directory.Packages.props sets for what Quartz
+      ships. An AppHost ships nothing, so it raises them for itself with VersionOverride rather than
+      dragging a floor up behind it - a floor is a demand made of every consumer, and no consumer of
+      Quartz should inherit Aspire's servicing schedule.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Quartz.Examples.Aspire.Worker\Quartz.Examples.Aspire.Worker.csproj" />
   </ItemGroup>
 

--- a/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
+++ b/src/Quartz.Extensions.DependencyInjection/Quartz.Extensions.DependencyInjection.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- An empty package under a 3.x id. ../QuartzShimPackage.props says what that means and why it ships. -->
+  <Import Project="..\QuartzShimPackage.props" />
+
+  <PropertyGroup>
+    <QuartzShimPackage>true</QuartzShimPackage>
+    <Title>Quartz.NET Dependency Injection (moved into Quartz)</Title>
+    <Description>Folded into Quartz in 4.0: AddQuartz, QuartzOptions and the rest live in the Quartz package now. This package is empty and exists only so a grouped dependency update can move to 4.x - remove the reference, and see the migration guide.</Description>
+    <PackageTags>$(PackageTags);dependency-injection;microsoft-extensions;moved;empty-package</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Extensions.DependencyInjection/README.md
+++ b/src/Quartz.Extensions.DependencyInjection/README.md
@@ -1,0 +1,14 @@
+# Quartz.Extensions.DependencyInjection
+
+This package is empty. Everything it used to carry was folded into
+[Quartz](https://www.nuget.org/packages/Quartz) in 4.0 — `AddQuartz`, `QuartzOptions`,
+`ITriggerConfigurator`, `JobFactoryOptions` and `SchedulingOptions` are all in the `Quartz` package and
+the `Quartz` namespace now. Remove this reference, keep `Quartz`, and read the
+[migration guide](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html) for the
+rest of the upgrade.
+
+It is published at every 4.x version for one reason: a dependency bot that updates `Quartz` and this
+package as one group resolves that group to the newest version *every* member has. With nothing under this
+id above 3.20.1 the group stops there, and the 4.0 pull request the bot had already opened is closed as
+superseded. `Quartz.OpenTracing` and `Quartz.OpenTelemetry.Instrumentation` deliberately have no such
+package: neither has a 4.x replacement, and an empty one would hide that rather than say it.

--- a/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
+++ b/src/Quartz.Extensions.Hosting/Quartz.Extensions.Hosting.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- An empty package under a 3.x id. ../QuartzShimPackage.props says what that means and why it ships. -->
+  <Import Project="..\QuartzShimPackage.props" />
+
+  <PropertyGroup>
+    <QuartzShimPackage>true</QuartzShimPackage>
+    <Title>Quartz.NET Hosting (moved into Quartz)</Title>
+    <Description>Folded into Quartz in 4.0: AddQuartzHostedService, QuartzHostedService and QuartzHostedServiceOptions live in the Quartz package now. This package is empty and exists only so a grouped dependency update can move to 4.x - remove the reference, and see the migration guide.</Description>
+    <PackageTags>$(PackageTags);hosting;hosted-service;moved;empty-package</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Extensions.Hosting/README.md
+++ b/src/Quartz.Extensions.Hosting/README.md
@@ -1,0 +1,14 @@
+# Quartz.Extensions.Hosting
+
+This package is empty. Everything it used to carry was folded into
+[Quartz](https://www.nuget.org/packages/Quartz) in 4.0 — `AddQuartzHostedService`, `QuartzHostedService`
+and `QuartzHostedServiceOptions` are all in the `Quartz` package and the `Quartz` namespace now. Remove
+this reference, keep `Quartz`, and read the
+[migration guide](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html) for the
+rest of the upgrade.
+
+It is published at every 4.x version for one reason: a dependency bot that updates `Quartz` and this
+package as one group resolves that group to the newest version *every* member has. With nothing under this
+id above 3.20.1 the group stops there, and the 4.0 pull request the bot had already opened is closed as
+superseded. `Quartz.OpenTracing` and `Quartz.OpenTelemetry.Instrumentation` deliberately have no such
+package: neither has a 4.x replacement, and an empty one would hide that rather than say it.

--- a/src/Quartz.Serialization.Json/Quartz.Serialization.Json.csproj
+++ b/src/Quartz.Serialization.Json/Quartz.Serialization.Json.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- An empty package under a 3.x id. ../QuartzShimPackage.props says what that means and why it ships. -->
+  <Import Project="..\QuartzShimPackage.props" />
+
+  <PropertyGroup>
+    <QuartzShimPackage>true</QuartzShimPackage>
+    <Title>Quartz.NET Json.NET Serialization (renamed to Quartz.Serialization.Newtonsoft)</Title>
+    <Description>Renamed to Quartz.Serialization.Newtonsoft in 4.0. This package is empty and exists only so a grouped dependency update can move to 4.x - reference Quartz.Serialization.Newtonsoft instead, and see the migration guide.</Description>
+    <PackageTags>$(PackageTags);json;newtonsoft;serialization;renamed;empty-package</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz.Serialization.Newtonsoft\Quartz.Serialization.Newtonsoft.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Serialization.Json/README.md
+++ b/src/Quartz.Serialization.Json/README.md
@@ -1,0 +1,15 @@
+# Quartz.Serialization.Json
+
+This package is empty. The Json.NET job store serializer is
+[Quartz.Serialization.Newtonsoft](https://www.nuget.org/packages/Quartz.Serialization.Newtonsoft) from 4.0
+on — the name says which JSON library it uses, now that the System.Text.Json one is built into
+[Quartz](https://www.nuget.org/packages/Quartz) and is the default. Reference
+`Quartz.Serialization.Newtonsoft` instead of this, call `UseNewtonsoftJsonSerializer()` as before, and read
+the [migration guide](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html) for
+the rest of the upgrade.
+
+It is published at every 4.x version for one reason: a dependency bot that updates `Quartz` and this
+package as one group resolves that group to the newest version *every* member has. With nothing under this
+id above 3.20.1 the group stops there, and the 4.0 pull request the bot had already opened is closed as
+superseded. `Quartz.OpenTracing` and `Quartz.OpenTelemetry.Instrumentation` deliberately have no such
+package: neither has a 4.x replacement, and an empty one would hide that rather than say it.

--- a/src/Quartz.Serialization.SystemTextJson/Quartz.Serialization.SystemTextJson.csproj
+++ b/src/Quartz.Serialization.SystemTextJson/Quartz.Serialization.SystemTextJson.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- An empty package under a 3.x id. ../QuartzShimPackage.props says what that means and why it ships. -->
+  <Import Project="..\QuartzShimPackage.props" />
+
+  <PropertyGroup>
+    <QuartzShimPackage>true</QuartzShimPackage>
+    <Title>Quartz.NET System.Text.Json Serialization (moved into Quartz)</Title>
+    <Description>Folded into Quartz in 4.0: the System.Text.Json job store serializer is built into the Quartz package and is the default. This package is empty and exists only so a grouped dependency update can move to 4.x - remove the reference, and see the migration guide.</Description>
+    <PackageTags>$(PackageTags);json;system-text-json;serialization;moved;empty-package</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Quartz\Quartz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Quartz.Serialization.SystemTextJson/README.md
+++ b/src/Quartz.Serialization.SystemTextJson/README.md
@@ -1,0 +1,14 @@
+# Quartz.Serialization.SystemTextJson
+
+This package is empty. The System.Text.Json job store serializer was folded into
+[Quartz](https://www.nuget.org/packages/Quartz) in 4.0, where it is the default — nothing has to be
+referenced or registered to get it, and `JsonSerializationException` is in the `Quartz` package now.
+Remove this reference, keep `Quartz`, and read the
+[migration guide](https://www.quartz-scheduler.net/documentation/quartz-4.x/migration-guide.html) for the
+rest of the upgrade.
+
+It is published at every 4.x version for one reason: a dependency bot that updates `Quartz` and this
+package as one group resolves that group to the newest version *every* member has. With nothing under this
+id above 3.20.1 the group stops there, and the 4.0 pull request the bot had already opened is closed as
+superseded. `Quartz.OpenTracing` and `Quartz.OpenTelemetry.Instrumentation` deliberately have no such
+package: neither has a 4.x replacement, and an empty one would hide that rather than say it.

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -36,6 +36,20 @@
          contract over a persistent store as well as over RAMJobStore; the store creates its own
          schema, so nothing else is needed. -->
     <PackageReference Include="Microsoft.Data.SQLite" />
+    <!--
+      The floors Directory.Packages.props sets are what Quartz asks of a consumer, and bunit and
+      Microsoft.AspNetCore.Mvc.Testing ask for more than that: 10.0.10 and 10.0.11 respectively, of
+      framework extensions this project never names itself. VersionOverride raises them for this
+      project alone, so nothing a consumer inherits moves.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />

--- a/src/Quartz.Tests.Integration.Seeder/Quartz.Tests.Integration.Seeder.csproj
+++ b/src/Quartz.Tests.Integration.Seeder/Quartz.Tests.Integration.Seeder.csproj
@@ -27,6 +27,13 @@
     <PackageReference Include="Quartz.Serialization.Json" VersionOverride="3.20.0" />
     <PackageReference Include="Quartz.Serialization.SystemTextJson" VersionOverride="3.20.0" />
 
+    <!--
+      Quartz.Serialization.Json 3.20.0 asks for Newtonsoft.Json 13.0.3, above the 13.0.1 floor this
+      repository's Quartz.Serialization.Newtonsoft now ships. Raised here only, for the same reason the
+      two pins above are: this project is a scratch process and inherits nothing to anyone.
+    -->
+    <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />
+
     <!-- The six providers 3.20's DbProvider loads by assembly name, one per dialect it can seed. -->
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" />
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/src/Quartz.Tests.Unit/LogCallSiteTest.cs
+++ b/src/Quartz.Tests.Unit/LogCallSiteTest.cs
@@ -150,9 +150,16 @@ public class LogCallSiteTest
     /// projects is the list of packable ones and nothing less.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Without this, a package added after the conversion would ship unguarded — and it would look
     /// exactly like a package with nothing to convert, because both spend their whole life passing every
     /// other test in this file. A project that packs nothing is not covered and does not need to be.
+    /// </para>
+    /// <para>
+    /// Nor is a shim: the four empty packages published under the ids 4.0 folded away carry a dependency
+    /// and a readme and no assembly at all, so there is no call site in one to convert and no operator
+    /// reading its messages. <c>src/QuartzShimPackage.props</c> says why they exist.
+    /// </para>
     /// </remarks>
     [Test]
     public void EveryPackableProjectIsCovered()
@@ -160,6 +167,7 @@ public class LogCallSiteTest
         DirectoryInfo root = RepositoryRoot.Find();
 
         List<string> packable = ShippedProjects.Find()
+            .Where(x => !ShippedProjects.IsShim(x))
             .Select(x => Path.GetRelativePath(root.FullName, x.DirectoryName!).Replace('\\', '/'))
             .ToList();
 

--- a/src/Quartz.Tests.Unit/PackageDependencyTest.cs
+++ b/src/Quartz.Tests.Unit/PackageDependencyTest.cs
@@ -25,6 +25,14 @@ namespace Quartz.Tests.Unit;
 /// that needs a restore graph rather than a file, and the stable-version packing dry run recorded on
 /// #3679 is what covers it.
 /// </para>
+/// <para>
+/// The same reading answers a second question, which 4.0.0 got wrong: not whether a dependency is
+/// stable but how low it is. Every version here is copied into a nuspec as a *minimum*, and NuGet
+/// resolves a minimum by raising everything else to meet it, so a floor at the newest servicing patch
+/// stops an application pinning the one before it from restoring at all (#3717). The floors live in
+/// their own item group in <c>Directory.Packages.props</c>, under a comment saying why, and
+/// <see cref="MicrosoftFloorIsTheMajorItself" /> is what holds them there.
+/// </para>
 /// </remarks>
 public class PackageDependencyTest
 {
@@ -36,6 +44,118 @@ public class PackageDependencyTest
 
         IsPrerelease(version).Should().BeFalse(
             $"{project} ships, and NuGet refuses a stable release with a prerelease dependency (NU5104) — {package} {version} would fail the tag build rather than this one");
+    }
+
+    /// <summary>
+    /// A <c>Microsoft.*</c> floor is the major itself — <c>x.0.0</c> — and never a servicing patch of it.
+    /// </summary>
+    /// <remarks>
+    /// This is the rule 4.0.0 broke. Its nuspecs floored six framework extensions at 10.0.11, the
+    /// central version on the day it was built, so an application pinning
+    /// <c>Microsoft.Extensions.Options</c> at 10.0.10 — which is what a .NET 10 project or SDK image
+    /// carries — was told "detected package downgrade" and stopped restoring (#3717). Nothing in Quartz
+    /// needs a servicing patch of the framework extensions, and a floor is a demand made of every
+    /// consumer, so the floor is the major.
+    /// </remarks>
+    [TestCaseSource(nameof(MicrosoftFloors))]
+    public void MicrosoftFloorIsTheMajorItself(string package, string version)
+    {
+        version.Should().MatchRegex(@"^\d+\.0\.0$",
+            $"{package} is a floor a consumer inherits from a shipped nuspec, and {version} would make "
+            + "every application pinning an earlier patch of it fail to restore with NU1605. See "
+            + "\"The floors a consumer inherits\" in Directory.Packages.props: a floor moves for a "
+            + "security advisory and nothing else, and then to the version that fixed it");
+    }
+
+    /// <summary>
+    /// Every <c>Microsoft.*</c> a shipped project references is declared with the floors, so the list
+    /// this file checks, the comment that explains them and the Dependabot ignore entries are one set.
+    /// </summary>
+    /// <remarks>
+    /// Without this a new package reference would land in the alphabetical group at whatever version
+    /// Dependabot last proposed, pass the test above because that test never sees it, and ship a floor
+    /// nobody chose. Transitive pinning makes the reach wider than the reference: <c>Quartz.Jobs</c>
+    /// names no framework extension at all and carries six of them in its nuspec, inherited from
+    /// <c>Quartz</c>.
+    /// </remarks>
+    [TestCaseSource(nameof(ShippedMicrosoftReferences))]
+    public void ShippedMicrosoftDependencyIsDeclaredAsAFloor(string project, string package)
+    {
+        Floors().Keys.Should().Contain(package,
+            $"{project} ships, so the version it resolves {package} at becomes a floor in its nuspec. "
+            + $"Move the PackageVersion into the \"{FloorsLabel}\" group in Directory.Packages.props, "
+            + "at the lowest version of its major that still compiles, and add an ignore entry for it "
+            + "in .github/dependabot.yml");
+    }
+
+    /// <summary>
+    /// A shipped project takes its versions from the central file and nowhere else.
+    /// </summary>
+    /// <remarks>
+    /// <c>VersionOverride</c> is how a project that ships nothing steps over a floor — the Aspire
+    /// example does it for nine ids, because Aspire asks for the newest patch of each and an AppHost
+    /// inherits nothing to anybody. On a shipped project the same attribute would write that version
+    /// into a nuspec, where it becomes a demand made of every consumer, and it would do it out of sight
+    /// of both this file's floor list and Dependabot's ignore entries.
+    /// </remarks>
+    [TestCaseSource(nameof(PackableProjects))]
+    public void ShippedProjectOverridesNoVersion(FileInfo project)
+    {
+        IEnumerable<string> overridden = XDocument.Load(project.FullName)
+            .Descendants("PackageReference")
+            .Where(x => x.Attribute("VersionOverride") is not null)
+            .Select(x => (string) x.Attribute("Include"));
+
+        overridden.Should().BeEmpty(
+            $"{project.Name} ships, so every version it resolves becomes a floor in its nuspec — and a "
+            + "VersionOverride is a floor written where neither Directory.Packages.props nor "
+            + ".github/dependabot.yml can see it");
+    }
+
+    public static IEnumerable<TestCaseData> PackableProjects() => ShippedProjects.Find()
+        .Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
+
+    public static IEnumerable<TestCaseData> MicrosoftFloors() => Floors()
+        .Where(x => IsMicrosoft(x.Key))
+        .OrderBy(x => x.Key, StringComparer.Ordinal)
+        .Select(x => new TestCaseData(x.Key, x.Value).SetArgDisplayNames(x.Key));
+
+    public static IEnumerable<TestCaseData> ShippedMicrosoftReferences() => ShippedProjects.Find()
+        .SelectMany(project => PackageReferences(project)
+            .Where(IsMicrosoft)
+            .Select(package => new TestCaseData(project.Directory!.Name, package)
+                .SetArgDisplayNames(project.Directory!.Name, package)));
+
+    /// <summary>
+    /// The ids that come out of <c>dotnet/runtime</c> and <c>dotnet/aspnetcore</c>, which are the ones
+    /// versioned in lockstep with the framework a consumer is already on.
+    /// </summary>
+    private static bool IsMicrosoft(string package) =>
+        package.StartsWith("Microsoft.", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The <c>Label</c> on the item group holding the floors, which is what makes the set readable from
+    /// here rather than guessed at by prefix.
+    /// </summary>
+    private const string FloorsLabel = "Dependency floors";
+
+    /// <summary>
+    /// The floors, read out of the labelled item group in <c>Directory.Packages.props</c>.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> Floors()
+    {
+        XElement group = PackagesProps()
+            .Descendants("ItemGroup")
+            .SingleOrDefault(x => string.Equals((string) x.Attribute("Label"), FloorsLabel, StringComparison.Ordinal));
+
+        group.Should().NotBeNull(
+            $"the floors are read from the item group labelled \"{FloorsLabel}\" in Directory.Packages.props, "
+            + "and this test cannot check a set it cannot find");
+
+        return group.Elements("PackageVersion").ToDictionary(
+            x => (string) x.Attribute("Include"),
+            x => (string) x.Attribute("Version"),
+            StringComparer.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -82,10 +202,7 @@ public class PackageDependencyTest
     /// </summary>
     private static IReadOnlyDictionary<string, string> CentralPackageVersions()
     {
-        FileInfo file = new(Path.Combine(RepositoryRoot.Find().FullName, "Directory.Packages.props"));
-        file.Exists.Should().BeTrue("every version in this repository is centrally managed, so this file is where they all are");
-
-        XDocument document = XDocument.Load(file.FullName);
+        XDocument document = PackagesProps();
 
         Dictionary<string, string> properties = document
             .Descendants("PropertyGroup")
@@ -98,6 +215,17 @@ public class PackageDependencyTest
                 x => (string) x.Attribute("Include"),
                 x => Resolve((string) x.Attribute("Version"), properties),
                 StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// <c>Directory.Packages.props</c>, which is where every version in this repository is written.
+    /// </summary>
+    private static XDocument PackagesProps()
+    {
+        FileInfo file = new(Path.Combine(RepositoryRoot.Find().FullName, "Directory.Packages.props"));
+        file.Exists.Should().BeTrue("every version in this repository is centrally managed, so this file is where they all are");
+
+        return XDocument.Load(file.FullName);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/PackageDependencyTest.cs
+++ b/src/Quartz.Tests.Unit/PackageDependencyTest.cs
@@ -112,6 +112,97 @@ public class PackageDependencyTest
             + ".github/dependabot.yml can see it");
     }
 
+    /// <summary>
+    /// A shim carries exactly one dependency, on the package that replaced it, at its own version.
+    /// </summary>
+    /// <remarks>
+    /// That single dependency is the entire payload of the four empty packages 4.0.1 publishes under the
+    /// ids 4.0 folded away, and both halves of it matter. A second dependency, or one on something other
+    /// than the replacement, and a consumer who takes the shim by accident gets a graph nobody designed;
+    /// a version that is not this build's, and the group a dependency bot resolves stops being pinned to
+    /// the release the shim was published with, which is the whole reason the package exists (#3717). A
+    /// <c>ProjectReference</c> gives the version for free, so this test is really about keeping it one.
+    /// </remarks>
+    [TestCaseSource(nameof(ShimProjects))]
+    public void ShimDependsOnItsReplacementAndNothingElse(FileInfo project)
+    {
+        XDocument document = XDocument.Load(project.FullName);
+
+        document.Descendants("PackageReference").Should().BeEmpty(
+            $"{project.Name} is a shim, and a PackageReference would be a version resolved from "
+            + "Directory.Packages.props rather than this build's own — the shim has to move with the "
+            + "release it is published beside");
+
+        List<string> replacements = document
+            .Descendants("ProjectReference")
+            .Select(x => Path.GetFileNameWithoutExtension(((string) x.Attribute("Include")).Replace('\\', '/')))
+            .ToList();
+
+        replacements.Should().ContainSingle(
+            $"{project.Name} ships one dependency and nothing else: the package that replaced it")
+            .Which.Should().BeOneOf(["Quartz", "Quartz.Serialization.Newtonsoft"],
+                "those are the two packages the four folded ids were folded into");
+
+        ShimProps().Descendants("CentralPackageTransitivePinningEnabled")
+            .Select(x => x.Value.Trim())
+            .Should().Equal(["false"],
+                "transitive pinning writes every centrally versioned id in the graph into the nuspec as a "
+                + "dependency of its own, which turned this package into one with seven of them the first "
+                + "time it was packed. A shim has no assembly to pin anything for");
+    }
+
+    /// <summary>
+    /// A shim packs no assembly, which is what keeps it clear of the types it used to hold.
+    /// </summary>
+    /// <remarks>
+    /// Eight type names exist in both a 3.x assembly under one of these ids and <c>Quartz</c> 4.x, and the
+    /// migration guide documents the <c>CS0433</c> a consumer gets when both are referenced. A shim that
+    /// packed its (empty) build output would put an assembly with that identity back on the compiler's
+    /// reference list; <c>IncludeBuildOutput=false</c> in <c>src/QuartzShimPackage.props</c> is what does
+    /// not, and the import is how a project gets it.
+    /// </remarks>
+    [TestCaseSource(nameof(ShimProjects))]
+    public void ShimPacksNoAssembly(FileInfo project)
+    {
+        IEnumerable<string> imports = XDocument.Load(project.FullName)
+            .Descendants("Import")
+            .Select(x => ((string) x.Attribute("Project"))?.Replace('\\', '/'))
+            .Where(x => x is not null);
+
+        imports.Should().Contain(x => x.EndsWith(ShimPropsFileName, StringComparison.Ordinal),
+            $"{project.Name} is a shim, and {ShimPropsFileName} is what turns IncludeBuildOutput off — a "
+            + "shim that packed an assembly would reintroduce the CS0433 the migration guide documents");
+
+        ShimProps().Descendants("IncludeBuildOutput")
+            .Select(x => x.Value.Trim())
+            .Should().Equal(["false"],
+                $"{ShimPropsFileName} is the one place that decides a shim carries no assembly");
+    }
+
+    /// <summary>
+    /// The shared properties the four shims import, which is where what makes a shim a shim is written.
+    /// </summary>
+    private const string ShimPropsFileName = "QuartzShimPackage.props";
+
+    private static XDocument ShimProps()
+    {
+        FileInfo file = new(Path.Combine(RepositoryRoot.Find().FullName, "src", ShimPropsFileName));
+        file.Exists.Should().BeTrue("the four shim projects import it, and it is where they say what they are");
+
+        return XDocument.Load(file.FullName);
+    }
+
+    public static IEnumerable<TestCaseData> ShimProjects()
+    {
+        List<FileInfo> shims = ShippedProjects.Find().Where(ShippedProjects.IsShim).ToList();
+
+        shims.Should().HaveCount(4,
+            "the four ids 4.0 folded away are each published as an empty package at every 4.x version, and "
+            + "a shim that stops being one takes its whole guard with it rather than failing anything");
+
+        return shims.Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
+    }
+
     public static IEnumerable<TestCaseData> PackableProjects() => ShippedProjects.Find()
         .Select(x => new TestCaseData(x).SetArgDisplayNames(x.Directory!.Name));
 

--- a/src/Quartz.Tests.Unit/PublicApiTest.cs
+++ b/src/Quartz.Tests.Unit/PublicApiTest.cs
@@ -113,8 +113,15 @@ public class PublicApiTest
             + "the ASP.NET Core dependencies live) and accept the baseline it writes");
     }
 
+    /// <remarks>
+    /// The four shim packages are left out, and that is the whole of what "no assembly" costs here: they
+    /// carry a dependency and a readme, <c>IncludeBuildOutput</c> is false so no <c>lib</c> folder is
+    /// packed, and a baseline of an empty surface would be a file that looks like a guard without being
+    /// one. <c>src/QuartzShimPackage.props</c> says why they exist.
+    /// </remarks>
     private static IEnumerable<TestCaseData> PackableProjects() =>
         ShippedProjects.Find()
+            .Where(x => !ShippedProjects.IsShim(x))
             .Select(x => Path.GetFileNameWithoutExtension(x.Name))
             .Select(x => new TestCaseData(x).SetArgDisplayNames(x));
 }

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -49,6 +49,17 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <!--
+      Two floors this project alone has to step over. Microsoft.Extensions.Diagnostics.Testing ships
+      on dotnet/extensions' own cadence and 10.9.0 asks for 10.0.11 of both, which is above the floor
+      Directory.Packages.props sets for what Quartz ships. VersionOverride raises them here and nowhere
+      else, so the shipped packages keep asking their consumers for 10.0.0 - which is the whole point
+      of the floor - while the test host runs on what the fake logger needs.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <!--

--- a/src/Quartz.Tests.Unit/ShippedProjects.cs
+++ b/src/Quartz.Tests.Unit/ShippedProjects.cs
@@ -32,6 +32,30 @@ internal static class ShippedProjects
         return projects;
     }
 
+    /// <summary>
+    /// Whether a project produces a package that carries no assembly — one of the four empty packages
+    /// published under the ids 4.0 folded away, so that a grouped dependency update can resolve to 4.x
+    /// instead of re-anchoring on 3.20.1 (#3717).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A test that asks something of an assembly has nothing to ask here: there is no public surface to
+    /// snapshot and no call site to route through a <c>[LoggerMessage]</c> method. Each such test skips a
+    /// shim by this property, with the reason written down, rather than by name or by an empty baseline
+    /// file that would look like a real one. Everything asked of a package *page* — its readme, its title,
+    /// its description — still applies, because an empty package is still a page somebody lands on.
+    /// </para>
+    /// <para>
+    /// The four say <c>QuartzShimPackage</c> in their own project files rather than inheriting it from
+    /// <c>src/QuartzShimPackage.props</c>, which holds the rest of what they share: it is the one property
+    /// that changes what other tests do with the project, so it is written where a reader of that project
+    /// sees it. Read here from the file rather than through MSBuild, the way the rest of this class reads.
+    /// </para>
+    /// </remarks>
+    public static bool IsShim(FileInfo project) => XDocument.Load(project.FullName)
+        .Descendants("QuartzShimPackage")
+        .Any(x => string.Equals(x.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase));
+
     private static bool IsOptedOut(FileInfo project) => XDocument.Load(project.FullName)
         .Descendants("IsPackable")
         .Any(x => string.Equals(x.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));

--- a/src/QuartzShimPackage.props
+++ b/src/QuartzShimPackage.props
@@ -1,0 +1,62 @@
+<Project>
+
+  <!--
+    What the four empty packages under 3.x ids are, and why they ship.
+
+    Quartz.Extensions.DependencyInjection, Quartz.Extensions.Hosting and Quartz.Serialization.SystemTextJson
+    were folded into Quartz in 4.0, and Quartz.Serialization.Json became Quartz.Serialization.Newtonsoft.
+    None of the four has a 4.0.0, so on nuget.org they stop at 3.20.1 — and a dependency bot that updates
+    Quartz together with any of them resolves the group to the newest version *every* member has. That is
+    3.20.1. The bot closes the 4.0.0 pull request it had already opened as superseded and lands 3.20.1 with
+    green checks, so the consumer's only signal that 4.0 exists disappears. Three repositories were found
+    doing exactly this in the adoption audit of 2026-09-08 (#3717), on ids that between them draw most of
+    the modern installed base.
+
+    So the four ship at every 4.x version and carry nothing at all. IncludeBuildOutput is false, so there is
+    no lib folder and no assembly — which is what keeps them clear of the CS0433 the migration guide
+    documents, the eight type names that exist in both a 3.x assembly under one of these ids and Quartz 4.x.
+    What a consumer gets is one dependency on the package that replaced it, at the same version, and a readme
+    saying to remove the reference. A one-off shim would not do the job: the group would re-anchor at 4.0.1
+    on the next bump, so these are republished with every release.
+
+    Quartz.OpenTracing and Quartz.OpenTelemetry.Instrumentation are deliberately not shimmed. Neither has a
+    4.x replacement, and an empty package would hide that rather than say it.
+
+    QuartzShimPackage is what the tests read, and each of the four sets it in its own project file rather
+    than inheriting it from here: it is the one property that changes what other tests do, so it belongs
+    where a reader of that project sees it. A shim has no assembly, so PublicApiTest has no surface to
+    snapshot and LogCallSiteTest has no call site to convert; both skip it by that property, with a reason,
+    rather than by name or by an empty baseline file. PackageReadmeTest and PackageMetadataTest still apply
+    in full — an empty package is still a package page somebody lands on — and PackageDependencyTest checks
+    the one thing that makes a shim work: exactly one dependency, on the package that replaced it, at this
+    package's own version.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- Nothing to symbolicate; a snupkg with no assembly in it is a file nobody can use. -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <!--
+      One dependency, and only one. Transitive pinning writes every centrally versioned id in the graph
+      into the nuspec as a dependency of its own - which is how Quartz.Jobs comes to list six framework
+      extensions it never names - and it did the same here, turning a shim into a package with seven
+      dependencies. There is no assembly to pin anything for, so it is off: what this package says is
+      "take the one that replaced me", and the replacement's own nuspec answers for the rest.
+    -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <!--
+      NU5128 reports a dependency group for a target framework the package has no lib folder for. That is
+      the shape of a shim rather than a mistake in one: the dependency group is the entire payload.
+    -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    PackageReadmeFile, the None item that packs it, Title, Description and PackageTags stay in each project
+    rather than being shared from here: PackageReadmeTest and PackageMetadataTest read the project file, and
+    a shared answer is exactly what those two exist to catch — a package described by whatever the defaults
+    happened to say.
+  -->
+
+</Project>


### PR DESCRIPTION
Five days after 4.0.0, the adoption audit of 2026-09-08 found two reasons a 4.0 upgrade never gets as far as compiling. Both are ours, both are patch-sized, and neither is visible from inside this repository. This is both fixes, for **4.0.1**.

## Part 1 — the floors

Every version in `Directory.Packages.props` is copied into a shipped nuspec as a *minimum*, and NuGet resolves a minimum by raising everything else to meet it. 4.0.0 floored six `Microsoft.Extensions.*` packages at `10.0.11` — the central version on the day it was built, not a version anything in Quartz needs — so an application pinned a patch lower could not restore at all.

### Reproduced first, against the released packages

Both scratch projects target `net10.0`, restore from nuget.org only, and reproduce the two failures in the issue verbatim:

```text
error NU1605: Detected package downgrade: Microsoft.Extensions.Options from 10.0.11 to 10.0.10.
  repro-options -> Quartz 4.0.0 -> Microsoft.Extensions.Diagnostics.HealthChecks 10.0.11 -> Microsoft.Extensions.Options (>= 10.0.11)
  repro-options -> Microsoft.Extensions.Options (>= 10.0.10)

error NU1605: Detected package downgrade: Microsoft.Extensions.Configuration from 10.0.11 to 10.0.9.
  repro-configuration -> Quartz.AspNetCore 4.0.0 -> Quartz 4.0.0 -> Microsoft.Extensions.Configuration.Binder 10.0.11 -> Microsoft.Extensions.Configuration (>= 10.0.11)
  repro-configuration -> Microsoft.Extensions.Configuration (>= 10.0.9)
```

One finding worth recording: the second one only reproduces in a `Microsoft.NET.Sdk` project. Under `Microsoft.NET.Sdk.Web` the SDK prunes the framework-provided `Microsoft.Extensions.Configuration` out of the transitive graph and the restore succeeds, so a web application escapes this particular one and a library does not.

### Where the sixth floor comes from

Not the binding generator: `CentralPackageTransitivePinningEnabled` is on, and NuGet writes every centrally versioned id in a project's graph into its nuspec as a *central transitive dependency*. That is how `Quartz` comes to floor `Microsoft.Extensions.Configuration.Binder`, which it never references, and how `Quartz.Jobs` — whose only reference is `Quartz` — comes to floor all six.

### Before and after

| Package | 4.0.0 / `main` before | after |
|---|---|---|
| `Microsoft.AspNetCore.SignalR.Client` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Configuration.Binder` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Configuration.EnvironmentVariables` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.DependencyInjection` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Diagnostics.HealthChecks` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Hosting.Abstractions` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Http` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Logging` | 10.0.11 | **10.0.0** |
| `Microsoft.Extensions.Options.ConfigurationExtensions` | 10.0.11 | **10.0.0** |
| `Newtonsoft.Json` | 13.0.4 | **13.0.2** |
| `OpenTelemetry.Extensions.Hosting` | 1.18.0 | **1.15.3** |
| `StackExchange.Redis` | 3.1.31 | **3.0.0** |
| `TimeZoneConverter` | 7.2.0 | **7.0.0** |

Per-package, that is the whole of the nuspec change; `Quartz.Aspire` additionally loses its inherited `Microsoft.Extensions.Configuration.EnvironmentVariables` dependency, which came from OpenTelemetry 1.18.0 and does not exist in 1.15.3.

### The two that are not the lowest of their major, and why

- **`Newtonsoft.Json` 13.0.2, not 13.0.1.** 13.0.1 is where the advisory-free 13.x line starts, and it is what this PR set first — at which point `JobDataMapPortabilityTest` failed with `Expected map.Get<TimeOnly>("timeOnly") to be <01:02:03.000>, but found <01:02:00.000>`. Json.NET reflects over `TimeOnly` and `DateOnly` member by member before 13.0.2, so a job data map round-trips through the Json.NET serializer having quietly lost its seconds. This is the criterion "has the API the code uses" doing its job.
- **`OpenTelemetry.Extensions.Hosting` 1.15.3, not 1.9.0.** `IOpenTelemetryBuilder`, which `Quartz.Aspire` uses, arrives in 1.9.0 — but every 1.x below 1.15.3 drags in an `OpenTelemetry.Api` with [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j), and `NU1902` is an error here. 1.15.3 is the version that fixed it. This is the "raise it for an advisory, to the fixed version" case.

`StackExchange.Redis` 3.0.0 and `TimeZoneConverter` 7.0.0 are the lowest of their current major, both compile, and `dotnet list package --vulnerable --include-transitive` reports nothing for any of the ten shipped projects.

### Mechanism

The floor ids moved into their own `<ItemGroup Label="Dependency floors">` in `Directory.Packages.props`, under a comment saying what a floor is, that the library and its tests compile against it on purpose, and that a security advisory is the only reason to raise one — to the fixed version, not the newest. `.github/dependabot.yml` gains an `ignore` entry per id for `semver-minor` and `semver-patch`; a major is still offered, because a major is a decision. `PackageDependencyTest` gains three assertions: a `Microsoft.*` floor is `x.0.0`, a shipped project's `Microsoft.*` reference is declared with the floors, and a shipped project uses no `VersionOverride`.

### Deviations from the brief, and why

- **`Microsoft.Extensions.Hosting` and `Microsoft.Extensions.Logging.Console` are in the floors group although only tests and examples reference them.** dotnet/runtime versions the family in lockstep, so 10.0.11 of either demands 10.0.11 of a floored id, which transitive pinning has already pinned at the floor — the restore fails here rather than at a consumer. They are at the floor for that reason and no other; the comment says so.
- **Five projects that ship nothing use `VersionOverride`, not one.** Aspire 13.5.3, bunit 2.9.0, `Microsoft.AspNetCore.Mvc.Testing` 10.0.11, NSwag 14.7.1 and the released `Quartz.Serialization.Json` 3.20.0 each ask for a newer patch than Quartz should demand of anybody, and the overrides cascade within the lockstep family. `Quartz.Examples.Aspire.AppHost` needs ten, `Quartz.Tests.AspNetCore` six, `Quartz.Tests.Unit` four, and the two remaining projects one each. All are literal, commented, and outside anything that ships — `ShippedProjectOverridesNoVersion` is what keeps them there.

## Part 2 — the anchor

Four new packable projects with no source: `Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`, `Quartz.Serialization.SystemTextJson` (each referencing `Quartz`) and `Quartz.Serialization.Json` (referencing `Quartz.Serialization.Newtonsoft`). `src/QuartzShimPackage.props` holds what they share and explains them.

Packed at `4.0.1-preview` and unzipped, each nupkg is:

```text
_rels/.rels
Quartz.Extensions.DependencyInjection.nuspec
README.md
quartz-logo-small.png
[Content_Types].xml
package/services/metadata/core-properties/nuget.psmdcp

<dependencies>
  <group targetFramework="net10.0">
    <dependency id="Quartz" version="4.0.1-preview" exclude="Build,Analyzers" />
  </group>
</dependencies>
```

No `lib/`, one dependency, same version. `Quartz.Serialization.Json` depends on `Quartz.Serialization.Newtonsoft 4.0.1-preview` instead; the other three on `Quartz`.

`CentralPackageTransitivePinningEnabled` is off for the shims, and that is load-bearing rather than tidy: the first pack produced a shim with **seven** dependencies, because transitive pinning had written all six of `Quartz`'s framework extensions into it. `PackageDependencyTest.ShimDependsOnItsReplacementAndNothingElse` pins both halves.

`Quartz.OpenTracing` and `Quartz.OpenTelemetry.Instrumentation` are deliberately not shimmed — those are the two 3.x ids this repository publishes that have no 4.x package to point at. (`OpenTelemetry.Instrumentation.Quartz` is opentelemetry-dotnet-contrib's and not ours; the migration guide said that one at first, and the commit that fixes it says so.) An empty package would tell a consumer they were up to date on a reference that has to go.

### Test harness

An explicit `<QuartzShimPackage>true</QuartzShimPackage>` on each of the four, exposed as `ShippedProjects.IsShim`. `PublicApiTest` and `LogCallSiteTest` skip a shim by that property with a reason rather than by name or by an empty baseline file that would look like a guard without being one; `PackageReadmeTest` and `PackageMetadataTest` apply in full. `PackageDependencyTest` gains `ShimDependsOnItsReplacementAndNothingElse` and `ShimPacksNoAssembly`.

## Verification

```text
dotnet fallout Compile UnitTest
  Passed!  - Failed: 0, Passed: 5458, Skipped: 36, Total: 5494 - Quartz.Tests.Unit.dll (net10.0)
  Passed!  - Failed: 0, Passed:  630, Skipped:  0, Total:  630 - Quartz.Tests.AspNetCore.dll (net10.0)
  Restore Succeeded / Compile Succeeded / UnitTest Succeeded

dotnet fallout Pack                Packages: 14  (the ten shipped plus the four shims)
dotnet fallout BenchmarkSmoke      Succeeded, 284 benchmarks
dotnet fallout VerifyDocsSnippets  Succeeded
npm run docs:check-links           224 pages, 1399 internal links, 857 fragments, no dead links or anchors
npm run docs:lint                  92 files, 0 errors
dotnet list package --vulnerable --include-transitive   nothing, on each of the ten shipped projects
```

No public API baseline changed — `git diff 197279fcbe --name-only` touches no `*.verified.txt`.

`Quartz.Tests.Integration` was **not** run: no Docker daemon is available on this machine.

### The two consumer scenarios, against a local feed of the packed 4.0.1-preview packages

Both restore clean, with no `NU1605`:

```shell
# Altafraner/afra-app#356 shape: Microsoft.Extensions.Options 10.0.10 + Quartz
dotnet restore consumer/fixed-options/fixed-options.csproj

# Arbeidstilsynet/receiver#236 shape: Microsoft.Extensions.Configuration 10.0.9 + Quartz.AspNetCore
dotnet restore consumer/fixed-configuration/fixed-configuration.csproj
```

And the grouped-update shape — `Quartz` 4.0.1-preview beside `Quartz.Extensions.Hosting` and `Quartz.Serialization.SystemTextJson` at the same version, which is what a bot leaves behind before the reference is removed — restores, compiles and runs the quick start:

```text
info: Quartz.Core.QuartzScheduler[1002]  Scheduler QuartzScheduler_$_NON_CLUSTERED started.
hello from the quick start, fired at 2026-09-08 18:37:48 +00:00
info: Quartz.Core.QuartzScheduler[1007]  Scheduler QuartzScheduler_$_NON_CLUSTERED Shutdown complete.
```

## Left alone, deliberately

`PackZip` copies `artifacts/bin/<project>` for `solution.Projects`, which Fallout defines as the projects whose parent is the solution *root*. Everything in a solution folder is therefore already absent from the source zip's `bin/` — the examples the `|| x.Name.Contains("Example")` clause means to include among them — and the four shims are absent for the same reason rather than by any decision. Pre-existing, unrelated to this issue, and not something to change in a patch.

## Before release

nuget.org's **trusted-publishing policy must cover the four new ids** before the `v4.0.1` tag is pushed, or `Publish` will fail on them: `Quartz.Extensions.DependencyInjection`, `Quartz.Extensions.Hosting`, `Quartz.Serialization.Json`, `Quartz.Serialization.SystemTextJson`. All four already exist on nuget.org under the same ownership at 3.20.1, so this is a policy edit rather than a first publish. Deprecating the 3.x versions remains a separate manual step.

Closes #3717

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
