### PR TITLE
The next invalid time is read off the expression's fields, not walked to

### DIFF
--- a/src/Quartz.Benchmark/CronExpressionBenchmark.cs
+++ b/src/Quartz.Benchmark/CronExpressionBenchmark.cs
@@ -61,6 +61,17 @@ public class CronExpressionBenchmark
     }
 
     /// <summary>
+    /// The complement of the above, which is what a <c>CronCalendar</c> asks for: the next second the
+    /// expression does <i>not</i> fire at. It used to be a next-fire computation per second of the run,
+    /// so the number here is a run length rather than a constant (#3690).
+    /// </summary>
+    [Benchmark]
+    public DateTimeOffset? NextNonOccurrence()
+    {
+        return expression.GetNextInvalidTimeAfter(Start);
+    }
+
+    /// <summary>
     /// Chains 100 next-fire computations, the most representative of real
     /// scheduler load and the clearest amplifier of the per-call win and the
     /// per-call allocations.

--- a/src/Quartz.Tests.Unit/CronExpressionNextInvalidTimeTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionNextInvalidTimeTest.cs
@@ -1,0 +1,416 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System.Diagnostics;
+using System.Text;
+
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// <see cref="CronExpression.GetNextInvalidTimeAfter" /> reads its answer off the expression's field
+/// sets. What it used to do was ask <see cref="CronExpression.GetNextValidTimeAfter" /> for one fire
+/// after another and stop when two of them were more than a second apart, which is correct and costs a
+/// full cron computation per second of the run — a century of them for an expression that fires at every
+/// second (#3690).
+/// </summary>
+/// <remarks>
+/// The old walk is the specification, so it is kept here as <see cref="ReferenceNextInvalidTimeAfter" />
+/// and the two are compared over a corpus wide enough to reach every branch of the new search: the
+/// complement of each field, the union of the two day fields, 'L', 'W' and '#', wrapping ranges, an
+/// explicit year, and both daylight saving transitions in four zones. The one answer they do not share
+/// is the one the issue is about: where the walk gave up and returned a time the expression <i>does</i>
+/// fire at, the search says <see langword="null" />.
+/// </remarks>
+/// <author>Marko Lahma (.NET)</author>
+public class CronExpressionNextInvalidTimeTest
+{
+    /// <summary>
+    /// How far the reference walk goes before it gives up. Every second of it costs a cron computation,
+    /// so this is what keeps a corpus of expressions that fire densely from taking minutes to check.
+    /// Three days reaches past a day boundary, which is the coarsest step the search takes that any
+    /// expression here can produce inside the horizon.
+    /// </summary>
+    private const int ReferenceWalkLimitSeconds = 3 * 24 * 60 * 60;
+
+    /// <summary>
+    /// The same budget for the daylight saving cases, where what is being checked is a few hours either
+    /// side of one clock change rather than how far the search can skip.
+    /// </summary>
+    private const int ClockChangeWalkLimitSeconds = 4 * 60 * 60;
+
+    /// <summary>
+    /// And for the cases searched from an expression's own fire times, where the answer is a second or
+    /// a minute away whenever there is one at all.
+    /// </summary>
+    private const int FireTimeWalkLimitSeconds = 60 * 60;
+
+    /// <summary>
+    /// The alternatives each field is drawn from to build the corpus. Every special form the day
+    /// search has to resolve per month appears here, because those are the ones a bitmask cannot
+    /// answer on its own.
+    /// </summary>
+    private static readonly string[][] FieldAlternatives =
+    [
+        ["0", "*", "0/15", "0-30", "5,10,45", "30", "*/20"],
+        ["0", "*", "0/5", "15-45", "0,30", "59"],
+        ["*", "12", "8-18", "0/6", "22-2", "0,23"],
+        ["*", "?", "1", "15", "L", "LW", "15W", "L-2", "1-7", "1/10"],
+        ["*", "1", "JAN-MAR", "*/3", "2,6,12", "NOV-FEB"],
+        ["?", "*", "MON", "MON-FRI", "6#3", "6L", "2/2", "SUN,SAT", "FRI-MON"]
+    ];
+
+    /// <summary>
+    /// Expressions worth naming rather than generating: the ones the benchmark measures, the ones the
+    /// documentation teaches, and the two that have no invalid time at all.
+    /// </summary>
+    private static readonly string[] NamedExpressions =
+    [
+        "* * * * * ?",
+        "* * * ? * *",
+        "0 15 10 * * ?",
+        "0 0 12 * * ?",
+        "0 0/5 * * * ?",
+        "0/15 * * * * ?",
+        "0 0-30 9-17 * * ?",
+        "0 0 8-18 ? * MON-FRI",
+        "0 0,10,20,30,40,50 * * * ?",
+        "0 15 10 1,2,3,4,5,10,15,20,25 * ? *",
+        "0 15 10 L * ?",
+        "0 15 10 L-2 * ?",
+        "0 15 10 LW * ?",
+        "0 15 10 ? * 6#3 *",
+        "0 15 10 ? * 6L",
+        "0 15 10 * * ? 2005-2025",
+        "* * * * * ? 2026",
+        "0 0 0 13 * FRI",
+        "* 0-59 * * * ?",
+        "* * 0-23 * * ?",
+        "0 * * * * ?",
+        "* 30 10 * * ?"
+    ];
+
+    /// <summary>
+    /// The instants the corpus is searched from: a year boundary, a mid-day second with nothing round
+    /// about it, the last second of a month, a leap day, and the last second of a year.
+    /// </summary>
+    private static readonly DateTimeOffset[] SearchInstants =
+    [
+        new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2026, 3, 15, 13, 47, 23, TimeSpan.Zero),
+        new DateTimeOffset(2026, 2, 28, 23, 59, 59, TimeSpan.Zero),
+        new DateTimeOffset(2024, 2, 29, 12, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2026, 12, 31, 23, 59, 30, TimeSpan.Zero)
+    ];
+
+    public static IEnumerable<string> Corpus()
+    {
+        foreach (string expression in NamedExpressions)
+        {
+            yield return expression;
+        }
+
+        // A fixed seed, so a failure names an expression that can be run again.
+        Random random = new Random(3690);
+        HashSet<string> seen = [.. NamedExpressions];
+
+        while (seen.Count < 220)
+        {
+            StringBuilder builder = new StringBuilder();
+            for (int field = 0; field < FieldAlternatives.Length; field++)
+            {
+                if (field > 0)
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append(FieldAlternatives[field][random.Next(FieldAlternatives[field].Length)]);
+            }
+
+            string expression = builder.ToString();
+            if (!seen.Add(expression))
+            {
+                continue;
+            }
+
+            yield return expression;
+        }
+    }
+
+    /// <summary>
+    /// The whole of the fix: for every expression the corpus can build, and from every instant it is
+    /// asked about, the structural search and the second-by-second walk name the same second.
+    /// </summary>
+    [TestCaseSource(nameof(Corpus))]
+    public void TheAnswerIsTheOneASecondBySecondWalkGives(string expression)
+    {
+        CronExpression cron = new CronExpression(expression, TimeZoneInfo.Utc);
+
+        foreach (DateTimeOffset from in SearchInstants)
+        {
+            AssertAgreesWithTheWalk(cron, from);
+        }
+    }
+
+    /// <summary>
+    /// The same comparison from the instants that discriminate: an expression's own fire times, and the
+    /// day, the week and the month after one of them. A clock reading that fires once is the reading a
+    /// day-of-month, day-of-week, 'L', 'W' or '#' rule has an opinion about, so an answer read off those
+    /// fields is only really tested where the calendar has moved under an otherwise identical reading —
+    /// the same 10:15 on the following Friday, which is a different Friday of the month.
+    /// </summary>
+    [TestCaseSource(nameof(Corpus))]
+    public void TheAnswerIsTheOneASecondBySecondWalkGivesAroundTheExpressionsOwnFireTimes(string expression)
+    {
+        CronExpression cron = new CronExpression(expression, TimeZoneInfo.Utc);
+        DateTimeOffset? fire = cron.GetNextValidTimeAfter(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        if (fire is null)
+        {
+            return;
+        }
+
+        foreach (DateTimeOffset from in FireTimeNeighbourhood(fire.Value))
+        {
+            AssertAgreesWithTheWalk(cron, from, FireTimeWalkLimitSeconds);
+        }
+    }
+
+    private static IEnumerable<DateTimeOffset> FireTimeNeighbourhood(DateTimeOffset fire)
+    {
+        yield return fire;
+        yield return fire.AddSeconds(1);
+        yield return fire.AddSeconds(-1);
+        yield return fire.AddDays(1);
+        yield return fire.AddDays(7);
+        yield return fire.AddMonths(1);
+    }
+
+    /// <summary>
+    /// The same comparison where a clock reading and an instant are not the same thing. A fall-back
+    /// replays an hour the search has already stepped through and a spring-forward gap swallows one it
+    /// never reaches, so this is where a search that skips whole runs of clock readings can skip a
+    /// second that real time does reach.
+    /// </summary>
+    [TestCaseSource(nameof(DaylightSavingCases))]
+    public void TheAnswerIsTheOneASecondBySecondWalkGivesAcrossAClockChange(TimeZoneInfo zone, string expression, DateTimeOffset from)
+    {
+        CronExpression cron = new CronExpression(expression, zone);
+
+        AssertAgreesWithTheWalk(cron, from, ClockChangeWalkLimitSeconds);
+    }
+
+    public static IEnumerable<TestCaseData> DaylightSavingCases()
+    {
+        (TimeZoneInfo Zone, DateTimeOffset SpringForward, DateTimeOffset FallBack)[] zones =
+        [
+            // the transition instants themselves, in UTC
+            (TestTimeZones.Eastern, new DateTimeOffset(2024, 3, 10, 7, 0, 0, TimeSpan.Zero), new DateTimeOffset(2024, 11, 3, 6, 0, 0, TimeSpan.Zero)),
+            (TestTimeZones.Helsinki, new DateTimeOffset(2024, 3, 31, 1, 0, 0, TimeSpan.Zero), new DateTimeOffset(2024, 10, 27, 1, 0, 0, TimeSpan.Zero)),
+            (TestTimeZones.Sydney, new DateTimeOffset(2024, 10, 5, 16, 0, 0, TimeSpan.Zero), new DateTimeOffset(2024, 4, 6, 16, 0, 0, TimeSpan.Zero)),
+            (TestTimeZones.Santiago, new DateTimeOffset(2019, 9, 8, 4, 0, 0, TimeSpan.Zero), new DateTimeOffset(2019, 4, 7, 3, 0, 0, TimeSpan.Zero))
+        ];
+
+        string[] expressions =
+        [
+            "* * * * * ?",          // fires at every second there is, so the run is real time itself
+            "* * 1-4 * * ?",        // an interval expression whose run ends inside the transition's day
+            "0 30 2 * * ?",         // the fixed time the gap swallows in the classic zones
+            "0 0 3 * * ?",          // and the one the gap ends on
+            "* 0-30 * * * ?",       // a run that ends every hour, so it straddles the transition itself
+            "0 0 0 * * ?",          // midnight, which is the transition in Santiago
+            "* * * ? * SAT,SUN"     // whole days, which is the coarsest skip the search can take
+        ];
+
+        foreach ((TimeZoneInfo zone, DateTimeOffset springForward, DateTimeOffset fallBack) in zones)
+        {
+            foreach (string expression in expressions)
+            {
+                foreach (DateTimeOffset transition in new[] { springForward, fallBack })
+                {
+                    // an hour before the clocks move, on the move itself, and a second after
+                    foreach (TimeSpan offset in new[] { TimeSpan.FromHours(-1), TimeSpan.Zero, TimeSpan.FromSeconds(1) })
+                    {
+                        yield return new TestCaseData(zone, expression, transition + offset)
+                            .SetArgDisplayNames(zone.Id, expression, (transition + offset).ToString("O"));
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The issue: <c>* * * * * ?</c> excludes every instant, so there is no next invalid time. The walk
+    /// spent one cron computation per second looking for one — some three billion of them — and then
+    /// returned a time the expression fires at anyway.
+    /// </summary>
+    [Test]
+    public void AnExpressionThatFiresAtEverySecondHasNoInvalidTime()
+    {
+        CronExpression cron = new CronExpression("* * * * * ?", TimeZoneInfo.Utc);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        DateTimeOffset? next = cron.GetNextInvalidTimeAfter(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        stopwatch.Stop();
+
+        next.Should().BeNull("the expression fires at every second, so no second after the search instant is invalid");
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(100),
+            "the answer is read off the fields; walking to the give-up year to find it took minutes");
+    }
+
+    /// <summary>
+    /// The same, one field at a time: an expression naming every value of every field it has to name
+    /// has no invalid time either, however it is spelled.
+    /// </summary>
+    [TestCase("* * * * * ?", "the plain spelling")]
+    [TestCase("* * * ? * *", "'?' restricts nothing, so this is the same expression")]
+    [TestCase("0-59 0-59 0-23 * * ?", "ranges covering every value are wildcards written out")]
+    [TestCase("*/1 */1 */1 */1 */1 ?", "and so is a step of one")]
+    [TestCase("* * * 1-31 1-12 ?", "every day of every month")]
+    public void EveryWayOfNamingEverySecondAnswersNull(string expression, string reason)
+    {
+        CronExpression cron = new CronExpression(expression, TimeZoneInfo.Utc);
+
+        cron.GetNextInvalidTimeAfter(new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero)).Should().BeNull(reason);
+    }
+
+    /// <summary>
+    /// The ordinary answer, which is the one the calendar is normally asking for: a single fire is over
+    /// after a second, and the next second is the answer.
+    /// </summary>
+    [TestCase("0 0 12 * * ?", "2026-06-01T00:00:00Z", "2026-06-01T00:00:00Z", "the search instant does not fire, so it is its own answer")]
+    [TestCase("0 0 12 * * ?", "2026-06-01T12:00:00Z", "2026-06-01T12:00:01Z", "the fire lasts one second")]
+    [TestCase("0 0 12 * * ?", "2026-06-01T11:59:59.500Z", "2026-06-01T11:59:59Z", "milliseconds are truncated, and that second does not fire")]
+    [TestCase("* 0 12 * * ?", "2026-06-01T12:00:30Z", "2026-06-01T12:01:00Z", "a whole minute of fires ends when the minute does")]
+    [TestCase("* * 12 * * ?", "2026-06-01T12:30:00Z", "2026-06-01T13:00:00Z", "a whole hour of fires ends when the hour does")]
+    [TestCase("* * * 1 * ?", "2026-06-01T12:30:00Z", "2026-06-02T00:00:00Z", "a whole day of fires ends at midnight")]
+    [TestCase("* * * ? * MON", "2026-06-01T12:30:00Z", "2026-06-02T00:00:00Z", "and a whole Monday likewise")]
+    [TestCase("* * * ? 6 *", "2026-06-15T12:30:00Z", "2026-07-01T00:00:00Z", "a whole June of fires ends when July starts")]
+    [TestCase("* * * * * ? 2026", "2026-06-15T12:30:00Z", "2027-01-01T00:00:00Z", "and a whole year when the year does")]
+    public void TheFirstSecondAfterTheRunIsTheAnswer(string expression, string from, string expected, string reason)
+    {
+        CronExpression cron = new CronExpression(expression, TimeZoneInfo.Utc);
+
+        cron.GetNextInvalidTimeAfter(DateTimeOffset.Parse(from)).Should().Be(DateTimeOffset.Parse(expected), reason);
+    }
+
+    /// <summary>
+    /// A run that has to be stepped over a month at a time, which is the coarsest skip there is, and the
+    /// one that used to take longest: every second of every February fires, so the answer is a year away.
+    /// </summary>
+    [Test]
+    public void ARunSteppedOverAMonthAtATimeStillAnswersInBoundedTime()
+    {
+        CronExpression cron = new CronExpression("* * * ? 2 *", TimeZoneInfo.Utc);
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        DateTimeOffset? next = cron.GetNextInvalidTimeAfter(new DateTimeOffset(2026, 2, 1, 0, 0, 0, TimeSpan.Zero));
+        stopwatch.Stop();
+
+        next.Should().Be(new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero), "February's last second is the run's last");
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromMilliseconds(100),
+            "2.4 million seconds of fires is the kind of run the walk could not step over");
+    }
+
+    /// <summary>
+    /// Past the give-up year nothing fires, so the search instant is its own answer — which is what the
+    /// walk said too, by way of <see cref="CronExpression.GetNextValidTimeAfter" /> returning null.
+    /// </summary>
+    [Test]
+    public void NothingFiresPastTheGiveUpYear()
+    {
+        CronExpression cron = new CronExpression("* * * * * ?", TimeZoneInfo.Utc);
+        DateTimeOffset pastTheEnd = new DateTimeOffset(TriggerConstants.YearToGiveUpSchedulingAt + 1, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        cron.GetNextInvalidTimeAfter(pastTheEnd).Should().Be(pastTheEnd,
+            "the expression schedules nothing that far out, so the instant asked about is already invalid");
+    }
+
+    /// <summary>
+    /// An expression whose years have run out has no fires left at all, so every second after them is
+    /// invalid — including the one asked about.
+    /// </summary>
+    [Test]
+    public void AnExpressionWhoseYearsHaveRunOutIsInvalidEverywhereAfterThem()
+    {
+        CronExpression cron = new CronExpression("0 0 12 * * ? 2020", TimeZoneInfo.Utc);
+        DateTimeOffset after = new DateTimeOffset(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+        cron.GetNextInvalidTimeAfter(after).Should().Be(after, "2020 is over, so this expression fires never again");
+    }
+
+    private static void AssertAgreesWithTheWalk(CronExpression cron, DateTimeOffset from, int limitSeconds = ReferenceWalkLimitSeconds)
+    {
+        DateTimeOffset? walked = ReferenceNextInvalidTimeAfter(cron, from, limitSeconds, out bool gaveUp);
+        DateTimeOffset? searched = cron.GetNextInvalidTimeAfter(from);
+
+        string context = $"'{cron.CronExpressionString}' in {cron.TimeZone.Id} searched from {from:O}";
+
+        if (gaveUp)
+        {
+            // The walk found nothing within its budget, which is the case the fix is about: the search
+            // either says there is no such time or names one past where the walk stopped looking.
+            (searched is null || searched.Value >= from.AddSeconds(limitSeconds)).Should().BeTrue(
+                $"{context}: the walk saw nothing but fires for {limitSeconds} seconds, so the search must not name one inside them, but it named {searched:O}");
+            return;
+        }
+
+        searched.Should().Be(walked, $"{context}: the structural search and the second-by-second walk are the same answer");
+    }
+
+    /// <summary>
+    /// <see cref="CronExpression.GetNextInvalidTimeAfter" /> as it was before #3690: ask for one fire
+    /// after another, and stop when two are more than a second apart. Bounded here by
+    /// <see cref="ReferenceWalkLimitSeconds" />, which is what the original lacked.
+    /// </summary>
+    private static DateTimeOffset? ReferenceNextInvalidTimeAfter(CronExpression expression, DateTimeOffset date, int limitSeconds, out bool gaveUp)
+    {
+        gaveUp = false;
+        long difference = 1000;
+
+        DateTimeOffset start = new DateTimeOffset(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Offset);
+        DateTimeOffset lastDate = start.AddSeconds(-1);
+
+        while (difference == 1000)
+        {
+            DateTimeOffset? newDate = expression.GetNextValidTimeAfter(lastDate);
+
+            if (newDate is null)
+            {
+                break;
+            }
+
+            difference = (long) (newDate.Value - lastDate).TotalMilliseconds;
+
+            if (difference == 1000)
+            {
+                lastDate = newDate.Value;
+
+                if ((lastDate - start).TotalSeconds >= limitSeconds)
+                {
+                    gaveUp = true;
+                    return null;
+                }
+            }
+        }
+
+        return lastDate.AddSeconds(1);
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/Calendar/CronCalendarTest.cs
@@ -19,6 +19,8 @@
 
 #endregion
 
+using System.Diagnostics;
+
 using Quartz.Impl.Calendar;
 using Quartz.Impl;
 
@@ -127,6 +129,68 @@ public class CronCalendarTest : SerializationTestSupport<CronCalendar, ICalendar
             "the search must step to the end of the excluded range, not crawl it millisecond by millisecond");
         (await search).Should().Be(new DateTimeOffset(2026, 1, 1, 10, 0, 0, TimeSpan.Zero),
             "the first included instant after 09:30 is the top of the next hour, where the expression stops matching");
+    }
+
+    /// <summary>
+    /// The other half of #3690: an expression that excludes every instant has no next included time to
+    /// answer with. The search used to look for one a second at a time until <c>GetTimeAfter</c> gave up
+    /// a century out, and then returned an instant the calendar excludes — a wrong answer after three
+    /// billion cron computations. It is a configuration mistake, so it is said out loud.
+    /// </summary>
+    [Test]
+    public void ACalendarThatExcludesEveryInstantSaysSoRatherThanWalkingACentury()
+    {
+        CronCalendar calendar = new CronCalendar(null, "* * * * * ?", TimeZoneInfo.Utc);
+        DateTimeOffset from = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        calendar.IsTimeIncluded(from).Should().BeFalse("the expression matches every instant, and this calendar excludes what it matches");
+
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        Action act = () => calendar.GetNextIncludedTimeUtc(from);
+        SchedulerException thrown = act.Should().Throw<SchedulerException>(
+            "there is no included time to return, and no answer is better than an excluded one").Which;
+        stopwatch.Stop();
+
+        thrown.Message.Should().Contain("excludes every instant", "the message has to say what is wrong with the calendar");
+        thrown.Message.Should().Contain("* * * * * ?", "and name the expression, which is the thing to change");
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(1),
+            "the answer is read off the expression's fields; walking to the give-up year for it took minutes");
+    }
+
+    /// <summary>
+    /// The two members have to agree: everything the next-included search steps over is a time
+    /// <see cref="CronCalendar.IsTimeIncluded" /> excludes, and the instant it lands on is one it
+    /// includes. A search that reads its answer off the expression's fields rather than walking to it is
+    /// only right if that holds.
+    /// </summary>
+    [TestCase("* * 9 ? * *", "2026-01-01T09:30:00Z", "the whole of the excluded hour is stepped over at once")]
+    [TestCase("* * 1-3 ? * *", "2026-01-01T02:00:00Z", "and the whole of a three hour range")]
+    [TestCase("0/15 * * * * ?", "2026-01-01T09:30:00Z", "an excluded run one second long ends at the next second")]
+    [TestCase("0 0 12 * * ?", "2026-01-01T12:00:00Z", "as does a single daily fire")]
+    [TestCase("* * * ? * MON", "2026-01-05T13:00:00Z", "a whole excluded Monday ends at midnight")]
+    public void EveryInstantTheNextIncludedSearchStepsOverIsOneTheCalendarExcludes(string expression, string from, string reason)
+    {
+        CronCalendar calendar = new CronCalendar(null, expression, TimeZoneInfo.Utc);
+        DateTimeOffset start = DateTimeOffset.Parse(from);
+
+        DateTimeOffset included = calendar.GetNextIncludedTimeUtc(start);
+
+        included.Should().BeAfter(start, reason);
+        calendar.IsTimeIncluded(included).Should().BeTrue($"{reason}: the instant the search lands on is included");
+
+        // Sample the stepped-over range rather than walk it: an excluded day is 86,400 instants, and
+        // each IsTimeIncluded is a cron computation.
+        TimeSpan range = included - start;
+        TimeSpan step = range.TotalSeconds > 2000 ? TimeSpan.FromTicks(range.Ticks / 2000) : TimeSpan.FromSeconds(1);
+
+        for (DateTimeOffset excluded = start.AddMilliseconds(1); excluded < included; excluded += step)
+        {
+            calendar.IsTimeIncluded(excluded).Should().BeFalse(
+                $"{reason}: {excluded:O} lies before the first included instant {included:O}, so it must be excluded");
+        }
+
+        calendar.IsTimeIncluded(included.AddMilliseconds(-1)).Should().BeFalse(
+            $"{reason}: the millisecond before the first included instant is still excluded");
     }
 
     protected override CronCalendar GetTargetObject()

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -390,38 +390,385 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     /// Returns the next date/time <i>after</i> the given date/time which does
     /// <i>not</i> satisfy the expression.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The expression fires on whole seconds, so the answer is the first whole second at or after
+    /// <paramref name="date" /> that it does not fire at. It is read off the expression's own field
+    /// sets rather than walked to: the complement of a cron field is as enumerable as the field is,
+    /// so a run of firing seconds is stepped over a minute, an hour, a day or a month at a time.
+    /// </para>
+    /// <para>
+    /// An expression can fire at every second there is — <c>* * * * * ?</c> is the plain one — and
+    /// then there is no such time to return. That answers <see langword="null" /> rather than walking a
+    /// century, one second at a time, to the year the scheduler gives up looking for a fire in.
+    /// </para>
+    /// </remarks>
     /// <param name="date">the date/time at which to begin the search for the next invalid date/time</param>
-    /// <returns>the next valid date/time</returns>
+    /// <returns>The first whole second at or after <paramref name="date" /> that this expression does not
+    /// fire at, or <see langword="null" /> when it fires at every second through to the give-up year.</returns>
     public DateTimeOffset? GetNextInvalidTimeAfter(DateTimeOffset date)
     {
-        long difference = 1000;
+        // move back to the nearest second: the expression has no opinion about milliseconds
+        DateTimeOffset cursor = CreateDateTimeWithoutMilliseconds(date);
 
-        // move back to the nearest second so differences will be accurate
-        var lastDate = new DateTimeOffset(date.Year, date.Month, date.Day, date.Hour, date.Minute, date.Second, date.Offset).AddSeconds(-1);
-
-        //TODO: IMPROVE THIS! The following is a BAD solution to this problem. Performance will be very bad here, depending on the cron expression. It is, however A solution.
-
-        // Keep getting the next included time until it's farther than one second
-        // apart. At that point, lastDate is the last valid fire time. We return
-        // the second immediately following it.
-        while (difference == 1000)
+        while (true)
         {
-            var newDate = GetTimeAfter(lastDate);
+            DateTime wallClock = TimeZones.ConvertTime(cursor, TimeZone).DateTime;
+            DateTime? firstNonMatching = FirstNonMatchingWallClock(wallClock);
 
-            if (newDate is null)
+            if (firstNonMatching is null)
             {
-                break;
+                // every clock reading from here to the give-up year names a fire
+                return null;
             }
 
-            difference = (long) (newDate.Value - lastDate).TotalMilliseconds;
-
-            if (difference == 1000)
+            if (firstNonMatching.Value == wallClock)
             {
-                lastDate = newDate.Value;
+                // The clock reading names no fire - but a reading a spring-forward gap swallowed
+                // fires at the end of the gap, so at that one instant the expression fires although
+                // the reading the clock shows does not match it. GetTimeAfter is what knows that, so
+                // it has the last word on the instant this is about to answer with.
+                if (!IsSatisfiedBy(cursor))
+                {
+                    return cursor;
+                }
+
+                cursor = cursor.AddSeconds(1);
+                continue;
+            }
+
+            cursor = AdvanceWallClock(cursor, wallClock, (long) (firstNonMatching.Value - wallClock).TotalSeconds);
+        }
+    }
+
+    /// <summary>
+    /// How far ahead a clock change is looked for before a long skip is trusted. Two hours covers
+    /// every transition delta a zone has ever moved its clocks by.
+    /// </summary>
+    private const int ClockChangeProbeSeconds = 2 * 60 * 60;
+
+    /// <summary>
+    /// Advances <paramref name="cursor" /> by <paramref name="wallClockSeconds" /> of the zone's own
+    /// clock, stopping short of a clock change rather than stepping over one.
+    /// </summary>
+    /// <remarks>
+    /// Real time and the zone's clock advance together everywhere but at a daylight saving transition,
+    /// where a fall-back replays a wall-clock hour that real time has already spent and a gap skips one
+    /// it never spends. The run being stepped over is a run of clock <i>readings</i>, so a skip that
+    /// crossed a transition could land past readings the replay makes current again. Each skip is
+    /// therefore verified - the clock has to have advanced by exactly what was asked of it - and halved
+    /// until it has, down to the single second that can skip nothing at all. The hour ahead is probed
+    /// on its own first, because a fall-back that close replays readings from <i>before</i> the cursor,
+    /// which a longer skip carrying the same offset at both ends would not otherwise notice.
+    /// </remarks>
+    /// <param name="cursor">The instant to advance from.</param>
+    /// <param name="wallClock">The zone's clock reading at <paramref name="cursor" />.</param>
+    /// <param name="wallClockSeconds">How far the clock should read ahead afterwards.</param>
+    private DateTimeOffset AdvanceWallClock(DateTimeOffset cursor, DateTime wallClock, long wallClockSeconds)
+    {
+        if (wallClockSeconds <= 1 || !TimeZone.SupportsDaylightSavingTime)
+        {
+            return cursor.AddSeconds(wallClockSeconds);
+        }
+
+        long step = wallClockSeconds;
+
+        if (step > ClockChangeProbeSeconds && WallClockAdvance(cursor, wallClock, ClockChangeProbeSeconds) != ClockChangeProbeSeconds)
+        {
+            step = ClockChangeProbeSeconds;
+        }
+
+        while (step > 1 && WallClockAdvance(cursor, wallClock, step) != step)
+        {
+            step /= 2;
+        }
+
+        return cursor.AddSeconds(step);
+    }
+
+    /// <summary>
+    /// How far the zone's clock reads ahead of <paramref name="wallClock" /> after
+    /// <paramref name="seconds" /> of real time.
+    /// </summary>
+    private long WallClockAdvance(DateTimeOffset cursor, DateTime wallClock, long seconds)
+    {
+        DateTime advanced = TimeZones.ConvertTime(cursor.AddSeconds(seconds), TimeZone).DateTime;
+        return (long) (advanced - wallClock).TotalSeconds;
+    }
+
+    /// <summary>
+    /// The earliest clock reading at or after <paramref name="from" /> whose fields this expression does
+    /// not name, or <see langword="null" /> when it names every one of them through to
+    /// <see cref="TriggerConstants.YearToGiveUpSchedulingAt" />.
+    /// </summary>
+    /// <remarks>
+    /// This reads the field sets and knows nothing about time zones, which is what lets it answer in one
+    /// step what a walk answers in a million: with a second the expression skips, the very next minute
+    /// holds a reading it does not name, whatever the rest of the fields say; with every second named,
+    /// only a minute it skips does, and so on up through hours, days, months and years. A reading a
+    /// spring-forward gap swallowed is answered about as though it existed - the caller walks instants,
+    /// and no instant carries one.
+    /// </remarks>
+    private DateTime? FirstNonMatchingWallClock(DateTime from)
+    {
+        if (from.Year > TriggerConstants.YearToGiveUpSchedulingAt || !MatchesWallClock(from))
+        {
+            return from;
+        }
+
+        bool everySecond = seconds.CoversRange(0, 59);
+        bool everyMinute = minutes.CoversRange(0, 59);
+
+        // the rest of this minute
+        if (seconds.TryGetFirstMissingValue(from.Second + 1, 59, out int second))
+        {
+            return new DateTime(from.Year, from.Month, from.Day, from.Hour, from.Minute, second);
+        }
+
+        // the rest of this hour
+        if (from.Minute < 59)
+        {
+            int minute = -1;
+            if (!everySecond)
+            {
+                minute = from.Minute + 1;
+            }
+            else if (minutes.TryGetFirstMissingValue(from.Minute + 1, 59, out int nextMinute))
+            {
+                minute = nextMinute;
+            }
+
+            if (minute >= 0)
+            {
+                return new DateTime(from.Year, from.Month, from.Day, from.Hour, minute, FirstNonMatchingSecond(minute));
             }
         }
 
-        return lastDate.AddSeconds(1);
+        // the rest of this day
+        if (from.Hour < 23)
+        {
+            int hour = -1;
+            if (!everySecond || !everyMinute)
+            {
+                hour = from.Hour + 1;
+            }
+            else if (hours.TryGetFirstMissingValue(from.Hour + 1, 23, out int nextHour))
+            {
+                hour = nextHour;
+            }
+
+            if (hour >= 0)
+            {
+                DateTime? insideTheDay = FirstNonMatchingInHour(from.Date, hour);
+                if (insideTheDay is not null)
+                {
+                    return insideTheDay;
+                }
+            }
+        }
+
+        // and then whole days
+        DateTime day = from.Date.AddDays(1);
+
+        if (day.Year > TriggerConstants.YearToGiveUpSchedulingAt)
+        {
+            // nothing fires past the give-up year, so its first midnight is a reading that names no fire
+            return day;
+        }
+
+        if (!DayMatches(day))
+        {
+            return day;
+        }
+
+        // a day the expression names holds an unnamed reading unless it names every second of the day,
+        // in which case the search is over whole days from the one after it
+        return FirstNonMatchingInDay(day) ?? FirstNonMatchingDay(day.AddDays(1));
+    }
+
+    /// <summary>
+    /// The first day at or after <paramref name="from" /> that this expression names no time on, or
+    /// <see langword="null" /> when it names every day through to the give-up year. Whole months are
+    /// stepped over rather than walked when neither day field restricts.
+    /// </summary>
+    private DateTime? FirstNonMatchingDay(DateTime from)
+    {
+        int year = from.Year;
+        int month = from.Month;
+        int day = from.Day;
+        bool everyDay = !IsRestrictedDayField(daysOfMonth) && !IsRestrictedDayField(daysOfWeek);
+
+        while (year <= TriggerConstants.YearToGiveUpSchedulingAt)
+        {
+            if (!years.Contains(year) || !months.Contains(month))
+            {
+                return new DateTime(year, month, day);
+            }
+
+            if (!everyDay)
+            {
+                int lastDayOfMonth = GetLastDayOfMonth(month, year);
+                for (int candidate = day; candidate <= lastDayOfMonth; candidate++)
+                {
+                    if (!DayOfMonthOrWeekMatches(new DateTime(year, month, candidate)))
+                    {
+                        return new DateTime(year, month, candidate);
+                    }
+                }
+            }
+
+            day = 1;
+            month++;
+            if (month > 12)
+            {
+                month = 1;
+                year++;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The earliest reading in <paramref name="day" /> this expression does not name, or
+    /// <see langword="null" /> when it names every second of it. The day itself is assumed to be one
+    /// the expression names.
+    /// </summary>
+    private DateTime? FirstNonMatchingInDay(DateTime day)
+    {
+        for (int hour = 0; hour <= 23; hour++)
+        {
+            DateTime? found = FirstNonMatchingInHour(day, hour);
+            if (found is not null)
+            {
+                return found;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The earliest reading in one hour of <paramref name="day" /> this expression does not name, or
+    /// <see langword="null" /> when it names every second of that hour.
+    /// </summary>
+    private DateTime? FirstNonMatchingInHour(DateTime day, int hour)
+    {
+        if (!hours.Contains(hour))
+        {
+            return new DateTime(day.Year, day.Month, day.Day, hour, 0, 0);
+        }
+
+        if (!seconds.CoversRange(0, 59))
+        {
+            // every minute of a named hour holds a second the expression skips, so its first minute does
+            return new DateTime(day.Year, day.Month, day.Day, hour, 0, FirstNonMatchingSecond(0));
+        }
+
+        if (minutes.TryGetFirstMissingValue(0, 59, out int minute))
+        {
+            return new DateTime(day.Year, day.Month, day.Day, hour, minute, 0);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The first second of <paramref name="minute" /> this expression does not name. The caller reaches
+    /// this only where one exists: either the minute names no fire at all, and so its first second does
+    /// not, or the seconds field skips a value.
+    /// </summary>
+    private int FirstNonMatchingSecond(int minute)
+    {
+        if (!minutes.Contains(minute))
+        {
+            return 0;
+        }
+
+        seconds.TryGetFirstMissingValue(0, 59, out int second);
+        return second;
+    }
+
+    /// <summary>
+    /// Whether every field of this expression names the given clock reading. This is
+    /// <see cref="IsSatisfiedBy" />'s answer everywhere a clock reading and an instant are the same
+    /// thing, which is everywhere but the end of a spring-forward gap.
+    /// </summary>
+    private bool MatchesWallClock(DateTime wallClock)
+    {
+        return seconds.Contains(wallClock.Second)
+               && minutes.Contains(wallClock.Minute)
+               && hours.Contains(wallClock.Hour)
+               && DayMatches(wallClock);
+    }
+
+    /// <summary>
+    /// Whether the year, month and day fields all name the given date.
+    /// </summary>
+    private bool DayMatches(DateTime date)
+    {
+        return years.Contains(date.Year)
+               && months.Contains(date.Month)
+               && DayOfMonthOrWeekMatches(date);
+    }
+
+    /// <summary>
+    /// Whether the two day fields name the given date, by the same rule
+    /// <see cref="ProgressNextFireTimeDay" /> walks them with: a field that restricts nothing defers to
+    /// the other, and two fields that both name days are unioned.
+    /// </summary>
+    private bool DayOfMonthOrWeekMatches(DateTime date)
+    {
+        bool dayOfMonthRestricted = IsRestrictedDayField(daysOfMonth);
+        bool dayOfWeekRestricted = IsRestrictedDayField(daysOfWeek);
+
+        if (!dayOfWeekRestricted)
+        {
+            return !dayOfMonthRestricted || DayOfMonthMatches(date);
+        }
+
+        if (!dayOfMonthRestricted)
+        {
+            return DayOfWeekMatches(date);
+        }
+
+        return DayOfMonthMatches(date) || DayOfWeekMatches(date);
+    }
+
+    /// <summary>
+    /// Whether the day-of-month field names the given date, 'L' and 'W' modifiers resolved for its month.
+    /// </summary>
+    private bool DayOfMonthMatches(DateTime date)
+    {
+        if (lastDaySpecs is null && nearestWeekdays is null)
+        {
+            return daysOfMonth.Contains(date.Day);
+        }
+
+        uint dayMask = CalculateDaysOfMonth(new DateTimeOffset(date.Year, date.Month, 1, 0, 0, 0, TimeSpan.Zero));
+        return (dayMask & (1u << date.Day)) != 0;
+    }
+
+    /// <summary>
+    /// Whether the day-of-week field names the given date, 'L' and '#' resolved for its month.
+    /// </summary>
+    private bool DayOfWeekMatches(DateTime date)
+    {
+        int dayOfWeek = (int) date.DayOfWeek + 1;
+
+        if (lastDayOfWeek)
+        {
+            // 'nL': that day of the week, in the last week of the month that has one
+            return dayOfWeek == daysOfWeek.Min && date.Day + 7 > GetLastDayOfMonth(date.Month, date.Year);
+        }
+
+        if (nthdayOfWeek != 0)
+        {
+            // 'n#m': that day of the week, in the mth week of the month
+            return dayOfWeek == daysOfWeek.Min && (date.Day - 1) / 7 + 1 == nthdayOfWeek;
+        }
+
+        return daysOfWeek.Contains(dayOfWeek);
     }
 
     /// <summary>
@@ -3071,6 +3418,48 @@ internal sealed class CronField : IEnumerable<int>
         overflow = null;
         isAllSpec = false;
         isNoSpec = false;
+    }
+
+    /// <summary>
+    /// The smallest value in <c>[start, end]</c> this field does <i>not</i> allow — the complement
+    /// scan the next-non-matching-time search is built on.
+    /// </summary>
+    /// <remarks>
+    /// A field holding the '*' or '?' marker allows every value, so it has no such value. The range
+    /// asked for is always one field's own, which is at most 0-59, so the scan stays inside
+    /// <see cref="bits" /> and never reaches the years overflow set.
+    /// </remarks>
+    /// <param name="start">The first value to consider.</param>
+    /// <param name="end">The last value to consider.</param>
+    /// <param name="missing">The smallest disallowed value, or 0 when there is none.</param>
+    /// <returns><see langword="true" /> when the field skips a value in the range.</returns>
+    internal bool TryGetFirstMissingValue(int start, int end, out int missing)
+    {
+        missing = 0;
+
+        if (isAllSpec || isNoSpec || start > end)
+        {
+            return false;
+        }
+
+        ulong window = (end - start == 63 ? ~0UL : (1UL << (end - start + 1)) - 1) << start;
+        ulong absent = ~bits & window;
+
+        if (absent == 0)
+        {
+            return false;
+        }
+
+        missing = BitUtil.TrailingZeroCount(absent);
+        return true;
+    }
+
+    /// <summary>
+    /// Whether this field allows every value in <c>[start, end]</c>.
+    /// </summary>
+    internal bool CoversRange(int start, int end)
+    {
+        return !TryGetFirstMissingValue(start, end, out _);
     }
 
     internal bool TryGetMinValueStartingFrom(int start, out int min)

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -424,11 +424,7 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
 
             if (firstNonMatching.Value == wallClock)
             {
-                // The clock reading names no fire - but a reading a spring-forward gap swallowed
-                // fires at the end of the gap, so at that one instant the expression fires although
-                // the reading the clock shows does not match it. GetTimeAfter is what knows that, so
-                // it has the last word on the instant this is about to answer with.
-                if (!IsSatisfiedBy(cursor))
+                if (!FiresOnAReadingItDoesNotName(cursor, wallClock))
                 {
                     return cursor;
                 }
@@ -439,6 +435,29 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
 
             cursor = AdvanceWallClock(cursor, wallClock, (long) (firstNonMatching.Value - wallClock).TotalSeconds);
         }
+    }
+
+    /// <summary>
+    /// Whether the expression fires at an instant whose clock reading its fields do not name, which is
+    /// true of exactly one instant per spring-forward gap: the one the clocks moved to, which is where
+    /// every reading the gap swallowed fires.
+    /// </summary>
+    /// <remarks>
+    /// The guard is <see cref="GetTimeAfter" />'s own - a reading whose predecessor does not exist is a
+    /// reading the clocks jumped to - so the two cannot disagree about which instant that is. Everywhere
+    /// else a clock reading and an instant name each other, so the fields have already answered and
+    /// there is nothing to walk.
+    /// </remarks>
+    private bool FiresOnAReadingItDoesNotName(DateTimeOffset cursor, DateTime wallClock)
+    {
+        if (!TimeZone.SupportsDaylightSavingTime
+            || wallClock.Ticks < TimeSpan.TicksPerSecond
+            || !TimeZone.IsInvalidTime(wallClock.AddSeconds(-1)))
+        {
+            return false;
+        }
+
+        return IsSatisfiedBy(cursor);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/Calendar/CronCalendar.cs
+++ b/src/Quartz/Impl/Calendar/CronCalendar.cs
@@ -165,6 +165,13 @@ public sealed class CronCalendar : BaseCalendar, IEquatable<CronCalendar>
     /// Calendar after the given time. Return the original value if timeStamp is
     /// included. Return 0 if all days are excluded.
     /// </summary>
+    /// <remarks>
+    /// An expression can exclude every instant there is — <c>* * * * * ?</c> is the plain one — and then
+    /// there is no time to answer with. That is a <see cref="SchedulerException" /> naming the
+    /// expression, because a calendar excluding everything is a configuration mistake rather than a
+    /// schedule with no next fire: a trigger it is attached to can never fire again.
+    /// </remarks>
+    /// <exception cref="SchedulerException">The calendar's expression excludes every instant.</exception>
     public override DateTimeOffset GetNextIncludedTimeUtc(DateTimeOffset timeUtc)
     {
         DateTimeOffset nextIncludedTime = timeUtc.AddMilliseconds(1); //plus on millisecond
@@ -182,7 +189,17 @@ public sealed class CronCalendar : BaseCalendar, IEquatable<CronCalendar>
                 // The end of the excluded range is the next time the expression does NOT satisfy.
                 // GetNextValidTimeAfter would land on another satisfied - excluded - time, and the
                 // loop would walk the excluded run millisecond by millisecond forever.
-                nextIncludedTime = cronExpression.GetNextInvalidTimeAfter(nextIncludedTime)!.Value;
+                DateTimeOffset? endOfExcludedRange = cronExpression.GetNextInvalidTimeAfter(nextIncludedTime);
+
+                if (endOfExcludedRange is null)
+                {
+                    Throw.SchedulerException(
+                        $"Cron calendar expression '{cronExpression.CronExpressionString}' excludes every instant, so no time after "
+                        + $"{timeUtc:o} is ever included. A calendar states the times a trigger may not fire; one that excludes them "
+                        + "all leaves the trigger nothing to fire at. Narrow the expression, or remove the calendar and the trigger with it.");
+                }
+
+                nextIncludedTime = endOfExcludedRange.Value;
             }
             else if (CalendarBase is not null &&
                      !CalendarBase.IsTimeIncluded(nextIncludedTime))


### PR DESCRIPTION
`CronExpression.GetNextInvalidTimeAfter` asked `GetNextValidTimeAfter` for one fire after another and stopped when two of them were more than a second apart. That is one full cron computation per second of the run, and for an expression that fires at every second — `* * * * * ?` — the run has no end: the walk spent some three billion of them reaching the give-up year, and then returned a time the expression *does* fire at. `CronCalendar.GetNextIncludedTimeUtc` is the caller that meets it, so a calendar built on such an expression walked a century to answer wrongly.

## What it does now

The complement of a cron field is as enumerable as the field is, so the answer is read off the field sets. With a second the expression skips, the very next minute holds a reading it does not name, whatever the other fields say; with every second named, only a minute it skips does, and so on up through hours, days, months and years. A run is stepped over a minute, an hour, a day or a month at a time, and an expression that names every second answers `null`.

The step is over clock *readings* while the search walks *instants*, so each skip is verified against the zone's own clock and halved until the clock has moved by exactly what was asked of it — a fall-back replays readings the search has already stepped through, and a spring-forward gap swallows readings no instant carries. The one instant where a reading and a fire disagree is the end of a gap, where every reading the gap swallowed fires; that is identified by the guard `GetTimeAfter` itself uses (a reading whose predecessor does not exist), so the two cannot disagree about which instant it is, and the ordinary answer needs no next-fire computation at all.

`CronCalendar.GetNextIncludedTimeUtc` now throws a `SchedulerException` naming the expression rather than walking. A calendar that excludes every instant leaves the trigger it is attached to nothing to fire at, which is a configuration mistake and not a schedule that has run out.

**Behaviour note for the release notes:** an expression that excludes every instant now fails fast with `SchedulerException`; before, it walked to the give-up year and returned an excluded instant.

## Public API

None. `GetNextInvalidTimeAfter` already returned `DateTimeOffset?`; no baseline line moves. The only additions are two `internal` members on `CronField`.

## Benchmarks

`dotnet run -c Release --project src/Quartz.Benchmark -- --filter "*CronExpressionBenchmark.NextOccurrence" "*CronExpressionBenchmark.NextNonOccurrence"`, default job, on `5ca17d4608` and on this branch, same machine and session (AMD Ryzen 9 5950X, .NET 10.0.11). `NextNonOccurrence` is new here, and was run against the base by reverting only `CronExpression.cs` and `CronCalendar.cs`.

`NextOccurrence` is `GetNextValidTimeAfter` — the path a scheduler runs, and the one that must not move:

| Expression | before | after | delta |
|---|---:|---:|---:|
| `0 0 12 * * ?` | 418 ns | 418 ns | +0.1% |
| `0 0 8-18 ? * MON-FRI` | 513 ns | 515 ns | +0.3% |
| `0 0-30 9-17 * * ?` | 429 ns | 440 ns | +2.4% |
| `0 0,10,20,30,40,50 * * * ?` | 433 ns | 430 ns | -0.8% |
| `0 0/5 * * * ?` | 426 ns | 425 ns | -0.4% |
| `0 15 10 ? * 6#3 *` | 797 ns | 807 ns | +1.2% |
| `0 15 10 ? * 6L` | 785 ns | 784 ns | -0.1% |
| `0 15 10 * * ?` | 485 ns | 489 ns | +0.9% |
| `0 15 10 * * ? 2005-2025` | 490 ns | 493 ns | +0.5% |
| `0 15 10 1,2,3,4,5,10,15,20,25 * ? *` | 489 ns | 486 ns | -0.6% |
| `0 15 10 L * ?` | 800 ns | 785 ns | -1.8% |
| `0 15 10 L-2 * ?` | 794 ns | 786 ns | -0.9% |
| `0 15 10 LW * ?` | 791 ns | 797 ns | +0.8% |
| `0/15 * * * * ?` | 360 ns | 358 ns | -0.5% |

Nothing outside ±2.4%, which is this benchmark's own run-to-run spread; `GetTimeAfter` and everything under it is untouched.

`NextNonOccurrence` is `GetNextInvalidTimeAfter`, the method this changes:

| Expression | before | after | delta |
|---|---:|---:|---:|
| `0 0 12 * * ?` | 429 ns | 94 ns | -78.1% |
| `0 0 8-18 ? * MON-FRI` | 522 ns | 99 ns | -81.1% |
| `0 0-30 9-17 * * ?` | 439 ns | 93 ns | -78.8% |
| `0 0,10,20,30,40,50 * * * ?` | 435 ns | 91 ns | -79.0% |
| `0 0/5 * * * ?` | 794 ns | 167 ns | -78.9% |
| `0 15 10 ? * 6#3 *` | 668 ns | 92 ns | -86.2% |
| `0 15 10 ? * 6L` | 666 ns | 92 ns | -86.2% |
| `0 15 10 * * ?` | 435 ns | 92 ns | -78.9% |
| `0 15 10 * * ? 2005-2025` | 438 ns | 94 ns | -78.5% |
| `0 15 10 1,2,3,4,5,10,15,20,25 * ? *` | 431 ns | 91 ns | -78.8% |
| `0 15 10 L * ?` | 666 ns | 99 ns | -85.1% |
| `0 15 10 L-2 * ?` | 673 ns | 94 ns | -86.0% |
| `0 15 10 LW * ?` | 677 ns | 94 ns | -86.1% |
| `0/15 * * * * ?` | 738 ns | 175 ns | -76.3% |

The two rows above 700 ns before are the ones whose search instant is itself a fire, so the walk needed a second computation. None of these is the interesting case, which the benchmark cannot hold: `* * * * * ?` answered in a couple of minutes before, and answers in microseconds now.

## Tests

The old walk is kept in `CronExpressionNextInvalidTimeTest` as the specification, and the two are compared:

- 220 expressions (a named set plus a seeded random combination of every field form, including `L`, `LW`, `L-2`, `15W`, `#`, `nL`, wrapping ranges and an explicit year) from five instants each;
- the same corpus from each expression's own fire times and the second, day, week and month around them — the instants where a day rule is what discriminates;
- 168 cases either side of both clock changes in America/New_York, Europe/Helsinki, Australia/Sydney and America/Santiago;
- `* * * * * ?` answers `null` in under 100 ms, and every other spelling of "every second" answers `null` too;
- `CronCalendar` fails fast, in bounded time, with the expression in the message, and everything its next-included search steps over is an instant `IsTimeIncluded` excludes.

Five load-bearing branches were mutation-checked: the clock-change guard, the gap-end reading, `nL`, `n#m` and the `L`/`W` day mask each fail the corpus when broken.

## Verification

```
dotnet build Quartz.slnx                  Build succeeded, 0 warnings
dotnet test src/Quartz.Tests.Unit         Passed: 6098, Failed: 0, Skipped: 36 (50 s)
dotnet test src/Quartz.Tests.AspNetCore   Passed:  630, Failed: 0
dotnet fallout BenchmarkSmoke             Succeeded, 298 benchmarks
```

Integration tests were not run: no Docker daemon on this machine.

Closes #3690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK