### PR TITLE
A textual day-of-week takes a step, and it is the numeric one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,9 @@ Extension policy, not taste. `how-tos/extending-quartz.md` is the reader-facing 
   runs the default on the forwarder; `DelegatingForwardingTest` sweeps both delegating types for it.
 - **Read-replica routing, if ever, is a DIM `IDbProvider.CreateReadConnection()`** — never a `readOnly`
   parameter on `CreateConnection`, which would break both public `IDbProvider` implementations.
-- **`MON/2` stays rejected** (ratified 2026-09-01); 4.1 may accept it additively.
+- **`MON/2` is 4.1's `2/2`**, and `MON-FRI/2` is `2-6/2`: a textual day-of-week takes a step, in lockstep
+  with the numeric form. 4.0 refused it because 3.x read it as a fortnight; that silent change of meaning
+  is a documented hazard, not a reason to reopen this.
 
 ## Build & Test
 

--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -446,14 +446,20 @@ for every other Monday and `FREQ=DAILY;INTERVAL=3` for a three-day cadence that 
 [3.x](/documentation/quartz-3.x/tutorial/recurrencetrigger). Reaching for several cron triggers, or
 for a cron expression with a workaround in it, is usually the sign.
 
-**Quartz 3.x only:** `0 0 0 ? * MON/2` — a textual day-of-week with a step — means every other
-Monday there. 4.x rejects it, because the fortnight's phase was anchored to whatever last asked the
-expression a question: a misfire, a restart or a failover recomputed it from a different day and
-moved it. `FREQ=WEEKLY;INTERVAL=2;BYDAY=MO` anchors on the trigger's start time instead, so the
-fortnight is a property of the trigger rather than of the caller. It is one of seven shapes 4.x
-refuses that 3.x accepted and then quietly reinterpreted;
+**The one expression that means three different things:** `0 0 0 ? * MON/2` — a textual day-of-week
+with a step. On **3.x** it is every other Monday. On **4.0** it is a `FormatException`. From **4.1**
+it parses and means what `0 0 0 ? * 2/2` means: Monday, Wednesday and Friday, 156 fires a year rather
+than 26, with nothing logged either way. So audit for it before upgrading from 3.x, whichever 4.x you
+are going to:
+[`MON/2` is a step through the week](/documentation/quartz-4.x/cron-expressions#mon-2-is-a-step-through-the-week)
+is the whole story, and
 [Forms the parser refuses](/documentation/quartz-4.x/cron-expressions#forms-the-parser-refuses) lists
-them, and the ones to audit a database for before upgrading.
+the six shapes 4.x rejects that 3.x accepted and then quietly reinterpreted.
+
+The fortnight went because its phase was anchored to whatever last asked the expression a question: a
+misfire, a restart or a failover recomputed it from a different day and moved it.
+`FREQ=WEEKLY;INTERVAL=2;BYDAY=MO` anchors on the trigger's start time instead, so the fortnight is a
+property of the trigger rather than of the caller.
 
 ### The two daylight saving rules
 

--- a/docs/documentation/quartz-4.x/cron-expressions.md
+++ b/docs/documentation/quartz-4.x/cron-expressions.md
@@ -54,6 +54,8 @@ but don't care what day of the week that happens to be, I would put `10` in the 
 And `5/15` in the seconds field means "the seconds 5, 20, 35, and 50".
 You can also specify `/` after the `*` character - in this case `*` is equivalent to having `0` before the `/`.
 `1/3` in the day-of-month field means "fire every 3 days starting on the first day of the month".
+A day-of-week step may start from a name: `MON/2` is `2/2`, Monday, Wednesday and Friday — but see
+[`MON/2` is a step through the week](#mon-2-is-a-step-through-the-week) if the expression came from 3.x.
 - `L` ("last") - has different meaning in each of the two fields in which it is allowed.
 For example, the value `L` in the day-of-month field means "the last day of the month" - day 31 for January, day 28 for February on non-leap years.
 If used in the day-of-week field by itself, it simply means "7" or "SAT". But if used in the day-of-week field after another value, it means "the last xxx day of the month" -
@@ -86,7 +88,7 @@ The legal characters and the names of months and days of the week are not case s
 
 ## Forms the parser refuses
 
-Seven shapes parsed on 3.x and then meant something other than what they said — a special character was
+Six shapes parsed on 3.x and then meant something other than what they said — a special character was
 dropped on the floor, or a step degenerated. Each is a `FormatException` in 4.x, and the message names
 the expression that says what the author meant.
 
@@ -98,19 +100,33 @@ the expression that says what the author meant.
 | `5C`, `1C` | `5` / `1` — `C` ("calendar") was never implemented | `WithCalendarName`, which is what a calendar is for |
 | `*/0`, `5/0`, `0-10/0` | no step at all | `*` for every value, or a step of 1 or more |
 | `0-10/120` | an unchecked step; `0/120` was already rejected | a step inside the field's range |
-| `MON/2` | every second week, with no stable phase | `MON,WED,FRI` for a step through the week, or `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")` for every second Monday |
-
-`MON/2` is the one that changes a schedule rather than only a spelling. A textual day-of-week followed by
-`/` meant "every N weeks", while the numeric `2/2` beside it meant an ordinary step — two readings of one
-grammar. The fortnight also had no phase to keep: it counted whole weeks from wherever the search
-happened to start, so a misfire, a restart, a failover or a dashboard query recomputed it from a
-different day and moved it. It is rejected rather than quietly re-read as a step, because re-reading it
-would turn a fortnightly job into a thrice-weekly one — 26 fires a year become 156 — with nothing logged.
-[`RecurrenceTrigger`](tutorial/recurrencetrigger.md) anchors the interval on the trigger's start time, so
-the fortnight belongs to the trigger.
 
 If a database may hold one of these expressions, audit it before upgrading:
 [Before you upgrade](migration-guide.md#before-you-upgrade) has the query.
+
+## `MON/2` is a step through the week
+
+A textual day-of-week may be followed by a step since 4.1, and it means exactly what its numeric twin
+means: `MON/2` is `2/2`, which is Monday, Wednesday and Friday. `MON-FRI/2` is `2-6/2`, the same three
+days. The step runs to Saturday and does not wrap, as it does after a number.
+
+::: danger An expression carried over from 3.x means something else
+On 3.x, `MON/2` meant **every second Monday** — a fortnight, not a step. On 4.0 it was rejected outright.
+On 4.1 it parses and fires on Monday, Wednesday and Friday: **26 fires a year become 156**, and nothing
+is logged, because the expression is valid.
+
+Audit for it before upgrading — [Before you upgrade](migration-guide.md#before-you-upgrade) has the
+query — and rewrite what you find. Every second Monday is
+`RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")`.
+[`RecurrenceTrigger`](tutorial/recurrencetrigger.md) anchors the interval on the trigger's start time, so
+the fortnight belongs to the trigger and keeps its phase — which 3.x's reading never did, counting whole
+weeks from wherever the search happened to start, so that a misfire, a restart, a failover or a dashboard
+query recomputed it from a different day and moved it.
+:::
+
+The value after the `/` has to be a whole number from 1 to 7, the same one the numeric spelling takes.
+`MON/X` and `SUN/9` are rejected, and the message says both what a step has to be and where the fortnight
+lives now.
 
 ## Macros
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -40,8 +40,8 @@ The rest of this guide is written as one statement about 3.x and 4.0, with no bu
 ## Upgrading from 4.0 to 4.1
 
 Nothing in the 4.0 public surface moved and the database schema did not either, so an application on
-4.0 compiles on 4.1 unchanged. What is here is what 4.1 makes newly possible, and the one cron
-expression it reads differently.
+4.0 compiles on 4.1 unchanged. What is here is what 4.1 makes newly possible, and the two cron
+expressions it reads differently.
 
 | Added | What it is |
 |---|---|
@@ -67,11 +67,12 @@ Three behaviours changed without a signature changing:
 The mechanics, the refusals and the recipes are in
 [Multi-Tenancy](multi-tenancy.md#adding-a-tenant-while-the-process-is-running).
 
-One cron expression changes what it means:
+Two cron expressions change what they mean, and neither can be reported to you — both parse on 4.1:
 
 | Change | 4.0 | 4.1 |
 |---|---|---|
 | **Behaviour change.** `MON/2` — a textual day-of-week with a step — in any cron expression | `FormatException` | Parses, and means what `2/2` means: Monday, Wednesday and Friday. It meant *every second Monday* on 3.x, so an expression carried across both majors fires 156 times a year rather than 26, and nothing reports it. [What to do about it](#mon-2-is-a-fortnight-on-3-x-and-a-step-from-4-1) |
+| **Behaviour change.** `MON-FRI/2` — a step after a textual *range* | Parsed, and the step was dropped: it meant `MON-FRI`, five days | `2-6/2` — Monday, Wednesday and Friday, the three days it says. A trigger written this way has been firing on two days it never asked for |
 
 ## The road from 3.x, phase by phase
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -34,10 +34,14 @@ If you ran a 4.0 alpha or beta, everything that changed between one pre-release 
 collected in [Appendix: if you ran a 4.0 pre-release](#appendix-if-you-ran-a-4-0-pre-release).
 The rest of this guide is written as one statement about 3.x and 4.0, with no build numbers in it.
 
+**Already on 4.0?** Then this guide is not your upgrade —
+[Upgrading from 4.0 to 4.1](#upgrading-from-4-0-to-4-1) is, and it is short.
+
 ## Upgrading from 4.0 to 4.1
 
-Everything in this section is an addition. Nothing in the 4.0 public surface moved, so an application
-on 4.0 compiles on 4.1 unchanged; what is here is what 4.1 makes newly possible.
+Nothing in the 4.0 public surface moved and the database schema did not either, so an application on
+4.0 compiles on 4.1 unchanged. What is here is what 4.1 makes newly possible, and the one cron
+expression it reads differently.
 
 | Added | What it is |
 |---|---|
@@ -62,6 +66,12 @@ Three behaviours changed without a signature changing:
 
 The mechanics, the refusals and the recipes are in
 [Multi-Tenancy](multi-tenancy.md#adding-a-tenant-while-the-process-is-running).
+
+One cron expression changes what it means:
+
+| Change | 4.0 | 4.1 |
+|---|---|---|
+| **Behaviour change.** `MON/2` — a textual day-of-week with a step — in any cron expression | `FormatException` | Parses, and means what `2/2` means: Monday, Wednesday and Friday. It meant *every second Monday* on 3.x, so an expression carried across both majors fires 156 times a year rather than 26, and nothing reports it. [What to do about it](#mon-2-is-a-fortnight-on-3-x-and-a-step-from-4-1) |
 
 ## The road from 3.x, phase by phase
 
@@ -5798,7 +5808,7 @@ turned `mon-fri` into `MON-FRI`.
 | `0 0 13 * 5` | `0 0 0 13 * FRI` — the 13th **and** every Friday, by the union rule |
 | `0 0 * * 0-6` | `0 0 0 * * ?` |
 | `0 0 * * 5-1` | `0 0 0 ? * FRI-MON` |
-| `0 0 * * 1/2` | `0 0 0 ? * 2/2` — numeric, because `MON/2` is [rejected](#the-parser-refuses-what-it-used-to-ignore) |
+| `0 0 * * 1/2` | `0 0 0 ? * 2/2` — numeric, although [`MON/2` parses from 4.1](#mon-2-is-a-fortnight-on-3-x-and-a-step-from-4-1) and means the same days |
 
 Because the format is an argument to the parse, **the XML schema, the HTTP API and the dashboard do not take
 one**: a five-field expression is something you write in C#, not something you store. The `@` macros below
@@ -5850,16 +5860,24 @@ A handful of expressions parsed, and then meant something other than what they s
 | `5C`, `1C` | parsed, meant `5` / `1`; `C` was never implemented | `FormatException` — use `ModifiedByCalendar` |
 | `*/0`, `5/0`, `0-10/0` | a step of 0 degenerated to no step | `FormatException` |
 | `0-10/120` | the step was never range-checked | `FormatException` — `Increment > 59 : 120`, as `0/120` already did |
-| `MON/2` | every second week — a fortnight with **no stable phase** | `FormatException` — `MON,WED,FRI` for a step through the week, or `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")` for every second Monday |
+| `MON/2` | every second week — a fortnight with **no stable phase** | `FormatException` on 4.0; **parses on 4.1, as the step `2/2`** — see below |
+
+### `MON/2` is a fortnight on 3.x and a step from 4.1
 
 `MON/2` is the one that changes a schedule rather than only a spelling, so it is worth the paragraph. A
-textual day-of-week followed by `/` meant "every N weeks", and the numeric `2/2` beside it meant an ordinary
-step — two readings of the same grammar. The fortnight also had no stable phase: it counted whole weeks from
-wherever the search started, so a misfire, a restart, a failover or a dashboard query recomputed it from a
-different day and moved it. It is rejected rather than quietly re-read as a step, because re-reading it would
-turn a fortnightly job into a thrice-weekly one — 26 fires a year become 156 — with nothing logged. Every
-second Monday is `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")`, which anchors the
-interval on the trigger's start time and so keeps its phase.
+textual day-of-week followed by `/` meant "every N weeks" on 3.x, and the numeric `2/2` beside it meant an
+ordinary step — two readings of the same grammar. The fortnight also had no stable phase: it counted whole
+weeks from wherever the search started, so a misfire, a restart, a failover or a dashboard query recomputed
+it from a different day and moved it.
+
+4.0 rejected the token outright rather than quietly re-reading it as a step. **4.1 accepts it as the step**:
+`MON/2` is `2/2`, Monday, Wednesday and Friday. So an expression carried from 3.x to 4.1 turns a fortnightly
+job into a thrice-weekly one — 26 fires a year become 156 — with nothing logged, because on 4.1 the
+expression is valid. It is the one shape in this guide that an upgrade cannot report to you, and the
+[audit below](#before-you-upgrade) is how to find it.
+
+Every second Monday is `RecurrenceScheduleBuilder.Create("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO")`, which anchors
+the interval on the trigger's start time and so keeps its phase.
 
 ### Before you upgrade
 
@@ -5875,14 +5893,16 @@ WHERE  CRON_EXPRESSION LIKE '%C%'    -- 'C' (calendar), never implemented
    OR  CRON_EXPRESSION LIKE '%/0%'   -- step of zero
    OR  CRON_EXPRESSION LIKE '%#%,%'  -- '#' beside other days
    OR  CRON_EXPRESSION LIKE '%,%#%'
-   OR  CRON_EXPRESSION LIKE '%/%'    -- then eyeball for a textual day-of-week step
+   OR  CRON_EXPRESSION LIKE '%/%'    -- then eyeball for a textual day-of-week step: 'MON/2'
    OR  CRON_EXPRESSION LIKE '%W%';   -- then eyeball for 'W' after a range
 ```
 
 Several of those clauses are deliberately over-wide and need reading by eye: most `/` is an ordinary step, most
 `W` is a legitimate `15W` or `LW`, and `%C%` also matches the month names `DEC` and `OCT`, because expressions
 are stored upper-cased. `CronExpression.TryParse` against the 4.0 assembly is the authoritative check once you
-have a candidate list.
+have a candidate list — **except for the textual day-of-week step**, which 4.1 parses. A name in front of a
+`/` — `MON/2`, `MON-FRI/2` — has to be read by eye whatever the parser says, because on 4.1 it is a valid
+expression that means something other than what it meant on 3.x.
 
 Two sources are **not** reachable from this query. `CronCalendar` expressions live inside the serialized blob
 in `QRTZ_CALENDARS` and surface only at deserialization, and expressions built in code or held in

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -5881,7 +5881,7 @@ the interval on the trigger's start time and so keeps its phase.
 
 ### Before you upgrade
 
-Every row in that table is a string 3.x stored happily. The exception is thrown from
+Every row in the rejection table above is a string 3.x stored happily. The exception is thrown from
 `CronTriggerImpl.CronExpressionString`'s setter, which the ADO.NET job store calls while materialising a row,
 so a surviving expression fails the *read* rather than only the trigger. Audit the stored expressions first:
 

--- a/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionBuilderTest.cs
@@ -87,9 +87,9 @@ public class CronExpressionBuilderTest
     [Test]
     public void TestDayOfWeekIncrementsMatchNumericIncrementSemantics()
     {
-        // numeric "2/2" means day 2 (MON) through SAT stepping by 2; the builder emits
-        // the equivalent explicit day name list instead, since a textual "MON/2" is
-        // rejected by the parser
+        // numeric "2/2" means day 2 (MON) through SAT stepping by 2; the builder emits the
+        // equivalent explicit day name list instead, which says the same thing as the "MON/2"
+        // the parser accepts and is the spelling a reader of the expression needs no rule for
         CronExpression expanded = CronExpressionBuilder.Create()
             .WithSecond(0)
             .WithMinute(0)

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -557,11 +557,10 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [TestCase("0 5/0 * * * ?", "a step of 1 or more", "a step of zero after a value degenerated to the plain value")]
     [TestCase("0 0-10/0 * * * ?", "a step of 1 or more", "a step of zero inside a range degenerated to the range's start")]
     [TestCase("0 0-10/ * * * ?", "'/' must be followed by an integer", "a range with an empty step said nothing at all")]
-    [TestCase("0 0 12 ? * MON/2", "MON,WED,FRI", "the numeric twin '2/2' is what a step through the week means")]
-    [TestCase("0 0 12 ? * MON/2", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a fortnight that keeps its phase is a recurrence rule, not a cron expression")]
-    [TestCase("0 0 12 ? * MON/2", "not stable", "the message has to say why the extension went, or it reads as an arbitrary removal")]
-    [TestCase("0 0 12 ? * MON/X", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a step that is not a number is still a textual day-of-week step")]
+    [TestCase("0 0 12 ? * MON/X", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a step that is not a number is not a step, and the fortnight is the likely intent behind one")]
+    [TestCase("0 0 12 ? * MON/X", "whole number from 1 to 7", "so the message says what a step has to be")]
     [TestCase("0 0 12 ? * SUN/9", "FREQ=WEEKLY;INTERVAL=2;BYDAY=SU", "a step outside 1-7 is rejected as the same construct, not as a range error")]
+    [TestCase("0 0 12 ? * MON/0", "a step of 1 or more", "a step of zero says the same thing here as it does after a number")]
     public void ExpressionsThatSaidOneThingAndDidAnotherAreRejected(string expression, string expectedInMessage, string reason)
     {
         Action act = () => new CronExpression(expression);
@@ -600,12 +599,60 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [TestCase("0 15 10 1-5 * ? 2010", "a range with nothing after it is a range")]
     [TestCase("0 0 18-21/1 ? * MON-FRI", "a step of 1 inside a range is a step, and a textual range is not a dash option")]
     [TestCase("0 0 12 ? * 2/2", "the numeric twin of 'MON/2' is an ordinary step and is untouched")]
+    [TestCase("0 0 12 ? * MON/2", "and 'MON/2' is that same step, spelled with a name")]
+    [TestCase("0 0 12 ? * MON-FRI/2", "as is a step through a textual range")]
     [TestCase("0 15 10 ? DEC * 2010", "'DEC' is a month name that happens to end in 'C', not a calendar option")]
     public void ExpressionsTheNewRejectionsMustNotCatchStillParse(string expression, string reason)
     {
         Action act = () => new CronExpression(expression);
 
         act.Should().NotThrow(reason);
+    }
+
+    /// <summary>
+    /// A day-of-week step is one construct with two spellings, and 4.1 accepts the textual one. The
+    /// point of the pair is that neither spelling can drift: every form below has to name the same days
+    /// as its numeric twin, and fire at the same instants through a week.
+    /// </summary>
+    /// <remarks>
+    /// Quartz.NET 3.x read <c>MON/2</c> as "every second Monday" rather than as the step, which is why
+    /// 4.0 refused it outright — see the migration guide. An expression carried over from 3.x therefore
+    /// means something else here, and something else again from what it meant on 4.0, where it did not
+    /// parse at all.
+    /// </remarks>
+    [TestCase("MON/2", "2/2", "every second day of the week from Monday: MON, WED, FRI")]
+    [TestCase("SUN/2", "1/2", "and from Sunday: SUN, TUE, THU, SAT")]
+    [TestCase("SAT/3", "7/3", "a step from the last day names only that day")]
+    [TestCase("MON/1", "2/1", "a step of one is every day from Monday on")]
+    [TestCase("TUE/7", "3/7", "the largest step this field takes")]
+    [TestCase("MON-FRI/2", "2-6/2", "a step through a range: MON, WED, FRI")]
+    [TestCase("FRI-MON/2", "6-2/2", "and through a range that wraps the week")]
+    public void ATextualDayOfWeekStepIsItsNumericTwin(string textual, string numeric, string reason)
+    {
+        CronExpression written = new CronExpression($"0 0 12 ? * {textual}", TimeZoneInfo.Utc);
+        CronExpression twin = new CronExpression($"0 0 12 ? * {numeric}", TimeZoneInfo.Utc);
+
+        written.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal(twin.GetSet(CronExpressionConstants.DayOfWeek),
+            $"'{textual}' is '{numeric}' spelled with names - {reason}");
+
+        // A week of fires, because two fields holding the same values is only half of the claim.
+        DateTimeOffset start = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        FireTimesThroughAWeek(written, start).Should().Equal(FireTimesThroughAWeek(twin, start),
+            $"'{textual}' and '{numeric}' have to fire at the same instants - {reason}");
+    }
+
+    private static List<DateTimeOffset> FireTimesThroughAWeek(CronExpression expression, DateTimeOffset start)
+    {
+        List<DateTimeOffset> fireTimes = [];
+        DateTimeOffset? next = start;
+        DateTimeOffset end = start.AddDays(7);
+
+        while ((next = expression.GetNextValidTimeAfter(next.Value)) is not null && next.Value < end)
+        {
+            fireTimes.Add(next.Value);
+        }
+
+        return fireTimes;
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -653,6 +653,20 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
             $"'{textual}' and '{numeric}' have to fire at the same instants - {reason}");
     }
 
+    /// <summary>
+    /// The textual range never rejected a step: it read the two day names, stopped, and dropped whatever
+    /// followed — so <c>MON-FRI/2</c> quietly meant <c>MON-FRI</c>, five days where the author asked for
+    /// three. That is the shape #3591 removed everywhere else, and reading the step is what removes it here.
+    /// </summary>
+    [Test]
+    public void AStepAfterATextualRangeIsNotDropped()
+    {
+        CronExpression stepped = new CronExpression("0 0 12 ? * MON-FRI/2", TimeZoneInfo.Utc);
+
+        stepped.GetSet(CronExpressionConstants.DayOfWeek).Should().Equal([2, 4, 6],
+            "'MON-FRI/2' is '2-6/2' - Monday, Wednesday and Friday - and not the five days of 'MON-FRI'");
+    }
+
     private static List<DateTimeOffset> FireTimesThroughAWeek(CronExpression expression, DateTimeOffset start)
     {
         List<DateTimeOffset> fireTimes = [];

--- a/src/Quartz.Tests.Unit/CronExpressionTest.cs
+++ b/src/Quartz.Tests.Unit/CronExpressionTest.cs
@@ -557,11 +557,23 @@ public class CronExpressionTest : SerializationTestSupport<CronExpression>
     [TestCase("0 5/0 * * * ?", "a step of 1 or more", "a step of zero after a value degenerated to the plain value")]
     [TestCase("0 0-10/0 * * * ?", "a step of 1 or more", "a step of zero inside a range degenerated to the range's start")]
     [TestCase("0 0-10/ * * * ?", "'/' must be followed by an integer", "a range with an empty step said nothing at all")]
-    [TestCase("0 0 12 ? * MON/X", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "a step that is not a number is not a step, and the fortnight is the likely intent behind one")]
-    [TestCase("0 0 12 ? * MON/X", "whole number from 1 to 7", "so the message says what a step has to be")]
+    public void ExpressionsThatSaidOneThingAndDidAnotherAreRejected(string expression, string expectedInMessage, string reason)
+    {
+        Action act = () => new CronExpression(expression);
+
+        act.Should().Throw<FormatException>(reason).WithMessage($"*{expectedInMessage}*", reason);
+    }
+
+    /// <summary>
+    /// A textual day-of-week takes a step, so what is left to reject is a step that is not one. The
+    /// message still names the fortnight <c>MON/2</c> meant on 3.x, because somebody writing a step this
+    /// field cannot take is usually reaching for it.
+    /// </summary>
+    [TestCase("0 0 12 ? * MON/X", "whole number from 1 to 7", "a step that is not a number is not a step, and the message says what one is")]
+    [TestCase("0 0 12 ? * MON/X", "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", "and where the fortnight the author may have meant lives now")]
     [TestCase("0 0 12 ? * SUN/9", "FREQ=WEEKLY;INTERVAL=2;BYDAY=SU", "a step outside 1-7 is rejected as the same construct, not as a range error")]
     [TestCase("0 0 12 ? * MON/0", "a step of 1 or more", "a step of zero says the same thing here as it does after a number")]
-    public void ExpressionsThatSaidOneThingAndDidAnotherAreRejected(string expression, string expectedInMessage, string reason)
+    public void ATextualDayOfWeekStepThatIsNotAStepIsRejected(string expression, string expectedInMessage, string reason)
     {
         Action act = () => new CronExpression(expression);
 

--- a/src/Quartz.Tests.Unit/UnixCronFormatTest.cs
+++ b/src/Quartz.Tests.Unit/UnixCronFormatTest.cs
@@ -46,7 +46,7 @@ public class UnixCronFormatTest
     [TestCase("0 0 * * 0-7", "0 0 0 * * ?", "crontab has two Sundays, 0 and 7, so 0-7 is also the whole week")]
     [TestCase("0 0 * * 1-7", "0 0 0 * * ?", "MON through SUN is seven days, so it too is the whole week")]
     [TestCase("0 0 * * 5-1", "0 0 0 ? * FRI-MON", "a range may wrap the end of the week")]
-    [TestCase("0 0 * * 1/2", "0 0 0 ? * 2/2", "a step start renumbers as a number, never as a name - Quartz rejects 'MON/2' outright, so a name here would make the rewrite emit an expression its own parser refuses")]
+    [TestCase("0 0 * * 1/2", "0 0 0 ? * 2/2", "a step start renumbers as a number, never as a name - 'MON/2' parses and means the same thing, but the numeric form is what the rewrite has always emitted and a stored expression must not change spelling under an upgrade")]
     [TestCase("15 10 * * 1-5", "0 15 10 ? * MON-FRI", "the crontab weekday range everybody writes")]
     [TestCase("0 0 * * MON-FRI", "0 0 0 ? * MON-FRI", "names mean the same day in both dialects, so they pass through")]
     [TestCase("0 0 * * 0", "0 0 0 ? * SUN", "crontab's 0 is Sunday")]

--- a/src/Quartz/CronExpression.cs
+++ b/src/Quartz/CronExpression.cs
@@ -1729,6 +1729,15 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
                             Throw.FormatException($"Invalid Day-of-Week value: '{sub.ToString()}'");
                         }
 
+                        // 'MON-FRI/2' is '2-6/2'. The two spellings stay in lockstep, so a step is read
+                        // here for the same reason HandleDashOption reads one after a numeric range.
+                        if (s.Length > i + 3 && s[i + 3] == '/')
+                        {
+                            CheckTextualDayOfWeekStep(s.Slice(i, 3), eval, s.Slice(i + 4));
+                            HandleSlashOption(s, sval, type, i + 3, eval);
+                            return;
+                        }
+
                         break;
                     case '#':
                         try
@@ -1747,8 +1756,10 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
 
                         break;
                     case '/':
-                        Throw.FormatException(TextualDayOfWeekStepMessage(sub, sval, s.Slice(i + 4)));
-                        break;
+                        // 'MON/2' is '2/2': the same step through the week, spelled with a name.
+                        CheckTextualDayOfWeekStep(sub, sval, s.Slice(i + 4));
+                        HandleSlashOption(s, sval, type, i + 3, -1);
+                        return;
                     case 'L':
                         lastDayOfWeek = true;
                         break;
@@ -2377,9 +2388,23 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
     }
 
     /// <summary>
-    /// Builds the rejection message for a textual day-of-week followed by a step, such as <c>MON/2</c>.
-    /// Up to Quartz.NET 3.x that token meant "every second week"; the extension is gone, and the two
-    /// things a caller might have meant by it now live in two different places, so the message names both.
+    /// Rejects a textual day-of-week step whose step is not a step: the number after the <c>/</c> has to
+    /// be a whole number from 1 to 7, which is what the numeric spelling beside it takes. A step of 0 is
+    /// left to <see cref="CheckIncrementRange" />, so that <c>MON/0</c> and <c>2/0</c> say the same thing.
+    /// </summary>
+    private static void CheckTextualDayOfWeekStep(ReadOnlySpan<char> dayName, int dayOfWeek, ReadOnlySpan<char> stepText)
+    {
+        if (!int.TryParse(stepText, NumberStyles.None, CultureInfo.InvariantCulture, out int step) || step > 7)
+        {
+            Throw.FormatException(TextualDayOfWeekStepMessage(dayName, dayOfWeek, stepText));
+        }
+    }
+
+    /// <summary>
+    /// Builds the rejection message for a textual day-of-week followed by something that is not a step,
+    /// such as <c>MON/X</c> or <c>SUN/9</c>. The message says what the token would have meant had the
+    /// step been one, and what Quartz.NET 3.x read it as instead — a caller who writes an out-of-range
+    /// step here is usually reaching for that fortnight, which lives somewhere else now.
     /// </summary>
     /// <param name="dayName">the three-letter day name that was written, e.g. <c>MON</c></param>
     /// <param name="dayOfWeek">that day in Quartz's 1-7 numbering</param>
@@ -2390,16 +2415,18 @@ public sealed partial class CronExpression : ISerializable, IEquatable<CronExpre
             ? parsed
             : 2;
 
-        return $"'{dayName.ToString()}/{stepText.ToString()}' is not supported. A textual day-of-week followed by '/' meant \"every second week\" "
-               + "in Quartz.NET 3.x, and that extension has been removed because its fortnight is not stable - a misfire, a restart or a "
-               + $"failover recomputes it from a different day and shifts the phase. Write '{StepThroughWeek(dayOfWeek, step)}' if you meant a "
-               + $"step through the week, or RecurrenceScheduleBuilder.Create(\"FREQ=WEEKLY;INTERVAL={step};BYDAY={RecurrenceDayCodes[dayOfWeek]}\") "
-               + $"if you meant one {DayOfWeekNames[dayOfWeek]} every {step} weeks.";
+        return $"'{dayName.ToString()}/{stepText.ToString()}' is not a step: the value after '/' has to be a whole number from 1 to 7, "
+               + $"the same one '{dayOfWeek}/{stepText.ToString()}' would take. A textual day-of-week followed by a step means what its "
+               + $"numeric twin means, so '{dayName.ToString()}/{step}' is '{StepThroughWeek(dayOfWeek, step)}' - a step through the week. "
+               + "Quartz.NET 3.x read it as \"every N weeks\" instead, and that reading is gone because its fortnight had no stable phase - "
+               + "a misfire, a restart or a failover recomputed it from a different day and moved it. "
+               + $"RecurrenceScheduleBuilder.Create(\"FREQ=WEEKLY;INTERVAL={step};BYDAY={RecurrenceDayCodes[dayOfWeek]}\") is one "
+               + $"{DayOfWeekNames[dayOfWeek]} every {step} weeks, and keeps its phase.";
     }
 
     /// <summary>
-    /// Renders the day names a numeric step through the week would have produced, e.g. Monday by 2 is
-    /// <c>MON,WED,FRI</c>. The list stops at Saturday and does not wrap, which is what <c>2/2</c> means.
+    /// Renders the day names a step through the week produces, e.g. Monday by 2 is <c>MON,WED,FRI</c>.
+    /// The list stops at Saturday and does not wrap, which is what <c>MON/2</c> and <c>2/2</c> mean.
     /// </summary>
     private static string StepThroughWeek(int dayOfWeek, int step)
     {

--- a/src/Quartz/UnixCronRewriter.cs
+++ b/src/Quartz/UnixCronRewriter.cs
@@ -183,8 +183,10 @@ internal static class UnixCronRewriter
         int day = ToQuartzDay(raw);
 
         // The name is the clearer thing to store - nobody reads 'MON' as the Unix 1 it came from - but
-        // only where it can stand on its own. A name in front of a step is 'MON/2', which Quartz rejects
-        // outright, and a name in front of a suffix would make 'SUNL' and '1L' two spellings of one day.
+        // only where it can stand on its own. A name in front of a step is 'MON/2', which 4.1 parses and
+        // reads exactly as '2/2' - but the numeric form is what this has always emitted, and an
+        // expression already stored must not change spelling under an upgrade. A name in front of a
+        // suffix would make 'SUNL' and '1L' two spellings of one day.
         return digits == value.Length && !stepped
             ? CronExpression.DayOfWeekNames[day]
             : string.Concat(day.ToString(CultureInfo.InvariantCulture), value.AsSpan(digits));


### PR DESCRIPTION
`MON/2` is `2/2`: Monday, Wednesday and Friday, the same step through the week its numeric twin has always named. `MON-FRI/2` is `2-6/2` by the same rule. The value after the `/` still has to be a whole number from 1 to 7, so `MON/X` and `SUN/9` are rejected — with a message that now says what a step has to be as well as where the fortnight lives — and `MON/0` says what `2/0` says.

Stacked on #3731 (the #3690 fix, milestone 4.0.1), which is where this branches from. **Rebase onto `main` once that merges**; the two touch `CronExpression.cs` in different places.

## The reviewer decision

Quartz.NET 3.x read `MON/2` as *every second Monday*. 4.0 refused the token rather than re-read it as a step in silence, and #3603 recorded the refusal with "4.1 may accept it additively". 4.1 accepting it means **an expression carried across both majors turns a fortnightly job into a thrice-weekly one — 26 fires a year become 156 — and nothing logs it, because on 4.1 the expression is valid.** That is precisely what 4.0's rationale said it would not do, and the mitigation is documentation rather than code: nothing can warn on a valid expression.

So the question a reviewer has to settle is whether the documentation carries it. What is written:

- `cron-expressions.md` gains a section of its own, [`MON/2` is a step through the week], with a `::: danger` box for the 3.x reading, and the `/` bullet points at it.
- The migration guide gains a **From 4.0 to 4.1** section (two rows) linked from *Start here*; the "parser refuses" table row becomes "`FormatException` on 4.0; parses on 4.1"; and *Before you upgrade* now says that `TryParse` against the new assembly is **not** the authoritative check for this one shape, because it parses — a name in front of a `/` has to be read by eye.
- `best-practices.md` says the expression means three different things on three versions, which is what an operator planning an upgrade needs in one sentence.
- `AGENTS.md`'s ruling becomes "`MON/2` is 4.1's `2/2`", so the next audit does not reopen it.

The `From 4.0 to 4.1` section is deliberately one small table; it will merge with whatever #3338 lands.

## A second behaviour change, found on the way

**`MON-FRI/2` parsed on 4.0 and meant `MON-FRI`.** The textual range read its two day names, stopped, and dropped whatever followed — so an expression asking for three days fired on five, silently. That is exactly the shape #3591 removed everywhere else (`1-5W`, `1-5X`, `? * L-3`), and it survived because nobody looked past the `/` in the *textual* range. Reading the step fixes it; `AStepAfterATextualRangeIsNotDropped` keeps it fixed, and the 4.0 → 4.1 table carries the row.

## What the parser does

`StoreExpressionGeneralValue`'s day-of-week `/` case no longer throws: it validates the step and hands off to `HandleSlashOption`, the same method the numeric path uses, so the two produce the same field by construction rather than by parallel code. The `-` case reads a following step through the same method.

A step of `0` is left to `CheckIncrementRange`, so `MON/0` and `2/0` give the same message. A step that is not a number, or is above 7, keeps the textual message, because a caller who writes one is usually reaching for 3.x's fortnight and the message is where that is explained. `2/9` still says `Increment > 7 : 9` — the two messages differ, which is deliberate: only the textual spelling has a fortnight to explain.

The Unix rewriter keeps emitting `2/2` for crontab's `1/2`. It could emit `MON/2` now, but an expression already stored must not change spelling under an upgrade.

## Public API

No change. No baseline line moves; the parser accepts a string it used to reject, which is behaviour, not surface.

## Tests

- `ATextualDayOfWeekStepIsItsNumericTwin` — seven forms, each compared with its numeric twin both as a resolved field and as a week of fire times, so neither spelling can drift from the other.
- `AStepAfterATextualRangeIsNotDropped` — `MON-FRI/2` is three days, not five.
- `ATextualDayOfWeekStepThatIsNotAStepIsRejected` — `MON/X`, `SUN/9`, `MON/0`. These were rows in `ExpressionsThatSaidOneThingAndDidAnotherAreRejected`, standing beside `MON/2`; that fixture is about shapes 3.x reinterpreted, and what is left here is a different claim.
- `ExpressionsTheNewRejectionsMustNotCatchStillParse` gains `MON/2` and `MON-FRI/2`.
- `UnixCronFormatTest` and `CronExpressionBuilderTest` keep their assertions; their reasons said "Quartz rejects `MON/2`" and now say why the numeric form is still what is emitted.

## Verification

```
dotnet build Quartz.slnx                  Build succeeded, 0 warnings
dotnet test src/Quartz.Tests.Unit         Passed: 6116, Failed: 0, Skipped: 36 (50 s)
dotnet test src/Quartz.Tests.AspNetCore   Passed:  630, Failed: 0
dotnet fallout VerifyDocsSnippets         Succeeded, 115 markdown files
npm run docs:check-links                  224 pages, 1412 internal links, 869 fragments, no dead links or anchors
npm run docs:lint                         92 files, 0 errors
```

Documentation sites touched: `docs/documentation/quartz-4.x/cron-expressions.md`, `docs/documentation/quartz-4.x/migration-guide.md`, `docs/documentation/best-practices.md`, and `AGENTS.md`. `docs/documentation/quartz-3.x/` is untouched, as it must be — on 3.x the token really does mean a fortnight.

Integration tests were not run: no Docker daemon on this machine.

Closes #3732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK