### PR TITLE
Schedulers can be added to and removed from a running container

### DIFF
--- a/docs/documentation/quartz-4.x/log-events.md
+++ b/docs/documentation/quartz-4.x/log-events.md
@@ -225,6 +225,9 @@ matching on its text is not.
 | 4017 | Debug | `Quartz` | `"Thread pool closed to new work with {RunningTaskCount} running tasks remaining."` |
 | 4018 | Debug | `Quartz` | `"Shutdown of threadpool complete."` |
 | 4019 | Debug | `Quartz` | `"Shutdown complete"` |
+| 4020 | Information | `Quartz` | `"Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' was added at runtime"` |
+| 4021 | Information | `Quartz` | `"Scheduler '{SchedulerName}' was removed at runtime"` |
+| 4022 | Information | `Quartz` | `"Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host"` |
 | 5000 | Information | `Quartz` | `"Parsing XML file: {FileName} with systemId: {SystemId}"` |
 | 5001 | Information | `Quartz` | `"Parsing XML from stream with systemId: {SystemId}"` |
 | 5002 | Debug | `Quartz` | `"Found {JobGroupCount} delete job group commands."` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -34,6 +34,35 @@ If you ran a 4.0 alpha or beta, everything that changed between one pre-release 
 collected in [Appendix: if you ran a 4.0 pre-release](#appendix-if-you-ran-a-4-0-pre-release).
 The rest of this guide is written as one statement about 3.x and 4.0, with no build numbers in it.
 
+## Upgrading from 4.0 to 4.1
+
+Everything in this section is an addition. Nothing in the 4.0 public surface moved, so an application
+on 4.0 compiles on 4.1 unchanged; what is here is what 4.1 makes newly possible.
+
+| Added | What it is |
+|---|---|
+| `ISchedulerRuntime : ISchedulerRegistry` | Adds and removes schedulers in a container that has already been built. `Add(schedulerName, configure, options, cancellationToken)` builds a scheduler into a container of its own and binds it into this container's repository; `Remove(schedulerName, waitForJobsToComplete, cancellationToken)` shuts it down and releases what was built for it. Registered by `AddQuartz`, and `ISchedulerRegistry` resolves to the same object, so one listing answers for both kinds of scheduler |
+| `SchedulerAddOptions` | What to add a scheduler with beyond its name and its recipe: `Properties`, `Configuration` and `CreateWithoutStarting`. A `readonly record struct`, like every other options type an application constructs and passes in, whose `default` means "build it from the recipe and run it" |
+
+Three behaviours changed without a signature changing:
+
+* **`ISchedulerFactory.LookupScheduler` builds a registered-but-unbuilt scheduler** rather than
+  answering `null` for every name but its own factory's. What makes a scheduler exist is its
+  registration, so "give me tenant acme" no longer depends on whether something else happened to
+  resolve acme first. A scheduler *added at runtime* is found while it is alive and deliberately not
+  rebuilt once it has been shut down — it has no registration to be rebuilt from.
+* **`QuartzHostedService` shuts down the schedulers added at runtime** when the host stops, each under
+  the `QuartzHostedServiceOptions` registered for its name — so
+  `AddQuartzHostedService("acme", o => o.WaitForJobsToComplete = true)` configures a tenant that does
+  not exist yet. They were otherwise left to container disposal, which happens after the graceful
+  shutdown window has closed.
+* **A health check falls back to the repository** when the container holds no scheduler registration
+  under the name it was given, so `AddHealthChecks().AddQuartz("acme")` written at build time reports on
+  the tenant added under that name later. Its message when nothing is found names both places it looked.
+
+The mechanics, the refusals and the recipes are in
+[Multi-Tenancy](multi-tenancy.md#adding-a-tenant-while-the-process-is-running).
+
 ## The road from 3.x, phase by phase
 
 The 4.0 API is the result of six passes over the public surface, each with its own theme. The guide
@@ -3034,8 +3063,9 @@ public because `IQuartzApiClient` is replaceable; an application that implements
 has to fill the new members.
 
 `ISchedulerRegistry` is deliberately the *narrow* half of the API [#3338](https://github.com/quartznet/quartznet/issues/3338)
-sketches for runtime tenant lifecycle. Adding and removing schedulers at runtime is a 4.1 concern; when it
-lands, its manager interface extends this one rather than replacing it.
+sketches for runtime tenant lifecycle, and the promise held: 4.1's `ISchedulerRuntime` extends this
+interface rather than replacing it, and resolving either answers with the same object. See
+[Upgrading from 4.0 to 4.1](#upgrading-from-4-0-to-4-1).
 
 ## A shared database says so when two schedulers disagree about the table prefix
 

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -17,8 +17,8 @@ mechanics.
 | | Scheduler per tenant | Group per tenant | Database or prefix per tenant |
 |---|---|---|---|
 | **Isolation** | strongest: separate job store, thread pool, clock, listeners | logical only — one scheduler, one pool | strongest at rest; one process still runs them all |
-| **Tenants known at** | startup | any time | startup |
-| **Add a tenant at runtime** | no (needs a new container) | yes | no |
+| **Tenants known at** | startup or runtime | any time | startup |
+| **Add a tenant at runtime** | yes — [`ISchedulerRuntime`](#adding-a-tenant-while-the-process-is-running) | yes | no |
 | **Per-tenant concurrency limits** | yes, naturally | yes, via execution groups | yes |
 | **Per-tenant dashboard and API access** | yes — [`SchedulerAuthorizationPolicy`](#authorizing-a-tenant-on-its-own-scheduler) | no: Quartz authorizes a scheduler, not a group | yes, if each is its own scheduler |
 | **Cost per tenant** | a scheduling loop, a connection pool, a thread pool | ~nothing | a schema |
@@ -27,9 +27,11 @@ mechanics.
 They compose. The common shape for a SaaS with many small tenants is *one* scheduler, groups per
 tenant, one database — and a second scheduler for the handful of tenants that bought isolation.
 
-The question that usually decides it: **can a tenant appear while the process is running?** If yes, the
-scheduler-per-tenant model is out, because a scheduler cannot be added to a container that has already
-been built.
+The question that usually decides it is no longer "can a tenant appear while the process is running?" —
+[`ISchedulerRuntime`](#adding-a-tenant-while-the-process-is-running) adds one to a container that has
+already been built. What decides it is **cost per tenant**: the scheduler-per-tenant model gives each
+tenant a scheduling loop, a thread pool and — with a persistent store — a connection pool and a cluster
+check-in, which is fine for tens of tenants and not for thousands, however they arrive.
 
 ## Scheduler per tenant
 
@@ -813,6 +815,172 @@ delegate's place.
 Per-fire options are a snapshot: read what the tenant's configuration says *inside* the hook or the job,
 not once at startup, if tenants can be reconfigured while the process runs.
 
+## Adding a tenant while the process is running
+
+`AddQuartz(name, …)` registers a scheduler against `IServiceCollection`, which is closed once the
+container is built, so a tenant that appears afterwards has no registrations to be built from.
+`ISchedulerRuntime` is the other door. It takes a name the container never heard of, builds a scheduler
+for it into a container of its own — its own thread pool, job store, connection provider, plugins and
+listeners — binds it into the same `ISchedulerRepository` as every other scheduler, and starts it:
+
+<!-- snippet: sample_tenancy_runtime_onboarding -->
+```csharp
+ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+IScheduler tenant = await runtime.Add(tenantId, q =>
+{
+    q.UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId]));
+    q.UseDefaultThreadPool(maxConcurrency: 5);
+    q.AddJob<NightlyReportJob>(j => j.WithIdentity("nightly"));
+    q.AddTrigger<NightlyReportJob>(t => t.WithCronSchedule("0 30 2 * * ?"));
+});
+```
+<!-- endSnippet -->
+
+The callback is the same `IQuartzBuilder` an `AddQuartz(name, …)` callback is given, applied in the same
+order to the same phases, and whatever `ConfigureAllQuartzSchedulers` said about every scheduler in the
+container reaches it too — a package that adds something to every scheduler cannot know which door a
+scheduler came through. Everything that reads the repository sees the tenant without knowing it arrived
+late: `GetAllSchedulers`, `ISchedulerFactory.LookupScheduler`, the HTTP API, and the dashboard, which
+lists it as `SchedulerOrigin.Runtime` beside the container's registrations.
+
+Offboarding is `Remove`:
+
+<!-- snippet: sample_tenancy_offboarding -->
+```csharp
+ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+// Shuts the scheduler down, unbinds it from the repository and releases the container it was
+// built in. Nothing is deleted from the store: the tenant's rows stay where they are.
+bool removed = await runtime.Remove(tenantId, waitForJobsToComplete: true);
+```
+<!-- endSnippet -->
+
+It shuts the scheduler down, unbinds it and releases the container built for it. A name this runtime did
+not add answers `false` rather than throwing, so removing twice — or removing a tenant something else
+shut down — says what happened.
+
+::: warning Removing a tenant deletes none of its data
+A removed tenant's rows under its `SCHED_NAME` stay exactly where they are, and its `SCHEDULER_STATE`
+row expires the way a stopped node's does. Deleting a tenant's data is the application's decision, not a
+side effect of removing its scheduler — and a tenant added again under the same name picks up everything
+that was left.
+:::
+
+### What `Add` refuses
+
+It fails soft: a name it cannot take is refused with a `SchedulerConfigException` saying which rule and
+what to do about it, only the caller hears about it, and nothing is left behind — no half-built scheduler
+in the repository and nothing in the listing.
+
+| Refused | Because |
+|---|---|
+| a name `AddQuartz(name, …)` registered | its parts are registered under that name already; build it with `GetRequiredKeyedService<ISchedulerFactory>(name).GetScheduler()` |
+| the default scheduler's `InstanceName` | the same, for the one registration that has no service key of its own |
+| a name already added at runtime | `Remove` it first; a scheduler's thread pool and job store cannot be replaced underneath it |
+| a name already bound in the repository | a scheduler bound by hand, or one `AddQuartzHttpClient` bound, occupies the name as surely as a registration does |
+| any name, once the host is stopping | it would be created after the shutdown that would have stopped it |
+
+### Three things worth knowing
+
+**`IQuartzBuilder.Services` means the tenant's own collection**, not the application's. What the callback
+registers there belongs to this tenant and goes away with it. The one thing it may not register is how
+the tenant builds a job — `AddJobType` — because a job is built by the *application's* container, which
+is where its dependencies are; a recipe that tries is refused rather than quietly ignored. Register the
+job type in the application's container and let the recipe schedule it with `AddJob<T>(…)`.
+
+**`[FromKeyedServices("acme")] IScheduler` cannot reach a tenant added at runtime.** That is a container
+registration, and the point of `Add` is a name the container was never told about. Reach it through the
+scheduler `Add` returned, through `ISchedulerFactory.LookupScheduler(name)`, or through
+`ISchedulerRepository.Lookup(name)`.
+
+**A health check for a tenant is registered at build time**, with
+`services.AddHealthChecks().AddQuartz("acme")` — a check cannot be added to a built container any more
+than a scheduler can. Written before the tenant exists it reports unhealthy, and once the tenant is added
+it finds it through the repository. `AddQuartzHostedService("acme", o => o.WaitForJobsToComplete = true)`
+works the same way: registered at build time, read when the host stops, and applied to whichever tenant
+is running under that name — which is also what shuts a runtime tenant down inside the host's graceful
+shutdown window rather than at container disposal, after it has closed.
+
+### Without an application container
+
+`QuartzSchedulerBuilder` builds a scheduler from a container of its own, at any point in the process's
+life, and `ISchedulerRepository.Bind` makes the result visible to `GetAllSchedulers`, the dashboard and
+the HTTP API. This is the path for a process that has no application container for a tenant to resolve
+from — and it is what `ISchedulerRuntime` is made of:
+
+<!-- snippet: sample_tenancy_standalone_onboarding -->
+```csharp
+StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder
+    .Create(q => q
+        .ConfigureScheduler(o => o.InstanceName = tenantId)
+        .UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId])))
+    .Build();
+
+IScheduler tenant = await tenantFactory.GetScheduler();
+await tenant.Start();
+
+// Keep the factory: it owns the container, and it is the only handle that can shut the tenant
+// down again.
+tenantFactories[tenantId] = tenantFactory;
+app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
+```
+<!-- endSnippet -->
+
+Keep the factory for as long as the tenant exists — `tenantFactories` above is a dictionary keyed by
+tenant id — because it owns the container and is the only handle that can shut the tenant down again.
+`BuildScheduler()` is the shorter spelling that drops it on the floor, which is fine for a scheduler
+that lives as long as the process and wrong for one that has to be offboarded.
+
+What you take on by doing this: the returned `StandaloneSchedulerFactory` owns the container, so *you*
+start the scheduler and dispose the factory — the hosted service will not; the scheduler's jobs resolve
+from its own container rather than the application's unless you give it an `IJobFactory` that bridges;
+and health checks registered at startup do not cover it. `ISchedulerRuntime.Add` is the same shape with
+all three answered, which is the reason to prefer it wherever there is an application container.
+
+`Bind` refuses a duplicate **(name, instance id)** pair, not a duplicate name: two schedulers of one
+name and different instance ids coexist by design, which is how proxies to several nodes of one cluster
+are held. In practice the common case still throws, because a scheduler that has not opted into
+clustering takes the default instance id `NON_CLUSTERED` — so two non-clustered tenants sharing a name
+collide on the pair. Give each tenant's scheduler a distinct `InstanceName` and the question does not
+arise.
+
+Offboarding is disposing the factory, which shuts the tenant's scheduler down and then disposes its
+container. Unbind it too, so the application's repository stops listing it at once rather than at its
+next read:
+
+<!-- snippet: sample_tenancy_offboarding_standalone -->
+```csharp
+StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
+tenantFactories.Remove(tenantId);
+
+// Disposal shuts the scheduler down without waiting for its jobs, so ask for the wait here.
+IScheduler tenant = await tenantFactory.GetScheduler();
+await tenant.Shutdown(waitForJobsToComplete: true);
+
+await tenantFactory.DisposeAsync();
+app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
+```
+<!-- endSnippet -->
+
+::: warning Disposal does not wait for running jobs
+`StandaloneSchedulerFactory.DisposeAsync` shuts down with `waitForJobsToComplete: false`, so a tenant's
+jobs are cut short — which is the same default `IScheduler.Shutdown()` and `QuartzHostedServiceOptions`
+both carry, and two Quartz-owned shutdown paths that disagreed about it would be a trap. Waiting is a
+call you make first, as above: `await scheduler.Shutdown(waitForJobsToComplete: true)` leaves the
+factory with nothing left to shut down, so the two compose and the disposal only releases the container.
+:::
+
+::: warning Unbinding is not offboarding
+`Remove` makes a tenant invisible; only the disposal stops it. A recipe that unbinds without disposing
+takes the tenant out of `GetAllSchedulers`, off the dashboard and out of the HTTP API while it goes on
+firing its triggers for the rest of the process's life, with nothing left able to reach it. Disposing
+the factory shuts its scheduler down, which is what makes the two steps above safe in either order.
+:::
+
+Weigh all of it against the group-per-tenant model, where onboarding a tenant is a `ScheduleJob` call
+and none of the above applies.
+
 ## Honest limits
 
 Things multi-tenant deployments ask Quartz for and do not get:
@@ -842,86 +1010,11 @@ is "this tenant may pause but not delete". The resource-based shape leaves room 
 evaluated against a `SchedulerResource`, and an operation requirement could join it later without another
 option — but that is not built.
 
-**Tenants cannot be onboarded at runtime *through the DI path*.** Schedulers are registered against
-`IServiceCollection`, which is closed once the container is built, and the hosted service enumerates
-them once at start. (Enumerating what *is* registered no longer requires starting anything —
-[`ISchedulerRegistry`](#listing-them) — but adding to it does still require a new container.) Nor can a
-scheduler be restarted after `Shutdown()`: the container owns its parts' lifetimes, and `GetScheduler()`
-throws rather than resurrecting a thread pool and a job store underneath a scheduler that can never run
-again. `Standby()` / `Start()` is the pause-and-resume pair.
-
-That is a limit of the DI path, not of the library. `QuartzSchedulerBuilder` builds a scheduler from a
-container of its own, at any point in the process's life, and `ISchedulerRepository.Bind` makes the
-result visible to `GetAllSchedulers`, the dashboard and the HTTP API:
-
-<!-- snippet: sample_tenancy_runtime_onboarding -->
-```csharp
-StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder
-    .Create(q => q
-        .ConfigureScheduler(o => o.InstanceName = tenantId)
-        .UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId])))
-    .Build();
-
-IScheduler tenant = await tenantFactory.GetScheduler();
-await tenant.Start();
-
-tenantFactories[tenantId] = tenantFactory;
-app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
-```
-<!-- endSnippet -->
-
-Keep the factory for as long as the tenant exists — `tenantFactories` above is a dictionary keyed by
-tenant id — because it owns the container and is the only handle that can shut the tenant down again.
-`BuildScheduler()` is the shorter spelling that drops it on the floor, which is fine for a scheduler
-that lives as long as the process and wrong for one that has to be offboarded.
-
-What you take on by doing this: the returned `StandaloneSchedulerFactory` owns the container, so *you*
-start the scheduler and dispose the factory — the hosted service will not; the scheduler's jobs resolve
-from its own container rather than the application's unless you give it an `IJobFactory` that bridges;
-and health checks registered at startup do not cover it.
-
-`Bind` refuses a duplicate **(name, instance id)** pair, not a duplicate name: two schedulers of one
-name and different instance ids coexist by design, which is how proxies to several nodes of one cluster
-are held. In practice the common case still throws, because a scheduler that has not opted into
-clustering takes the default instance id `NON_CLUSTERED` — so two non-clustered tenants sharing a name
-collide on the pair. Give each tenant's scheduler a distinct `InstanceName` and the question does not
-arise.
-
-Offboarding is disposing the factory, which shuts the tenant's scheduler down and then disposes its
-container. Unbind it too, so the application's repository stops listing it at once rather than at its
-next read:
-
-<!-- snippet: sample_tenancy_offboarding -->
-```csharp
-StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
-tenantFactories.Remove(tenantId);
-
-// Disposal shuts the scheduler down without waiting for its jobs, so ask for the wait here.
-IScheduler tenant = await tenantFactory.GetScheduler();
-await tenant.Shutdown(waitForJobsToComplete: true);
-
-await tenantFactory.DisposeAsync();
-app.Services.GetRequiredService<ISchedulerRepository>().Remove(tenantId);
-```
-<!-- endSnippet -->
-
-::: warning Disposal does not wait for running jobs
-`StandaloneSchedulerFactory.DisposeAsync` shuts down with `waitForJobsToComplete: false`, so a tenant's
-jobs are cut short — which is the same default `IScheduler.Shutdown()` and `QuartzHostedServiceOptions`
-both carry, and two Quartz-owned shutdown paths that disagreed about it would be a trap. Waiting is a
-call you make first, as above: `await scheduler.Shutdown(waitForJobsToComplete: true)` leaves the
-factory with nothing left to shut down, so the two compose and the disposal only releases the container.
-:::
-
-::: warning Unbinding is not offboarding
-`Remove` makes a tenant invisible; only the disposal stops it. A recipe that unbinds without disposing
-takes the tenant out of `GetAllSchedulers`, off the dashboard and out of the HTTP API while it goes on
-firing its triggers for the rest of the process's life, with nothing left able to reach it. Disposing
-the factory shuts its scheduler down, which is what makes the two steps above safe in either order.
-:::
-
-Weigh that against the group-per-tenant model, where onboarding is a `ScheduleJob` call and none of
-the above applies.
+**A scheduler cannot be restarted after `Shutdown()`.** The container owns its parts' lifetimes, and
+`GetScheduler()` throws rather than resurrecting a thread pool and a job store underneath a scheduler
+that can never run again. `Standby()` / `Start()` is the pause-and-resume pair; for a tenant added at
+runtime, `ISchedulerRuntime.Remove` followed by `Add` builds a new set of parts, which is what a restart
+would have to mean.
 
 **A per-tenant thread pool is a real cost.** Under the scheduler-per-tenant model each tenant gets a
 scheduling loop that wakes on its own idle timer, a thread pool, and — with a persistent store — a

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -445,6 +445,7 @@ rather than an isolation one.
 | Per-scheduler health check | No — one check, on the default scheduler | Yes, `q.AddQuartzHealthChecks()` per scheduler |
 | Metrics | No | Yes |
 | Runtime tenant onboarding without a container | Yes, `StdSchedulerFactory` / `DirectSchedulerFactory` | Yes, `QuartzSchedulerBuilder` |
+| Runtime tenant onboarding into the application's container | No | Yes, `ISchedulerRuntime.Add` / `Remove` |
 
 Both trees carry the mechanics in full:
 
@@ -545,14 +546,20 @@ ordinary API call.
 
 Under the scheduler-per-tenant model, the DI path is closed once the container is built —
 `AddQuartz` mutates `IServiceCollection`, and the hosted service enumerates schedulers once at
-start. But that is a limit of the DI path, not of the library. Both versions can build a scheduler at
-runtime outside the container: 3.x through `StdSchedulerFactory` or `DirectSchedulerFactory`, and 4.x
-through `QuartzSchedulerBuilder`, which creates and owns a container of its own.
+start. Both versions can nonetheless build a scheduler at runtime *outside* the container: 3.x through
+`StdSchedulerFactory` or `DirectSchedulerFactory`, and 4.x through `QuartzSchedulerBuilder`, which
+creates and owns a container of its own.
 
 What that costs you is worth knowing before you build on it: a scheduler created this way gets no
 hosted-service lifetime (you start and dispose it), its jobs resolve from its own container rather
 than the application's unless you give it a job factory that bridges, and it is not covered by health
-checks registered at startup. The per-version guides spell out the API and the trade-offs.
+checks registered at startup.
+
+4.1 answers all three with `ISchedulerRuntime.Add(name, configure)`, which builds the tenant into a
+container of its own but resolves the application's services, jobs and options from the application's —
+so the tenant's jobs are ordinary application components, the host drains it when it stops, and a health
+check registered under its name finds it. `Remove` shuts it down and releases everything built for it.
+The per-version guides spell out the API and the trade-offs.
 
 ## Anti-patterns
 

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -286,10 +286,43 @@ public static class MultiTenancySamples
     public static async Task OnboardAtRuntime(
         IHost app,
         string tenantId,
+        IReadOnlyDictionary<string, string> connectionStrings)
+    {
+        #region sample_tenancy_runtime_onboarding
+
+        ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+        IScheduler tenant = await runtime.Add(tenantId, q =>
+        {
+            q.UsePersistentStore(s => s.UseSqlServer(connectionStrings[tenantId]));
+            q.UseDefaultThreadPool(maxConcurrency: 5);
+            q.AddJob<NightlyReportJob>(j => j.WithIdentity("nightly"));
+            q.AddTrigger<NightlyReportJob>(t => t.WithCronSchedule("0 30 2 * * ?"));
+        });
+
+        #endregion
+    }
+
+    public static async Task Offboard(IHost app, string tenantId)
+    {
+        #region sample_tenancy_offboarding
+
+        ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+        // Shuts the scheduler down, unbinds it from the repository and releases the container it was
+        // built in. Nothing is deleted from the store: the tenant's rows stay where they are.
+        bool removed = await runtime.Remove(tenantId, waitForJobsToComplete: true);
+
+        #endregion
+    }
+
+    public static async Task OnboardWithoutAContainer(
+        IHost app,
+        string tenantId,
         IReadOnlyDictionary<string, string> connectionStrings,
         Dictionary<string, StandaloneSchedulerFactory> tenantFactories)
     {
-        #region sample_tenancy_runtime_onboarding
+        #region sample_tenancy_standalone_onboarding
 
         StandaloneSchedulerFactory tenantFactory = QuartzSchedulerBuilder
             .Create(q => q
@@ -300,18 +333,20 @@ public static class MultiTenancySamples
         IScheduler tenant = await tenantFactory.GetScheduler();
         await tenant.Start();
 
+        // Keep the factory: it owns the container, and it is the only handle that can shut the tenant
+        // down again.
         tenantFactories[tenantId] = tenantFactory;
         app.Services.GetRequiredService<ISchedulerRepository>().Bind(tenant);
 
         #endregion
     }
 
-    public static async Task Offboard(
+    public static async Task OffboardWithoutAContainer(
         IHost app,
         string tenantId,
         Dictionary<string, StandaloneSchedulerFactory> tenantFactories)
     {
-        #region sample_tenancy_offboarding
+        #region sample_tenancy_offboarding_standalone
 
         StandaloneSchedulerFactory tenantFactory = tenantFactories[tenantId];
         tenantFactories.Remove(tenantId);

--- a/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/InProcessQuartzApiClientTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Quartz.Dashboard.Components.Shared;
@@ -806,6 +807,58 @@ public class InProcessQuartzApiClientTest
         finally
         {
             await scheduler.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// A scheduler added while the application was running reaches the dashboard's listing carrying the
+    /// origin that says so.
+    /// </summary>
+    /// <remarks>
+    /// Over a real container rather than the stub registry above, because what is under test is the
+    /// whole path — <c>SchedulerRuntime</c> appending the tenant to the container's registrations, and
+    /// this client joining that against the repository for the instance id. The origin is the only thing
+    /// in the listing that distinguishes the two kinds, and an operator needs it: a container
+    /// registration comes back after a restart and this one does not.
+    /// </remarks>
+    [Test]
+    public async Task TheListingCarriesASchedulerAddedAtRuntimeWithItsOrigin()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddQuartz("core", q => q.UseInMemoryStore());
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler tenant = await provider.GetRequiredService<ISchedulerRuntime>()
+            .Add("runtime-acme", q => q.UseInMemoryStore());
+
+        try
+        {
+            IOptions<QuartzDashboardOptions> options = Options.Create(new QuartzDashboardOptions());
+            InProcessQuartzApiClient client = new(
+                provider.GetRequiredService<ISchedulerRepository>(),
+                provider.GetRequiredService<ISchedulerRegistry>(),
+                options,
+                TestData.Dashboard.HistoryStore(),
+                new SchedulerAuthorization(options, new TestSchedulerAuthorizationService(), new TestAuthenticationStateProvider()));
+
+            List<SchedulerHeaderDto> schedulers = await client.GetSchedulers();
+
+            SchedulerHeaderDto header = schedulers.Should().ContainSingle(x => x.SchedulerName == "runtime-acme").Subject;
+            header.Origin.Should().Be(SchedulerOrigin.Runtime,
+                "nothing in the container registered it, so nothing in the container will bring it back");
+            header.Status.Should().Be(SchedulerStatus.Running);
+            header.SchedulerInstanceId.Should().Be(tenant.SchedulerInstanceId,
+                "the registration carries no instance id, so the repository is asked for it - and the "
+                + "tenant is in the same repository every other scheduler is in");
+
+            schedulers.Should().ContainSingle(x => x.SchedulerName == "core")
+                .Which.Origin.Should().Be(SchedulerOrigin.Container);
+        }
+        finally
+        {
+            await tenant.Shutdown();
         }
     }
 

--- a/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/TenantSchedulerRoutingTest.cs
@@ -178,6 +178,73 @@ public abstract class TenantSchedulerRoutingTest
     }
 
     /// <summary>
+    /// A tenant the container never registered, added while the application was running: its routes
+    /// answer, the listing carries it, and removing it takes both away again.
+    /// </summary>
+    /// <remarks>
+    /// Nothing in the HTTP API knows this scheduler arrived late. Every endpoint group resolves through
+    /// <see cref="ISchedulerRepository" /> and the listing reads <see cref="ISchedulerRegistry" />, so a
+    /// tenant that binds itself into the one and is appended to the other is visible everywhere without a
+    /// special case — which is what makes runtime onboarding an addition rather than a second kind of
+    /// scheduler the whole API would have to learn about. The origin is what tells an operator which
+    /// kind of scheduler is in front of them: a container registration survives a restart, and this one
+    /// does not.
+    /// </remarks>
+    [Test]
+    public async Task ATenantAddedAtRuntimeIsListedWithOriginRuntimeAndItsRoutesAnswer()
+    {
+        WebApplicationFactory<Program> application = CreateApplication("acme");
+
+        using HttpClient client = application.CreateClient();
+
+        ISchedulerRuntime runtime = application.Services.GetRequiredService<ISchedulerRuntime>();
+        IScheduler tenant = await runtime.Add("runtime-acme", ConfigureStore);
+
+        try
+        {
+            using (HttpResponseMessage details = await client.GetAsync("schedulers/runtime-acme"))
+            {
+                details.StatusCode.Should().Be(HttpStatusCode.OK,
+                    "the route resolves through the repository, and a tenant added at runtime binds itself "
+                    + "into the same repository every other scheduler is in");
+            }
+
+            using (HttpResponseMessage jobs = await client.GetAsync("schedulers/runtime-acme/jobs"))
+            {
+                jobs.StatusCode.Should().Be(HttpStatusCode.OK,
+                    "every endpoint group resolves the same way, so none of them needs to know this "
+                    + "scheduler arrived after the container was built");
+            }
+
+            SchedulerHeaderDto[] listed = await ReadSchedulers(client);
+
+            SchedulerHeaderDto header = listed.Should().ContainSingle(x => x.Name == "runtime-acme").Subject;
+            header.Origin.Should().Be(SchedulerOrigin.Runtime,
+                "the origin is what tells an operator that this scheduler is not in the container's "
+                + "registrations and will not come back on its own after a restart");
+            header.Status.Should().Be(SchedulerStatus.Running);
+            header.SchedulerInstanceId.Should().Be(tenant.SchedulerInstanceId);
+
+            listed.Should().ContainSingle(x => x.Name == "acme")
+                .Which.Origin.Should().Be(SchedulerOrigin.Container,
+                    "the two kinds are listed side by side and told apart by their origin alone");
+        }
+        finally
+        {
+            (await runtime.Remove("runtime-acme")).Should().BeTrue();
+        }
+
+        using (HttpResponseMessage afterRemoval = await client.GetAsync("schedulers/runtime-acme"))
+        {
+            afterRemoval.StatusCode.Should().Be(HttpStatusCode.NotFound,
+                "removing shuts it down, which unbinds it from the repository the route reads");
+        }
+
+        (await ReadSchedulers(client)).Should().NotContain(x => x.Name == "runtime-acme",
+            "and the runtime forgot it, so nothing is left claiming a tenant that is gone");
+    }
+
+    /// <summary>
     /// Builds the test application with one named scheduler registered beside the default one, and
     /// records it for disposal. Per test rather than per fixture, because whether the tenant has been
     /// created is exactly what these tests differ on.

--- a/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsConventionTest.cs
@@ -92,7 +92,12 @@ public class OptionsConventionTest
         // a keyed-service key is typed 'object' by Microsoft.Extensions.DependencyInjection's own
         // contract (ServiceDescriptor.ServiceKey, [FromKeyedServices(object)]), so an option that
         // carries one to the container cannot be narrower than the container itself.
-        ["Quartz.DataSourceOptions.DataSourceServiceKey"] = "a DI service key is typed 'object' by the container's contract"
+        ["Quartz.DataSourceOptions.DataSourceServiceKey"] = "a DI service key is typed 'object' by the container's contract",
+
+        // #3338: the runtime spelling of AddQuartz(name, configuration, …). A configuration section is
+        // Microsoft.Extensions.Configuration's own contract, and this member carries one *into* Quartz
+        // rather than being a setting bound *out of* one — which is the direction the rule is about.
+        ["Quartz.SchedulerAddOptions.Configuration"] = "a configuration section is Microsoft.Extensions.Configuration's contract, carried in rather than bound out of"
     };
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
@@ -164,7 +164,7 @@ public sealed class SchedulerGenerationScopeTest
         return SchedulerGeneration.Build(
             application,
             schedulerName,
-            new SchedulerAddOptions(),
+            default,
             builder => builder.ConfigureJobScope((scope, _, scheduler) =>
             {
                 ScopeRecorder recorder = scope.ServiceProvider.GetService<ScopeRecorder>();

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
@@ -1,0 +1,303 @@
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// What a job of a scheduler built at runtime is handed, and whose scope it runs in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the test that decides whether the mechanism is honest. A scheduler added at runtime lives in
+/// a container of its own, and the well-known way of doing that — a composite provider that asks the
+/// child and falls back to the parent — resolves <see cref="IServiceScopeFactory" /> from the child, so
+/// the per-execution scope is not the application's at all. Every application-scoped service a job takes
+/// is then created outside any scope the application owns and never disposed, which shows up in
+/// production as a leak and in development as an exception, and is the reason the DI platform declined
+/// to ship child containers.
+/// </para>
+/// <para>
+/// So: the firing's scope is the application's, a scoped service is one instance across everything the
+/// firing touches, it is disposed when the job is returned, and the scheduler's own parts are still the
+/// tenant's.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerGenerationScopeTest
+{
+    private static readonly TimeSpan firingTimeout = TimeSpan.FromSeconds(30);
+
+    [Test]
+    public async Task AJobOfARuntimeTenantIsBuiltInTheApplicationsScope()
+    {
+        using ServiceProvider application = Application(services =>
+        {
+            services.AddScoped<UnitOfWork>();
+            services.AddScoped<ScopedProbeJob>();
+        });
+
+        ScopeRecorder recorder = application.GetRequiredService<ScopeRecorder>();
+
+        await using SchedulerGeneration acme = Generation(application, "acme");
+        await using SchedulerGeneration initech = Generation(application, "initech");
+
+        IScheduler acmeScheduler = await Fire<ScopedProbeJob>(acme);
+        IScheduler initechScheduler = await Fire<ScopedProbeJob>(initech);
+
+        Observation first = await recorder.Wait("acme");
+        Observation second = await recorder.Wait("initech");
+
+        first.UnitOfWork.Should().BeSameAs(recorder.FromScope["acme"],
+            "the job and the scheduler's own ConfigureJobScope hook run inside one firing, so a scoped "
+            + "service they both reach has to be one instance - two would mean two scopes, and the "
+            + "application's half of the firing living outside the one that gets disposed");
+        first.UnitOfWork.Should().NotBeSameAs(second.UnitOfWork,
+            "each firing gets its own scope, and two tenants firing the same job are two firings");
+
+        await acmeScheduler.Shutdown(waitForJobsToComplete: true);
+        await initechScheduler.Shutdown(waitForJobsToComplete: true);
+
+        first.UnitOfWork.Disposed.Should().BeTrue(
+            "the scope is closed when the job is returned, and the application's scope is closed with it - "
+            + "otherwise every firing of every tenant leaks whatever its jobs resolved");
+        second.UnitOfWork.Disposed.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ARuntimeTenantsJobGetsItsOwnSchedulerParts()
+    {
+        using ServiceProvider application = Application(services => { });
+
+        ScopeRecorder recorder = application.GetRequiredService<ScopeRecorder>();
+
+        await using SchedulerGeneration generation = Generation(application, "acme");
+        IScheduler scheduler = await Fire<PartsProbeJob>(generation);
+
+        Observation observed = await recorder.Wait("acme");
+
+        try
+        {
+            IScheduler resolved = await observed.SchedulerFactory.GetScheduler();
+            resolved.Should().BeSameAs(scheduler,
+                "a scheduler's parts are keyed by its name in its own container, so a job activated for a "
+                + "tenant is handed that tenant's factory rather than the application's default scheduler's");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ApplicationOptionsAreTheApplications()
+    {
+        using ServiceProvider application = Application(services =>
+            services.Configure<ApplicationOptions>(options => options.Value = "from-the-application"));
+
+        ScopeRecorder recorder = application.GetRequiredService<ScopeRecorder>();
+
+        await using SchedulerGeneration generation = Generation(application, "acme");
+        IScheduler scheduler = await Fire<PartsProbeJob>(generation);
+
+        Observation observed = await recorder.Wait("acme");
+
+        try
+        {
+            observed.ApplicationOption.Should().Be("from-the-application",
+                "nothing in the tenant's recipe said anything about this options type, so reading it from "
+                + "the tenant's container would answer with a defaulted instance nobody wrote");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    [Test]
+    public async Task ASchedulerScopedOptionsSnapshotIsTheTenants()
+    {
+        using ServiceProvider application = Application(services => { });
+
+        ScopeRecorder recorder = application.GetRequiredService<ScopeRecorder>();
+
+        await using SchedulerGeneration generation = Generation(application, "acme");
+        IScheduler scheduler = await Fire<PartsProbeJob>(generation);
+
+        Observation observed = await recorder.Wait("acme");
+
+        try
+        {
+            observed.SnapshotInstanceName.Should().Be("acme",
+                "a tenant's container holds exactly one scheduler, and Quartz's own options read inside it "
+                + "are that scheduler's - reading them from the application would answer with whatever the "
+                + "application's default scheduler was configured with");
+        }
+        finally
+        {
+            await scheduler.Shutdown(waitForJobsToComplete: true);
+        }
+    }
+
+    /// <summary>
+    /// An application container with its own default scheduler, so that the tenant is genuinely a second
+    /// scheduler beside one rather than the only thing in the process.
+    /// </summary>
+    private static ServiceProvider Application(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddQuartz();
+        services.AddSingleton<ScopeRecorder>();
+        configure(services);
+
+        // Scope validation on, because the leak this test exists to catch is exactly what it reports.
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    private static SchedulerGeneration Generation(IServiceProvider application, string schedulerName)
+    {
+        return SchedulerGeneration.Build(
+            application,
+            schedulerName,
+            new SchedulerAddOptions(),
+            builder => builder.ConfigureJobScope((scope, _, scheduler) =>
+            {
+                ScopeRecorder recorder = scope.ServiceProvider.GetService<ScopeRecorder>();
+                UnitOfWork unitOfWork = scope.ServiceProvider.GetService<UnitOfWork>();
+                if (recorder is not null && unitOfWork is not null)
+                {
+                    recorder.FromScope[scheduler.SchedulerName] = unitOfWork;
+                }
+            }),
+            number: 1);
+    }
+
+    /// <summary>
+    /// Creates and starts the tenant, and schedules one firing of a job the recipe never registered — so
+    /// the job factory activates it through the tenant's provider, which is the path a job's constructor
+    /// parameters are decided on one at a time.
+    /// </summary>
+    private static async Task<IScheduler> Fire<T>(SchedulerGeneration generation) where T : IJob
+    {
+        IScheduler scheduler = await generation.Create();
+        await scheduler.Start();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<T>().WithIdentity("probe").Build(),
+            TriggerBuilder.Create().WithIdentity("probe").StartNow().Build());
+
+        return scheduler;
+    }
+
+    private sealed class ScopeRecorder
+    {
+        private readonly ConcurrentDictionary<string, TaskCompletionSource<Observation>> firings = new();
+
+        /// <summary>
+        /// What the scheduler's own per-firing hook saw, by scheduler name.
+        /// </summary>
+        public ConcurrentDictionary<string, UnitOfWork> FromScope { get; } = new();
+
+        public void Record(Observation observation)
+        {
+            Slot(observation.SchedulerName).TrySetResult(observation);
+        }
+
+        public async Task<Observation> Wait(string schedulerName)
+        {
+            Task<Observation> firing = Slot(schedulerName).Task;
+            Task finished = await Task.WhenAny(firing, Task.Delay(firingTimeout));
+            finished.Should().BeSameAs(firing, $"the job of scheduler '{schedulerName}' has to have fired");
+            return await firing;
+        }
+
+        private TaskCompletionSource<Observation> Slot(string schedulerName)
+        {
+            return firings.GetOrAdd(
+                schedulerName,
+                static _ => new TaskCompletionSource<Observation>(TaskCreationOptions.RunContinuationsAsynchronously));
+        }
+    }
+
+    private sealed record Observation(
+        string SchedulerName,
+        UnitOfWork UnitOfWork,
+        ISchedulerFactory SchedulerFactory,
+        string ApplicationOption,
+        string SnapshotInstanceName);
+
+    /// <summary>
+    /// Registered in the application's container, and taking only application services — the shape the
+    /// documentation asks a registered job to have.
+    /// </summary>
+    private sealed class ScopedProbeJob : IJob
+    {
+        private readonly ScopeRecorder recorder;
+        private readonly UnitOfWork unitOfWork;
+
+        public ScopedProbeJob(ScopeRecorder recorder, UnitOfWork unitOfWork)
+        {
+            this.recorder = recorder;
+            this.unitOfWork = unitOfWork;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(new Observation(context.Scheduler.SchedulerName, unitOfWork, null, null, null));
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Registered nowhere, so the job factory activates it and every constructor parameter is routed one
+    /// at a time — which is where "this scheduler's" and "the application's" have to come apart.
+    /// </summary>
+    private sealed class PartsProbeJob : IJob
+    {
+        private readonly ScopeRecorder recorder;
+        private readonly ISchedulerFactory schedulerFactory;
+        private readonly IOptions<ApplicationOptions> applicationOptions;
+        private readonly IOptionsSnapshot<QuartzSchedulerOptions> schedulerOptions;
+
+        public PartsProbeJob(
+            ScopeRecorder recorder,
+            ISchedulerFactory schedulerFactory,
+            IOptions<ApplicationOptions> applicationOptions,
+            IOptionsSnapshot<QuartzSchedulerOptions> schedulerOptions)
+        {
+            this.recorder = recorder;
+            this.schedulerFactory = schedulerFactory;
+            this.applicationOptions = applicationOptions;
+            this.schedulerOptions = schedulerOptions;
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            recorder.Record(new Observation(
+                context.Scheduler.SchedulerName,
+                null,
+                schedulerFactory,
+                applicationOptions.Value.Value,
+                schedulerOptions.Value.InstanceName));
+
+            return default;
+        }
+    }
+
+    private sealed class ApplicationOptions
+    {
+        public string Value { get; set; }
+    }
+
+    private sealed class UnitOfWork : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
@@ -1,0 +1,345 @@
+using FakeItEasy;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Adding and removing schedulers in a container that has already been built.
+/// </summary>
+/// <remarks>
+/// Two halves. The first is that a scheduler added here is an ordinary scheduler: built, bound into the
+/// container's repository, started, listed, and visible to everything that reads the repository. The
+/// second — most of the tests — is the refusals, because the value of this API is decided by what it
+/// says no to. A name already spoken for must be refused where the caller can read why, rather than
+/// raced into the repository's own duplicate check, and a failed add must leave nothing behind at all:
+/// runtime fails soft, and the only thing that hears about it is the caller.
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerRuntimeTest
+{
+    private readonly List<IScheduler> started = [];
+
+    [TearDown]
+    public async Task ShutDownWhateverIsLeft()
+    {
+        foreach (IScheduler scheduler in started)
+        {
+            try
+            {
+                await scheduler.Shutdown();
+            }
+            catch (SchedulerException)
+            {
+                // Already shut down by the test itself.
+            }
+        }
+
+        started.Clear();
+    }
+
+    [Test]
+    public async Task AddBuildsBindsAndStartsATenant()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme");
+
+        tenant.SchedulerName.Should().Be("acme");
+        tenant.Status.Should().Be(SchedulerStatus.Running, "a scheduler added at runtime is started by default");
+
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant,
+            "binding it into the container's own repository is what makes the HTTP API, the dashboard and "
+            + "GetAllSchedulers see it without any of them knowing it arrived late");
+
+        List<SchedulerRegistration> listing = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+        listing.Should().ContainSingle(x => x.Name == "acme").Which.Should().BeEquivalentTo(
+            new { Name = "acme", Origin = SchedulerOrigin.Runtime, Status = SchedulerStatus.Running });
+    }
+
+    [Test]
+    public async Task AddWithStartFalseLeavesTheTenantCreated()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme", options: SchedulerAddOptions.WithoutStarting);
+
+        tenant.Status.Should().Be(SchedulerStatus.Created,
+            "the starting policy is the whole of what this option decides, and CreateWithoutStarting means the "
+            + "application presses start");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant,
+            "a scheduler that has not been started is still bound, exactly as one the hosted service created "
+            + "with AutoStart false is");
+    }
+
+    [Test]
+    public async Task AddRefusesAContainerRegisteredName()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        Func<Task> add = async () => await Add(provider, "ACME");
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "the container registered that name, and its parts are already registered under it - a second "
+                + "set would be two schedulers wearing one name"))
+            .WithMessage("*registered with the container*")
+            .WithMessage("*GetRequiredKeyedService<ISchedulerFactory>(\"acme\")*",
+                "the message names the spelling the container used, so the caller can copy it");
+    }
+
+    [Test]
+    public async Task AddRefusesTheDefaultSchedulersName()
+    {
+        using ServiceProvider provider = Container(services =>
+            services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne")));
+
+        Func<Task> add = async () => await Add(provider, "TheDefaultOne");
+
+        await add.Should().ThrowAsync<SchedulerConfigException>(
+            "the default scheduler is the one registration whose name is not the name it was registered "
+            + "under - it has no service key at all - so the name has to be read out of its options");
+    }
+
+    [Test]
+    public async Task AddRefusesABoundScheduler()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler standalone = await QuartzSchedulerBuilder
+            .Create(q => q.ConfigureScheduler(o => o.InstanceName = "bound-by-hand"))
+            .BuildScheduler();
+        started.Add(standalone);
+
+        provider.GetRequiredService<ISchedulerRepository>().Bind(standalone);
+
+        Func<Task> add = async () => await Add(provider, "bound-by-hand");
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "a scheduler bound by hand, or one AddQuartzHttpClient bound, occupies the name as surely as a "
+                + "registration does"))
+            .WithMessage("*already bound in this container's repository*");
+    }
+
+    [Test]
+    public async Task AddRefusesANameAlreadyAdded()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        await Add(provider, "acme");
+
+        Func<Task> again = async () => await Add(provider, "acme");
+
+        (await again.Should().ThrowAsync<SchedulerConfigException>(
+                "a scheduler's thread pool and job store cannot be replaced underneath it, which is why there "
+                + "is no way to add over one"))
+            .WithMessage("*has already been added at runtime*")
+            .WithMessage("*Remove(\"acme\")*");
+    }
+
+    [Test]
+    public async Task AddRefusesWhileTheHostIsStopping()
+    {
+        using CancellationTokenSource stopping = new();
+        IHostApplicationLifetime lifetime = A.Fake<IHostApplicationLifetime>();
+        A.CallTo(() => lifetime.ApplicationStopping).Returns(stopping.Token);
+
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddSingleton(lifetime);
+            services.AddQuartz("main", _ => { });
+        });
+
+        await stopping.CancelAsync();
+
+        Func<Task> add = async () => await Add(provider, "acme");
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "a scheduler created after the shutdown that would have stopped it is one nothing comes back for"))
+            .WithMessage("*host is stopping*");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task AFailedAddRetainsNothing()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+        List<SchedulerRegistration> before = await registry.QuerySchedulers();
+
+        Func<Task> add = async () => await Add(
+            provider,
+            "acme",
+            options: new SchedulerAddOptions
+            {
+                Properties = new Dictionary<string, string> { ["quartz.thisKeyIsNotRead"] = "true" }
+            });
+
+        await add.Should().ThrowAsync<SchedulerConfigException>(
+            "the property bag is checked exactly as AddQuartz(name, properties) checks it, so a misspelling "
+            + "is reported rather than ignored");
+
+        List<SchedulerRegistration> after = await registry.QuerySchedulers();
+        after.Should().BeEquivalentTo(before,
+            "runtime fails soft: only the caller hears about it, and half a tenant in the listing would be "
+            + "worse than none because nothing would ever come back for it");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ConfigureAllQuartzSchedulersReachesARuntimeTenant()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz("main", _ => { });
+            services.ConfigureAllQuartzSchedulers(q => q.ConfigureScheduler(o => o.Context["applied"] = "yes"));
+        });
+
+        IScheduler tenant = await Add(provider, "acme");
+
+        tenant.Context.Should().ContainKey("applied").WhoseValue.Should().Be("yes",
+            "ConfigureAllQuartzSchedulers says 'every scheduler in this container', and a tenant bound into "
+            + "this container's repository is one of them - a package that adds something to every scheduler "
+            + "cannot know which door a scheduler came through");
+    }
+
+    [Test]
+    public async Task AddJobTypeWithAnImplementationMappingIsRefusedForARuntimeTenant()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        Func<Task> add = async () => await Add(
+            provider,
+            "acme",
+            configure: q => q.AddJobType<RuntimeJob, DerivedRuntimeJob>());
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "a mapping nothing reads is worse than a mapping refused: the tenant would run the type the "
+                + "recipe replaced, and nothing would say so"))
+            .WithMessage("*does not build its own jobs*")
+            .WithMessage($"*{typeof(RuntimeJob).FullName}*");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task RemoveShutsDownUnbindsAndForgets()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme");
+
+        ISchedulerRuntime runtime = provider.GetRequiredService<ISchedulerRuntime>();
+        (await runtime.Remove("acme")).Should().BeTrue();
+
+        tenant.Status.Should().Be(SchedulerStatus.Shutdown);
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeNull(
+            "a scheduler unbinds itself from the repository when it shuts down");
+
+        List<SchedulerRegistration> listing = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+        listing.Should().NotContain(x => x.Name == "acme",
+            "removing forgets the unit, which is what tells a shut-down tenant waiting to be removed from one "
+            + "that has been");
+
+        (await runtime.Remove("acme")).Should().BeFalse(
+            "a name this runtime does not hold is not an error - removing twice says what happened rather "
+            + "than throwing");
+    }
+
+    [Test]
+    public async Task RemoveRefusesAContainerName()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        Func<Task> remove = async () => await provider.GetRequiredService<ISchedulerRuntime>().Remove("acme");
+
+        (await remove.Should().ThrowAsync<SchedulerConfigException>(
+                "the container owns the parts of what it registered, and disposing them is the container's "
+                + "business rather than this runtime's"))
+            .WithMessage("*IScheduler.Shutdown()*");
+    }
+
+    [Test]
+    public async Task AShutDownTenantIsListedWithANullStatusUntilRemoved()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme");
+        await tenant.Shutdown();
+
+        ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+
+        List<SchedulerRegistration> listing = await registry.QuerySchedulers();
+        SchedulerRegistration listed = listing.Should().ContainSingle(x => x.Name == "acme",
+            "the repository drops a shut-down scheduler, and the registrations never knew about this one - so "
+            + "without the runtime's own list it would vanish while Remove still had work to do").Subject;
+        listed.Origin.Should().Be(SchedulerOrigin.Runtime);
+        listed.Status.Should().BeNull("there is no live scheduler under this name any more");
+
+        (await provider.GetRequiredService<ISchedulerRuntime>().Remove("acme")).Should().BeTrue(
+            "shutting a tenant down by hand does not remove it - its container is still there to release");
+
+        (await registry.QuerySchedulers()).Should().NotContain(x => x.Name == "acme");
+    }
+
+    [Test]
+    public async Task TheDefaultRegistryListingIsUnchangedForAContainerWithNoRuntimeTenants()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne"));
+            services.AddQuartz("acme", _ => { });
+        });
+
+        ISchedulerRegistry registry = provider.GetRequiredService<ISchedulerRegistry>();
+
+        registry.Should().BeOfType<SchedulerRuntime>(
+            "one object answers both interfaces, because a listing that omitted the runtime tenants would be "
+            + "wrong and a second registry to merge with the first is how it would come to be wrong");
+
+        List<SchedulerRegistration> listing = await registry.QuerySchedulers();
+
+        listing.Select(x => x.Name).Should().Equal(["TheDefaultOne", "acme"],
+            "a container with no runtime tenants answers exactly what it answered before this existed");
+        listing.Should().OnlyContain(x => x.Origin == SchedulerOrigin.Container && x.Status == null);
+    }
+
+    private async Task<IScheduler> Add(
+        ServiceProvider provider,
+        string schedulerName,
+        Action<IQuartzBuilder> configure = null,
+        SchedulerAddOptions options = default)
+    {
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerRuntime>()
+            .Add(schedulerName, configure, options);
+
+        started.Add(scheduler);
+        return scheduler;
+    }
+
+    private static ServiceProvider Container(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    private class RuntimeJob : IJob
+    {
+        public virtual ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return default;
+        }
+    }
+
+    private sealed class DerivedRuntimeJob : RuntimeJob;
+}

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
@@ -194,6 +194,28 @@ public sealed class SchedulerRuntimeTest
     }
 
     [Test]
+    public async Task AddRefusesSettingsGivenTwoWaysAtOnce()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        Func<Task> add = async () => await Add(
+            provider,
+            "acme",
+            options: new SchedulerAddOptions
+            {
+                Properties = new Dictionary<string, string> { ["quartz.scheduler.instanceId"] = "one" },
+                Configuration = new ConfigurationBuilder().Build()
+            });
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "a section says everything a property bag does, so honouring one of them would drop the "
+                + "other without a word - which is what AddQuartzSchedulers refuses in the same words"))
+            .WithMessage("*Use one or the other*");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty();
+    }
+
+    [Test]
     public async Task ConfigureAllQuartzSchedulersReachesARuntimeTenant()
     {
         using ServiceProvider provider = Container(services =>

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
@@ -193,6 +193,33 @@ public sealed class SchedulerRuntimeTest
         provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty();
     }
 
+    /// <summary>
+    /// Bad configuration reaches the caller as the exception every other Quartz configuration mistake
+    /// does, rather than as the options framework's own.
+    /// </summary>
+    /// <remarks>
+    /// Options validation is <em>how</em> configuration is checked and <c>OptionsValidationException</c>
+    /// is an implementation detail of that. <c>DefaultSchedulerFactory.GetScheduler</c> makes the same
+    /// translation, and a caller adding a scheduler at runtime should not have to catch two exception
+    /// types depending on which door the scheduler came through.
+    /// </remarks>
+    [Test]
+    public async Task AddReportsBadConfigurationAsASchedulerConfigException()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        Func<Task> add = async () => await Add(
+            provider,
+            "acme",
+            configure: q => q.ConfigureScheduler(o => o.IdleWaitTime = TimeSpan.Zero));
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>())
+            .WithMessage("*IdleWaitTime*", "the caller is told which setting is wrong");
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty(
+            "the failure happens before anything is bound, and nothing is retained either way");
+    }
+
     [Test]
     public async Task AddRefusesSettingsGivenTwoWaysAtOnce()
     {

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeTest.cs
@@ -194,6 +194,62 @@ public sealed class SchedulerRuntimeTest
     }
 
     /// <summary>
+    /// A host that begins stopping while a tenant is being built ends up with no tenant, rather than one
+    /// running past the shutdown that should have drained it.
+    /// </summary>
+    /// <remarks>
+    /// The window is between the check that lets the add proceed and the line that registers the unit:
+    /// building and starting a scheduler is not instantaneous, and a host stopping in the middle of it
+    /// takes the live schedulers from a map this one is not in yet. The scheduler would then be started
+    /// and bound with the graceful shutdown already behind it, and only container disposal — which runs
+    /// after the shutdown window closes — left to catch it. So the signal is read again once the
+    /// scheduler is running, and the add undoes itself.
+    /// <para>
+    /// The window is entered on purpose rather than raced for: the scheduler's own
+    /// <see cref="ISchedulerListener.SchedulerStarted" /> is awaited inside <c>Start()</c>, so cancelling
+    /// the host's token there lands between the start and the second reading every time.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public async Task AddRacingTheHostsStopIsShutDownAndRefused()
+    {
+        using CancellationTokenSource stopping = new();
+        IHostApplicationLifetime lifetime = A.Fake<IHostApplicationLifetime>();
+        A.CallTo(() => lifetime.ApplicationStopping).Returns(stopping.Token);
+
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddSingleton(lifetime);
+            services.AddQuartz("main", _ => { });
+        });
+
+        RecordingThreadPool pool = new();
+
+        Func<Task> add = async () => await Add(
+            provider,
+            "acme",
+            configure: q => q
+                .UseThreadPool(pool)
+                .AddSchedulerListener(new StopTheHostWhenStarted(stopping)));
+
+        (await add.Should().ThrowAsync<SchedulerConfigException>(
+                "the host began stopping before this tenant was registered, so nothing was ever going to "
+                + "shut it down"))
+            .WithMessage("*host is stopping*");
+
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeNull(
+            "the scheduler was bound and started before the second reading, so undoing the add has to "
+            + "unbind it - which shutting it down does");
+
+        (await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers())
+            .Should().NotContain(x => x.Name == "acme", "the unit was never registered, so nothing lists it");
+
+        pool.ShutdownCalled.Should().BeTrue(
+            "the whole generation is released, not merely forgotten: its thread pool is what would have "
+            + "gone on running work nothing could reach");
+    }
+
+    /// <summary>
     /// Bad configuration reaches the caller as the exception every other Quartz configuration mistake
     /// does, rather than as the options framework's own.
     /// </summary>
@@ -380,6 +436,52 @@ public sealed class SchedulerRuntimeTest
         services.AddLogging();
         configure(services);
         return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Stops the host from inside the scheduler's own start notification, which is awaited by
+    /// <c>Start()</c> — so the flip lands in the window under test rather than near it.
+    /// </summary>
+    private sealed class StopTheHostWhenStarted : ISchedulerListener
+    {
+        private readonly CancellationTokenSource stopping;
+
+        public StopTheHostWhenStarted(CancellationTokenSource stopping) => this.stopping = stopping;
+
+        public ValueTask SchedulerStarted(IScheduler scheduler, CancellationToken cancellationToken = default)
+        {
+            stopping.Cancel();
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// A thread pool that says whether it was shut down, which is how a released generation is told from
+    /// a forgotten one.
+    /// </summary>
+    private sealed class RecordingThreadPool : IThreadPool
+    {
+        public bool ShutdownCalled { get; private set; }
+
+        public int PoolSize => 1;
+
+        public ValueTask Initialize(CancellationToken cancellationToken = default) => default;
+
+        public ValueTask<int> WaitForAvailableThreads(CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<int>(ShutdownCalled ? 0 : 1);
+        }
+
+        public ValueTask<bool> TryRun(Func<ValueTask> action, CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<bool>(false);
+        }
+
+        public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default)
+        {
+            ShutdownCalled = true;
+            return default;
+        }
     }
 
     private class RuntimeJob : IJob

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerScopedServiceProviderLinkTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerScopedServiceProviderLinkTest.cs
@@ -1,0 +1,268 @@
+using System.Collections.Frozen;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// <see cref="SchedulerScopedServiceProvider" /> over two containers: a scheduler's own, and the
+/// application's.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the composite a scheduler added at runtime resolves through. The two containers are built
+/// here by hand rather than through <c>SchedulerGeneration</c>, because what is under test is the
+/// routing itself — which request each container answers, and whose scope a firing runs in — and that
+/// is decided in this class rather than in whatever assembled the pair.
+/// </para>
+/// <para>
+/// The DI platform declined to ship parent/child containers, and the reason it gives is exactly the
+/// case the last two tests here pin down: the folk implementation resolves <c>IServiceScopeFactory</c>
+/// from the child, so the per-execution scope is not the application's, and every application-scoped
+/// service a job takes is leaked instead of disposed. So each of these is a rule that has to hold
+/// rather than a preference.
+/// </para>
+/// </remarks>
+public sealed class SchedulerScopedServiceProviderLinkTest
+{
+    [Test]
+    public void AJobIsBuiltByTheApplicationEvenWhenTheSchedulersOwnContainerHasOne()
+    {
+        using ServiceProvider application = Application(services => services.AddSingleton(new LinkedJob("application")));
+        using ServiceProvider tenant = Tenant(application, services => services.AddSingleton(new LinkedJob("tenant")));
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetService<LinkedJob>()!.Origin.Should().Be("application",
+            "a job's constructor takes the application's services, and a container resolves a service's "
+            + "dependencies from itself - so a job built by the tenant's container would be built out of the "
+            + "half of the graph that does not have them");
+    }
+
+    [Test]
+    public void AnApplicationsOptionsTypeIsTheApplications()
+    {
+        using ServiceProvider application = Application(services =>
+            services.Configure<LinkedOptions>(options => options.Owner = "application"));
+        using ServiceProvider tenant = Tenant(application, _ => { });
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetService<IOptions<LinkedOptions>>()!.Value.Owner.Should().Be("application",
+            "nothing in the tenant's recipe configured these, so reading them there would answer with a "
+            + "freshly defaulted instance nobody wrote");
+    }
+
+    [Test]
+    public void AnOptionsTypeTheRecipeConfiguredIsTheTenants()
+    {
+        using ServiceProvider application = Application(services =>
+            services.Configure<LinkedOptions>(options => options.Owner = "application"));
+        using ServiceProvider tenant = Tenant(
+            application,
+            services => services.Configure<LinkedOptions>(options => options.Owner = "tenant"),
+            configuredOptions: [typeof(LinkedOptions)]);
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetService<IOptions<LinkedOptions>>()!.Value.Owner.Should().Be("tenant",
+            "the tenant said something about this options type, and what a tenant says about its own "
+            + "configuration is the whole point of giving it a recipe");
+    }
+
+    [Test]
+    public void AQuartzOptionsTypeIsAlwaysTheTenants()
+    {
+        using ServiceProvider application = Application(services =>
+            services.Configure<JobFactoryOptions>(options => options.ConfigureScope = (_, _, _) => { }));
+        using ServiceProvider tenant = Tenant(application, _ => { });
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetService<IOptions<JobFactoryOptions>>()!.Value.ConfigureScope.Should().BeNull(
+            "a tenant's container holds exactly one scheduler, so Quartz's own options read there are that "
+            + "scheduler's - reading them from the application would hand the tenant whatever the "
+            + "application's own scheduler was configured with");
+    }
+
+    [Test]
+    public void AnEnumerableComesFromWhicheverContainerDeclaresIt()
+    {
+        using ServiceProvider application = Application(services => services.AddSingleton(new LinkedNote("application")));
+        using ServiceProvider tenant = Tenant(application, services => services.AddSingleton(new LinkedMark("tenant")));
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetService<IEnumerable<LinkedNote>>().Should().ContainSingle().Which.Origin.Should().Be("application",
+            "an empty sequence and 'this container has none of these' are the same answer, so the decision "
+            + "is made on which container declares the item type rather than on what came back");
+        composite.GetService<IEnumerable<LinkedMark>>().Should().ContainSingle().Which.Origin.Should().Be("tenant");
+    }
+
+    [Test]
+    public void ThisSchedulersKeyMeansItsOwnContainerAndAnotherKeyMeansTheApplications()
+    {
+        using ServiceProvider application = Application(services =>
+        {
+            services.AddKeyedSingleton("acme", new LinkedNote("application-acme"));
+            services.AddKeyedSingleton("initech", new LinkedNote("application-initech"));
+        });
+        using ServiceProvider tenant = Tenant(application, services =>
+            services.AddKeyedSingleton("acme", new LinkedNote("tenant-acme")));
+
+        IKeyedServiceProvider composite = (IKeyedServiceProvider) SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.GetKeyedService<LinkedNote>("acme")!.Origin.Should().Be("tenant-acme",
+            "this scheduler's own key is where its recipe put whatever it keyed");
+        composite.GetKeyedService<LinkedNote>("initech")!.Origin.Should().Be("application-initech",
+            "another key is another scheduler's, and the application is what holds those");
+    }
+
+    [Test]
+    public void WhatCanBeSuppliedIsTheUnionOfBothContainers()
+    {
+        using ServiceProvider application = Application(services => services.AddSingleton(new LinkedNote("application")));
+        using ServiceProvider tenant = Tenant(application, services => services.AddSingleton(new LinkedMark("tenant")));
+
+        IServiceProviderIsService composite = (IServiceProviderIsService) SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        composite.IsService(typeof(LinkedNote)).Should().BeTrue(
+            "ActivatorUtilities treats a service it is told does not exist as a parameter it cannot supply, "
+            + "and this provider can supply it");
+        composite.IsService(typeof(LinkedMark)).Should().BeTrue();
+        composite.IsService(typeof(SchedulerScopedServiceProviderLinkTest)).Should().BeFalse();
+    }
+
+    [Test]
+    public void AFiringsScopeIsTheApplicationsScope()
+    {
+        using ServiceProvider application = Application(services => services.AddScoped<LinkedUnitOfWork>());
+        using ServiceProvider tenant = Tenant(application, _ => { });
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        LinkedUnitOfWork first;
+        using (IServiceScope scope = composite.CreateScope())
+        {
+            first = scope.ServiceProvider.GetRequiredService<LinkedUnitOfWork>();
+            scope.ServiceProvider.GetRequiredService<LinkedUnitOfWork>().Should().BeSameAs(first,
+                "everything one firing resolves shares one scope, so a unit of work a job and a middleware "
+                + "both take is one unit of work");
+            first.Disposed.Should().BeFalse();
+        }
+
+        first.Disposed.Should().BeTrue(
+            "the application's scope is disposed with the tenant's, so an application-scoped service a job "
+            + "took is torn down when the job is returned rather than leaked for the life of the process");
+
+        using IServiceScope second = composite.CreateScope();
+        second.ServiceProvider.GetRequiredService<LinkedUnitOfWork>().Should().NotBeSameAs(first,
+            "each firing gets its own scope");
+    }
+
+    [Test]
+    public async Task AFiringsScopeIsDisposedAsynchronouslyThroughBothContainers()
+    {
+        using ServiceProvider application = Application(services => services.AddScoped<LinkedUnitOfWork>());
+        using ServiceProvider tenant = Tenant(application, services => services.AddScoped<LinkedUnitOfWork>());
+
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(tenant, "acme");
+
+        IServiceScope scope = composite.CreateScope();
+        LinkedUnitOfWork resolved = scope.ServiceProvider.GetRequiredService<LinkedUnitOfWork>();
+
+        await ((IAsyncDisposable) scope).DisposeAsync();
+
+        resolved.Disposed.Should().BeTrue("jobs are torn down through IAsyncDisposable, and both scopes are");
+    }
+
+    [Test]
+    public void ASchedulerWithNoApplicationBehindItResolvesExactlyAsItDidBefore()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton(new LinkedNote("container"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        IServiceProvider composite = SchedulerScopedServiceProvider.For(provider, "acme");
+
+        composite.GetService<LinkedNote>()!.Origin.Should().Be("container");
+        composite.GetService<LinkedMark>().Should().BeNull(
+            "with nothing linked there is no second container to fall back to, which is the container-registered "
+            + "scheduler's path and has to stay what it was");
+
+        using IServiceScope scope = composite.CreateScope();
+        scope.ServiceProvider.GetService<LinkedNote>()!.Origin.Should().Be("container");
+    }
+
+    private static ServiceProvider Application(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddOptions();
+        configure(services);
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    /// <summary>
+    /// The container one scheduler lives in, linked back to the application's — the shape
+    /// <c>SchedulerGeneration</c> builds.
+    /// </summary>
+    private static ServiceProvider Tenant(
+        IServiceProvider application,
+        Action<IServiceCollection> configure,
+        Type[] configuredOptions = null)
+    {
+        ServiceCollection services = new();
+        services.AddOptions();
+        configure(services);
+        services.AddSingleton(new ApplicationLink(application)
+        {
+            ConfiguredOptions = (configuredOptions ?? []).ToFrozenSet()
+        });
+
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    private sealed class LinkedJob : IJob
+    {
+        public LinkedJob(string origin) => Origin = origin;
+
+        public string Origin { get; }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default) => default;
+    }
+
+    private sealed class LinkedNote
+    {
+        public LinkedNote(string origin) => Origin = origin;
+
+        public string Origin { get; }
+    }
+
+    private sealed class LinkedMark
+    {
+        public LinkedMark(string origin) => Origin = origin;
+
+        public string Origin { get; }
+    }
+
+    private sealed class LinkedOptions
+    {
+        public string Owner { get; set; }
+    }
+
+    private sealed class LinkedUnitOfWork : IDisposable, IAsyncDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose() => Disposed = true;
+
+        public ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
@@ -33,9 +33,10 @@ public sealed class SharedServiceForwardingTest
             "written while a collection is being registered into, and a generation's collection holds "
             + "exactly one scheduler - the application's list of names is not that",
 
-        [typeof(ISchedulerRegistry)] =
-            "answers 'what schedulers are there', which a container holding one tenant cannot; removed "
-            + "from the generation's collection so the question falls through to the application's",
+        [typeof(ISchedulerRegistry)] = ContainerWide,
+        [typeof(ISchedulerRuntime)] = ContainerWide,
+        [typeof(SchedulerRuntime)] = ContainerWide,
+        [typeof(ContainerSchedulerRegistry)] = ContainerWide,
 
         [typeof(Microsoft.Extensions.Options.IValidateOptions<>)] =
             "a generation validates its own scheduler's options, and the validators are stateless - "
@@ -61,6 +62,10 @@ public sealed class SharedServiceForwardingTest
         [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfigurationFactory)] = Logging,
         [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<>)] = Logging,
     };
+
+    private const string ContainerWide =
+        "answers 'what schedulers are there', which a container holding one tenant cannot; removed from "
+        + "the generation's collection so the question falls through to the application's";
 
     private const string OptionsFramework =
         "the options framework's own plumbing, which every container that reads options has; a "

--- a/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Configuration;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// The drift guard between <c>AddQuartzSharedServices</c> and what a scheduler built at runtime is
+/// handed from the application.
+/// </summary>
+/// <remarks>
+/// A generation's container is seeded with the application's shared services rather than registering
+/// its own, and the list of them is written by hand — there is no way to derive it, because "shared"
+/// is a statement about meaning rather than about a registration's shape. So the failure mode is that
+/// a shared service is added to <c>AddQuartzSharedServices</c> and nobody remembers this list, and a
+/// tenant quietly gets a second copy of something there is supposed to be one of. That failure does not
+/// show up as an exception; it shows up as a tenant the dashboard cannot see, or measurements nobody is
+/// collecting.
+/// <para>
+/// So every service type the shared registration produces must be classified: either forwarded, or
+/// excused here with the reason it is not. A new one fails this test until somebody decides which it
+/// is.
+/// </para>
+/// </remarks>
+public sealed class SharedServiceForwardingTest
+{
+    /// <summary>
+    /// The service types a generation's container deliberately registers for itself, and why.
+    /// </summary>
+    private static readonly Dictionary<Type, string> excused = new()
+    {
+        [typeof(SchedulerNameRegistry)] =
+            "written while a collection is being registered into, and a generation's collection holds "
+            + "exactly one scheduler - the application's list of names is not that",
+
+        [typeof(ISchedulerRegistry)] =
+            "answers 'what schedulers are there', which a container holding one tenant cannot; removed "
+            + "from the generation's collection so the question falls through to the application's",
+
+        [typeof(Microsoft.Extensions.Options.IValidateOptions<>)] =
+            "a generation validates its own scheduler's options, and the validators are stateless - "
+            + "sharing them would buy nothing and tie a tenant's validation to the application's",
+
+        [typeof(Microsoft.Extensions.Options.IConfigureOptions<>)] =
+            "configuration is per collection by definition: what the application configured is the "
+            + "application's schedulers, and the recipe configures the tenant's",
+
+        [typeof(Microsoft.Extensions.Options.IStartupValidator)] =
+            "what ValidateOnStart registers, and a host is what runs it - a generation is built after "
+            + "the host started, so its options are validated on the first read of them instead, which "
+            + "is inside the Add call the caller is awaiting",
+
+        [typeof(Microsoft.Extensions.Options.IOptions<>)] = OptionsFramework,
+        [typeof(Microsoft.Extensions.Options.IOptionsSnapshot<>)] = OptionsFramework,
+        [typeof(Microsoft.Extensions.Options.IOptionsMonitor<>)] = OptionsFramework,
+        [typeof(Microsoft.Extensions.Options.IOptionsFactory<>)] = OptionsFramework,
+        [typeof(Microsoft.Extensions.Options.IOptionsMonitorCache<>)] = OptionsFramework,
+
+        [typeof(Microsoft.Extensions.Logging.ILogger<>)] = Logging,
+        [typeof(Microsoft.Extensions.Logging.ILoggerFactory)] = Logging,
+        [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfigurationFactory)] = Logging,
+        [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<>)] = Logging,
+    };
+
+    private const string OptionsFramework =
+        "the options framework's own plumbing, which every container that reads options has; a "
+        + "generation reads its own options through its own";
+
+    private const string Logging =
+        "AddLogging()'s registrations, which follow the ILoggerFactory that is forwarded - the factory "
+        + "is what decides where a log line goes, and it is the application's";
+
+    [Test]
+    public void EverySharedServiceIsEitherForwardedOrExcused()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzSharedServices();
+
+        List<string> unclassified = [];
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (IsClassified(descriptor.ServiceType))
+            {
+                continue;
+            }
+
+            unclassified.Add(descriptor.ServiceType.FullName!);
+        }
+
+        unclassified.Should().BeEmpty(
+            "a service AddQuartzSharedServices registers is either one thing per container - in which "
+            + "case SchedulerGeneration.ForwardedServiceTypes has to carry it to a tenant - or one thing "
+            + "per scheduler, in which case say so here. Silently getting a second copy is the failure "
+            + "this test exists to prevent, and it has no symptom until production");
+    }
+
+    [Test]
+    public void EveryForwardedServiceIsOneTheSharedRegistrationActuallyMakes()
+    {
+        ServiceCollection services = new();
+        services.AddQuartzSharedServices();
+
+        HashSet<Type> registered = [];
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            registered.Add(descriptor.ServiceType);
+        }
+
+        SchedulerGeneration.ForwardedServiceTypes.Should().OnlyContain(x => registered.Contains(x),
+            "the list drifts in both directions: a service that stopped being registered here is one a "
+            + "generation is still trying to carry across, which is a forward of nothing at all");
+    }
+
+    [Test]
+    public void TheExcusedListSaysWhy()
+    {
+        excused.Should().OnlyContain(x => !string.IsNullOrWhiteSpace(x.Value),
+            "an excuse without a reason is a service somebody classified in a hurry, and the next reader "
+            + "has no way to tell whether it was thought about");
+    }
+
+    private static bool IsClassified(Type serviceType)
+    {
+        if (SchedulerGeneration.ForwardedServiceTypes.Contains(serviceType) || excused.ContainsKey(serviceType))
+        {
+            return true;
+        }
+
+        return serviceType.IsConstructedGenericType
+            && (SchedulerGeneration.ForwardedServiceTypes.Contains(serviceType.GetGenericTypeDefinition())
+                || excused.ContainsKey(serviceType.GetGenericTypeDefinition()));
+    }
+}

--- a/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
+++ b/src/Quartz.Tests.Unit/Extensions/DependencyInjection/SchedulerRegistryTest.cs
@@ -213,6 +213,33 @@ public sealed class SchedulerRegistryTest
                 + "them is behind a network that is down");
     }
 
+    [Test]
+    public async Task ARuntimeTenantIsListedWithOriginRuntime()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler tenant = await provider.GetRequiredService<ISchedulerRuntime>().Add("initech");
+
+        try
+        {
+            List<SchedulerRegistration> registrations = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+            registrations.Select(x => x.Name).Should().Equal(["acme", "initech"],
+                "one listing answers for both doors a scheduler can come through, ordered the same way");
+            registrations.Should().ContainSingle(x => x.Name == "acme")
+                .Which.Origin.Should().Be(SchedulerOrigin.Container);
+
+            SchedulerRegistration runtime = registrations.Should().ContainSingle(x => x.Name == "initech").Subject;
+            runtime.Origin.Should().Be(SchedulerOrigin.Runtime,
+                "no registration accounts for it - it was added to a container that was already built");
+            runtime.Status.Should().Be(SchedulerStatus.Running);
+        }
+        finally
+        {
+            await tenant.Shutdown();
+        }
+    }
+
     private static ServiceProvider Container(Action<IServiceCollection> configure)
     {
         ServiceCollection services = new();

--- a/src/Quartz.Tests.Unit/HealthChecks/QuartzHealthCheckTests.cs
+++ b/src/Quartz.Tests.Unit/HealthChecks/QuartzHealthCheckTests.cs
@@ -278,6 +278,62 @@ public class QuartzHealthCheckTests
         A.CallTo(() => scheduler.QueryClusterNodes(A<CancellationToken>._)).MustNotHaveHappened();
     }
 
+    /// <summary>
+    /// A health check registered for a name the container does not hold reports on the scheduler added
+    /// under that name at runtime.
+    /// </summary>
+    /// <remarks>
+    /// A health check is registered while the container is being built, when a tenant that has not been
+    /// added yet has no keyed <c>ISchedulerFactory</c> for the check to resolve — and never will have
+    /// one. The repository is where everything else that reads across both kinds of scheduler looks, so
+    /// the check looks there too rather than reporting a running tenant as absent.
+    /// </remarks>
+    [Test]
+    public async Task AHealthCheckForARuntimeTenantFindsItInTheRepository()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddQuartz("core", q => q.UseInMemoryStore());
+        services.AddHealthChecks().AddQuartz("acme");
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetKeyedService<ISchedulerFactory>("acme").Should().BeNull(
+            "the premise of the test is a name the container never registered");
+
+        IScheduler tenant = await provider.GetRequiredService<ISchedulerRuntime>().Add("acme", q => q.UseInMemoryStore());
+
+        try
+        {
+            HealthReportEntry result = await Run(provider, "quartz-scheduler-acme");
+
+            result.Status.Should().Be(HealthStatus.Healthy);
+            result.Description.Should().Contain("acme");
+        }
+        finally
+        {
+            await tenant.Shutdown();
+        }
+    }
+
+    [Test]
+    public async Task AHealthCheckForANameNothingHoldsSaysBothPlacesItLooked()
+    {
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddQuartz("core", q => q.UseInMemoryStore());
+        services.AddHealthChecks().AddQuartz("acme");
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        HealthReportEntry result = await Run(provider, "quartz-scheduler-acme");
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Description.Should().Contain("added at runtime under that name",
+            "the message names both places the check looked, so an operator can tell 'never registered' "
+            + "from 'registered and not built'");
+    }
+
     private static async Task<HealthReportEntry> Check(
         SchedulerStatus status,
         SchedulerException? storeFailure = null,

--- a/src/Quartz.Tests.Unit/Impl/DefaultSchedulerFactoryLookupTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DefaultSchedulerFactoryLookupTest.cs
@@ -1,0 +1,139 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// What <see cref="ISchedulerFactory.LookupScheduler" /> can find, now that a registration is enough.
+/// </summary>
+/// <remarks>
+/// The lookup used to answer only from the repository for any name but its own factory's, so under a
+/// multi-tenant registration "give me tenant acme" depended on whether something else had happened to
+/// resolve acme first — the same call returning a scheduler or <see langword="null" /> according to what
+/// the rest of the application had done. What makes a scheduler exist is the registration, so that is
+/// what the lookup reads.
+/// </remarks>
+[NonParallelizable]
+public sealed class DefaultSchedulerFactoryLookupTest
+{
+    private readonly List<IScheduler> started = [];
+
+    [TearDown]
+    public async Task ShutDownWhateverIsLeft()
+    {
+        foreach (IScheduler scheduler in started)
+        {
+            try
+            {
+                await scheduler.Shutdown();
+            }
+            catch (SchedulerException)
+            {
+                // Already shut down by the test itself.
+            }
+        }
+
+        started.Clear();
+    }
+
+    [Test]
+    public async Task LookupSchedulerBuildsARegisteredButUnbuiltScheduler()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz("acme", _ => { });
+            services.AddQuartz("initech", _ => { });
+        });
+
+        ISchedulerRepository repository = provider.GetRequiredService<ISchedulerRepository>();
+        repository.LookupAll().Should().BeEmpty("the premise is that nothing has been built");
+
+        ISchedulerFactory acme = provider.GetRequiredKeyedService<ISchedulerFactory>("acme");
+
+        IScheduler initech = await Track(await acme.LookupScheduler("initech"));
+
+        initech.Should().NotBeNull(
+            "the registration is what says the scheduler exists, so asking one tenant's factory for "
+            + "another's name builds it rather than answering that there is no such scheduler");
+        initech.SchedulerName.Should().Be("initech");
+
+        repository.Lookup("initech").Should().BeSameAs(initech,
+            "it was built through its own factory, so it is bound exactly as it would have been had the "
+            + "container resolved it");
+
+        (await acme.LookupScheduler("INITECH")).Should().BeSameAs(initech,
+            "the comparison ignores case, because that is how the repository indexes names");
+    }
+
+    [Test]
+    public async Task LookupSchedulerBuildsTheDefaultSchedulerFromANamedOnesFactory()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne"));
+            services.AddQuartz("acme", _ => { });
+        });
+
+        ISchedulerFactory acme = provider.GetRequiredKeyedService<ISchedulerFactory>("acme");
+
+        IScheduler standard = await Track(await acme.LookupScheduler("TheDefaultOne"));
+
+        standard.Should().NotBeNull(
+            "the default scheduler is the one registration whose name is not the name it was registered "
+            + "under - it has no service key at all - so its options are read to learn it");
+        standard.SchedulerName.Should().Be("TheDefaultOne");
+    }
+
+    [Test]
+    public async Task LookupSchedulerStillAnswersNullForANameNothingRegistered()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        ISchedulerFactory acme = provider.GetRequiredKeyedService<ISchedulerFactory>("acme");
+
+        (await acme.LookupScheduler("nobody")).Should().BeNull();
+
+        provider.GetRequiredService<ISchedulerRepository>().LookupAll().Should().BeEmpty(
+            "a name nothing registered builds nothing at all, so the lookup is still the read it says it is");
+    }
+
+    [Test]
+    public async Task LookupSchedulerDoesNotBuildADownRuntimeTenant()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        ISchedulerFactory acme = provider.GetRequiredKeyedService<ISchedulerFactory>("acme");
+        IScheduler tenant = await Track(await provider.GetRequiredService<ISchedulerRuntime>().Add("initech"));
+
+        (await acme.LookupScheduler("initech")).Should().BeSameAs(tenant,
+            "while it is alive it is in the repository, which is where the lookup finds it");
+
+        await tenant.Shutdown();
+
+        (await acme.LookupScheduler("initech")).Should().BeNull(
+            "a scheduler added at runtime has no registration to be rebuilt from - its parts were one set "
+            + "of instances in a container of their own - so adding it again is ISchedulerRuntime's "
+            + "rather than something a lookup does behind the caller's back");
+    }
+
+    private Task<IScheduler> Track(IScheduler scheduler)
+    {
+        if (scheduler is not null)
+        {
+            started.Add(scheduler);
+        }
+
+        return Task.FromResult(scheduler);
+    }
+
+    private static ServiceProvider Container(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
+++ b/src/Quartz.Tests.Unit/QuartzHostedServiceTests.cs
@@ -847,6 +847,78 @@ public class QuartzHostedServiceTests
     }
 
     /// <summary>
+    /// A scheduler added while the host was running is shut down when the host stops, under the settings
+    /// registered for its name.
+    /// </summary>
+    /// <remarks>
+    /// Not because it is this service's - nothing here created it, and it learns of it only at the stop -
+    /// but because the alternative is leaving it to container disposal, which happens after the graceful
+    /// shutdown window has closed. A tenant's running jobs would be abandoned rather than waited for,
+    /// which is what <c>WaitForJobsToComplete</c> exists to prevent; that it is read under the tenant's
+    /// own name is what lets the setting be written before the tenant exists, which is the only time a
+    /// registration can be written at all.
+    /// </remarks>
+    [Test]
+    public async Task StopAsyncShutsDownARuntimeTenant()
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings());
+        builder.Services.AddSingleton<IHostLifetime, SilentHostLifetime>();
+        builder.Services.AddQuartz(q => q.ConfigureScheduler(options => options.InstanceName = "runtime-drain"));
+        builder.Services.AddQuartzHostedService();
+
+        // Written before the tenant exists, which is the only time a registration can be written.
+        builder.Services.AddQuartzHostedService("acme", options => options.WaitForJobsToComplete = true);
+
+        using IHost host = builder.Build();
+        await host.StartAsync();
+
+        IScheduler tenant = await host.Services.GetRequiredService<ISchedulerRuntime>().Add("acme");
+
+        await tenant.ScheduleJob(
+            JobBuilder.Create<DrainingJob>().WithIdentity("draining").Build(),
+            TriggerBuilder.Create().WithIdentity("draining").StartNow().Build());
+
+        (await DrainingJob.Started.Task.WaitAsync(TimeSpan.FromSeconds(30))).Should().BeTrue();
+
+        await host.StopAsync();
+
+        tenant.Status.Should().Be(SchedulerStatus.Shutdown,
+            "the host's graceful shutdown window is where a tenant is stopped, and container disposal "
+            + "happens after that window has closed");
+
+        DrainingJob.Finished.Should().BeTrue(
+            "WaitForJobsToComplete was registered under the tenant's name, so the drain waited for the job "
+            + "the tenant was running - a shutdown that did not read those options would have returned "
+            + "while it was still going");
+
+        List<SchedulerRegistration> listing =
+            await host.Services.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+        listing.Should().NotContain(x => x.Name == "acme",
+            "the runtime let go of it when the host took it, so it is no longer something Remove has work "
+            + "left to do for");
+    }
+
+    /// <summary>
+    /// A job that is still running when the host is asked to stop.
+    /// </summary>
+    private sealed class DrainingJob : IJob
+    {
+        public static readonly TaskCompletionSource<bool> Started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static bool Finished { get; private set; }
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Started.TrySetResult(true);
+
+            // Long enough that a shutdown which did not wait would return first, short enough that the
+            // test is not a stopwatch.
+            await Task.Delay(TimeSpan.FromMilliseconds(500), CancellationToken.None);
+            Finished = true;
+        }
+    }
+
+    /// <summary>
     /// A host lifetime that neither waits for anything nor installs a console handler.
     /// </summary>
     private sealed class SilentHostLifetime : IHostLifetime

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -338,6 +338,12 @@
     "Shutdown of threadpool complete."
 4019  Debug  ConfigurationLog.ZeroSizeThreadPoolShutdownComplete
     "Shutdown complete"
+4020  Information  ConfigurationLog.RuntimeSchedulerAdded
+    "Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' was added at runtime"
+4021  Information  ConfigurationLog.RuntimeSchedulerRemoved
+    "Scheduler '{SchedulerName}' was removed at runtime"
+4022  Information  ConfigurationLog.RuntimeSchedulerShutDownByHost
+    "Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host"
 5000  Information  XmlSchedulingLog.ParsingFile
     "Parsing XML file: {FileName} with systemId: {SystemId}"
 5001  Information  XmlSchedulingLog.ParsingStream

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -1426,6 +1426,13 @@ namespace Quartz
         public System.DateTimeOffset FirstFireTimeUtc { get; init; }
         public Quartz.TriggerKey TriggerKey { get; init; }
     }
+    public sealed class SchedulerAddOptions
+    {
+        public SchedulerAddOptions() { }
+        public Microsoft.Extensions.Configuration.IConfiguration? Configuration { get; init; }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>>? Properties { get; init; }
+        public bool Start { get; init; }
+    }
     public sealed class SchedulerConfigException : Quartz.SchedulerException
     {
         public SchedulerConfigException(string message) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -744,6 +744,11 @@ namespace Quartz
     {
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.SchedulerRegistration>> QuerySchedulers(System.Threading.CancellationToken cancellationToken = default);
     }
+    public interface ISchedulerRuntime : Quartz.ISchedulerRegistry
+    {
+        System.Threading.Tasks.ValueTask<Quartz.IScheduler> Add(string schedulerName, System.Action<Quartz.IQuartzBuilder>? configure = null, Quartz.SchedulerAddOptions options = default, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<bool> Remove(string schedulerName, bool waitForJobsToComplete = false, System.Threading.CancellationToken cancellationToken = default);
+    }
     public interface ISimpleTrigger : Quartz.ITrigger
     {
         Quartz.SimpleTriggerMisfireInstruction MisfireInstruction { get; }
@@ -1426,12 +1431,12 @@ namespace Quartz
         public System.DateTimeOffset FirstFireTimeUtc { get; init; }
         public Quartz.TriggerKey TriggerKey { get; init; }
     }
-    public sealed class SchedulerAddOptions
+    public readonly record struct SchedulerAddOptions : System.IEquatable<Quartz.SchedulerAddOptions>
     {
-        public SchedulerAddOptions() { }
         public Microsoft.Extensions.Configuration.IConfiguration? Configuration { get; init; }
+        public bool CreateWithoutStarting { get; init; }
         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>>? Properties { get; init; }
-        public bool Start { get; init; }
+        public static Quartz.SchedulerAddOptions WithoutStarting { get; }
     }
     public sealed class SchedulerConfigException : Quartz.SchedulerException
     {

--- a/src/Quartz/Configuration/ConfigurationLog.cs
+++ b/src/Quartz/Configuration/ConfigurationLog.cs
@@ -113,4 +113,13 @@ internal static partial class ConfigurationLog
 
     [LoggerMessage(EventId = 4019, Level = LogLevel.Debug, Message = "Shutdown complete")]
     public static partial void ZeroSizeThreadPoolShutdownComplete(this ILogger logger);
+
+    [LoggerMessage(EventId = 4020, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' was added at runtime")]
+    public static partial void RuntimeSchedulerAdded(this ILogger logger, string schedulerName, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 4021, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' was removed at runtime")]
+    public static partial void RuntimeSchedulerRemoved(this ILogger logger, string schedulerName);
+
+    [LoggerMessage(EventId = 4022, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host")]
+    public static partial void RuntimeSchedulerShutDownByHost(this ILogger logger, string schedulerName);
 }

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -342,6 +342,25 @@ public static partial class QuartzServiceCollectionExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(configuration);
 
+        return AddQuartzScheduler(services, name, configuration, configure);
+    }
+
+    /// <summary>
+    /// Registers one named scheduler described by a configuration section, into whichever collection is
+    /// building it.
+    /// </summary>
+    /// <remarks>
+    /// Factored out of the public overload so that a scheduler added at runtime — whose collection is
+    /// its own rather than the application's — is registered by the same three steps in the same order.
+    /// Two roads to a configured scheduler that only resembled each other is how a setting comes to be
+    /// read on one of them and dropped on the other.
+    /// </remarks>
+    internal static IServiceCollection AddQuartzScheduler(
+        IServiceCollection services,
+        string name,
+        IConfiguration configuration,
+        Action<IQuartzBuilder>? configure)
+    {
         // Callers may pass either the scheduler's own section or the root section containing
         // "Schedulers:{name}", so resolve to whichever actually holds this scheduler's settings.
         var own = configuration.GetSection("Schedulers").GetSection(name);
@@ -362,7 +381,7 @@ public static partial class QuartzServiceCollectionExtensions
     /// collection would change what the scheduler was configured with, long after <c>AddQuartz</c>
     /// returned. The standalone builder has always copied for this reason, and these doors now agree.
     /// </remarks>
-    private static NameValueCollection PropertyBag(IEnumerable<KeyValuePair<string, string?>> properties)
+    internal static NameValueCollection PropertyBag(IEnumerable<KeyValuePair<string, string?>> properties)
     {
         return Checked(QuartzConfigurationHelper.ToNameValueCollection(properties));
     }
@@ -430,11 +449,19 @@ public static partial class QuartzServiceCollectionExtensions
     /// Registers one scheduler: its services, its configuration, and whatever the caller adds to it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The six phases below, and why they are in this order, are documented on
     /// <see cref="AddQuartz(IServiceCollection, IConfiguration, Action{IQuartzBuilder})"/> — where a
     /// caller can read them.
+    /// </para>
+    /// <para>
+    /// Internal rather than private because a scheduler added at runtime is registered by this method
+    /// too, into a collection of its own. That is what makes a runtime tenant an ordinary scheduler: it
+    /// is not assembled by a second construction path that has to be kept in step with this one, and the
+    /// recipe it is handed sees the same <see cref="IQuartzBuilder"/> in the same phase order.
+    /// </para>
     /// </remarks>
-    private static IServiceCollection AddQuartzScheduler(
+    internal static IServiceCollection AddQuartzScheduler(
         IServiceCollection services,
         string? schedulerName,
         NameValueCollection properties,

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -75,7 +75,16 @@ internal static class QuartzServiceRegistration
         // What the container was told to register, which the repository cannot know - it holds
         // schedulers, and a registration nothing has resolved yet has none. Listing tenants must not
         // start them, so the two are read together rather than by building everything registered.
-        services.TryAddSingleton<ISchedulerRegistry, ContainerSchedulerRegistry>();
+        services.TryAddSingleton<ContainerSchedulerRegistry>();
+
+        // And the schedulers the container was never told about, added after it was built. One object
+        // answers both interfaces because they are one question asked twice: a listing that omitted the
+        // runtime tenants would be wrong, and a second registry to be merged with the first at every
+        // call site is how it would come to be wrong. Registered whether or not anything ever adds a
+        // scheduler - it resolves nothing and opens nothing until it is asked to.
+        services.TryAddSingleton<SchedulerRuntime>();
+        services.TryAddSingleton<ISchedulerRegistry>(static provider => provider.GetRequiredService<SchedulerRuntime>());
+        services.TryAddSingleton<ISchedulerRuntime>(static provider => provider.GetRequiredService<SchedulerRuntime>());
 
         // "Another scheduler shares this database" is only knowable here, one level above the store.
         services.TryAddSingleton<SharedDatabaseValidator>();

--- a/src/Quartz/Configuration/SchedulerGeneration.cs
+++ b/src/Quartz/Configuration/SchedulerGeneration.cs
@@ -1,0 +1,366 @@
+using System.Collections.Frozen;
+using System.Collections.Specialized;
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Quartz.Core;
+using Quartz.Diagnostics;
+using Quartz.Extensibility;
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Serialization.SystemTextJson;
+using Quartz.Util;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// One scheduler built after the application's container was: its own service collection, its own
+/// provider, and the scheduler that came out of them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The name is deliberate. A generation is <em>one</em> set of instances — a thread pool, a job store,
+/// a connection provider, the plugins and listeners the recipe registered — and none of those can be
+/// re-used after they have been shut down. So a scheduler that is to exist while the host is already
+/// running gets a container of its own to hold them, and removing it disposes that container rather
+/// than trying to persuade dead components back to life.
+/// </para>
+/// <para>
+/// The container is not a general-purpose child container, which is a thing the DI platform declined to
+/// ship and for good reasons. It holds exactly one scheduler's registrations plus the application's
+/// shared services forwarded in as instances, and everything else is resolved from the application
+/// through <see cref="ApplicationLink" />. That is the whole of the mechanism: this type builds the
+/// collection, and <see cref="SchedulerScopedServiceProvider" /> is what routes a request afterwards.
+/// </para>
+/// <para>
+/// Registration goes through <c>QuartzServiceCollectionExtensions.AddQuartzScheduler</c>, keyed by the
+/// tenant's name, exactly as a container-registered scheduler is. There is no second construction path
+/// to keep in step, and a recipe written for <c>AddQuartz(name, …)</c> is the same recipe here.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerGeneration : IAsyncDisposable
+{
+    /// <summary>
+    /// The services <c>AddQuartzSharedServices</c> registers that a generation is handed rather than
+    /// registering for itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each of these means one thing per container and not one thing per scheduler: the repository a
+    /// tenant binds itself into is the application's, and so is the meter its measurements land on, the
+    /// type loader that reads its aliases, and the serializer registry the HTTP API reads its triggers
+    /// with. A second copy of any of them would be a tenant the dashboard cannot see, or measurements
+    /// nobody is collecting.
+    /// </para>
+    /// <para>
+    /// They are forwarded as <em>instances</em>. Microsoft's container never disposes an instance it did
+    /// not create, so disposing a generation cannot take the application's meter or repository with it —
+    /// which a <c>AddSingleton&lt;T&gt;(_ =&gt; theApplicationsOne)</c> factory registration would.
+    /// </para>
+    /// <para>
+    /// <c>SharedServiceForwardingTest</c> is the guard: it enumerates what <c>AddQuartzSharedServices</c>
+    /// registers and fails on anything that is neither in this list nor excused there with a reason. A
+    /// new shared service has to be classified, because the failure mode of forgetting one is a tenant
+    /// that works until the day it does not.
+    /// </para>
+    /// </remarks>
+    internal static readonly FrozenSet<Type> ForwardedServiceTypes = FrozenSet.ToFrozenSet(
+    [
+        typeof(ILoggerFactory),
+        typeof(Meters),
+        typeof(TimeProvider),
+        typeof(ITypeLoader),
+        typeof(ISchedulerRepository),
+        typeof(SharedDatabaseValidator),
+        typeof(IJobExecutionContextAccessor),
+        typeof(SystemTextJsonSerializerRegistry),
+        typeof(DbMetadataFactory),
+        typeof(DbMetadataResolver),
+    ]);
+
+    /// <summary>
+    /// The container-wide reads a generation must never answer for itself, removed from its collection
+    /// after registration so they fall through to the application's.
+    /// </summary>
+    /// <remarks>
+    /// Each of these answers "what schedulers are there", and a tenant's container knows about exactly
+    /// one — itself. A job that resolved <see cref="ISchedulerRegistry" /> and was handed its own
+    /// scheduler as the whole world would be quietly wrong, and one that resolved a
+    /// <c>SchedulerRuntime</c> of its own could add a tenant that is forgotten the moment the generation
+    /// that owns it is disposed.
+    /// </remarks>
+    private static readonly Type[] containerWideReads =
+    [
+        typeof(ISchedulerRegistry),
+        typeof(ContainerSchedulerRegistry),
+    ];
+
+    private readonly ServiceProvider provider;
+
+    private SchedulerGeneration(
+        int number,
+        string schedulerName,
+        ServiceProvider provider,
+        IServiceProvider scoped,
+        QuartzSchedulerResources resources)
+    {
+        Number = number;
+        SchedulerName = schedulerName;
+        this.provider = provider;
+        Scoped = scoped;
+        StoreInstance = JobStores.Unwrap(resources.JobStore);
+        PoolInstance = resources.ThreadPool;
+    }
+
+    /// <summary>
+    /// Which generation of this name this is, counting from one.
+    /// </summary>
+    /// <remarks>
+    /// Nothing reads it yet. It is recorded because a generation is only meaningful as one of a series —
+    /// the whole reason for the name — and "which set of instances is this" is what a restart has to be
+    /// able to say about a scheduler whose name did not change.
+    /// </remarks>
+    public int Number { get; }
+
+    /// <summary>
+    /// The name this scheduler was added under, which is also its service key and its options name.
+    /// </summary>
+    public string SchedulerName { get; }
+
+    /// <summary>
+    /// This generation's view of its own container: keyed to the tenant's name and linked back to the
+    /// application.
+    /// </summary>
+    public IServiceProvider Scoped { get; }
+
+    /// <summary>
+    /// The store this generation was built with, underneath whatever the application decorated it with.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than resolved on demand, so that "is this the same object the last generation
+    /// had" can be answered after that generation's container is gone. A part supplied as an instance —
+    /// <c>UseJobStore(myStore)</c> — is the one thing a replayed recipe cannot give a second generation,
+    /// and comparing by reference is how that is detected rather than guessed.
+    /// </remarks>
+    public IJobStore StoreInstance { get; }
+
+    /// <inheritdoc cref="StoreInstance" />
+    public IThreadPool PoolInstance { get; }
+
+    /// <summary>
+    /// The scheduler this generation built, once it has been built.
+    /// </summary>
+    public IScheduler? Scheduler { get; private set; }
+
+    /// <summary>
+    /// Builds one scheduler's container, without creating the scheduler.
+    /// </summary>
+    /// <remarks>
+    /// Everything that can fail on bad configuration fails here, before anything has been bound or
+    /// started: the property bag is checked, the recipe runs, the container is built, and the parts are
+    /// constructed. What construction deliberately does not do is <em>initialize</em> them — a thread
+    /// pool starts no thread and a database store opens no connection until <c>Initialize</c>, which is
+    /// <see cref="Create" />'s to call.
+    /// </remarks>
+    public static SchedulerGeneration Build(
+        IServiceProvider application,
+        string schedulerName,
+        SchedulerAddOptions options,
+        Action<IQuartzBuilder>? configure,
+        int number)
+    {
+        ServiceCollection services = new();
+
+        Forward(services, application);
+
+        // Applied before the tenant's own registration, so that a scheduler registered here by a
+        // container-wide delegate is covered by the delegates recorded after it, exactly as it would be
+        // in the application's collection.
+        SchedulerNameRegistry registry = SchedulerNameRegistry.For(services);
+        SchedulerNameRegistry? applicationNames = application.GetService<SchedulerNameRegistry>();
+        foreach (Action<IQuartzBuilder> configureAll in applicationNames?.ConfigureAllDelegates ?? [])
+        {
+            registry.AddConfigureAll(configureAll);
+        }
+
+        if (options.Configuration is not null)
+        {
+            QuartzServiceCollectionExtensions.AddQuartzScheduler(services, schedulerName, options.Configuration, configure);
+        }
+        else
+        {
+            NameValueCollection properties = QuartzServiceCollectionExtensions.PropertyBag(options.Properties ?? []);
+            QuartzServiceCollectionExtensions.AddQuartzScheduler(services, schedulerName, properties, configure);
+        }
+
+        ThrowIfAJobIsRegisteredHere(services, schedulerName);
+
+        foreach (Type containerWide in containerWideReads)
+        {
+            services.RemoveAll(containerWide);
+        }
+
+        services.AddSingleton(new ApplicationLink(application) { ConfiguredOptions = ConfiguredOptions(services) });
+
+        // ValidateOnBuild would check every constructor against this collection alone, and half of what
+        // a tenant's components take is the application's - so it would refuse a graph that resolves
+        // perfectly through the link. Scope validation is kept: it is what catches the leak a composite
+        // provider is famous for, and it costs a dictionary lookup per resolution.
+        ServiceProvider provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = false, ValidateScopes = true });
+
+        try
+        {
+            IServiceProvider scoped = SchedulerScopedServiceProvider.For(provider, schedulerName);
+            QuartzSchedulerResources resources = scoped.GetScheduler<QuartzSchedulerResources>(schedulerName);
+            return new SchedulerGeneration(number, schedulerName, provider, scoped, resources);
+        }
+        catch
+        {
+            provider.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates the scheduler, which initializes its parts and binds it into the application's
+    /// repository.
+    /// </summary>
+    /// <remarks>
+    /// The factory asked is this generation's own, so everything <c>DefaultSchedulerFactory</c> does for
+    /// a container-registered scheduler is done here too — the instance id, the plugins, the store's
+    /// schema check, the declared jobs and triggers — and the repository it binds into is the
+    /// application's, because that is the one that was forwarded in.
+    /// </remarks>
+    public async ValueTask<IScheduler> Create(CancellationToken cancellationToken = default)
+    {
+        IScheduler scheduler = await Scoped.GetRequiredKeyedService<ISchedulerFactory>(SchedulerName)
+            .GetScheduler(cancellationToken)
+            .ConfigureAwait(false);
+
+        Scheduler = scheduler;
+        return scheduler;
+    }
+
+    /// <summary>
+    /// Releases this generation's container, and with it every part it built.
+    /// </summary>
+    /// <remarks>
+    /// The forwarded services are untouched: they were registered as instances this container did not
+    /// create, and Microsoft's container disposes only what it created.
+    /// </remarks>
+    public ValueTask DisposeAsync()
+    {
+        return provider.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Hands the tenant's collection the application's shared services, as instances.
+    /// </summary>
+    /// <remarks>
+    /// Added before anything else, so that <c>AddQuartzSharedServices</c>' <c>TryAdd</c> registrations
+    /// all lose to what is already here. <see cref="DbMetadataFactory" /> is the one enumerable of the
+    /// set, and every one the application holds is forwarded in the application's order, because the
+    /// order is what decides which description of a provider name wins.
+    /// </remarks>
+    private static void Forward(IServiceCollection services, IServiceProvider application)
+    {
+        Add(services, application.GetService<ILoggerFactory>());
+        Add(services, application.GetService<Meters>());
+        Add(services, application.GetService<TimeProvider>());
+        Add(services, application.GetService<ITypeLoader>());
+        Add(services, application.GetService<ISchedulerRepository>());
+        Add(services, application.GetService<SharedDatabaseValidator>());
+        Add(services, application.GetService<IJobExecutionContextAccessor>());
+        Add(services, application.GetService<SystemTextJsonSerializerRegistry>());
+        Add(services, application.GetService<DbMetadataResolver>());
+
+        foreach (DbMetadataFactory factory in application.GetServices<DbMetadataFactory>())
+        {
+            services.AddSingleton(factory);
+        }
+
+        static void Add<T>(IServiceCollection services, T? instance) where T : class
+        {
+            if (instance is not null)
+            {
+                services.AddSingleton(instance);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The options types this collection says something about, so that reading one of them resolves
+    /// here rather than from the application.
+    /// </summary>
+    /// <remarks>
+    /// Read off the descriptors rather than probed for through the built container, because probing
+    /// means closing <c>IConfigureOptions&lt;&gt;</c> over a type known only at run time — which a
+    /// native AOT publish cannot do, and which this list gets for free by reading the closed generics
+    /// that are already there.
+    /// </remarks>
+    private static FrozenSet<Type> ConfiguredOptions(IServiceCollection services)
+    {
+        HashSet<Type> configured = [];
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (!descriptor.ServiceType.IsConstructedGenericType)
+            {
+                continue;
+            }
+
+            Type definition = descriptor.ServiceType.GetGenericTypeDefinition();
+            if (definition == typeof(IConfigureOptions<>)
+                || definition == typeof(IPostConfigureOptions<>)
+                || definition == typeof(IValidateOptions<>))
+            {
+                configured.Add(descriptor.ServiceType.GenericTypeArguments[0]);
+            }
+        }
+
+        return configured.ToFrozenSet();
+    }
+
+    /// <summary>
+    /// Refuses a recipe that maps a job type onto something else, which a generation cannot honour.
+    /// </summary>
+    /// <remarks>
+    /// A job is built by the application, because its constructor takes the application's services and a
+    /// container resolves a service's dependencies from itself. So a mapping registered here — a
+    /// different implementation type, or a factory — would be read by nobody, and the job would be
+    /// activated as though the mapping had never been written. Saying so is the only honest answer;
+    /// silently ignoring it is how a tenant comes to run the wrong code.
+    /// <para>
+    /// <c>AddJob&lt;T&gt;</c> and <c>ScheduleJob&lt;T&gt;</c> register a job type as itself, which is
+    /// inert rather than wrong: the type resolves from the application if it is registered there, and is
+    /// activated from this provider if it is not, which is what would have happened anyway.
+    /// </para>
+    /// </remarks>
+    private static void ThrowIfAJobIsRegisteredHere(IServiceCollection services, string schedulerName)
+    {
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (!typeof(IJob).IsAssignableFrom(descriptor.ServiceType))
+            {
+                continue;
+            }
+
+            if (descriptor.ImplementationType is not null && descriptor.ImplementationType == descriptor.ServiceType)
+            {
+                continue;
+            }
+
+            Throw.SchedulerConfigException(
+                $"The recipe for scheduler '{schedulerName}' registers the job type "
+                + $"'{descriptor.ServiceType.FullName}' as something other than itself, and a scheduler added at "
+                + "runtime cannot honour that: its jobs are built by the application's container, which is where "
+                + "their dependencies are. Register the job type in the application's container instead — "
+                + "services.AddScoped<TJob, TImplementation>() or services.AddScoped<TJob>(provider => ...) — and "
+                + "leave the recipe to schedule it.");
+        }
+    }
+}

--- a/src/Quartz/Configuration/SchedulerGeneration.cs
+++ b/src/Quartz/Configuration/SchedulerGeneration.cs
@@ -96,6 +96,8 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
     private static readonly Type[] containerWideReads =
     [
         typeof(ISchedulerRegistry),
+        typeof(ISchedulerRuntime),
+        typeof(SchedulerRuntime),
         typeof(ContainerSchedulerRegistry),
     ];
 
@@ -326,18 +328,22 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
     }
 
     /// <summary>
-    /// Refuses a recipe that maps a job type onto something else, which a generation cannot honour.
+    /// Refuses a recipe that says how <em>this scheduler</em> builds a job type, which a generation
+    /// cannot honour.
     /// </summary>
     /// <remarks>
-    /// A job is built by the application, because its constructor takes the application's services and a
-    /// container resolves a service's dependencies from itself. So a mapping registered here — a
-    /// different implementation type, or a factory — would be read by nobody, and the job would be
-    /// activated as though the mapping had never been written. Saying so is the only honest answer;
-    /// silently ignoring it is how a tenant comes to run the wrong code.
     /// <para>
-    /// <c>AddJob&lt;T&gt;</c> and <c>ScheduleJob&lt;T&gt;</c> register a job type as itself, which is
-    /// inert rather than wrong: the type resolves from the application if it is registered there, and is
-    /// activated from this provider if it is not, which is what would have happened anyway.
+    /// A job is built by the application, because its constructor takes the application's services and a
+    /// container resolves a service's dependencies from itself. So <c>AddJobType</c> here — whichever
+    /// overload — would either be read by nobody or build the job out of the half of the graph that does
+    /// not have its dependencies. Saying so is the only honest answer; silently ignoring it is how a
+    /// tenant comes to run the wrong code, or to fail at its first firing rather than where the mistake
+    /// was written.
+    /// </para>
+    /// <para>
+    /// <c>AddJob&lt;T&gt;</c> and <c>ScheduleJob&lt;T&gt;</c> register a job type as itself and without a
+    /// key, which is inert rather than wrong: the type resolves from the application if it is registered
+    /// there and is activated from this provider if it is not, which is what would have happened anyway.
     /// </para>
     /// </remarks>
     private static void ThrowIfAJobIsRegisteredHere(IServiceCollection services, string schedulerName)
@@ -349,18 +355,21 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
                 continue;
             }
 
-            if (descriptor.ImplementationType is not null && descriptor.ImplementationType == descriptor.ServiceType)
+            // A keyed descriptor's ImplementationType throws rather than answering, so the shape is
+            // tested before anything is read off it - and every AddJobType overload is keyed here,
+            // because a scheduler added at runtime always has a name.
+            if (!descriptor.IsKeyedService && descriptor.ImplementationType == descriptor.ServiceType)
             {
                 continue;
             }
 
             Throw.SchedulerConfigException(
-                $"The recipe for scheduler '{schedulerName}' registers the job type "
-                + $"'{descriptor.ServiceType.FullName}' as something other than itself, and a scheduler added at "
-                + "runtime cannot honour that: its jobs are built by the application's container, which is where "
-                + "their dependencies are. Register the job type in the application's container instead — "
-                + "services.AddScoped<TJob, TImplementation>() or services.AddScoped<TJob>(provider => ...) — and "
-                + "leave the recipe to schedule it.");
+                $"The recipe for scheduler '{schedulerName}' says how it builds the job type "
+                + $"'{descriptor.ServiceType.FullName}', and a scheduler added at runtime does not build its own "
+                + "jobs: they are built by the application's container, which is where their dependencies are. "
+                + "Register the job type there instead — services.AddScoped<TJob>() or "
+                + "services.AddScoped<TJob, TImplementation>() — and leave the recipe to schedule it with "
+                + "AddJob<TJob>(...).");
         }
     }
 }

--- a/src/Quartz/Configuration/SchedulerGeneration.cs
+++ b/src/Quartz/Configuration/SchedulerGeneration.cs
@@ -191,6 +191,17 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
 
         if (options.Configuration is not null)
         {
+            // Both would mean one of them read and the other dropped without a word, which is what
+            // AddQuartzSchedulers refuses in the same words for the same reason: a section says
+            // everything a property bag does, so there is no reading of "both" that is not a silent loss.
+            if (options.Properties is not null)
+            {
+                Throw.SchedulerConfigException(
+                    $"The options for scheduler '{schedulerName}' set both Properties and Configuration. A "
+                    + "configuration section says everything a flat property bag does, so only one of them "
+                    + "would be read and the other dropped without a word. Use one or the other.");
+            }
+
             QuartzServiceCollectionExtensions.AddQuartzScheduler(services, schedulerName, options.Configuration, configure);
         }
         else

--- a/src/Quartz/Configuration/SchedulerNameRegistry.cs
+++ b/src/Quartz/Configuration/SchedulerNameRegistry.cs
@@ -36,6 +36,18 @@ internal sealed class SchedulerNameRegistry
     public IReadOnlyList<string> Names => names;
 
     /// <summary>
+    /// The container-wide delegates, in the order they were recorded, for a scheduler this collection
+    /// will never register.
+    /// </summary>
+    /// <remarks>
+    /// A scheduler added at runtime is built in a collection of its own, so nothing here applies it —
+    /// but <c>ConfigureAllQuartzSchedulers</c> says "every scheduler in this container", and a tenant
+    /// bound into the container's repository is one. Replaying them onto the tenant's own collection is
+    /// what keeps that promise, and this is what it reads to do it.
+    /// </remarks>
+    public IReadOnlyList<Action<IQuartzBuilder>> ConfigureAllDelegates => configureAll;
+
+    /// <summary>
     /// Whether a default scheduler is registered — <c>AddQuartz()</c> without a name, or
     /// <c>AddQuartzScheduler()</c> directly, which is also how the standalone builder registers its one
     /// scheduler.

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -125,6 +125,14 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 {
                     await scheduler.Start(cancellationToken).ConfigureAwait(false);
                 }
+
+                // Asked again, because building and starting a scheduler is not instantaneous and the
+                // unit is not registered until the line below this block. A host that began stopping in
+                // that window took the live schedulers from a map this one was not in yet, so the
+                // shutdown that should have drained it has already been and gone — and a started, bound
+                // scheduler would run past the graceful shutdown window with only container disposal
+                // left to catch it. Refusing here undoes it while there is still something holding it.
+                ThrowIfTheHostIsStopping(schedulerName);
             }
             catch
             {
@@ -399,6 +407,20 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 + "scheduler bound by hand, or one AddQuartzHttpClient bound, is not this runtime's to remove.");
         }
 
+        ThrowIfTheHostIsStopping(schedulerName);
+    }
+
+    /// <summary>
+    /// Refuses a name while the schedulers are being taken away.
+    /// </summary>
+    /// <remarks>
+    /// Asked twice: before the work starts, and again once the scheduler is running and about to be
+    /// registered. The two readings answer different questions — "is it worth building this" and "is
+    /// there still something that will shut it down" — and only the second one is about the scheduler
+    /// that now exists.
+    /// </remarks>
+    private void ThrowIfTheHostIsStopping(string schedulerName)
+    {
         if (Volatile.Read(ref draining) == 1 || applicationLifetime?.ApplicationStopping.IsCancellationRequested == true)
         {
             Throw.SchedulerConfigException(

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -431,6 +431,16 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         return string.Equals(instanceName, schedulerName, StringComparison.OrdinalIgnoreCase) ? instanceName : null;
     }
 
+    /// <summary>
+    /// The gate serialising add and remove for one name.
+    /// </summary>
+    /// <remarks>
+    /// Kept after a removal rather than dropped with the unit. A caller already waiting has the old gate
+    /// in hand, so removing it from the map would let the next <see cref="Add" /> take a fresh one and
+    /// run beside them — which is the exact race the gate exists to prevent, arriving only under the
+    /// remove-then-add sequence this API is for. What is retained is one semaphore per name ever used,
+    /// and a name space is bounded by the tenants an application has.
+    /// </remarks>
     private SemaphoreSlim Gate(string schedulerName)
     {
         return gates.GetOrAdd(schedulerName, static _ => new SemaphoreSlim(1, 1));

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -1,0 +1,487 @@
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+using Quartz.Util;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// The schedulers a container was asked for after it was built, and the answer to
+/// <see cref="ISchedulerRegistry" /> for a container that has any.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One object answers both interfaces because they are one question asked twice: a listing that omitted
+/// the tenants this holds would be wrong, and a second registry that had to be merged with the first at
+/// every call site is how it would come to be wrong. <see cref="ContainerSchedulerRegistry" /> still
+/// does the container's half; this appends what the container never registered.
+/// </para>
+/// <para>
+/// The unit it owns is a <see cref="SchedulerGeneration" /> — one scheduler's container and the
+/// instances in it — plus the blueprint that built it. Operations on one name are serialised behind a
+/// gate of that name, so two callers adding "acme" at once produce one scheduler and one refusal rather
+/// than a race against the repository's own duplicate check, which would report the collision from the
+/// wrong place.
+/// </para>
+/// </remarks>
+internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, IDisposable
+{
+    private readonly IServiceProvider application;
+    private readonly ISchedulerRepository repository;
+    private readonly SchedulerNameRegistry names;
+    private readonly ContainerSchedulerRegistry registrations;
+    private readonly IOptionsMonitor<QuartzSchedulerOptions> schedulerOptions;
+    private readonly ILogger<SchedulerRuntime> logger;
+    private readonly IHostApplicationLifetime? applicationLifetime;
+
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> gates = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, RuntimeUnit> units = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Generations whose schedulers somebody else is shutting down, waiting to have their containers
+    /// released.
+    /// </summary>
+    private readonly ConcurrentQueue<SchedulerGeneration> drained = new();
+
+    /// <summary>
+    /// Set once the schedulers are being taken away — by the host stopping, or by this being disposed —
+    /// after which nothing new is added.
+    /// </summary>
+    private int draining;
+
+    private int disposed;
+
+    /// <param name="application">
+    /// The application's container, which every tenant resolves what its own recipe did not register
+    /// from. Nothing is resolved out of it here: a container that holds this type must be buildable
+    /// whether or not anything ever adds a scheduler.
+    /// </param>
+    /// <param name="repository">Where a tenant is bound, and where a name already taken is noticed.</param>
+    /// <param name="names">What the container was registered with, which a runtime name may not collide with.</param>
+    /// <param name="registrations">The container's half of the listing.</param>
+    /// <param name="schedulerOptions">Read for the default scheduler's name, which is not a registered one.</param>
+    /// <param name="logger">Where an add, a removal and a host-driven shutdown are recorded.</param>
+    /// <param name="applicationLifetime">
+    /// The host's lifetime, when there is a host. Optional because a container built by
+    /// <see cref="QuartzSchedulerBuilder" /> has none, and a scheduler added there is still this
+    /// object's to own.
+    /// </param>
+    public SchedulerRuntime(
+        IServiceProvider application,
+        ISchedulerRepository repository,
+        SchedulerNameRegistry names,
+        ContainerSchedulerRegistry registrations,
+        IOptionsMonitor<QuartzSchedulerOptions> schedulerOptions,
+        ILogger<SchedulerRuntime> logger,
+        IHostApplicationLifetime? applicationLifetime = null)
+    {
+        this.application = application;
+        this.repository = repository;
+        this.names = names;
+        this.registrations = registrations;
+        this.schedulerOptions = schedulerOptions;
+        this.logger = logger;
+        this.applicationLifetime = applicationLifetime;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IScheduler> Add(
+        string schedulerName,
+        Action<IQuartzBuilder>? configure = null,
+        SchedulerAddOptions options = default,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedulerName);
+
+        SemaphoreSlim gate = Gate(schedulerName);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfTheNameIsNotAvailable(schedulerName);
+
+            SchedulerGeneration generation;
+            try
+            {
+                generation = SchedulerGeneration.Build(application, schedulerName, options, configure, number: 1);
+            }
+            catch (OptionsValidationException e)
+            {
+                // The same translation DefaultSchedulerFactory makes: options validation is how
+                // configuration is checked, and OptionsValidationException is an implementation detail
+                // of that rather than something a caller of this should have to catch.
+                throw new SchedulerConfigException(string.Join(" ", e.Failures), e);
+            }
+
+            IScheduler scheduler;
+            try
+            {
+                scheduler = await generation.Create(cancellationToken).ConfigureAwait(false);
+
+                if (!options.CreateWithoutStarting)
+                {
+                    await scheduler.Start(cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch
+            {
+                // Nothing is retained on any failure: a scheduler that was bound before the failure
+                // unbinds itself when it is shut down, and the container goes with it. Half a tenant in
+                // the listing is worse than none, because nothing would ever come back for it.
+                await Discard(generation).ConfigureAwait(false);
+                throw;
+            }
+
+            units[schedulerName] = new RuntimeUnit
+            {
+                Name = schedulerName,
+                Options = options,
+                Configure = configure,
+                Generation = generation
+            };
+
+            logger.RuntimeSchedulerAdded(scheduler.SchedulerName, scheduler.SchedulerInstanceId);
+            return scheduler;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> Remove(
+        string schedulerName,
+        bool waitForJobsToComplete = false,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedulerName);
+
+        if (ContainerRegistration(schedulerName) is { } registered)
+        {
+            Throw.SchedulerConfigException(
+                $"Scheduler '{registered}' is registered with the container, so it is not this runtime's to "
+                + "remove: the container owns its parts and decides their lifetime. Shut it down with "
+                + "IScheduler.Shutdown(), which unbinds it from the repository, or stop the host, which shuts "
+                + "down every scheduler it started.");
+        }
+
+        SemaphoreSlim gate = Gate(schedulerName);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!units.TryRemove(schedulerName, out RuntimeUnit? unit))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (unit.Generation.Scheduler is { } scheduler)
+                {
+                    await scheduler.Shutdown(waitForJobsToComplete, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Even when the shutdown threw: the container is this generation's, and leaking it would
+                // leak the thread pool, the job store and its database connections along with it.
+                await unit.Generation.DisposeAsync().ConfigureAwait(false);
+            }
+
+            logger.RuntimeSchedulerRemoved(unit.Name);
+            return true;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<List<SchedulerRegistration>> QuerySchedulers(CancellationToken cancellationToken = default)
+    {
+        List<SchedulerRegistration> listing = await registrations.QuerySchedulers(cancellationToken).ConfigureAwait(false);
+
+        // A tenant that is running is already in the repository, so the container's half has reported it
+        // as Runtime with its status. What is left to add is one that was shut down - by the host, or by
+        // hand - and has not been removed: the repository drops it, and the registrations know nothing
+        // about it, so without this it would vanish from the listing while Remove still had work to do.
+        HashSet<string> reported = new(StringComparer.OrdinalIgnoreCase);
+        foreach (SchedulerRegistration registration in listing)
+        {
+            reported.Add(registration.Name);
+        }
+
+        bool appended = false;
+        foreach (RuntimeUnit unit in units.Values)
+        {
+            if (reported.Add(unit.Name))
+            {
+                listing.Add(new SchedulerRegistration(unit.Name, SchedulerOrigin.Runtime, Status: null));
+                appended = true;
+            }
+        }
+
+        if (appended)
+        {
+            listing.Sort(static (left, right) => string.CompareOrdinal(left.Name, right.Name));
+        }
+
+        return listing;
+    }
+
+    /// <summary>
+    /// Hands the live schedulers to the host, which shuts them down inside its graceful shutdown window
+    /// rather than leaving them for container disposal, which happens after it.
+    /// </summary>
+    /// <remarks>
+    /// The units are taken rather than read, so a tenant is shut down once whoever gets to it first: the
+    /// host through this, <see cref="Remove" /> through its gate, or <see cref="DisposeAsync" />. Their
+    /// containers are kept back to be released when this is disposed, because the shutdown the caller is
+    /// about to do has not happened yet.
+    /// </remarks>
+    internal List<IScheduler> TakeLiveSchedulers()
+    {
+        // Set first: an Add that has not yet taken its name's gate is refused from here on, rather than
+        // creating a scheduler nothing will ever stop.
+        Interlocked.Exchange(ref draining, 1);
+
+        List<IScheduler> live = [];
+        foreach (string name in units.Keys)
+        {
+            if (!units.TryRemove(name, out RuntimeUnit? unit))
+            {
+                continue;
+            }
+
+            drained.Enqueue(unit.Generation);
+
+            if (unit.Generation.Scheduler is { } scheduler)
+            {
+                logger.RuntimeSchedulerShutDownByHost(unit.Name);
+                live.Add(scheduler);
+            }
+        }
+
+        return live;
+    }
+
+    /// <summary>
+    /// Shuts down whatever is still running and releases every container this runtime built.
+    /// </summary>
+    /// <remarks>
+    /// Reached when the container is disposed. A host that stopped first has already taken the
+    /// schedulers through <see cref="TakeLiveSchedulers" /> and shut them down with the settings each
+    /// was configured with, and what is left here is their containers. What is still running at this
+    /// point is a scheduler in a container nobody stopped — a test, or an application that disposed its
+    /// provider without stopping its host — and it is shut down without waiting, because there is
+    /// nothing left to wait on behalf of.
+    /// </remarks>
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) == 1)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref draining, 1);
+
+        List<Exception>? exceptions = null;
+
+        try
+        {
+            foreach (string name in units.Keys)
+            {
+                if (!units.TryRemove(name, out RuntimeUnit? unit))
+                {
+                    continue;
+                }
+
+                drained.Enqueue(unit.Generation);
+
+                if (unit.Generation.Scheduler is not { } scheduler)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    (exceptions ??= []).Add(e);
+                }
+            }
+        }
+        finally
+        {
+            while (drained.TryDequeue(out SchedulerGeneration? generation))
+            {
+                try
+                {
+                    await generation.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    (exceptions ??= []).Add(e);
+                }
+            }
+        }
+
+        if (exceptions is not null)
+        {
+            throw new AggregateException("One or more runtime scheduler shutdowns failed.", exceptions);
+        }
+    }
+
+    /// <inheritdoc cref="DisposeAsync" />
+    /// <remarks>
+    /// <para>
+    /// Present, and not as a formality: Microsoft's container refuses to dispose <em>at all</em>
+    /// synchronously once it holds a service that is only <see cref="IAsyncDisposable" />, and
+    /// <c>ServiceProvider.Dispose()</c> is still what a console application's <c>using var host</c>
+    /// reaches. A registration nothing in the application ever asked for must not be the thing that
+    /// turns its shutdown into an <see cref="InvalidOperationException" />.
+    /// </para>
+    /// <para>
+    /// It waits for the asynchronous one, which is bounded: nothing there waits for a running job, and
+    /// every await inside continues on the thread pool rather than on the caller's context, so there is
+    /// no context for it to deadlock against.
+    /// </para>
+    /// </remarks>
+    public void Dispose()
+    {
+        DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// Refuses every name this runtime must not take, saying which rule and what to do instead.
+    /// </summary>
+    /// <remarks>
+    /// In this order because it is the order of how specifically the name is already spoken for: the
+    /// container registered it, this runtime already holds it, something else is bound under it. A live
+    /// tenant is both of the last two — it is in the repository because this runtime put it there — and
+    /// "Remove it first" is the answer worth giving, so the runtime's own list is asked before the
+    /// repository is. Letting the repository's duplicate check catch the collision instead would report
+    /// it from the wrong place entirely: after a whole container had been built for a tenant that cannot
+    /// exist.
+    /// </remarks>
+    private void ThrowIfTheNameIsNotAvailable(string schedulerName)
+    {
+        if (ContainerRegistration(schedulerName) is { } registered)
+        {
+            Throw.SchedulerConfigException(
+                $"Scheduler '{registered}' is registered with the container, and a container registration "
+                + "cannot be added again at runtime: its parts are registered under that name already, and a "
+                + "second set of them would be two schedulers wearing one name. Build it with "
+                + $"GetRequiredKeyedService<ISchedulerFactory>(\"{registered}\").GetScheduler(), or add this one "
+                + "under a name of its own.");
+        }
+
+        if (units.ContainsKey(schedulerName))
+        {
+            Throw.SchedulerConfigException(
+                $"A scheduler named '{schedulerName}' has already been added at runtime. Remove it first with "
+                + $"ISchedulerRuntime.Remove(\"{schedulerName}\") and add it again: a scheduler's thread pool and "
+                + "job store cannot be replaced underneath it, which is why there is no way to add over one.");
+        }
+
+        if (repository.Lookup(schedulerName) is not null)
+        {
+            Throw.SchedulerConfigException(
+                $"A scheduler named '{schedulerName}' is already bound in this container's repository, so adding "
+                + "one would be a second scheduler under one name. Shut down the one that is there first — a "
+                + "scheduler bound by hand, or one AddQuartzHttpClient bound, is not this runtime's to remove.");
+        }
+
+        if (Volatile.Read(ref draining) == 1 || applicationLifetime?.ApplicationStopping.IsCancellationRequested == true)
+        {
+            Throw.SchedulerConfigException(
+                $"The host is stopping, so scheduler '{schedulerName}' was not added: it would be created after "
+                + "the shutdown that would have stopped it, and nothing would come back for it.");
+        }
+    }
+
+    /// <summary>
+    /// The container's own spelling of a name it registered, or <see langword="null" /> when it did not.
+    /// </summary>
+    /// <remarks>
+    /// The default scheduler is the one registration whose name is not the name it was registered under —
+    /// it has no service key at all — so its options are read to learn it, which is also what
+    /// <see cref="ContainerSchedulerRegistry" /> does to list it.
+    /// </remarks>
+    private string? ContainerRegistration(string schedulerName)
+    {
+        if (names.Find(schedulerName) is { } registered)
+        {
+            return registered;
+        }
+
+        if (!names.HasDefaultScheduler)
+        {
+            return null;
+        }
+
+        string instanceName = schedulerOptions.Get(Options.DefaultName).InstanceName;
+        return string.Equals(instanceName, schedulerName, StringComparison.OrdinalIgnoreCase) ? instanceName : null;
+    }
+
+    private SemaphoreSlim Gate(string schedulerName)
+    {
+        return gates.GetOrAdd(schedulerName, static _ => new SemaphoreSlim(1, 1));
+    }
+
+    /// <summary>
+    /// Throws away a generation that failed on its way up, without letting its teardown hide what went
+    /// wrong.
+    /// </summary>
+    private static async ValueTask Discard(SchedulerGeneration generation)
+    {
+        try
+        {
+            if (generation.Scheduler is { } scheduler)
+            {
+                await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            // The failure being unwound is what the caller needs to read. A scheduler that could not be
+            // started is quite likely one that cannot be shut down cleanly either, and reporting the
+            // second failure instead of the first would say nothing about the cause.
+        }
+
+        try
+        {
+            await generation.DisposeAsync().ConfigureAwait(false);
+        }
+        catch
+        {
+            // As above.
+        }
+    }
+
+    /// <summary>
+    /// One scheduler this runtime holds: what built it, and what it built.
+    /// </summary>
+    /// <remarks>
+    /// The blueprint is kept rather than discarded after the generation exists, because a recipe that
+    /// has been run and thrown away can never be run again — which is what every comparable system found
+    /// out about restart, and what this leaves room for.
+    /// </remarks>
+    private sealed class RuntimeUnit
+    {
+        public required string Name { get; init; }
+
+        public required SchedulerAddOptions Options { get; init; }
+
+        public required Action<IQuartzBuilder>? Configure { get; init; }
+
+        public required SchedulerGeneration Generation { get; init; }
+    }
+}

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -318,7 +318,10 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
 
                 try
                 {
-                    await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+                    // No token, said rather than defaulted. The host's own is the only one in reach and
+                    // it is already cancelled by the time a container is being disposed, so passing it
+                    // would abort the shutdown this exists to perform.
+                    await scheduler.Shutdown(waitForJobsToComplete: false, CancellationToken.None).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -478,7 +481,10 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         {
             if (generation.Scheduler is { } scheduler)
             {
-                await scheduler.Shutdown(waitForJobsToComplete: false).ConfigureAwait(false);
+                // No token, said rather than defaulted, and deliberately not the caller's: a cancelled
+                // add is one of the ways to arrive here, and unwinding it must not be cancelled by the
+                // very token that caused it - that would leave the scheduler this is undoing running.
+                await scheduler.Shutdown(waitForJobsToComplete: false, CancellationToken.None).ConfigureAwait(false);
             }
         }
         catch

--- a/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
+++ b/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -111,12 +112,29 @@ internal sealed class SchedulerScopedServiceProvider
 
     private readonly IServiceProvider inner;
     private readonly object? key;
+
+    /// <summary>
+    /// The application container this scheduler was built beside, when it was built at runtime into a
+    /// container of its own, or <see langword="null" /> for a scheduler the application container
+    /// registered.
+    /// </summary>
+    /// <remarks>
+    /// A scheduler registered with <c>AddQuartz</c> lives in the application's own container, so
+    /// "everything else" is already one <see cref="IServiceProvider.GetService" /> away and there is
+    /// nothing to link to. One added at runtime lives in a container built for it alone, and this is
+    /// what everything the recipe did not register resolves from — which is what
+    /// makes a tenant's job an ordinary application component rather than something assembled out of a
+    /// second, half-empty container.
+    /// </remarks>
+    private readonly ApplicationLink? link;
+
     private Dictionary<Type, Func<IServiceProvider, string, object>>? declared;
 
-    private SchedulerScopedServiceProvider(IServiceProvider inner, object? key)
+    private SchedulerScopedServiceProvider(IServiceProvider inner, object? key, ApplicationLink? link)
     {
         this.inner = inner;
         this.key = key;
+        this.link = link;
     }
 
     private string Name => key as string ?? Options.DefaultName;
@@ -187,9 +205,19 @@ internal sealed class SchedulerScopedServiceProvider
     /// Returns a provider that resolves the given scheduler's parts. The default scheduler's services
     /// are not keyed, so it needs no wrapper.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="ApplicationLink" /> is read from the provider rather than passed in, because the
+    /// registrations that call this are the same ones for a container scheduler and a runtime one — the
+    /// whole point of building a tenant through <c>AddQuartzScheduler</c> is that there is one
+    /// registration path. A container-registered scheduler pays one lookup that answers
+    /// <see langword="null" /> per part it constructs, which is build time rather than fire time; the
+    /// default scheduler pays nothing at all, since it needs no wrapper.
+    /// </remarks>
     public static IServiceProvider For(IServiceProvider provider, object? key)
     {
-        return key is null ? provider : new SchedulerScopedServiceProvider(provider, key);
+        return key is null
+            ? provider
+            : new SchedulerScopedServiceProvider(provider, key, provider.GetService<ApplicationLink>());
     }
 
     public object? GetService(Type serviceType)
@@ -235,35 +263,149 @@ internal sealed class SchedulerScopedServiceProvider
             return this;
         }
 
-        return inner.GetService(serviceType);
+        return link is null ? inner.GetService(serviceType) : FromGeneration(serviceType, link);
+    }
+
+    /// <summary>
+    /// Answers a request this scheduler's own registrations did not, for a scheduler that lives in a
+    /// container of its own.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Three requests are decided rather than tried, because "ask the tenant, then the application" is
+    /// the wrong answer for each of them.
+    /// </para>
+    /// <para>
+    /// A <see cref="IJob" /> is the application's to build. Its constructor takes the application's
+    /// services — a unit of work, a database context — and a container resolves a service's dependencies
+    /// from itself rather than through whatever wrapper was asked, so a job built by the tenant's
+    /// container would be built from the half of the graph that does not have them.
+    /// </para>
+    /// <para>
+    /// Options belong to whoever configured them. The tenant's own settings are its container's, and so
+    /// is anything Quartz declares, since the tenant is the only scheduler its container holds; an
+    /// application's options type is the application's, and reading it from the tenant would answer with
+    /// a freshly defaulted instance nobody configured.
+    /// </para>
+    /// <para>
+    /// An <see cref="IEnumerable{T}" /> is the one shape where "the tenant answered nothing" and "the
+    /// tenant has none of these" are indistinguishable — a container answers an empty sequence rather
+    /// than <see langword="null" /> — so the decision is made on whether the tenant declares the item
+    /// type at all rather than on what came back.
+    /// </para>
+    /// </remarks>
+    private object? FromGeneration(Type serviceType, ApplicationLink application)
+    {
+        if (typeof(IJob).IsAssignableFrom(serviceType))
+        {
+            return application.Application.GetService(serviceType);
+        }
+
+        if (serviceType.IsConstructedGenericType)
+        {
+            Type definition = serviceType.GetGenericTypeDefinition();
+
+            if (definition == typeof(IOptions<>)
+                || definition == typeof(IOptionsMonitor<>)
+                || definition == typeof(IOptionsSnapshot<>)
+                || definition == typeof(IOptionsFactory<>))
+            {
+                return application.ConfiguresOptions(serviceType.GenericTypeArguments[0])
+                    ? inner.GetService(serviceType)
+                    : application.Application.GetService(serviceType);
+            }
+
+            if (definition == typeof(IEnumerable<>))
+            {
+                return Declares(serviceType.GenericTypeArguments[0])
+                    ? inner.GetService(serviceType)
+                    : application.Application.GetService(serviceType);
+            }
+        }
+
+        return inner.GetService(serviceType) ?? application.Application.GetService(serviceType);
+    }
+
+    /// <summary>
+    /// Whether this scheduler's own container holds a registration of a service type.
+    /// </summary>
+    private bool Declares(Type serviceType)
+    {
+        return inner.GetService<IServiceProviderIsService>()?.IsService(serviceType) ?? false;
     }
 
     /// <summary>
     /// Creates a scope whose provider still resolves this scheduler's parts.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Jobs are built inside a scope. Without this the scope comes straight from the container, so a job
     /// that takes an <see cref="ISchedulerFactory"/> is handed the default scheduler's — or, when only
     /// named schedulers exist, cannot be constructed at all.
+    /// </para>
+    /// <para>
+    /// A scheduler that lives in a container of its own opens <em>two</em> scopes, one in each container,
+    /// and hands out a provider over both. That is what makes a firing's scope the application's: a
+    /// scoped service a job and a middleware both take is one instance, created in the application's
+    /// scope and disposed with it when the job is returned. One scope over the tenant's container alone
+    /// would give the application's scoped services no scope to live in — the leak the platform's own
+    /// refusal of child containers warns about.
+    /// </para>
     /// </remarks>
     public IServiceScope CreateScope()
     {
-        return new Scope(inner.GetRequiredService<IServiceScopeFactory>().CreateScope(), key);
+        if (link is null)
+        {
+            return new Scope(inner.GetRequiredService<IServiceScopeFactory>().CreateScope(), key, link: null, application: null);
+        }
+
+        // The application's scope first: if the tenant's container cannot open one, there is something
+        // to dispose, and the other order would leave the application's scope behind instead.
+        IServiceScope application = link.Application.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        try
+        {
+            IServiceScope scope = inner.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            return new Scope(scope, key, link with { Application = application.ServiceProvider }, application);
+        }
+        catch
+        {
+            application.Dispose();
+            throw;
+        }
     }
 
     private sealed class Scope : IServiceScope, IAsyncDisposable
     {
         private readonly IServiceScope scope;
 
-        public Scope(IServiceScope scope, object? key)
+        /// <summary>
+        /// The scope opened in the application's container, for a scheduler that lives in one of its
+        /// own, or <see langword="null" /> when there is no second container.
+        /// </summary>
+        private readonly IServiceScope? application;
+
+        public Scope(IServiceScope scope, object? key, ApplicationLink? link, IServiceScope? application)
         {
             this.scope = scope;
-            ServiceProvider = For(scope.ServiceProvider, key);
+            this.application = application;
+            ServiceProvider = new SchedulerScopedServiceProvider(scope.ServiceProvider, key, link);
         }
 
         public IServiceProvider ServiceProvider { get; }
 
-        public void Dispose() => scope.Dispose();
+        public void Dispose()
+        {
+            try
+            {
+                scope.Dispose();
+            }
+            finally
+            {
+                // Always, even when the tenant's scope threw on the way out: the application's scope
+                // holds the job's own scoped services, and leaking those is the worse of the two.
+                application?.Dispose();
+            }
+        }
 
         /// <summary>
         /// Disposes the wrapped scope asynchronously where it supports it.
@@ -272,7 +414,22 @@ internal sealed class SchedulerScopedServiceProvider
         /// Jobs are torn down through <see cref="IAsyncDisposable"/>. Without it here, a scoped service
         /// that is only async-disposable throws when the container disposes the scope synchronously.
         /// </remarks>
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await DisposeOne(scope).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (application is not null)
+                {
+                    await DisposeOne(application).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private static ValueTask DisposeOne(IServiceScope scope)
         {
             if (scope is IAsyncDisposable asyncDisposable)
             {
@@ -286,22 +443,46 @@ internal sealed class SchedulerScopedServiceProvider
 
     public object? GetKeyedService(Type serviceType, object? serviceKey)
     {
-        return inner.GetKeyedService(serviceType, serviceKey);
+        if (link is null)
+        {
+            return inner.GetKeyedService(serviceType, serviceKey);
+        }
+
+        // This scheduler's own key means its own container first — that is where its recipe registered
+        // whatever it keyed. Any other key is somebody else's scheduler, and the application is the one
+        // that has those.
+        return Equals(serviceKey, key)
+            ? inner.GetKeyedService(serviceType, serviceKey) ?? link.Application.GetKeyedService(serviceType, serviceKey)
+            : link.Application.GetKeyedService(serviceType, serviceKey) ?? inner.GetKeyedService(serviceType, serviceKey);
     }
 
     public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
     {
-        return inner.GetRequiredKeyedService(serviceType, serviceKey);
+        if (link is null)
+        {
+            return inner.GetRequiredKeyedService(serviceType, serviceKey);
+        }
+
+        return GetKeyedService(serviceType, serviceKey)
+            ?? throw new InvalidOperationException(
+                $"No service for type '{serviceType}' with key '{serviceKey}' has been registered.");
     }
 
     /// <summary>
     /// Answers what this scheduler can be given, not what the container holds unkeyed.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// <see cref="ActivatorUtilities"/> asks this before choosing a constructor, and treats a service it
     /// is told does not exist as a parameter it cannot supply. Answering from the container directly
     /// would report every one of a named scheduler's own parts as missing, so a component with more than
     /// one constructor gets the wrong one chosen — or is rejected outright.
+    /// </para>
+    /// <para>
+    /// For a scheduler that lives in a container of its own the answer is the union of the two, because
+    /// what this provider <em>can supply</em> is the union: whichever container holds it,
+    /// <see cref="GetService" /> will find it.
+    /// </para>
     /// </remarks>
     public bool IsService(Type serviceType)
     {
@@ -326,12 +507,62 @@ internal sealed class SchedulerScopedServiceProvider
             return true;
         }
 
-        return inner.GetService<IServiceProviderIsService>()?.IsService(serviceType) ?? false;
+        return Declares(serviceType)
+            || (link is not null && (link.Application.GetService<IServiceProviderIsService>()?.IsService(serviceType) ?? false));
     }
 
+    /// <inheritdoc cref="IsService" />
     public bool IsKeyedService(Type serviceType, object? serviceKey)
     {
-        return inner.GetService<IServiceProviderIsKeyedService>()?.IsKeyedService(serviceType, serviceKey) ?? false;
+        return (inner.GetService<IServiceProviderIsKeyedService>()?.IsKeyedService(serviceType, serviceKey) ?? false)
+            || (link is not null
+                && (link.Application.GetService<IServiceProviderIsKeyedService>()?.IsKeyedService(serviceType, serviceKey) ?? false));
+    }
+}
+
+/// <summary>
+/// The application container a scheduler built at runtime resolves everything else from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as an instance in the container <c>SchedulerGeneration</c> builds for one tenant, which is
+/// how <see cref="SchedulerScopedServiceProvider.For" /> finds it without every registration having to
+/// be told about it. A container-registered scheduler has none, and behaves exactly as it did before
+/// this type existed.
+/// </para>
+/// <para>
+/// A record so that <c>with</c> can re-point it at a scope's provider while keeping what was computed
+/// once for the generation.
+/// </para>
+/// </remarks>
+/// <param name="Application">The application's provider, or the scope of it a firing is running in.</param>
+internal sealed record ApplicationLink(IServiceProvider Application)
+{
+    private static readonly Assembly quartz = typeof(IScheduler).Assembly;
+
+    /// <summary>
+    /// The options types the tenant's own container configures, validates or post-configures.
+    /// </summary>
+    /// <remarks>
+    /// Read off the tenant's service collection while it is being built, rather than probed for at
+    /// resolution time: asking the container whether it holds an <c>IConfigureOptions&lt;X&gt;</c> means
+    /// closing that generic over a type only known at run time, which is the one thing a native AOT
+    /// publish cannot do.
+    /// </remarks>
+    public FrozenSet<Type> ConfiguredOptions { get; init; } = FrozenSet<Type>.Empty;
+
+    /// <summary>
+    /// Whether an options type belongs to the tenant rather than to the application.
+    /// </summary>
+    /// <remarks>
+    /// Quartz's own options types always do: a tenant's container holds exactly one scheduler, so
+    /// <see cref="QuartzSchedulerOptions" /> read there is that scheduler's, and reading it from the
+    /// application would answer with whatever the application's own scheduler was configured with — or
+    /// with nothing. Anything else belongs to the tenant only if the recipe configured it.
+    /// </remarks>
+    public bool ConfiguresOptions(Type optionsType)
+    {
+        return optionsType.Assembly == quartz || ConfiguredOptions.Contains(optionsType);
     }
 }
 

--- a/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheck.cs
+++ b/src/Quartz/Diagnostics/HealthChecks/QuartzHealthCheck.cs
@@ -47,17 +47,38 @@ internal sealed class QuartzHealthCheck : IHealthCheck
             ? serviceProvider.GetService<ISchedulerFactory>()
             : serviceProvider.GetKeyedService<ISchedulerFactory>(target.SchedulerName);
 
-        if (schedulerFactory is null)
+        if (schedulerFactory is not null)
         {
-            return HealthCheckResult.Unhealthy(target.SchedulerName is null
-                ? "There is no default Quartz scheduler in this container, so this health check has nothing to "
-                  + "report on. Every scheduler here is registered under a name; call AddQuartzHealthChecks() on "
-                  + "the scheduler's own builder, or AddQuartz(schedulerName) on the health checks builder, so the "
-                  + "check knows which one it is for."
-                : $"There is no Quartz scheduler named '{target.SchedulerName}' in this container.");
+            return await Evaluate(
+                await schedulerFactory.GetScheduler(cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
-        IScheduler scheduler = await schedulerFactory.GetScheduler(cancellationToken).ConfigureAwait(false);
+        // No registration under that name — but a scheduler added at runtime has none and is still a
+        // scheduler this container is running. It is in the repository, which is where everything else
+        // that reads across both kinds looks, so the check does too. A health check is registered at
+        // build time, when a tenant that has not been added yet has no name for anybody to write, so
+        // AddQuartz("acme") on the health-checks builder is how a check waits for one.
+        if (target.SchedulerName is not null
+            && serviceProvider.GetService<Extensibility.ISchedulerRepository>()?.Lookup(target.SchedulerName) is { } tenant)
+        {
+            return await Evaluate(tenant, cancellationToken).ConfigureAwait(false);
+        }
+
+        return HealthCheckResult.Unhealthy(target.SchedulerName is null
+            ? "There is no default Quartz scheduler in this container, so this health check has nothing to "
+              + "report on. Every scheduler here is registered under a name; call AddQuartzHealthChecks() on "
+              + "the scheduler's own builder, or AddQuartz(schedulerName) on the health checks builder, so the "
+              + "check knows which one it is for."
+            : $"There is no Quartz scheduler named '{target.SchedulerName}' in this container, nor a scheduler "
+              + "added at runtime under that name.");
+    }
+
+    /// <summary>
+    /// Reports on a scheduler, however it was found.
+    /// </summary>
+    private async ValueTask<HealthCheckResult> Evaluate(IScheduler scheduler, CancellationToken cancellationToken)
+    {
         string name = scheduler.SchedulerName;
 
         switch (scheduler.Status)

--- a/src/Quartz/Hosting/QuartzHostedService.cs
+++ b/src/Quartz/Hosting/QuartzHostedService.cs
@@ -326,10 +326,25 @@ public class QuartzHostedService : IHostedLifecycleService
     /// enumerating a list somebody else was clearing, which is the
     /// <see cref="InvalidOperationException" /> #3701 reported out of <c>RunAsync</c>.
     /// </para>
+    /// <para>
+    /// The schedulers added while the host was running are drained here too. They are not this
+    /// service's — nothing here created them, and it learns of them only now — but the alternative is
+    /// leaving them to container disposal, which happens after the graceful shutdown window has closed,
+    /// so a tenant's running jobs would be abandoned rather than waited for. There is no second hosted
+    /// service and nothing is resolved at start; a container with no runtime tenants asks a question
+    /// that answers nothing.
+    /// </para>
     /// </remarks>
     private async ValueTask ShutdownSchedulers(CancellationToken cancellationToken)
     {
         List<HostedScheduler> toShutDown = Interlocked.Exchange(ref schedulers, []);
+
+        // Each under its own name, so AddQuartzHostedService("acme", o => o.WaitForJobsToComplete = true)
+        // configures a tenant that did not exist when that line was written.
+        foreach (IScheduler tenant in serviceProvider.GetService<SchedulerRuntime>()?.TakeLiveSchedulers() ?? [])
+        {
+            toShutDown.Add(new HostedScheduler(tenant, options.Get(tenant.SchedulerName)));
+        }
 
         // Every shutdown is started before any of them is awaited, so that the waits for running jobs
         // overlap. A scheduler that throws before it yields is captured rather than left to abandon the

--- a/src/Quartz/ISchedulerFactory.cs
+++ b/src/Quartz/ISchedulerFactory.cs
@@ -54,9 +54,15 @@ public interface ISchedulerFactory
     /// <para>
     /// This is a lookup, which is why it is named for one and why it is nullable while
     /// <see cref="GetScheduler(CancellationToken)" /> is not: any name other than this factory's own
-    /// belongs to a scheduler somebody else registered, and it may not exist. Asking for this factory's
-    /// own scheduler by name builds it on demand, exactly as <see cref="GetScheduler(CancellationToken)" />
-    /// would; the comparison ignores case, because that is how the repository indexes names.
+    /// belongs to a scheduler somebody else registered, and it may not exist. The comparison ignores
+    /// case, because that is how the repository indexes names.
+    /// </para>
+    /// <para>
+    /// A name the container <em>registered</em> is built on demand, whether or not it is this factory's
+    /// own: what makes a scheduler exist is the registration, so "give me tenant acme" does not depend
+    /// on whether something else happened to resolve it first. A name added at runtime with
+    /// <see cref="ISchedulerRuntime" /> is found while it is alive and not rebuilt after it has been
+    /// shut down — it has no registration to be rebuilt from, and adding it again is that interface's.
     /// </para>
     /// <para>
     /// Only schedulers from the same container are visible. A scheduler built by a

--- a/src/Quartz/ISchedulerRuntime.cs
+++ b/src/Quartz/ISchedulerRuntime.cs
@@ -1,0 +1,135 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Adds and removes schedulers in a container that has already been built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A scheduler registered with <c>AddQuartz</c> is a set of registrations fixed when the container was
+/// built, and a name the container never heard of has none. This is the other door: a scheduler added
+/// here is built into a container of its own, holding its own thread pool, job store, connection
+/// provider, plugins and listeners, and resolving everything else — the application's services, its
+/// jobs, its options — from the application's container. It is bound into the same
+/// <see cref="Extensibility.ISchedulerRepository" /> as every other scheduler, so the HTTP API, the
+/// dashboard and <see cref="ISchedulerFactory.GetAllSchedulers" /> see it without knowing it arrived
+/// late.
+/// </para>
+/// <para>
+/// It extends <see cref="ISchedulerRegistry" />: <see cref="ISchedulerRegistry.QuerySchedulers" /> lists
+/// what the container registered and what was added at runtime alike, the latter with
+/// <see cref="SchedulerOrigin.Runtime" />. Resolving either interface answers with the same object, so
+/// an application that only reads the listing need not know this one exists.
+/// </para>
+/// <para>
+/// Registered by <c>AddQuartz</c>, so any container with Quartz in it has one. What it holds is the
+/// container's for as long as the container lives: a scheduler still running when the host stops is
+/// shut down with the rest, and one still running when the container is disposed is shut down then.
+/// </para>
+/// <para>
+/// One thing it deliberately does not do is delete data. A removed tenant's rows under its
+/// <c>SCHED_NAME</c> stay exactly where they are, and its <c>SCHEDULER_STATE</c> row expires the way a
+/// stopped node's does. Deleting a tenant's data is the application's decision, not a side effect of
+/// removing its scheduler.
+/// </para>
+/// </remarks>
+public interface ISchedulerRuntime : ISchedulerRegistry
+{
+    /// <summary>
+    /// Builds a scheduler under a name the container does not hold, binds it into the repository and —
+    /// unless told otherwise — starts it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="configure" /> is the same <see cref="IQuartzBuilder" /> an
+    /// <c>AddQuartz(name, …)</c> callback is given, applied in the same order to the same phases, so a
+    /// recipe reads identically whichever door it came through. Its
+    /// <see cref="IQuartzBuilder.Services" /> is <em>this scheduler's</em> collection rather than the
+    /// application's: what it registers there belongs to this scheduler and goes away with it.
+    /// </para>
+    /// <para>
+    /// Whatever <c>ConfigureAllQuartzSchedulers</c> said about every scheduler in the container is
+    /// applied here too, after <paramref name="configure" />, exactly where a scheduler registered at
+    /// startup receives it.
+    /// </para>
+    /// <para>
+    /// This fails soft: a name that cannot be added is refused with a
+    /// <see cref="SchedulerConfigException" /> saying which rule and what to do about it, and nothing is
+    /// left behind — no half-built scheduler in the repository, and nothing in the listing. A name is
+    /// refused when the container registered it, when a scheduler is already bound under it, when one
+    /// has already been added under it, and when the host is stopping.
+    /// </para>
+    /// <para>
+    /// The scheduler is reached afterwards through <see cref="ISchedulerFactory.LookupScheduler" /> or
+    /// the repository. It is <em>not</em> reachable as
+    /// <c>[FromKeyedServices("name")] IScheduler</c>: that is a container registration, and the point of
+    /// this method is a scheduler the container was never told about.
+    /// </para>
+    /// </remarks>
+    /// <param name="schedulerName">
+    /// The scheduler's name, which is also its instance name and the name of its options.
+    /// </param>
+    /// <param name="configure">Configures the scheduler, as an <c>AddQuartz(name, …)</c> callback does.</param>
+    /// <param name="options">
+    /// Settings for the scheduler and whether to start it. The default is a scheduler configured
+    /// entirely by <paramref name="configure" /> and started.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The scheduler, created and bound.</returns>
+    /// <exception cref="SchedulerConfigException">
+    /// The name cannot be added, or the scheduler could not be built from what it was configured with.
+    /// </exception>
+    ValueTask<IScheduler> Add(
+        string schedulerName,
+        Action<IQuartzBuilder>? configure = null,
+        SchedulerAddOptions options = default,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Shuts down a scheduler this runtime added, unbinds it from the repository and releases everything
+    /// built for it.
+    /// </summary>
+    /// <remarks>
+    /// A name this runtime did not add is not an error: it answers <see langword="false" />, so removing
+    /// twice, or removing a tenant that was shut down by hand, says what happened rather than throwing.
+    /// A name the <em>container</em> registered is a different matter and is refused — the container owns
+    /// those, and <see cref="IScheduler.Shutdown" /> is how one of them stops.
+    /// <para>
+    /// Nothing is deleted from the store. See the remarks on <see cref="ISchedulerRuntime" />.
+    /// </para>
+    /// </remarks>
+    /// <param name="schedulerName">The scheduler's name.</param>
+    /// <param name="waitForJobsToComplete">
+    /// Whether to wait for the jobs that are running to finish before the scheduler shuts down.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>
+    /// <see langword="true" /> when a scheduler was removed, <see langword="false" /> when this runtime
+    /// held none under that name.
+    /// </returns>
+    /// <exception cref="SchedulerConfigException">The container registered this name.</exception>
+    ValueTask<bool> Remove(
+        string schedulerName,
+        bool waitForJobsToComplete = false,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -64,7 +64,72 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
             return await GetScheduler(cancellationToken).ConfigureAwait(false);
         }
 
-        return schedulerRepository.Lookup(schedulerName);
+        if (schedulerRepository.Lookup(schedulerName) is { } live)
+        {
+            return live;
+        }
+
+        return await Build(schedulerName, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds another of this container's registered schedulers, for a name nothing has built yet.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Asking for this factory's own scheduler by name has always been able to create it; asking for a
+    /// sibling's could not, so under a multi-tenant registration the answer to "give me tenant acme"
+    /// depended on whether somebody else had happened to resolve it first. The registration is what says
+    /// the scheduler exists, so it is what this reads: a registered name is built through that
+    /// scheduler's own factory, which binds it into the repository the same way it would have been bound
+    /// had the container resolved it.
+    /// </para>
+    /// <para>
+    /// A scheduler <em>added at runtime</em> is deliberately not built here. It is in the repository
+    /// while it is alive, so the branch above answers for it; once it has been shut down there is
+    /// nothing to rebuild from — its parts are one set of instances in a container of their own, which
+    /// is the whole reason it was built that way. It is <see cref="ISchedulerRuntime" />'s to add again.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<IScheduler?> Build(string schedulerName, CancellationToken cancellationToken)
+    {
+        SchedulerNameRegistry? registry = serviceProvider.GetService<SchedulerNameRegistry>();
+        if (registry is null)
+        {
+            return null;
+        }
+
+        if (registry.Find(schedulerName) is { } registered)
+        {
+            return await Factory(registered).GetScheduler(cancellationToken).ConfigureAwait(false);
+        }
+
+        // The default scheduler is the one registration whose name is not the name it was registered
+        // under - it has no service key at all - so its options are read to learn it.
+        if (registry.HasDefaultScheduler
+            && string.Equals(
+                serviceProvider.GetSchedulerOptions<QuartzSchedulerOptions>(null).InstanceName,
+                schedulerName,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return await Factory(null).GetScheduler(cancellationToken).ConfigureAwait(false);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Another scheduler's factory, by the key its parts are registered under — <see langword="null" />
+    /// for the default scheduler, whose registrations are the unkeyed ones.
+    /// </summary>
+    /// <remarks>
+    /// Asked for by key rather than by type, because this factory's own provider is scoped to this
+    /// scheduler: a plain <c>GetRequiredService&lt;ISchedulerFactory&gt;()</c> here would answer with
+    /// this one, whichever scheduler was asked for.
+    /// </remarks>
+    private ISchedulerFactory Factory(string? key)
+    {
+        return serviceProvider.GetRequiredKeyedService<ISchedulerFactory>(key);
     }
 
     public async ValueTask<IScheduler> GetScheduler(CancellationToken cancellationToken = default)

--- a/src/Quartz/SchedulerAddOptions.cs
+++ b/src/Quartz/SchedulerAddOptions.cs
@@ -63,9 +63,9 @@ public readonly record struct SchedulerAddOptions
     /// </summary>
     /// <remarks>
     /// Either the scheduler's own section or a root section containing <c>Schedulers:{name}</c>; the
-    /// same resolution the registration-time overload does. Takes precedence over
-    /// <see cref="Properties" /> when both are set, because a section says everything a property bag
-    /// does and more.
+    /// same resolution the registration-time overload does. Setting this <em>and</em>
+    /// <see cref="Properties" /> is refused rather than resolved by precedence: a section says
+    /// everything a property bag does, so one of them would be read and the other dropped without a word.
     /// </remarks>
     public IConfiguration? Configuration { get; init; }
 

--- a/src/Quartz/SchedulerAddOptions.cs
+++ b/src/Quartz/SchedulerAddOptions.cs
@@ -27,12 +27,26 @@ namespace Quartz;
 /// What to add a scheduler with, beyond its name and the recipe that configures it.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The two settings-shaped members are the runtime spellings of the two <c>AddQuartz(name, …)</c>
 /// overloads that take settings, so a tenant described by a configuration section at startup is
 /// described by the same section when it arrives at runtime instead.
+/// </para>
+/// <para>
+/// Defaults are the conservative ones: no settings beyond what the recipe says, and the scheduler is
+/// started — which is the whole of what adding one at runtime is for. So <see langword="default"/> —
+/// which is what omitting the argument gives — is "build it from the recipe and run it".
+/// </para>
 /// </remarks>
-public sealed class SchedulerAddOptions
+/// <seealso cref="ISchedulerRuntime.Add" />
+public readonly record struct SchedulerAddOptions
 {
+    /// <summary>
+    /// Create the scheduler and leave starting it to the application. The name for
+    /// <c>new SchedulerAddOptions { CreateWithoutStarting = true }</c>.
+    /// </summary>
+    public static SchedulerAddOptions WithoutStarting => new() { CreateWithoutStarting = true };
+
     /// <summary>
     /// Flat <c>quartz.*</c> properties for the scheduler, as
     /// <c>AddQuartz(name, properties, …)</c> takes them.
@@ -56,7 +70,8 @@ public sealed class SchedulerAddOptions
     public IConfiguration? Configuration { get; init; }
 
     /// <summary>
-    /// Whether to start the scheduler once it has been created. <see langword="true" /> by default.
+    /// Whether the scheduler is left for the application to start, rather than started as soon as it
+    /// has been created.
     /// </summary>
     /// <remarks>
     /// This is the whole of the starting policy for a scheduler added at runtime.
@@ -66,5 +81,5 @@ public sealed class SchedulerAddOptions
     /// runtime arrives long after both. <see cref="QuartzHostedServiceOptions.WaitForJobsToComplete" />
     /// <em>does</em> apply, because it is about the host stopping, which is still ahead.
     /// </remarks>
-    public bool Start { get; init; } = true;
+    public bool CreateWithoutStarting { get; init; }
 }

--- a/src/Quartz/SchedulerAddOptions.cs
+++ b/src/Quartz/SchedulerAddOptions.cs
@@ -1,0 +1,70 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.Extensions.Configuration;
+
+namespace Quartz;
+
+/// <summary>
+/// What to add a scheduler with, beyond its name and the recipe that configures it.
+/// </summary>
+/// <remarks>
+/// The two settings-shaped members are the runtime spellings of the two <c>AddQuartz(name, …)</c>
+/// overloads that take settings, so a tenant described by a configuration section at startup is
+/// described by the same section when it arrives at runtime instead.
+/// </remarks>
+public sealed class SchedulerAddOptions
+{
+    /// <summary>
+    /// Flat <c>quartz.*</c> properties for the scheduler, as
+    /// <c>AddQuartz(name, properties, …)</c> takes them.
+    /// </summary>
+    /// <remarks>
+    /// Checked against the keys Quartz reads, so a misspelling is reported rather than ignored. Set
+    /// <c>quartz.checkConfiguration</c> to <see langword="false" /> to allow keys of your own.
+    /// </remarks>
+    public IEnumerable<KeyValuePair<string, string?>>? Properties { get; init; }
+
+    /// <summary>
+    /// A configuration section describing the scheduler, as <c>AddQuartz(name, configuration, …)</c>
+    /// takes it.
+    /// </summary>
+    /// <remarks>
+    /// Either the scheduler's own section or a root section containing <c>Schedulers:{name}</c>; the
+    /// same resolution the registration-time overload does. Takes precedence over
+    /// <see cref="Properties" /> when both are set, because a section says everything a property bag
+    /// does and more.
+    /// </remarks>
+    public IConfiguration? Configuration { get; init; }
+
+    /// <summary>
+    /// Whether to start the scheduler once it has been created. <see langword="true" /> by default.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole of the starting policy for a scheduler added at runtime.
+    /// <see cref="QuartzHostedServiceOptions.StartDelay" /> and
+    /// <see cref="QuartzHostedServiceOptions.AwaitApplicationStarted" /> do not apply: both are about
+    /// the window between a host starting and its application being ready, and a scheduler added at
+    /// runtime arrives long after both. <see cref="QuartzHostedServiceOptions.WaitForJobsToComplete" />
+    /// <em>does</em> apply, because it is about the host stopping, which is still ahead.
+    /// </remarks>
+    public bool Start { get; init; } = true;
+}


### PR DESCRIPTION
`ISchedulerRuntime` is the other door beside `AddQuartz`. It takes a name the container never heard of,
builds a scheduler for it into a container of its own, binds it into the same `ISchedulerRepository` as
every other scheduler, and starts it. Everything that reads the repository — `GetAllSchedulers`, the HTTP
API, the dashboard — sees it without knowing it arrived late, and the listing tells the two kinds apart by
`SchedulerOrigin`.

```csharp
ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();

IScheduler tenant = await runtime.Add("acme", q =>
{
    q.UsePersistentStore(s => s.UseSqlServer(connectionStrings["acme"]));
    q.AddJob<NightlyReportJob>(j => j.WithIdentity("nightly"));
    q.AddTrigger<NightlyReportJob>(t => t.WithCronSchedule("0 30 2 * * ?"));
});

await runtime.Remove("acme", waitForJobsToComplete: true);
```

This is PR1 of #3338 — the add/remove half. `Restart`, blueprint capture for container-registered
schedulers and the `DeferredScheduler` change are PR2; the room they need is left here (see
[Leaving room for PR2](#leaving-room-for-pr2) below).

## How it works

**A generation is one scheduler's container.** `SchedulerGeneration` builds a fresh `ServiceCollection`,
forwards the application's shared services into it as *instances* (never a factory: MS DI would then have
the child dispose the application's meter and repository), replays the application's
`ConfigureAllQuartzSchedulers` delegates onto it, and calls the same
`QuartzServiceCollectionExtensions.AddQuartzScheduler` a container scheduler goes through, keyed by the
tenant's name. There is no second construction path to keep in step with the first, and a recipe written
for `AddQuartz(name, …)` is the same recipe here.

**`SchedulerScopedServiceProvider` gained an `ApplicationLink`** — everything the recipe did not register
resolves from the application. Three requests are decided rather than tried, because "ask the tenant, then
the application" is the wrong answer for each:

* an `IJob` is built by the application, because a container resolves a service's dependencies from
  *itself* and the tenant's container has none of them;
* an options type is read from whichever container configured it, with Quartz's own always the tenant's;
* an `IEnumerable<T>` is routed on whether the tenant declares `T`, because an empty sequence and "none of
  these here" are the same answer.

**`CreateScope()` opens a scope in each container** and hands out a provider over both. That is the part
that decides whether the mechanism is honest: the well-known composite resolves `IServiceScopeFactory` from
the child, so the per-execution scope is not the application's at all and every application-scoped service a
job takes is created outside any scope and never disposed. `SchedulerGenerationScopeTest` holds the
opposite — one instance across the firing, disposed when the job is returned, with `ValidateScopes` on.

**`SharedServiceForwardingTest` is the drift guard.** It enumerates what `AddQuartzSharedServices`
registers and fails on anything that is neither forwarded nor excused with a reason. Forgetting one has no
symptom until production — a tenant the dashboard cannot see, or measurements nobody collects.

## The refusals, verbatim

`Add` fails soft: only the caller hears, and nothing is left behind. In this order, because it is the
order of how specifically the name is already spoken for.

> Scheduler '{name}' is registered with the container, and a container registration cannot be added again
> at runtime: its parts are registered under that name already, and a second set of them would be two
> schedulers wearing one name. Build it with
> `GetRequiredKeyedService<ISchedulerFactory>("{name}").GetScheduler()`, or add this one under a name of
> its own.

> A scheduler named '{name}' has already been added at runtime. Remove it first with
> `ISchedulerRuntime.Remove("{name}")` and add it again: a scheduler's thread pool and job store cannot be
> replaced underneath it, which is why there is no way to add over one.

> A scheduler named '{name}' is already bound in this container's repository, so adding one would be a
> second scheduler under one name. Shut down the one that is there first — a scheduler bound by hand, or
> one AddQuartzHttpClient bound, is not this runtime's to remove.

> The host is stopping, so scheduler '{name}' was not added: it would be created after the shutdown that
> would have stopped it, and nothing would come back for it.

That last one is read **twice** — before the generation is built, and again once the scheduler is
running and immediately before the unit is registered. Building and starting is not instantaneous, so
a host that begins stopping in that window takes the live schedulers from a map the new tenant is not
in yet, leaving it started and bound with the graceful shutdown already behind it and only container
disposal left to catch it. The second reading undoes the add through the same refusal path, so the
generation is shut down, unbound and released.
`AddRacingTheHostsStopIsShutDownAndRefused` enters that window deliberately rather than racing for it:
a scheduler's own `SchedulerStarted` notification is awaited inside `Start()`, so a listener that
cancels the host's token lands between the start and the second reading every time. It fails without
the second reading.

And settings given two ways at once are refused rather than resolved by precedence, which is what
`AddQuartzSchedulers` already does in the same words:

> The options for scheduler '{name}' set both Properties and Configuration. A configuration section says
> everything a flat property bag does, so only one of them would be read and the other dropped without a
> word. Use one or the other.

`Remove` refuses one thing:

> Scheduler '{name}' is registered with the container, so it is not this runtime's to remove: the container
> owns its parts and decides their lifetime. Shut it down with `IScheduler.Shutdown()`, which unbinds it
> from the repository, or stop the host, which shuts down every scheduler it started.

And a recipe that says how the tenant builds a job is refused where it is written rather than ignored at
the first firing:

> The recipe for scheduler '{name}' says how it builds the job type '{type}', and a scheduler added at
> runtime does not build its own jobs: they are built by the application's container, which is where their
> dependencies are. Register the job type there instead — `services.AddScoped<TJob>()` or
> `services.AddScoped<TJob, TImplementation>()` — and leave the recipe to schedule it with
> `AddJob<TJob>(...)`.

## Three seams that read across both kinds of scheduler

* **`QuartzHostedService`** takes the runtime's live schedulers into the same concurrent shutdown as its
  own, each under the `QuartzHostedServiceOptions` registered for its name — so
  `AddQuartzHostedService("acme", o => o.WaitForJobsToComplete = true)` configures a tenant that does not
  exist yet. Not because those schedulers are its own, but because the alternative is container disposal,
  which happens after the graceful shutdown window has closed. No second hosted service, nothing resolved
  at start.
* **The health check** falls back to `ISchedulerRepository` when the keyed factory is absent, because a
  check is registered while the container is being built and a tenant added later never gets a keyed
  factory at all. Its missing-name message now names both places it looked.
* **`ISchedulerFactory.LookupScheduler`** builds a registered-but-unbuilt scheduler (A7 of #3340, moved
  here) rather than answering `null` for every name but its own factory's: what makes a scheduler exist is
  its registration, so "give me tenant acme" no longer depends on whether something else happened to resolve
  acme first. A runtime tenant is found while alive and deliberately **not** rebuilt after shutdown.

## Public API

Additions only; no line was removed or changed in any baseline.

```csharp
public interface ISchedulerRuntime : ISchedulerRegistry
{
    ValueTask<IScheduler> Add(string schedulerName, Action<IQuartzBuilder>? configure = null,
        SchedulerAddOptions options = default, CancellationToken cancellationToken = default);
    ValueTask<bool> Remove(string schedulerName, bool waitForJobsToComplete = false,
        CancellationToken cancellationToken = default);
}

public readonly record struct SchedulerAddOptions
{
    public static SchedulerAddOptions WithoutStarting { get; }
    public IEnumerable<KeyValuePair<string, string?>>? Properties { get; init; }
    public IConfiguration? Configuration { get; init; }
    public bool CreateWithoutStarting { get; init; }
}
```

`PublicApiTest_Quartz.verified.txt` and `LogEventCatalogTest_Quartz.verified.txt` regenerated;
`log-events.md` regenerated by `dotnet fallout DocsLogEvents` (ids 4020–4022). The migration guide gains an
"Upgrading from 4.0 to 4.1" section, which also settles the promise 4.0 made — `ISchedulerRuntime` extends
`ISchedulerRegistry` rather than replacing it.

## Deviations from the spec, and why

1. **`SchedulerAddOptions` is a `readonly record struct` with `CreateWithoutStarting`, not a class with
   `Start = true`.** The spec asked for a context object with `init` properties. The repository's ratified
   S6 options rule says the opposite for this kind of type, and `OptionsConventionTest` enforces it: an
   options type the *application* constructs and passes to a Quartz method is a `readonly record struct`
   whose `default` is the recommended behaviour. Adding a scheduler at runtime and running it *is* the
   recommended behaviour, so the flag says the other thing, and `SchedulerAddOptions.WithoutStarting` is
   the named preset — the shape `AddJobOptions.Replacing` already has. **A reviewer may want to weigh in
   on the member name.**
   `OptionsConventionTest.referencedTypeExceptions` gains one entry for `Configuration`, with the reason
   the list asks for: `IConfiguration` is a contract imposed from outside Quartz, and this member carries
   one *in* rather than being bound *out of* one.
2. **The "already added at runtime" check runs before the "already bound in the repository" check**, where
   the spec put them the other way round. A live runtime tenant is both — it is in the repository because
   this runtime put it there — and "Remove it first" is the answer worth giving. In the spec's order that
   message was unreachable for a live tenant.
3. **`AddJobType` is refused for a runtime tenant in *every* overload**, not only the mapping and factory
   ones. `AddJobType<TJob>()` registers the job type *keyed by the scheduler name*, so it would be resolved
   from the tenant's container — which is exactly what "a job is built by the application" forbids, and
   would fail at the first firing on any job taking an application service. `AddJob<T>` / `ScheduleJob<T>`
   register the type as itself and unkeyed, which stays inert and is untouched. (Also: a keyed
   `ServiceDescriptor.ImplementationType` *throws* rather than answering, so the spec's shape test had to
   be written against `IsKeyedService` first.)
4. **`SchedulerRuntime` implements `IDisposable` as well as `IAsyncDisposable`.** Not in the spec, and not
   optional: MS DI refuses to dispose synchronously *at all* once the container holds a service that is
   only `IAsyncDisposable`, so a registration nothing in the application ever asked for would have turned
   `using var host = …` into an `InvalidOperationException`. Fourteen tests caught it.
5. **Rule 7's "does the child hold a closed `IConfigureOptions<X>` descriptor" is computed once from the
   child's descriptors rather than probed per type**, and there is no `ConcurrentDictionary` verdict cache.
   Probing needs `MakeGenericType`, which is `[RequiresDynamicCode]` — an `IL3050`, which `Quartz` treats
   as an error and AGENTS.md says it produces none of. The precomputed `FrozenSet` on the link makes the
   verdict two cheap reads, so a cache in front of it would be slower than what it cached.
6. **`ISchedulerRegistry`/`ISchedulerRuntime`/`SchedulerRuntime`/`ContainerSchedulerRegistry` are
   *removed* from the tenant's collection** rather than merely not forwarded. `AddQuartzSharedServices`
   runs inside the tenant's container too, so not forwarding them leaves the tenant with its own — which
   would answer "what schedulers are there" with one tenant, and would let a job add a tenant to a runtime
   that is disposed with the generation. Removing them makes the question fall through to the
   application's.
7. **`SchedulerGenerationScopeTest`'s first case uses `ConfigureJobScope` where the spec said an
   `IJobExecutionMiddleware`.** *This is a spec statement the code proves wrong*: middleware is built once
   per scheduler, in the `QuartzSchedulerResources` factory (`ComposeJobExecutionPipeline`), so it cannot
   take a per-firing scoped service by constructor injection at all — under any scheduler, not just a
   runtime one. `ConfigureJobScope` is the per-firing hook a recipe actually has, it receives the
   `IServiceScope`, and it proves the same thing: the job's `UnitOfWork` and the hook's are one instance.
8. **`SchedulerGenerationScopeTest` landed with commit 2** (which introduces `SchedulerGeneration`) rather
   than with commit 1, which the brief allowed. Commit 1 carries
   `SchedulerScopedServiceProviderLinkTest` instead — ten cases over the composite's routing and its
   two-scope `CreateScope` directly, written before the generation existed. Both files stay.
9. **`sample_tenancy_offboarding_standalone` is a fifth snippet** the spec did not name. The spec asked for
   `sample_tenancy_standalone_onboarding`; its offboarding half needed a name too, since the old
   `sample_tenancy_offboarding` body is now the `ISchedulerRuntime` one.
10. **`SchedulerAddOptions` refuses `Properties` and `Configuration` together.** The spec gave
    `Configuration` precedence; that is a documented silent drop, and this repository refuses the same
    ambiguity in `AddQuartzSchedulers` with the same closing sentence. Refusing can be relaxed
    additively later; a precedence rule people have started relying on could not.
11. **`ISchedulerFactory.LookupScheduler` also builds the *default* scheduler by name** from a named
    scheduler's factory. The spec asked for this and it is worth naming because it is the one case that
    needs a `null` service key rather than a name.

## Verification

`build.cmd Compile UnitTest`:

```
Passed!  - Failed: 0, Passed: 5507, Skipped: 36, Total: 5543, Duration: 51 s - Quartz.Tests.Unit.dll
Passed!  - Failed: 0, Passed:  633, Skipped:  0, Total:  633, Duration:  7 s - Quartz.Tests.AspNetCore.dll
Restore  Succeeded 0:02 · Compile Succeeded 0:47 · UnitTest Succeeded 1:02
```

`build.cmd Compile UnitTest IntegrationTest --database sqlite` (`QUARTZ_TEST_DATABASE=sqlite`):

```
Passed!  - Failed: 0, Passed:   15, Skipped:  0, Total:   15, Duration: 2 m 14 s - Quartz.Tests.Integration.dll
Restore Succeeded 0:01 · Compile Succeeded 0:06 · IntegrationTest Succeeded 2:16 · UnitTest Succeeded 1:01
```

The other five dialect legs need a Docker daemon, and none is running on this machine
(`open //./pipe/docker_engine: The system cannot find the file specified`), so only the SQLite leg was
run locally. `dotnet fallout BenchmarkSmoke` succeeded. `dotnet fallout PublishTrimmed` succeeded — the
canary ran and reported nothing outside the recorded trim baseline. `PublishAot` fails on this machine in
the *native link* step (`'vswhere.exe' is not recognized`, `link.exe` exit 123), before its assertion runs;
the ILCompiler analysis it did complete reports 29 Quartz warnings, all of them types already in
`TrimAnalysisBaseline.cs` and none of them anything added here.

Docs: `dotnet fallout DocsSnippets`, `dotnet fallout VerifyDocsSnippets` (111 markdown files up to date),
`npm run docs:check-links` (224 pages, 1402 links, 860 fragments — no dead links or anchors) and
`npm run docs:lint` (92 files, 0 errors) all pass. The lint run caught something worth knowing: MD004 is
*consistent*-style, so a new dash list placed before the document's first list flips the expectation for
the whole file — the new migration-guide bullets use `*` to match what is already there.

### `SchedulerScopedServiceProviderBenchmark`

Before (`197279fcb`):

| Method                 | Mean     | Error    | StdDev   | Median   | Ratio | Allocated |
|----------------------- |---------:|---------:|---------:|---------:|------:|----------:|
| Dictionaries           | 34.75 ns | 0.691 ns | 1.642 ns | 33.97 ns |  1.00 |         - |
| Frozen                 | 31.54 ns | 0.220 ns | 0.172 ns | 31.47 ns |  0.91 |         - |
| ResolveThroughProvider | 10.99 ns | 0.067 ns | 0.063 ns | 10.98 ns |  0.32 |         - |

After:

| Method                 | Mean     | Error    | StdDev   | Ratio | Allocated |
|----------------------- |---------:|---------:|---------:|------:|----------:|
| Dictionaries           | 32.80 ns | 0.147 ns | 0.123 ns |  1.00 |         - |
| Frozen                 | 32.05 ns | 0.151 ns | 0.134 ns |  0.98 |         - |
| ResolveThroughProvider | 10.97 ns | 0.040 ns | 0.037 ns |  0.33 |         - |

`ResolveThroughProvider` — one whole resolution through the real wrapper for a container-named scheduler —
is 10.99 ns before and 10.97 ns after. The container-named hot path is unchanged: with no link it is one
null check, and the `GetService<ApplicationLink>()` lookup is paid once per part construction at build
time, never per fire. The per-fire `CreateScope` does not do the lookup at all — the scope is handed the
link by its parent.

## Leaving room for PR2

`SchedulerGeneration` records `Number`, `StoreInstance` and `PoolInstance`, so "is this the same object the
last generation had" — the instance-supplied part that a replayed recipe cannot give a second generation —
can be answered by reference after the old container is gone. `RuntimeUnit` keeps the blueprint (name,
`SchedulerAddOptions`, the `configure` delegate) so `Restart` can replay it. No blueprint is captured for
container-registered schedulers, and `DeferredScheduler` is untouched.

## For a reviewer to decide

* The `SchedulerAddOptions.CreateWithoutStarting` name (deviation 1). The S6 rule fixes the *shape*; the
  name is a judgement.
* Whether refusing `AddJobType<TJob>()` outright (deviation 3) is right, or whether the identity overload
  should be allowed for a job that takes nothing from the application. Refusing is the conservative reading
  and can be relaxed additively; allowing it and then refusing it later could not.
* **This must not merge before the `v4.0.1` tag exists on `main`.**

Part of #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
