### PR TITLE
A scheduler can be restarted from the recipe that built it

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/external-leader.md
+++ b/docs/documentation/quartz-4.x/how-tos/external-leader.md
@@ -121,9 +121,11 @@ Three things decide the shape:
 * **`Start` is idempotent and resumes from standby.** The first call starts the scheduler; every later
   one resumes it. Only the first runs the store's start-up recovery and starts the plugins, so a
   re-election is cheap.
-* **`Standby` is not `Shutdown`.** Shutdown is terminal — a shut-down scheduler cannot be started again,
-  and `Start` after it throws *"The Scheduler cannot be restarted after Shutdown() has been called."*
-  Standby is reversible, which is what a leadership that can come back needs.
+* **`Standby` is not `Shutdown`.** Shutdown is terminal for that scheduler — `Start` after it throws
+  *"The Scheduler cannot be restarted after Shutdown() has been called."*, and what
+  [`ISchedulerRuntime.Restart`](../multi-tenancy.md#restarting-a-scheduler) offers is a *new* scheduler
+  built from the same registration, which is far more than losing a lease should cost. Standby is
+  reversible, which is what a leadership that can come back needs.
 * **`Standby` after shutdown throws**, with `SchedulerException("The Scheduler has been Shutdown.")`.
   Losing a lease while the host is already stopping is ordinary, so read `Status` before standing down
   rather than catching the exception.

--- a/docs/documentation/quartz-4.x/log-events.md
+++ b/docs/documentation/quartz-4.x/log-events.md
@@ -228,6 +228,9 @@ matching on its text is not.
 | 4020 | Information | `Quartz` | `"Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' was added at runtime"` |
 | 4021 | Information | `Quartz` | `"Scheduler '{SchedulerName}' was removed at runtime"` |
 | 4022 | Information | `Quartz` | `"Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host"` |
+| 4023 | Information | `Quartz` | `"Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' is being restarted; waiting for {JobsExecuting} executing job(s)"` |
+| 4024 | Information | `Quartz` | `"Scheduler '{SchedulerName}' was restarted; instanceId '{PreviousSchedulerInstanceId}' replaced by '{SchedulerInstanceId}'"` |
+| 4025 | Warning | `Quartz` | `"Scheduler '{SchedulerName}' was shut down for a restart but {JobsStillExecuting} job(s) outlived the {DrainTimeout} drain, so no new scheduler was built; restart again once the work has finished"` |
 | 5000 | Information | `Quartz` | `"Parsing XML file: {FileName} with systemId: {SystemId}"` |
 | 5001 | Information | `Quartz` | `"Parsing XML from stream with systemId: {SystemId}"` |
 | 5002 | Debug | `Quartz` | `"Found {JobGroupCount} delete job group commands."` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -1674,7 +1674,7 @@ public enum SchedulerStatus
     Running,        // firing triggers
     Standby,        // started once, stood down, can be started again
     ShuttingDown,   // Shutdown() is running
-    Shutdown        // down, and not restartable
+    Shutdown        // down for good; a new scheduler replaces it, this one never runs again
 }
 ```
 

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -47,6 +47,9 @@ expressions it reads differently.
 |---|---|
 | `ISchedulerRuntime : ISchedulerRegistry` | Adds and removes schedulers in a container that has already been built. `Add(schedulerName, configure, options, cancellationToken)` builds a scheduler into a container of its own and binds it into this container's repository; `Remove(schedulerName, waitForJobsToComplete, cancellationToken)` shuts it down and releases what was built for it. Registered by `AddQuartz`, and `ISchedulerRegistry` resolves to the same object, so one listing answers for both kinds of scheduler |
 | `SchedulerAddOptions` | What to add a scheduler with beyond its name and its recipe: `Properties`, `Configuration` and `CreateWithoutStarting`. A `readonly record struct`, like every other options type an application constructs and passes in, whose `default` means "build it from the recipe and run it" |
+| `ISchedulerRuntime.Restart` | `Restart(schedulerName, options, cancellationToken)` shuts a scheduler down and builds another from the recipe that built it — for a tenant this runtime added, and for one `AddQuartz(name, …)` registered, whose recipe is now recorded at registration. Nothing is restarted in place: the name is the only thing the two schedulers share |
+| `SchedulerRestartOptions` | `DrainTimeout` — how long to wait for the outgoing scheduler's jobs, thirty seconds by default — and `Start`, which defaults to "as the old one was". A `readonly record struct` whose `default` is a restart that changes nothing but the instances |
+| `SchedulerRestartException` | Thrown when the outgoing scheduler's jobs outlived the drain. Carries `SchedulerName`, `JobsStillExecuting` and `DrainTimeout`. The old scheduler is down and the new one was never built; ask again once the work has finished |
 
 Three behaviours changed without a signature changing:
 

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -19,6 +19,7 @@ mechanics.
 | **Isolation** | strongest: separate job store, thread pool, clock, listeners | logical only — one scheduler, one pool | strongest at rest; one process still runs them all |
 | **Tenants known at** | startup or runtime | any time | startup |
 | **Add a tenant at runtime** | yes — [`ISchedulerRuntime`](#adding-a-tenant-while-the-process-is-running) | yes | no |
+| **Reconfigure a tenant at runtime** | yes — [`Restart`](#restarting-a-scheduler) rebuilds it from its recipe | its jobs and triggers, any time | no |
 | **Per-tenant concurrency limits** | yes, naturally | yes, via execution groups | yes |
 | **Per-tenant dashboard and API access** | yes — [`SchedulerAuthorizationPolicy`](#authorizing-a-tenant-on-its-own-scheduler) | no: Quartz authorizes a scheduler, not a group | yes, if each is its own scheduler |
 | **Cost per tenant** | a scheduling loop, a connection pool, a thread pool | ~nothing | a schema |
@@ -881,6 +882,109 @@ in the repository and nothing in the listing.
 | a name already bound in the repository | a scheduler bound by hand, or one `AddQuartzHttpClient` bound, occupies the name as surely as a registration does |
 | any name, once the host is stopping | it would be created after the shutdown that would have stopped it |
 
+### Restarting a scheduler
+
+`Restart` shuts a scheduler down and builds another one from the recipe that built it — for a tenant this
+runtime added, and for one `AddQuartz(name, …)` registered, whose recipe is recorded when the
+registration is made. Nothing is restarted in place: a scheduler's thread pool, job store, connection
+provider, plugins and listeners all refuse work once they have been shut down, so the second scheduler is
+a second set of instances and the name is the only thing the two share.
+
+<!-- snippet: sample_tenancy_restart -->
+```csharp
+ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+try
+{
+    // The new scheduler's container is built first, so a recipe that no longer works leaves the
+    // running one alone; then the old one is shut down waiting for its jobs; then the new one is
+    // created and started, which is when its store is initialised and its recovery runs.
+    IScheduler tenant = await runtime.Restart(tenantId, new SchedulerRestartOptions
+    {
+        DrainTimeout = TimeSpan.FromMinutes(2)
+    });
+}
+catch (SchedulerRestartException e)
+{
+    // The old scheduler is down and the new one was never built, which is deliberate: its first
+    // act would have been a recovery sweep over work that is still running. Nothing has to be
+    // undone - ask again once the jobs have finished, and until then the tenant is listed with
+    // no status.
+    logger.LogWarning(
+        e,
+        "Tenant {Tenant} still has {Count} job(s) running; restarting again shortly",
+        tenantId,
+        e.JobsStillExecuting);
+}
+```
+<!-- endSnippet -->
+
+The order is build, drain, create, and each step is where it is for a reason:
+
+- **Build first.** The new scheduler's container is built before the old one is touched, so a recipe that
+  no longer works — a connection string gone from configuration, a setting a later version rejects —
+  fails with a `SchedulerConfigException` and leaves the scheduler that is running exactly where it was.
+  Construction is not initialization: nothing opens a connection or starts a thread until the last step.
+- **Drain second.** The old scheduler is shut down waiting for its jobs, and waiting is not optional.
+  A persistent scheduler's first act on start is a crash-recovery sweep over its whole `SCHED_NAME` —
+  acquired and blocked triggers back to waiting, triggers left in `COMPLETE` deleted, every fired-trigger
+  row deleted — and none of it is filtered by instance id. A new generation started beside a job the old
+  one is still running would tear that job's bookkeeping out from under it.
+- **Create last.** The store is initialized, its schema checked, the declared jobs and triggers applied
+  and the recovery sweep run only once the drain has finished.
+
+`SchedulerRestartOptions.DrainTimeout` is how long that wait may take — thirty seconds by default,
+`Timeout.InfiniteTimeSpan` to wait until the jobs finish or the cancellation token fires. A wait that
+expires throws `SchedulerRestartException`, and the state it leaves is worth knowing precisely: the old
+scheduler is **shut down**, the new one was **never built**, and the tenant is listed with `Status: null`
+until a restart completes. Nothing has to be undone. Ask again once the work has finished — the next
+attempt waits for the abandoned generation before it builds anything, and starts the new scheduler if the
+one the failed attempt shut down was running.
+
+Making a drain finish is the job's business rather than the restart's:
+[`ShutdownJobInterruption`](configuration/reference.md#scheduler) asks running jobs to stop when the
+scheduler shuts down, and `[JobTimeout]` plus `AddJobTimeout` bounds one from the inside. Without either,
+a job that ignores its cancellation token will outlive any deadline.
+
+::: warning A job that outlives the drain is at-least-once
+If a job survives the timeout, the restart fails and the old generation goes on running it — but if you
+force the issue by restarting again once it has finished, the new generation's recovery re-fires anything
+it finds marked for recovery, exactly as it would after a crash. A restart is a node failure as far as
+recovery is concerned, because that is what it is.
+:::
+
+Four things a restart is observably not invisible about:
+
+- **Clustering.** With a fixed `InstanceId` the new generation's first check-in finds its own
+  `SCHEDULER_STATE` row and recovers nothing. With `AUTO` it takes a new id and the old row is left to
+  expire the way a stopped node's does, after which a peer — or the new generation — recovers it. Either
+  way a peer sees a restart the way it sees a node being restarted.
+- **Declared content is re-applied**, under the recipe's own `OverwriteExistingData`, which defaults to
+  `true`. A declared trigger's state in the database is reset by the restart; set
+  `Scheduling.IgnoreDuplicates` if that is not what you want.
+- **`RAMJobStore` keeps only what the recipe declares.** Anything scheduled through the API at runtime
+  goes away with the store the old generation owned. This is the one place where the store choice changes
+  what a restart means.
+- **Configuration written beside `AddQuartz` is not part of the recipe.** A
+  `services.Configure<QuartzSchedulerOptions>("acme", …)`, a keyed registration made directly against the
+  application's collection, an `AddQuartzHostedService("acme", …)` — these belong to the application's
+  container, and the next generation is built in a container of its own from what `AddQuartz` itself was
+  handed. Move the line inside the `AddQuartz("acme", …)` callback and both generations read it.
+
+Two refusals are worth reading before reaching for this:
+
+| Refused | Because |
+|---|---|
+| the default scheduler | its parts are the container's unkeyed registrations, which nothing can tell apart from the application's own, so there is no recipe to replay. Register it with `AddQuartz("name", …)` to make it restartable; `Standby()`/`Start()` pause and resume it |
+| a recipe that supplies a part as an instance | `UseJobStore(IJobStore)`, `UseThreadPool(IThreadPool)`, `UseJobFactory(instance)` and `UseInstanceIdGenerator(instance)` hand the new scheduler the object the old one is about to shut down. Register a type or a factory instead — `UseJobStore<T>()` or `UseJobStore(provider => …)` builds a new instance each time the recipe runs. The scheduler that is running is not touched |
+
+A name neither this runtime nor the container knows is a `SchedulerNotFoundException`. A name it knows
+whose scheduler has already been shut down — by hand, by the host, or by a restart whose drain gave up —
+is not an error at all: there is nothing to stop first, so restarting it starts it again.
+
+`Remove` is still the way to offboard a tenant. `Restart` keeps the tenant; it replaces the instances
+behind its name.
+
 ### Three things worth knowing
 
 **`IQuartzBuilder.Services` means the tenant's own collection**, not the application's. What the callback
@@ -1010,11 +1114,13 @@ is "this tenant may pause but not delete". The resource-based shape leaves room 
 evaluated against a `SchedulerResource`, and an operation requirement could join it later without another
 option — but that is not built.
 
-**A scheduler cannot be restarted after `Shutdown()`.** The container owns its parts' lifetimes, and
+**A scheduler is never restarted in place.** The container owns its parts' lifetimes, and
 `GetScheduler()` throws rather than resurrecting a thread pool and a job store underneath a scheduler
-that can never run again. `Standby()` / `Start()` is the pause-and-resume pair; for a tenant added at
-runtime, `ISchedulerRuntime.Remove` followed by `Add` builds a new set of parts, which is what a restart
-would have to mean.
+that can never run again. `Standby()` / `Start()` is the pause-and-resume pair.
+[`ISchedulerRuntime.Restart`](#restarting-a-scheduler) is the other answer: it builds a *new* set of
+parts from the recipe that built the old ones, which is what a restart can honestly mean. What it cannot
+replay is configuration written beside `AddQuartz` rather than inside it, and the default scheduler has
+no recipe at all.
 
 **A per-tenant thread pool is a real cost.** Under the scheduler-per-tenant model each tenant gets a
 scheduling loop that wakes on its own idle timer, a thread pool, and — with a persistent store — a
@@ -1057,4 +1163,4 @@ rest — so a view or a filter can reference them rather than repeat the strings
 - [Clustering](tutorial/advanced-enterprise-features.md) — what a shared database gives you
 - [Dashboard](packages/dashboard.md) — the Schedulers page, read-only mode, and how the policy above gates the UI
 - [HTTP API](packages/http-api.md#authorizing-per-scheduler) — the same policy on the other surface, and why it answers 403 before 404
-- [Migration Guide](migration-guide.md) — including why a shut-down scheduler cannot be restarted
+- [Migration Guide](migration-guide.md) — including why a shut-down scheduler is replaced rather than revived

--- a/docs/documentation/quartz-4.x/multi-tenancy.md
+++ b/docs/documentation/quartz-4.x/multi-tenancy.md
@@ -971,12 +971,13 @@ Four things a restart is observably not invisible about:
   container, and the next generation is built in a container of its own from what `AddQuartz` itself was
   handed. Move the line inside the `AddQuartz("acme", …)` callback and both generations read it.
 
-Two refusals are worth reading before reaching for this:
+Three refusals are worth reading before reaching for this:
 
 | Refused | Because |
 |---|---|
 | the default scheduler | its parts are the container's unkeyed registrations, which nothing can tell apart from the application's own, so there is no recipe to replay. Register it with `AddQuartz("name", …)` to make it restartable; `Standby()`/`Start()` pause and resume it |
-| a recipe that supplies a part as an instance | `UseJobStore(IJobStore)`, `UseThreadPool(IThreadPool)`, `UseJobFactory(instance)` and `UseInstanceIdGenerator(instance)` hand the new scheduler the object the old one is about to shut down. Register a type or a factory instead — `UseJobStore<T>()` or `UseJobStore(provider => …)` builds a new instance each time the recipe runs. The scheduler that is running is not touched |
+| a recipe that supplies a part as an instance | `UseJobStore(IJobStore)`, `UseThreadPool(IThreadPool)`, `UseJobFactory(instance)` and `UseInstanceIdGenerator(instance)` hand the new scheduler the object the old one is about to shut down. Register a type or a factory instead — `UseJobStore<T>()` or `UseJobStore(provider => new …)` builds a new instance each time the recipe runs. Refused before anything is built, so the scheduler that is running is not touched at all |
+| a factory that returns the running scheduler's part | `UseJobStore(provider => sharedInstance)` is a factory by its shape and an instance by its effect, and only building the next generation and comparing tells them apart. **A factory registration must return a new instance per generation**: it is replayed once for each, and the container built for a refused generation is released, taking whatever the factory returned with it |
 
 A name neither this runtime nor the container knows is a `SchedulerNotFoundException`. A name it knows
 whose scheduler has already been shut down — by hand, by the host, or by a restart whose drain gave up —

--- a/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
+++ b/docs/documentation/quartz-4.x/tutorial/standalone-scheduler.md
@@ -125,9 +125,11 @@ story exists for the cases where a scheduler is *shorter*-lived than the process
 subcommand, a plug-in host.
 
 ::: warning
-A scheduler that has been shut down cannot be restarted. The container owns its parts' lifetimes, so
-`GetScheduler()` after a `Shutdown()` throws rather than quietly handing back a dead instance — build a
-new factory instead. `Standby()` / `Start()` is the pause-and-resume pair.
+A scheduler that has been shut down is not restarted in place. The container owns its parts' lifetimes,
+so `GetScheduler()` after a `Shutdown()` throws rather than quietly handing back a dead instance — build
+a new factory instead. `Standby()` / `Start()` is the pause-and-resume pair. In an application that has a
+container, [`ISchedulerRuntime.Restart`](../multi-tenancy.md#restarting-a-scheduler) does the
+build-a-new-one step for you, from the recipe the old one was built with.
 :::
 
 ## Jobs, triggers and calendars

--- a/docs/documentation/tenancy-patterns.md
+++ b/docs/documentation/tenancy-patterns.md
@@ -530,9 +530,12 @@ name a policy evaluated per request against a `SchedulerResource` carrying the s
 may *do* to the scheduler it reaches is still process-wide — the dashboard's read-only flag — so
 "this tenant may look, that one may act" remains outside Quartz.NET on either version.
 
-**A shut-down scheduler cannot be restarted.** `Standby()` / `Start()` is the pause-and-resume pair.
-Shutdown is terminal: the scheduler refuses to start again and every other operation throws. You can
-build a *new* scheduler with the same name, but it is a new one, not a revived one.
+**A shut-down scheduler is not restarted in place.** `Standby()` / `Start()` is the pause-and-resume
+pair. Shutdown is terminal: the scheduler refuses to start again and every other operation throws. You
+can build a *new* scheduler with the same name, but it is a new one, not a revived one. On 4.1 and later
+[`ISchedulerRuntime.Restart`](quartz-4.x/multi-tenancy.md#restarting-a-scheduler) is that step as an API
+— it replays the recipe the scheduler was registered with, waits for the outgoing one's jobs, and binds
+the result under the same name.
 
 **The tenant does not reach your logs by itself.** The job and trigger group are tags on the execution
 traces, and on 4.x's metrics, but neither version puts them into a logging scope; if you want

--- a/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
+++ b/src/Quartz.Documentation.Samples/MultiTenancySamples.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 using Quartz.Extensibility;
 using Quartz.Plugins.Json;
@@ -299,6 +300,38 @@ public static class MultiTenancySamples
             q.AddJob<NightlyReportJob>(j => j.WithIdentity("nightly"));
             q.AddTrigger<NightlyReportJob>(t => t.WithCronSchedule("0 30 2 * * ?"));
         });
+
+        #endregion
+    }
+
+    public static async Task Restart(IHost app, string tenantId, ILogger logger)
+    {
+        #region sample_tenancy_restart
+
+        ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();
+
+        try
+        {
+            // The new scheduler's container is built first, so a recipe that no longer works leaves the
+            // running one alone; then the old one is shut down waiting for its jobs; then the new one is
+            // created and started, which is when its store is initialised and its recovery runs.
+            IScheduler tenant = await runtime.Restart(tenantId, new SchedulerRestartOptions
+            {
+                DrainTimeout = TimeSpan.FromMinutes(2)
+            });
+        }
+        catch (SchedulerRestartException e)
+        {
+            // The old scheduler is down and the new one was never built, which is deliberate: its first
+            // act would have been a recovery sweep over work that is still running. Nothing has to be
+            // undone - ask again once the jobs have finished, and until then the tenant is listed with
+            // no status.
+            logger.LogWarning(
+                e,
+                "Tenant {Tenant} still has {Count} job(s) running; restarting again shortly",
+                tenantId,
+                e.JobsStillExecuting);
+        }
 
         #endregion
     }

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerBlueprintTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerBlueprintTest.cs
@@ -1,0 +1,161 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Quartz.Configuration;
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// What <c>AddQuartz(name, …)</c> records about itself, which is what a restart replays.
+/// </summary>
+/// <remarks>
+/// A registration is descriptors in a collection that is closed once the container is built, and the
+/// instances behind them cannot be initialised twice — so building a scheduler a second time means
+/// running the registration again rather than reviving anything. That is only possible if the
+/// registration was written down, and this is where the boundary of what was written down is drawn: what
+/// <c>AddQuartz</c> itself was handed, and nothing that was written beside it.
+/// </remarks>
+public sealed class SchedulerBlueprintTest
+{
+    [Test]
+    public void ANamedRegistrationRecordsWhatItWasTold()
+    {
+        ServiceCollection services = new();
+        Action<IQuartzBuilder> configure = _ => { };
+
+        services.AddQuartz("acme", new Dictionary<string, string?> { ["quartz.threadPool.maxConcurrency"] = "7" }, configure);
+
+        SchedulerBlueprint blueprint = Blueprint(services, "acme")!;
+
+        blueprint.Name.Should().Be("acme", "the recipe is found by the name it was registered under");
+        blueprint.Configure.Should().BeSameAs(configure,
+            "a delegate that has been run and thrown away can never be run again, which is the whole reason a "
+            + "recipe is recorded rather than reconstructed");
+        blueprint.Properties["quartz.threadPool.maxConcurrency"].Should().Be("7");
+        blueprint.Configuration.Should().BeNull("this registration was given a property bag, not a section");
+    }
+
+    [Test]
+    public void ARegistrationWithNoRecipeAtAllStillRecordsOne()
+    {
+        ServiceCollection services = new();
+
+        services.AddQuartz("acme");
+
+        SchedulerBlueprint? blueprint = Blueprint(services, "acme");
+
+        blueprint.Should().NotBeNull(
+            "a scheduler registered with nothing but a name is still restartable - the recipe is empty, not absent");
+        blueprint!.Configure.Should().BeNull();
+        blueprint.Properties.Count.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The recipe is looked up the way the repository indexes names, so a restart asked for under a
+    /// different spelling finds it.
+    /// </summary>
+    [Test]
+    public void ARecipeIsFoundWhateverTheCaseOfTheNameAskedFor()
+    {
+        ServiceCollection services = new();
+
+        services.AddQuartz("Acme", _ => { });
+
+        Blueprint(services, "ACME").Should().NotBeNull();
+        Blueprint(services, "acme")!.Name.Should().Be("Acme", "the recipe carries the spelling the registration used");
+    }
+
+    /// <summary>
+    /// A registration made from a root section records the section it actually read, not the one it was
+    /// handed.
+    /// </summary>
+    /// <remarks>
+    /// <c>AddQuartz(name, configuration, …)</c> takes either the scheduler's own section or a root
+    /// section holding <c>Schedulers:{name}</c>, and resolves between them. Recording the caller's would
+    /// leave that resolution to be done again later against a configuration that is free to have changed
+    /// in between.
+    /// </remarks>
+    [Test]
+    public void TheConfigurationOverloadRecordsTheSectionItRead()
+    {
+        IConfiguration root = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Schedulers:acme:quartz.threadPool.maxConcurrency"] = "3"
+            })
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddQuartz("acme", root);
+
+        SchedulerBlueprint blueprint = Blueprint(services, "acme")!;
+
+        blueprint.Configuration.Should().NotBeNull();
+        blueprint.Configuration!["quartz.threadPool.maxConcurrency"].Should().Be("3",
+            "the recorded section is the resolved one, so replaying it reads the settings directly rather than "
+            + "looking for a Schedulers:acme child underneath them");
+    }
+
+    /// <summary>
+    /// The default scheduler has no recipe, and that is not an oversight.
+    /// </summary>
+    /// <remarks>
+    /// Its parts are the container's <em>unkeyed</em> registrations, which nothing can tell apart from
+    /// the application's own — so there is no set of descriptors to replay into a container of its own.
+    /// <c>ISchedulerRuntime.Restart</c> says so rather than guessing.
+    /// </remarks>
+    [Test]
+    public void TheDefaultSchedulerRecordsNoRecipe()
+    {
+        ServiceCollection services = new();
+
+        services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne"));
+
+        Blueprint(services, "TheDefaultOne").Should().BeNull();
+        SchedulerNameRegistry.For(services).HasDefaultScheduler.Should().BeTrue(
+            "the registration is recorded as existing; it is the recipe that cannot be");
+    }
+
+    /// <summary>
+    /// Configuration written <em>beside</em> the registration is not part of it.
+    /// </summary>
+    /// <remarks>
+    /// This is the limit of what a restart can promise, and it is drawn where the call is: nothing in a
+    /// service descriptor says which scheduler an application wrote it for, so the alternative to this
+    /// boundary is guessing. Move the setting inside the <c>AddQuartz(name, …)</c> callback and it is
+    /// part of the recipe.
+    /// </remarks>
+    [Test]
+    public void OptionsConfiguredBesideTheRegistrationAreNotPartOfIt()
+    {
+        ServiceCollection services = new();
+
+        services.AddQuartz("acme", q => q.ConfigureScheduler(o => o.InstanceId = "from-the-recipe"));
+        services.Configure<QuartzSchedulerOptions>("acme", o => o.InstanceId = "from-beside-it");
+        services.AddKeyedSingleton<ISchedulerListener, CountingListener>("acme");
+
+        SchedulerBlueprint blueprint = Blueprint(services, "acme")!;
+
+        ServiceCollection replayed = new();
+        blueprint.Configure!(new QuartzBuilder(replayed, "acme"));
+
+        ServiceProvider provider = replayed.AddOptions().BuildServiceProvider();
+        provider.GetRequiredService<IOptionsMonitor<QuartzSchedulerOptions>>().Get("acme").InstanceId
+            .Should().Be("from-the-recipe",
+                "the recipe is what AddQuartz was handed; a Configure written beside the call belongs to the "
+                + "application's container and is replayed by nobody");
+
+        provider.Dispose();
+    }
+
+    private static SchedulerBlueprint? Blueprint(IServiceCollection services, string name)
+    {
+        return SchedulerNameRegistry.For(services).Blueprint(name);
+    }
+
+    private sealed class CountingListener : ISchedulerListener;
+}

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerGenerationScopeTest.cs
@@ -174,7 +174,8 @@ public sealed class SchedulerGenerationScopeTest
                     recorder.FromScope[scheduler.SchedulerName] = unitOfWork;
                 }
             }),
-            number: 1);
+            number: 1,
+            refuseInstanceParts: false);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeDrainTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeDrainTest.cs
@@ -1,0 +1,292 @@
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+using Quartz.Tests.Unit.Plugin.History;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Why a restart drains before it starts the next generation, over a store where the answer is
+/// observable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A persistent scheduler's first act on <c>Start</c> is <c>RecoverJobs</c>: every acquired and blocked
+/// trigger back to waiting, every misfire handled, and — the one that matters here —
+/// <c>DeleteFiredTriggers</c> with an empty query, which deletes <em>every</em> fired-trigger row under
+/// the scheduler's name. It is crash recovery, so it is unfiltered by instance id on purpose. Start a
+/// second generation beside a job the first one is still running and that sweep deletes the running
+/// job's row and unblocks its <c>[DisallowConcurrentExecution]</c> siblings while it runs.
+/// </para>
+/// <para>
+/// A SQLite file, because none of that is visible over an in-memory store: <c>RAMJobStore</c> goes away
+/// with its generation, so there is nothing for a second one to sweep. The count the sweep reports is
+/// the assertion — zero when the restart waited, one when it did not.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerRuntimeDrainTest
+{
+    /// <summary>
+    /// The four counters <c>RecoverJobs</c> reports, which together say what the sweep found to recover.
+    /// </summary>
+    /// <remarks>
+    /// All four, because the sweep reaches a running job's bookkeeping by more than one road: it deletes
+    /// every fired-trigger row, and it also deletes triggers left in <c>COMPLETE</c> — which a one-shot
+    /// trigger is from the moment it fires until the job that is running it finishes — and deleting a
+    /// trigger takes its fired-trigger row with it. Watching only the last counter would have shown zero
+    /// while the row was being deleted one step earlier.
+    /// </remarks>
+    private static readonly int[] recoveryCounters = [3018, 3019, 3021, 3022];
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-runtime-drain-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+        GatedJob.Reset();
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        GatedJob.Release();
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            try
+            {
+                File.Delete(databaseFile);
+            }
+            catch (IOException)
+            {
+                // A connection pool that has not finished closing. The file is in the temp directory and
+                // the test has already said what it had to say.
+            }
+        }
+    }
+
+    /// <summary>
+    /// The next generation is created and started only once the previous one's jobs have finished, so
+    /// its recovery sweep finds nothing to recover.
+    /// </summary>
+    /// <remarks>
+    /// Written failing-first against a restart that shut the old scheduler down without waiting — the
+    /// obvious implementation, and the one the design spike said would corrupt in-flight work. That
+    /// version reports <c>Removed 1 stale fired job entries.</c>: the row it deleted belonged to the job
+    /// that was still running.
+    /// </remarks>
+    [Test]
+    public async Task RestartWaitsForRunningJobsBeforeStartingTheNextGeneration()
+    {
+        RecordingLoggerProvider log = new();
+        await using ServiceProvider provider = Container(log);
+        ISchedulerRuntime runtime = provider.GetRequiredService<ISchedulerRuntime>();
+
+        IScheduler first = await runtime.Add("acme", Recipe);
+        await Schedule(first);
+        await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        int mark = log.Entries.Count;
+
+        Task<IScheduler> restart = runtime
+            .Restart("acme", new SchedulerRestartOptions { DrainTimeout = TimeSpan.FromSeconds(30) })
+            .AsTask();
+
+        await Task.Delay(500);
+
+        restart.IsCompleted.Should().BeFalse(
+            "the job is still running, and the restart's whole job is to wait for it before anything of the "
+            + "next generation's touches the store");
+
+        GatedJob.Release();
+
+        IScheduler second = await restart.WaitAsync(TimeSpan.FromSeconds(60));
+
+        second.Should().NotBeSameAs(first);
+        GatedJob.Finished.IsCompletedSuccessfully.Should().BeTrue(
+            "the restart returned, which it may only do once the work it drained has finished");
+
+        Recovered(log, mark).Should().Equal(
+            [
+                "Freed 0 triggers from 'acquired' / 'blocked' state.",
+                "Recovering 0 jobs that were in-progress at the time of the last shut-down.",
+                "Removed 0 'complete' triggers.",
+                "Removed 0 stale fired job entries."
+            ],
+            "the drain finished before the new generation started, so the job had already completed its own "
+            + "trigger and deleted its own fired-trigger row - anything the sweep found to recover here would "
+            + "be a running job's bookkeeping");
+    }
+
+    /// <summary>
+    /// A drain that expires fails the restart rather than proceeding, and the next attempt succeeds once
+    /// the work has finished.
+    /// </summary>
+    [Test]
+    public async Task RestartFailsWhenTheDrainGivesUpAndSucceedsWhenAskedAgain()
+    {
+        RecordingLoggerProvider log = new();
+        await using ServiceProvider provider = Container(log);
+        ISchedulerRuntime runtime = provider.GetRequiredService<ISchedulerRuntime>();
+
+        IScheduler first = await runtime.Add("acme", Recipe);
+        await Schedule(first);
+        await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        int mark = log.Entries.Count;
+
+        Func<Task> restart = async () => await runtime.Restart(
+            "acme",
+            new SchedulerRestartOptions { DrainTimeout = TimeSpan.FromMilliseconds(200) });
+
+        SchedulerRestartException failure = (await restart.Should().ThrowAsync<SchedulerRestartException>(
+                "the job outlived the drain, and building the next generation now would run its recovery sweep "
+                + "over that job's own bookkeeping"))
+            .Which;
+
+        failure.SchedulerName.Should().Be("acme");
+        failure.JobsStillExecuting.Should().Be(1);
+        failure.DrainTimeout.Should().Be(TimeSpan.FromMilliseconds(200));
+
+        Recovered(log, mark).Should().BeEmpty(
+            "the next generation was never started, so nothing swept the store - which is the whole point of "
+            + "failing rather than proceeding");
+
+        first.Status.Should().Be(SchedulerStatus.Shutdown, "the old scheduler is down; only the new one was not built");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeNull();
+
+        List<SchedulerRegistration> listing = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+        listing.Should().ContainSingle(x => x.Name == "acme",
+            "an abandoned restart leaves the name in the listing with nothing running under it, which is how an "
+            + "operator sees that it is waiting to be asked again")
+            .Which.Status.Should().BeNull();
+
+        GatedJob.Release();
+        await GatedJob.Finished.WaitAsync(TimeSpan.FromSeconds(30));
+
+        IScheduler second = await runtime.Restart(
+            "acme",
+            new SchedulerRestartOptions { DrainTimeout = TimeSpan.FromSeconds(30) });
+
+        second.SchedulerName.Should().Be("acme");
+        second.Status.Should().Be(SchedulerStatus.Running,
+            "the old one was running when the first attempt shut it down, and asking again is the whole of the "
+            + "recovery");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(second);
+    }
+
+    /// <summary>
+    /// Asking again while the abandoned generation's jobs are still running is refused, not queued
+    /// behind them.
+    /// </summary>
+    [Test]
+    public async Task AskingAgainWhileTheAbandonedGenerationIsStillWorkingIsRefused()
+    {
+        RecordingLoggerProvider log = new();
+        await using ServiceProvider provider = Container(log);
+        ISchedulerRuntime runtime = provider.GetRequiredService<ISchedulerRuntime>();
+
+        IScheduler first = await runtime.Add("acme", Recipe);
+        await Schedule(first);
+        await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        SchedulerRestartOptions impatient = new() { DrainTimeout = TimeSpan.FromMilliseconds(200) };
+
+        Func<Task> restart = async () => await runtime.Restart("acme", impatient);
+
+        await restart.Should().ThrowAsync<SchedulerRestartException>();
+
+        (await restart.Should().ThrowAsync<SchedulerRestartException>(
+                "the generation the first attempt gave up on is still running the job, and the next generation "
+                + "may not be built over it"))
+            .Which.JobsStillExecuting.Should().Be(1,
+                "the count is read again rather than remembered, so it says what is true now");
+
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeNull(
+            "nothing was built, so nothing is bound");
+
+        GatedJob.Release();
+        await GatedJob.Finished.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    /// <summary>
+    /// The sweeps a generation ran at start, in the order they were logged, from a mark taken earlier.
+    /// </summary>
+    private static List<string> Recovered(RecordingLoggerProvider log, int mark)
+    {
+        return log.Entries
+            .Skip(mark)
+            .Where(entry => recoveryCounters.Contains(entry.EventId.Id))
+            .Select(entry => entry.Message)
+            .ToList();
+    }
+
+    private static async Task Schedule(IScheduler scheduler)
+    {
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<GatedJob>().WithIdentity("gated").Build(),
+            TriggerBuilder.Create().WithIdentity("gated").StartNow().Build());
+    }
+
+    private void Recipe(IQuartzBuilder builder)
+    {
+        builder.UsePersistentStore(store =>
+        {
+            store.UseSqlite(SqliteFactory.Instance, connectionString);
+            store.ProvisionSchema();
+        });
+    }
+
+    private static ServiceProvider Container(RecordingLoggerProvider log)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging(builder => builder.AddProvider(log).SetMinimumLevel(LogLevel.Information));
+        services.AddQuartz("main", _ => { });
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// A job that runs until the test lets it stop, so that a restart has something to wait for.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    private sealed class GatedJob : IJob
+    {
+        private static TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task Started => started.Task;
+
+        public static Task Finished => finished.Task;
+
+        public static void Reset()
+        {
+            started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void Release()
+        {
+            release.TrySetResult();
+        }
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            started.TrySetResult();
+            await release.Task.ConfigureAwait(false);
+            finished.TrySetResult();
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
@@ -159,13 +159,20 @@ public sealed class SchedulerRuntimeRestartTest
     }
 
     /// <summary>
-    /// A recipe that closes over an object cannot produce a second generation, and says so instead of
-    /// handing the new scheduler the instance the old one shut down.
+    /// A recipe that closes over an object cannot produce a second generation, and says so before it has
+    /// built anything at all.
     /// </summary>
+    /// <remarks>
+    /// The timing is what the assertions are about. A refusal reached by building the next generation and
+    /// comparing the parts would have to release the container it built, and Microsoft's container
+    /// releases whatever a factory delegate returned — which here is the store the <em>running</em>
+    /// scheduler is using. So the test watches the store: it must not have been initialized a second
+    /// time, it must not have been disposed, and the scheduler that has it must still fire.
+    /// </remarks>
     [Test]
     public async Task RestartRefusesARecipeThatSuppliesAJobStoreInstance()
     {
-        IJobStore shared = TestJobStores.Ram();
+        RecordingJobStore shared = new(TestJobStores.Ram());
 
         await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
@@ -174,14 +181,78 @@ public sealed class SchedulerRuntimeRestartTest
         Func<Task> restart = async () => await Restart(provider, "acme");
 
         (await restart.Should().ThrowAsync<SchedulerConfigException>(
-                "replaying the recipe hands the new scheduler the object the old one is about to shut down, and "
-                + "an instance is the one thing a recipe cannot produce twice"))
-            .WithMessage("*a job store as an instance*")
+                "replaying the recipe would hand the new scheduler the object the old one is using, and an "
+                + "instance is the one thing a recipe cannot produce twice"))
+            .WithMessage("*IJobStore as an instance*")
             .WithMessage("*UseJobStore(IJobStore)*")
-            .WithMessage("*still running*");
+            .WithMessage("*was not touched*");
+
+        shared.Disposed.Should().BeFalse(
+            "the refusal happens before a provider exists, so there is no container to release — and one that "
+            + "had to be released would have taken the running scheduler's own store with it");
+        shared.Initializations.Should().Be(1,
+            "nothing of the next generation was built, so the store was never initialized a second time");
 
         tenant.Status.Should().Be(SchedulerStatus.Running,
             "the refusal is decided before anything is shut down, so a caller that gets it has lost nothing");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant);
+
+        await FiresAJob(tenant);
+    }
+
+    /// <summary>
+    /// The same, for the thread pool — the other part whose object a recipe most often closes over.
+    /// </summary>
+    [Test]
+    public async Task RestartRefusesARecipeThatSuppliesAThreadPoolInstance()
+    {
+        DisposableThreadPool shared = new();
+
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme", q => q.UseThreadPool(shared));
+
+        Func<Task> restart = async () => await Restart(provider, "acme");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>())
+            .WithMessage("*IThreadPool as an instance*")
+            .WithMessage("*UseThreadPool(IThreadPool)*");
+
+        shared.Disposed.Should().BeFalse(
+            "a pool the running scheduler draws its threads from has to survive a refusal that exists to "
+            + "protect it");
+        shared.ShutdownCalled.Should().BeFalse("nothing was shut down, because nothing was built");
+        tenant.Status.Should().Be(SchedulerStatus.Running);
+    }
+
+    /// <summary>
+    /// A factory that closes over a shared object is refused too — by the second line, which is why its
+    /// message says a factory must return a new instance.
+    /// </summary>
+    /// <remarks>
+    /// This is the case the collection cannot be read for: <c>UseJobStore(provider =&gt; shared)</c> is a
+    /// factory registration by its shape and an instance registration by its effect, and only comparing
+    /// what two containers produced tells them apart.
+    /// </remarks>
+    [Test]
+    public async Task RestartRefusesAFactoryThatReturnsTheStoreTheRunningSchedulerHas()
+    {
+        IJobStore shared = TestJobStores.Ram();
+
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme", q => q.UseJobStore(_ => shared));
+
+        Func<Task> restart = async () => await Restart(provider, "acme");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>(
+                "a factory is replayed once per generation, so one that hands back the same object every time "
+                + "is an instance registration wearing a factory's clothes"))
+            .WithMessage("*the same job store (UseJobStore(provider => *")
+            .WithMessage("*must return a new instance each time*")
+            .WithMessage("*still running*");
+
+        tenant.Status.Should().Be(SchedulerStatus.Running);
         provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant);
     }
 
@@ -398,11 +469,104 @@ public sealed class SchedulerRuntimeRestartTest
         return store;
     }
 
+    /// <summary>
+    /// Proves a scheduler still works by making it fire something, which is the only assertion a refusal
+    /// that claims to have left it alone can be held to.
+    /// </summary>
+    private static async Task FiresAJob(IScheduler scheduler)
+    {
+        SignallingJob.Reset();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<SignallingJob>().WithIdentity("after-the-refusal").Build(),
+            TriggerBuilder.Create().WithIdentity("after-the-refusal").StartNow().Build());
+
+        await SignallingJob.Fired.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
     private sealed class RestartJob : IJob
     {
         public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
         {
             return default;
+        }
+    }
+
+    private sealed class SignallingJob : IJob
+    {
+        private static TaskCompletionSource fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task Fired => fired.Task;
+
+        public static void Reset()
+        {
+            fired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            fired.TrySetResult();
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// A store that is <see cref="IDisposable" />, which is what makes the refusal's timing observable:
+    /// a container built for a refused generation would dispose it, and the running scheduler's store is
+    /// the very object it holds.
+    /// </summary>
+    private sealed class RecordingJobStore : DelegatingJobStore, IDisposable
+    {
+        public RecordingJobStore(IJobStore inner) : base(inner)
+        {
+        }
+
+        public bool Disposed { get; private set; }
+
+        public int Initializations { get; private set; }
+
+        public override ValueTask Initialize(SchedulerIdentity identity, CancellationToken cancellationToken = default)
+        {
+            Initializations++;
+            return base.Initialize(identity, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    /// <inheritdoc cref="RecordingJobStore" />
+    private sealed class DisposableThreadPool : IThreadPool, IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public bool ShutdownCalled { get; private set; }
+
+        public int PoolSize => 1;
+
+        public ValueTask Initialize(CancellationToken cancellationToken = default) => default;
+
+        public ValueTask<int> WaitForAvailableThreads(CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<int>(ShutdownCalled ? 0 : 1);
+        }
+
+        public ValueTask<bool> TryRun(Func<ValueTask> action, CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<bool>(false);
+        }
+
+        public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default)
+        {
+            ShutdownCalled = true;
+            return default;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
         }
     }
 }

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
@@ -55,7 +55,7 @@ public sealed class SchedulerRuntimeRestartTest
     {
         List<IJobStore> stores = [];
 
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         IScheduler first = await Add(provider, "acme", q => q.UseJobStore(p => Record(stores, p)));
         first.Status.Should().Be(SchedulerStatus.Running);
@@ -85,7 +85,7 @@ public sealed class SchedulerRuntimeRestartTest
     {
         JobKey jobKey = new("nightly", "acme");
 
-        using ServiceProvider provider = Container(services => services.AddQuartz("acme", q =>
+        await using ServiceProvider provider = Container(services => services.AddQuartz("acme", q =>
             q.AddJob<RestartJob>(job => job.WithIdentity(jobKey).StoreDurably())));
 
         IScheduler first = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
@@ -105,6 +105,13 @@ public sealed class SchedulerRuntimeRestartTest
         throughTheFactory.Should().BeSameAs(second,
             "the factory answers from the repository, so a name that was restarted resolves to the generation "
             + "that is alive rather than to the one it replaced");
+
+        IScheduler handle = provider.GetRequiredKeyedService<IScheduler>("acme");
+        handle.SchedulerInstanceId.Should().Be(second.SchedulerInstanceId);
+        handle.Status.Should().Be(SchedulerStatus.Running,
+            "every [FromKeyedServices(\"acme\")] IScheduler in the application is one of these handles, and a "
+            + "handle that went on answering for the generation it first resolved would leave the application "
+            + "injecting the dead one while everything that reads the repository showed the live one");
     }
 
     /// <summary>
@@ -113,7 +120,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task RestartOfARegisteredButUnbuiltSchedulerBuildsIt()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
 
         IScheduler scheduler = await Restart(provider, "acme");
 
@@ -125,7 +132,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task RestartRefusesTheDefaultScheduler()
     {
-        using ServiceProvider provider = Container(services =>
+        await using ServiceProvider provider = Container(services =>
             services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne")));
 
         Func<Task> restart = async () => await Restart(provider, "TheDefaultOne");
@@ -141,7 +148,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task RestartOfAnUnknownNameThrowsSchedulerNotFound()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         Func<Task> restart = async () => await Restart(provider, "nobody");
 
@@ -160,7 +167,7 @@ public sealed class SchedulerRuntimeRestartTest
     {
         IJobStore shared = TestJobStores.Ram();
 
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         IScheduler tenant = await Add(provider, "acme", q => q.UseJobStore(shared));
 
@@ -192,7 +199,7 @@ public sealed class SchedulerRuntimeRestartTest
     {
         int runs = 0;
 
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         IScheduler tenant = await Add(provider, "acme", q =>
         {
@@ -218,7 +225,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task RestartStartsTheNewSchedulerOnlyIfTheOldWasRunning()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         IScheduler tenant = await Add(provider, "acme");
         await tenant.Standby();
@@ -241,7 +248,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task AShutDownTenantCanBeRestarted()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         IScheduler tenant = await Add(provider, "acme");
         await tenant.Shutdown();
@@ -267,7 +274,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task OptionsConfiguredBesideAddQuartzAreNotReplayed()
     {
-        using ServiceProvider provider = Container(services =>
+        await using ServiceProvider provider = Container(services =>
         {
             services.AddQuartz("acme", _ => { });
             services.Configure<QuartzSchedulerOptions>("acme", o => o.InstanceId = "written-beside-the-call");
@@ -289,7 +296,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task QuerySchedulersKeepsOriginContainerAcrossARestart()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
 
         IScheduler first = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
         started.Add(first);
@@ -317,7 +324,7 @@ public sealed class SchedulerRuntimeRestartTest
         IHostApplicationLifetime lifetime = A.Fake<IHostApplicationLifetime>();
         A.CallTo(() => lifetime.ApplicationStopping).Returns(stopping.Token);
 
-        using ServiceProvider provider = Container(services =>
+        await using ServiceProvider provider = Container(services =>
         {
             services.AddSingleton(lifetime);
             services.AddQuartz("main", _ => { });
@@ -340,7 +347,7 @@ public sealed class SchedulerRuntimeRestartTest
     [Test]
     public async Task RestartRefusesABlankName()
     {
-        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+        await using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
 
         Func<Task> restart = async () => await provider.GetRequiredService<ISchedulerRuntime>().Restart("  ");
 

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeRestartTest.cs
@@ -1,0 +1,401 @@
+using FakeItEasy;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Building a second generation of a scheduler from the recipe that built the first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing here restarts anything. A scheduler's thread pool, job store, connection provider, plugins
+/// and listeners are one-way — every one of them refuses work once it has been shut down — so a restart
+/// is the recipe run again into a container of its own, and the name is the only thing the two
+/// schedulers share. What the tests are really about is the order of the three steps and what each
+/// refusal protects: build first so a broken recipe leaves the old scheduler running, drain second so
+/// the new one's recovery sweep cannot run beside the old one's jobs, create last.
+/// </para>
+/// <para>
+/// The corruption that ordering prevents needs a persistent store to be observable at all, and is in
+/// <see cref="SchedulerRuntimeDrainTest" />.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerRuntimeRestartTest
+{
+    private readonly List<IScheduler> started = [];
+
+    [TearDown]
+    public async Task ShutDownWhateverIsLeft()
+    {
+        foreach (IScheduler scheduler in started)
+        {
+            try
+            {
+                await scheduler.Shutdown();
+            }
+            catch (SchedulerException)
+            {
+                // Already shut down by the test itself.
+            }
+        }
+
+        started.Clear();
+    }
+
+    [Test]
+    public async Task RestartOfARuntimeTenantIsANewSetOfInstances()
+    {
+        List<IJobStore> stores = [];
+
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler first = await Add(provider, "acme", q => q.UseJobStore(p => Record(stores, p)));
+        first.Status.Should().Be(SchedulerStatus.Running);
+
+        IScheduler second = await Restart(provider, "acme");
+
+        second.Should().NotBeSameAs(first, "the handle a caller holds across a restart is the name, not the scheduler");
+        second.Status.Should().Be(SchedulerStatus.Running, "the old one was running, so the new one is");
+        first.Status.Should().Be(SchedulerStatus.Shutdown, "the old scheduler is shut down, not reused");
+
+        stores.Should().HaveCount(2).And.OnlyHaveUniqueItems(
+            "the recipe was run again, and a second Initialize on the same store is exactly what a restart "
+            + "must never be");
+
+        ISchedulerRepository repository = provider.GetRequiredService<ISchedulerRepository>();
+        repository.Lookup("acme").Should().BeSameAs(second, "the repository holds the generation that is alive");
+        repository.LookupAll().Should().ContainSingle(x => x.SchedulerName == "acme",
+            "the old one unbound itself when it shut down, so nothing has to remember to");
+    }
+
+    /// <summary>
+    /// A scheduler <c>AddQuartz(name, …)</c> registered is restartable, because the registration wrote
+    /// down what it was told.
+    /// </summary>
+    [Test]
+    public async Task RestartOfAContainerRegisteredSchedulerReplaysItsRecipe()
+    {
+        JobKey jobKey = new("nightly", "acme");
+
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", q =>
+            q.AddJob<RestartJob>(job => job.WithIdentity(jobKey).StoreDurably())));
+
+        IScheduler first = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        started.Add(first);
+        await first.Start();
+
+        IScheduler second = await Restart(provider, "acme");
+
+        second.Should().NotBeSameAs(first);
+        (await second.GetJobDetail(jobKey)).Should().NotBeNull(
+            "the declared content is part of the recipe, so the new generation applies it exactly as the "
+            + "container's own registration did");
+
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(second);
+
+        IScheduler throughTheFactory = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        throughTheFactory.Should().BeSameAs(second,
+            "the factory answers from the repository, so a name that was restarted resolves to the generation "
+            + "that is alive rather than to the one it replaced");
+    }
+
+    /// <summary>
+    /// A registration nothing has built yet is restarted by simply building it.
+    /// </summary>
+    [Test]
+    public async Task RestartOfARegisteredButUnbuiltSchedulerBuildsIt()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler scheduler = await Restart(provider, "acme");
+
+        scheduler.SchedulerName.Should().Be("acme");
+        scheduler.Status.Should().Be(SchedulerStatus.Created,
+            "nothing was running under that name, so there was nothing whose running to preserve");
+    }
+
+    [Test]
+    public async Task RestartRefusesTheDefaultScheduler()
+    {
+        using ServiceProvider provider = Container(services =>
+            services.AddQuartz(q => q.ConfigureScheduler(o => o.InstanceName = "TheDefaultOne")));
+
+        Func<Task> restart = async () => await Restart(provider, "TheDefaultOne");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>(
+                "the default scheduler's parts are the container's unkeyed registrations, and nothing can tell "
+                + "them apart from the application's own"))
+            .WithMessage("*registered without a name*")
+            .WithMessage("*AddQuartz(\"TheDefaultOne\", …)*")
+            .WithMessage("*Standby()/Start()*", "the pause-and-resume pair is what the caller probably wanted");
+    }
+
+    [Test]
+    public async Task RestartOfAnUnknownNameThrowsSchedulerNotFound()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        Func<Task> restart = async () => await Restart(provider, "nobody");
+
+        (await restart.Should().ThrowAsync<SchedulerNotFoundException>(
+                "there is no recipe to replay, and 'no such scheduler' is the one failure a caller can act on "
+                + "without changing anything"))
+            .Which.SchedulerName.Should().Be("nobody");
+    }
+
+    /// <summary>
+    /// A recipe that closes over an object cannot produce a second generation, and says so instead of
+    /// handing the new scheduler the instance the old one shut down.
+    /// </summary>
+    [Test]
+    public async Task RestartRefusesARecipeThatSuppliesAJobStoreInstance()
+    {
+        IJobStore shared = TestJobStores.Ram();
+
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme", q => q.UseJobStore(shared));
+
+        Func<Task> restart = async () => await Restart(provider, "acme");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>(
+                "replaying the recipe hands the new scheduler the object the old one is about to shut down, and "
+                + "an instance is the one thing a recipe cannot produce twice"))
+            .WithMessage("*a job store as an instance*")
+            .WithMessage("*UseJobStore(IJobStore)*")
+            .WithMessage("*still running*");
+
+        tenant.Status.Should().Be(SchedulerStatus.Running,
+            "the refusal is decided before anything is shut down, so a caller that gets it has lost nothing");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant);
+    }
+
+    /// <summary>
+    /// The new generation is built before the old one is touched, so a recipe that no longer works costs
+    /// nothing.
+    /// </summary>
+    /// <remarks>
+    /// The failure is provoked on the second run of the recipe rather than the first, because that is the
+    /// shape of the real thing: a connection string that disappeared from configuration, a validator a
+    /// package added, a setting a later version rejects. The scheduler that is running has to survive it.
+    /// </remarks>
+    [Test]
+    public async Task AConfigurationErrorInTheNewGenerationLeavesTheOldRunning()
+    {
+        int runs = 0;
+
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme", q =>
+        {
+            if (Interlocked.Increment(ref runs) > 1)
+            {
+                q.ConfigureScheduler(o => o.IdleWaitTime = TimeSpan.Zero);
+            }
+        });
+
+        Func<Task> restart = async () => await Restart(provider, "acme");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>(
+                "options validation is how configuration is checked, and a caller should not have to catch the "
+                + "options framework's own exception type"))
+            .WithMessage("*IdleWaitTime*");
+
+        tenant.Status.Should().Be(SchedulerStatus.Running,
+            "building comes first precisely so that a recipe which no longer works leaves the scheduler that "
+            + "is running exactly where it was");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(tenant);
+    }
+
+    [Test]
+    public async Task RestartStartsTheNewSchedulerOnlyIfTheOldWasRunning()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme");
+        await tenant.Standby();
+
+        IScheduler second = await Restart(provider, "acme");
+
+        second.Status.Should().Be(SchedulerStatus.Created,
+            "a scheduler in standby is not firing, and a restart that started it would be a second decision "
+            + "hidden inside the first");
+
+        IScheduler third = await Restart(provider, "acme", new SchedulerRestartOptions { Start = true });
+
+        third.Status.Should().Be(SchedulerStatus.Running, "saying so decides it deliberately");
+
+        IScheduler fourth = await Restart(provider, "acme", SchedulerRestartOptions.WithoutStarting);
+
+        fourth.Status.Should().Be(SchedulerStatus.Created, "and so does saying the other thing");
+    }
+
+    [Test]
+    public async Task AShutDownTenantCanBeRestarted()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        IScheduler tenant = await Add(provider, "acme");
+        await tenant.Shutdown();
+
+        IScheduler second = await Restart(provider, "acme");
+
+        second.Should().NotBeSameAs(tenant);
+        second.Status.Should().Be(SchedulerStatus.Created,
+            "there was nothing running, so restarting is starting again rather than replacing");
+        provider.GetRequiredService<ISchedulerRepository>().Lookup("acme").Should().BeSameAs(second);
+    }
+
+    /// <summary>
+    /// Configuration written beside <c>AddQuartz</c> is not part of the recipe, and a restart is where
+    /// that stops being a curiosity.
+    /// </summary>
+    /// <remarks>
+    /// Generation one reads it, because it is the container's own scheduler and the container is where
+    /// the setting was written. Generation two does not, because it is built from the registration and
+    /// nothing in a service descriptor says which scheduler an application wrote a <c>Configure</c> for.
+    /// Move the line inside the <c>AddQuartz("acme", …)</c> callback and both generations read it.
+    /// </remarks>
+    [Test]
+    public async Task OptionsConfiguredBesideAddQuartzAreNotReplayed()
+    {
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddQuartz("acme", _ => { });
+            services.Configure<QuartzSchedulerOptions>("acme", o => o.InstanceId = "written-beside-the-call");
+        });
+
+        IScheduler first = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        started.Add(first);
+
+        first.SchedulerInstanceId.Should().Be("written-beside-the-call",
+            "the container's own scheduler reads the container's options, whoever wrote them");
+
+        IScheduler second = await Restart(provider, "acme");
+
+        second.SchedulerInstanceId.Should().Be(QuartzSchedulerOptions.DefaultInstanceId,
+            "the recipe is what AddQuartz was handed; the next generation is built in a container of its own, "
+            + "which was never told about a Configure written outside the call");
+    }
+
+    [Test]
+    public async Task QuerySchedulersKeepsOriginContainerAcrossARestart()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("acme", _ => { }));
+
+        IScheduler first = await provider.GetRequiredKeyedService<ISchedulerFactory>("acme").GetScheduler();
+        started.Add(first);
+        await first.Start();
+
+        await Restart(provider, "acme");
+
+        List<SchedulerRegistration> listing = await provider.GetRequiredService<ISchedulerRegistry>().QuerySchedulers();
+
+        listing.Should().ContainSingle(x => x.Name == "acme",
+            "a restarted registration is one scheduler, not one registration and one runtime tenant")
+            .Which.Should().BeEquivalentTo(new
+            {
+                Name = "acme",
+                Origin = SchedulerOrigin.Container,
+                Status = SchedulerStatus.Running
+            },
+            "a restart changes which instances answer for a name; it does not change where the name came from");
+    }
+
+    [Test]
+    public async Task RestartRefusesWhileTheHostIsStopping()
+    {
+        using CancellationTokenSource stopping = new();
+        IHostApplicationLifetime lifetime = A.Fake<IHostApplicationLifetime>();
+        A.CallTo(() => lifetime.ApplicationStopping).Returns(stopping.Token);
+
+        using ServiceProvider provider = Container(services =>
+        {
+            services.AddSingleton(lifetime);
+            services.AddQuartz("main", _ => { });
+        });
+
+        IScheduler tenant = await Add(provider, "acme");
+        await stopping.CancelAsync();
+
+        Func<Task> restart = async () => await Restart(provider, "acme");
+
+        (await restart.Should().ThrowAsync<SchedulerConfigException>())
+            .WithMessage("*host is stopping*")
+            .WithMessage("*was not restarted*");
+
+        tenant.Status.Should().Be(SchedulerStatus.Running,
+            "the refusal comes before the shutdown, so the host still has a scheduler to drain rather than a "
+            + "name with nothing under it");
+    }
+
+    [Test]
+    public async Task RestartRefusesABlankName()
+    {
+        using ServiceProvider provider = Container(services => services.AddQuartz("main", _ => { }));
+
+        Func<Task> restart = async () => await provider.GetRequiredService<ISchedulerRuntime>().Restart("  ");
+
+        await restart.Should().ThrowAsync<ArgumentException>();
+    }
+
+    private async Task<IScheduler> Add(
+        ServiceProvider provider,
+        string schedulerName,
+        Action<IQuartzBuilder> configure = null)
+    {
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerRuntime>().Add(schedulerName, configure);
+        started.Add(scheduler);
+        return scheduler;
+    }
+
+    private async Task<IScheduler> Restart(
+        ServiceProvider provider,
+        string schedulerName,
+        SchedulerRestartOptions options = default)
+    {
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerRuntime>().Restart(schedulerName, options);
+        started.Add(scheduler);
+        return scheduler;
+    }
+
+    private static ServiceProvider Container(Action<IServiceCollection> configure)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        configure(services);
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// A store built by the recipe, kept so a test can say whether the second generation got one of its
+    /// own.
+    /// </summary>
+    private static IJobStore Record(List<IJobStore> stores, IServiceProvider provider)
+    {
+        IJobStore store = ActivatorUtilities.CreateInstance<RAMJobStore>(provider);
+        lock (stores)
+        {
+            stores.Add(store);
+        }
+
+        return store;
+    }
+
+    private sealed class RestartJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
@@ -133,9 +133,92 @@ public class ShutdownDrainTest
             + "ShutdownJobInterruption's decision, and it defaults to never");
     }
 
+    /// <summary>
+    /// The answer <c>Shutdown</c> could not give its caller, kept where whoever performed the shutdown
+    /// can read it afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Three readings, because the property has three states and each one means something different to
+    /// the caller that acts on it: nothing has been shut down, the work finished, and the wait was
+    /// abandoned with work still running. Only the middle one licenses building a second generation of a
+    /// scheduler over the same store.
+    /// </remarks>
+    [Test]
+    public async Task ShutdownRecordsWhetherItsWaitForRunningWorkSucceeded()
+    {
+        IScheduler scheduler = await QuartzSchedulerBuilder
+            .Create(q => q.ConfigureScheduler(options => options.InstanceName = "running-work-drained"))
+            .BuildScheduler();
+
+        Drained(scheduler).Should().BeNull("nothing has been shut down, so there is no answer to give yet");
+
+        GatedJob.Reset();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<GatedJob>().WithIdentity("gated").Build(),
+            TriggerBuilder.Create().WithIdentity("gated").StartNow().Build());
+
+        await scheduler.Start();
+        await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        using CancellationTokenSource deadline = new(TimeSpan.FromMilliseconds(100));
+        await scheduler.Shutdown(waitForJobsToComplete: true, deadline.Token);
+
+        Drained(scheduler).Should().BeFalse(
+            "the deadline expired with the job still running, and a caller about to build a second scheduler over "
+            + "the same store needs to hear that rather than to infer it from a count that already reads zero");
+
+        GatedJob.Release();
+        await GatedJob.Finished.WaitAsync(TimeSpan.FromSeconds(30));
+
+        IScheduler quiet = await QuartzSchedulerBuilder
+            .Create(q => q.ConfigureScheduler(options => options.InstanceName = "running-work-drained-quiet"))
+            .BuildScheduler();
+
+        await quiet.Start();
+        await quiet.Shutdown(waitForJobsToComplete: true);
+
+        Drained(quiet).Should().BeTrue("nothing was running, so the wait for running work succeeded immediately");
+    }
+
+    /// <summary>
+    /// A shutdown that did not wait answers from the count of executing jobs, which is the only evidence
+    /// it has.
+    /// </summary>
+    [Test]
+    public async Task AShutdownThatDidNotWaitSaysWhetherAnythingWasStillRunning()
+    {
+        IScheduler scheduler = await QuartzSchedulerBuilder
+            .Create(q => q.ConfigureScheduler(options => options.InstanceName = "running-work-abandoned"))
+            .BuildScheduler();
+
+        GatedJob.Reset();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<GatedJob>().WithIdentity("gated").Build(),
+            TriggerBuilder.Create().WithIdentity("gated").StartNow().Build());
+
+        await scheduler.Start();
+        await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await scheduler.Shutdown(waitForJobsToComplete: false);
+
+        Drained(scheduler).Should().BeFalse(
+            "a shutdown that abandoned a running job did not drain, and saying it had would license a second "
+            + "generation to start over a store the job is still writing to");
+
+        GatedJob.Release();
+        await GatedJob.Finished.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
     private static int ExecutingJobCount(IScheduler scheduler)
     {
         return ((StdScheduler) scheduler).scheduler.NumberOfJobsExecutingHere;
+    }
+
+    private static bool? Drained(IScheduler scheduler)
+    {
+        return ((StdScheduler) scheduler).scheduler.RunningWorkDrained;
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/DeferredSchedulerGenerationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/DeferredSchedulerGenerationTest.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// What <c>[FromKeyedServices("acme")] IScheduler</c> points at once the scheduler behind it has been
+/// replaced.
+/// </summary>
+/// <remarks>
+/// The handle a container hands out is a proxy that resolves its scheduler on first use and remembers
+/// it, and every constructor in the application holds one. A restart builds a second generation under
+/// the same name, so a handle that never looked again would leave the whole application injecting the
+/// dead one while the repository, the dashboard and the HTTP API all showed the live one. The
+/// registration is the identity, not the instance.
+/// </remarks>
+[NonParallelizable]
+public sealed class DeferredSchedulerGenerationTest
+{
+    [Test]
+    public async Task AHandleRepointsAtTheGenerationARestartBuilt()
+    {
+        await using ServiceProvider provider = Container();
+
+        IScheduler handle = provider.GetRequiredKeyedService<IScheduler>("acme");
+        await handle.Start();
+
+        string firstId = handle.SchedulerInstanceId;
+        firstId.Should().NotBeNull();
+
+        IScheduler next = await provider.GetRequiredService<ISchedulerRuntime>().Restart("acme");
+
+        handle.Status.Should().Be(SchedulerStatus.Running,
+            "the handle a constructor was injected with has to answer for the scheduler that is alive, not "
+            + "for the one it happened to resolve first");
+
+        (await handle.GetMetadata()).SchedulerInstanceId.Should().Be(next.SchedulerInstanceId);
+        (await handle.GetJobDetail(new JobKey("nothing"))).Should().BeNull(
+            "an asynchronous member re-points too, and does it without a second build");
+
+        await next.Shutdown();
+    }
+
+    [Test]
+    public async Task AHandleWithNoLiveSchedulerLeftStillRefuses()
+    {
+        await using ServiceProvider provider = Container();
+
+        IScheduler handle = provider.GetRequiredKeyedService<IScheduler>("acme");
+        await handle.Start();
+        await handle.Shutdown();
+
+        Func<Task> act = async () => await handle.GetJobDetail(new JobKey("nothing"));
+
+        await act.Should().ThrowAsync<SchedulerException>(
+                "asking again finds nothing in the repository and falls through to the container's own "
+                + "scheduler, which is shut down - re-pointing must not become rebuilding")
+            .WithMessage("*has been shut down*");
+    }
+
+    private static ServiceProvider Container()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        services.AddQuartz("acme", q => q.UseInMemoryStore());
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/ShutDownSchedulerIsNotRestartedTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/ShutDownSchedulerIsNotRestartedTest.cs
@@ -13,6 +13,13 @@ namespace Quartz.Tests.Unit.Impl;
 /// with its thread pool and job store re-initialized underneath it, which looks alive and schedules
 /// nothing. The factory refuses instead, and says what to do rather than what went wrong.
 /// </summary>
+/// <remarks>
+/// The refusal stands, and what changed is what it can offer: <c>ISchedulerRuntime.Restart</c> builds
+/// another scheduler from the same registration into a container of its own, which is what a caller
+/// asking for a shut-down scheduler actually wanted. It is not what this path does, and the distinction
+/// is the point — the factory hands out a scheduler, and building a second generation of one is a
+/// decision somebody has to make on purpose.
+/// </remarks>
 [NonParallelizable]
 public sealed class ShutDownSchedulerIsNotRestartedTest
 {
@@ -28,10 +35,13 @@ public sealed class ShutDownSchedulerIsNotRestartedTest
 
         Func<Task> act = async () => await factory.GetScheduler();
 
-        await act.Should().ThrowAsync<SchedulerException>()
+        (await act.Should().ThrowAsync<SchedulerException>()
             .WithMessage("*RestartRefusedScheduler*has been shut down*Standby()/Start()*",
                 "a dead scheduler has to name the scheduler and the way to pause and resume, rather than "
-                + "silently handing back an instance that can never run again");
+                + "silently handing back an instance that can never run again"))
+            .WithMessage("*ISchedulerRuntime.Restart(\"RestartRefusedScheduler\")*",
+                "and the message now names the thing that does build another one from the same "
+                + "registration, since refusing without an alternative was the whole complaint");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/TaskSchedulingThreadPoolTest.cs
@@ -427,6 +427,56 @@ public class TaskSchedulingThreadPoolTest
         ran.Should().BeFalse("a refused work item must not run, since nothing will wait for it any more");
     }
 
+    /// <summary>
+    /// A drain that gave up ends in <c>ReleaseResources</c>, and the question is whether a pool that has
+    /// given back what it owns can still answer for the work it is still running.
+    /// </summary>
+    /// <remarks>
+    /// It can, and this pins it: the completion the first drain waited on is the one the second waits on
+    /// too, so the second answers <see langword="false" /> while the work runs and
+    /// <see langword="true" /> once it finishes. A caller that gave up on a restart and came back to it
+    /// therefore learns the truth rather than being told the pool drained because it had already been
+    /// torn down. Without this the retry path would need the completion kept in a field of its own.
+    /// </remarks>
+    [Test]
+    public async Task ASecondDrainAfterOneThatGaveUpStillAnswersForTheWorkThatIsRunning()
+    {
+        CustomTaskSchedulingThreadPool threadPool = new CustomTaskSchedulingThreadPool(TaskScheduler.Default, 2);
+        await threadPool.Initialize();
+
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource finished = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await threadPool.TryRun(async () =>
+        {
+            started.TrySetResult();
+            await release.Task.ConfigureAwait(false);
+            finished.TrySetResult();
+        });
+
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        using (CancellationTokenSource deadline = new(TimeSpan.FromMilliseconds(50)))
+        {
+            (await threadPool.Drain(deadline.Token)).Should().BeFalse("the work item outlived the deadline");
+        }
+
+        using (CancellationTokenSource second = new(TimeSpan.FromMilliseconds(50)))
+        {
+            (await threadPool.Drain(second.Token)).Should().BeFalse(
+                "the pool released its resources when the first drain gave up, and a pool that answered 'drained' "
+                + "on that account would be lying about work it is still running");
+        }
+
+        release.TrySetResult();
+        await finished.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        using CancellationTokenSource generous = new(TimeSpan.FromSeconds(30));
+        (await threadPool.Drain(generous.Token)).Should().BeTrue(
+            "the work has finished, so asking again is how a caller that gave up learns it may go ahead");
+    }
+
     [Test]
     public async Task DrainingAndShuttingDownInEitherOrderIsSafe()
     {

--- a/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/LogEventCatalogTest_Quartz.verified.txt
@@ -344,6 +344,12 @@
     "Scheduler '{SchedulerName}' was removed at runtime"
 4022  Information  ConfigurationLog.RuntimeSchedulerShutDownByHost
     "Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host"
+4023  Information  ConfigurationLog.SchedulerRestarting
+    "Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' is being restarted; waiting for {JobsExecuting} executing job(s)"
+4024  Information  ConfigurationLog.SchedulerRestarted
+    "Scheduler '{SchedulerName}' was restarted; instanceId '{PreviousSchedulerInstanceId}' replaced by '{SchedulerInstanceId}'"
+4025  Warning  ConfigurationLog.SchedulerRestartAbandoned
+    "Scheduler '{SchedulerName}' was shut down for a restart but {JobsStillExecuting} job(s) outlived the {DrainTimeout} drain, so no new scheduler was built; restart again once the work has finished"
 5000  Information  XmlSchedulingLog.ParsingFile
     "Parsing XML file: {FileName} with systemId: {SystemId}"
 5001  Information  XmlSchedulingLog.ParsingStream

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -748,6 +748,7 @@ namespace Quartz
     {
         System.Threading.Tasks.ValueTask<Quartz.IScheduler> Add(string schedulerName, System.Action<Quartz.IQuartzBuilder>? configure = null, Quartz.SchedulerAddOptions options = default, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<bool> Remove(string schedulerName, bool waitForJobsToComplete = false, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<Quartz.IScheduler> Restart(string schedulerName, Quartz.SchedulerRestartOptions options = default, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISimpleTrigger : Quartz.ITrigger
     {
@@ -1576,6 +1577,18 @@ namespace Quartz
         public string Name { get; init; }
         public Quartz.SchedulerOrigin Origin { get; init; }
         public Quartz.SchedulerStatus? Status { get; init; }
+    }
+    public sealed class SchedulerRestartException : Quartz.SchedulerException
+    {
+        public System.TimeSpan DrainTimeout { get; }
+        public int JobsStillExecuting { get; }
+        public string SchedulerName { get; }
+    }
+    public readonly record struct SchedulerRestartOptions : System.IEquatable<Quartz.SchedulerRestartOptions>
+    {
+        public System.TimeSpan? DrainTimeout { get; init; }
+        public bool? Start { get; init; }
+        public static Quartz.SchedulerRestartOptions WithoutStarting { get; }
     }
     public enum SchedulerStatus
     {

--- a/src/Quartz/Configuration/ConfigurationLog.cs
+++ b/src/Quartz/Configuration/ConfigurationLog.cs
@@ -122,4 +122,13 @@ internal static partial class ConfigurationLog
 
     [LoggerMessage(EventId = 4022, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' was added at runtime and is being shut down with the host")]
     public static partial void RuntimeSchedulerShutDownByHost(this ILogger logger, string schedulerName);
+
+    [LoggerMessage(EventId = 4023, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' with instanceId '{SchedulerInstanceId}' is being restarted; waiting for {JobsExecuting} executing job(s)")]
+    public static partial void SchedulerRestarting(this ILogger logger, string schedulerName, string schedulerInstanceId, int jobsExecuting);
+
+    [LoggerMessage(EventId = 4024, Level = LogLevel.Information, Message = "Scheduler '{SchedulerName}' was restarted; instanceId '{PreviousSchedulerInstanceId}' replaced by '{SchedulerInstanceId}'")]
+    public static partial void SchedulerRestarted(this ILogger logger, string schedulerName, string previousSchedulerInstanceId, string schedulerInstanceId);
+
+    [LoggerMessage(EventId = 4025, Level = LogLevel.Warning, Message = "Scheduler '{SchedulerName}' was shut down for a restart but {JobsStillExecuting} job(s) outlived the {DrainTimeout} drain, so no new scheduler was built; restart again once the work has finished")]
+    public static partial void SchedulerRestartAbandoned(this ILogger logger, string schedulerName, int jobsStillExecuting, TimeSpan drainTimeout);
 }

--- a/src/Quartz/Configuration/QuartzBuilder.cs
+++ b/src/Quartz/Configuration/QuartzBuilder.cs
@@ -78,14 +78,14 @@ internal sealed class QuartzBuilder : IQuartzBuilder
     public IQuartzBuilder UseThreadPool(IThreadPool threadPool)
     {
         ArgumentNullException.ThrowIfNull(threadPool);
-        RegisterConfigured<IThreadPool>((_, _) => threadPool);
+        RegisterConfiguredInstance(threadPool);
         return this;
     }
 
     public IQuartzBuilder UseJobStore(IJobStore jobStore)
     {
         ArgumentNullException.ThrowIfNull(jobStore);
-        RegisterConfigured<IJobStore>((_, _) => jobStore);
+        RegisterConfiguredInstance(jobStore);
         return this;
     }
 
@@ -209,7 +209,7 @@ internal sealed class QuartzBuilder : IQuartzBuilder
     public IQuartzBuilder UseJobFactory(IJobFactory jobFactory)
     {
         ArgumentNullException.ThrowIfNull(jobFactory);
-        RegisterConfigured<IJobFactory>((_, _) => jobFactory);
+        RegisterConfiguredInstance(jobFactory);
         return this;
     }
 
@@ -244,7 +244,7 @@ internal sealed class QuartzBuilder : IQuartzBuilder
     {
         ArgumentNullException.ThrowIfNull(generator);
         GenerateInstanceId();
-        RegisterConfigured<IInstanceIdGenerator>((_, _) => generator);
+        RegisterConfiguredInstance(generator);
         return this;
     }
 
@@ -540,6 +540,73 @@ internal sealed class QuartzBuilder : IQuartzBuilder
         {
             Services.TryAddKeyedSingleton(schedulerKey, (provider, key) => factory(provider, key));
         }
+    }
+
+    /// <summary>
+    /// Registers a part the caller supplied as an object, and notes that it did.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The registration is the same one <see cref="RegisterConfigured{TService}" /> makes — a factory
+    /// closing over the object — and nothing about resolving it changes. What is added beside it is a
+    /// <see cref="SchedulerInstancePart" /> saying which part came in that way, so a second generation
+    /// of this scheduler can be refused by <em>reading</em> the collection rather than by building one
+    /// and comparing. See the remarks on <see cref="SchedulerInstancePart" /> for why that distinction
+    /// is not a nicety.
+    /// </para>
+    /// <para>
+    /// The note is added only when this registration is the one that takes. Registration is first-wins,
+    /// so an instance supplied after something else already claimed the part is inert — and a note about
+    /// an object nothing will ever resolve would refuse a restart that replays perfectly.
+    /// </para>
+    /// </remarks>
+    private void RegisterConfiguredInstance<TService>(TService instance)
+        where TService : class
+    {
+        bool alreadyClaimed = IsRegistered(typeof(TService));
+
+        RegisterConfigured<TService>((_, _) => instance);
+
+        if (alreadyClaimed)
+        {
+            return;
+        }
+
+        SchedulerInstancePart part = new(typeof(TService));
+
+        if (schedulerKey is null)
+        {
+            Services.AddSingleton(part);
+        }
+        else
+        {
+            Services.AddKeyedSingleton(schedulerKey, part);
+        }
+    }
+
+    /// <summary>
+    /// Whether this scheduler's collection already says how to build one of its parts.
+    /// </summary>
+    private bool IsRegistered(Type serviceType)
+    {
+        foreach (ServiceDescriptor descriptor in Services)
+        {
+            if (descriptor.ServiceType != serviceType)
+            {
+                continue;
+            }
+
+            bool mine = schedulerKey is null
+                ? !descriptor.IsKeyedService
+                : descriptor.IsKeyedService && string.Equals(descriptor.ServiceKey as string, schedulerKey, StringComparison.Ordinal);
+
+            if (mine)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
+++ b/src/Quartz/Configuration/QuartzServiceCollectionExtensions.cs
@@ -368,7 +368,12 @@ public static partial class QuartzServiceCollectionExtensions
 
         services.BindQuartzOptions(effective, name);
         JsonSchedulingHelper.ConfigureOptionsFromConfiguration(services, effective, name);
-        AddQuartzScheduler(services, name, LegacyProperties(effective), configure);
+
+        // The resolved section rather than the caller's, so that the recipe recorded for a restart reads
+        // exactly what this registration read. Handing the caller's back would leave the resolution to be
+        // redone against a configuration that is free to have changed - a reloading provider that gained
+        // a "Schedulers:{name}" child in between would make the replay read a different section.
+        AddQuartzScheduler(services, name, LegacyProperties(effective), configure, effective);
         return services;
     }
 
@@ -460,12 +465,19 @@ public static partial class QuartzServiceCollectionExtensions
     /// is not assembled by a second construction path that has to be kept in step with this one, and the
     /// recipe it is handed sees the same <see cref="IQuartzBuilder"/> in the same phase order.
     /// </para>
+    /// <para>
+    /// <c>configuration</c> is the section <c>properties</c> was flattened out of, recorded so that a
+    /// restart replays the section rather than its flattening — the two are not the same recipe, since
+    /// binding onto typed options is what the section does and the flat form does not. It is
+    /// <see langword="null"/> for a registration that was given a property bag to begin with.
+    /// </para>
     /// </remarks>
     internal static IServiceCollection AddQuartzScheduler(
         IServiceCollection services,
         string? schedulerName,
         NameValueCollection properties,
-        Action<IQuartzBuilder>? configure)
+        Action<IQuartzBuilder>? configure,
+        IConfiguration? configuration = null)
     {
         services.AddOptions();
 
@@ -512,6 +524,12 @@ public static partial class QuartzServiceCollectionExtensions
         if (schedulerName is not null)
         {
             registry.Add(schedulerName);
+
+            // Kept because a delegate that has been run and thrown away can never be run again, and
+            // building a second generation of this scheduler is running the whole of this method again
+            // into a collection of its own. The default scheduler records none: its parts are the
+            // unkeyed registrations, which nothing can tell apart from the application's own.
+            registry.AddBlueprint(new SchedulerBlueprint(schedulerName, properties, configuration, configure));
         }
 
         return services;

--- a/src/Quartz/Configuration/SchedulerBlueprint.cs
+++ b/src/Quartz/Configuration/SchedulerBlueprint.cs
@@ -1,0 +1,49 @@
+using System.Collections.Specialized;
+
+using Microsoft.Extensions.Configuration;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// What <c>AddQuartz(name, …)</c> was told, kept so that the scheduler it registered can be built a
+/// second time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A container registration is a set of descriptors fixed when the container was built, and the
+/// instances they produce are singletons that cannot be initialised twice. So restarting a scheduler is
+/// not restarting anything: it is running the registration again into a container of its own, which is
+/// what <see cref="SchedulerGeneration" /> already does for a scheduler added at runtime. This is the
+/// recipe that generation replays, and the reason it has to be recorded at registration time is that a
+/// delegate which has been run and thrown away can never be run again.
+/// </para>
+/// <para>
+/// Only what <c>AddQuartz</c> itself was handed is here. Anything written <em>beside</em> the call —
+/// <c>services.Configure&lt;QuartzSchedulerOptions&gt;("acme", …)</c>, a keyed registration made
+/// directly against the application's collection, <c>AddQuartzHostedService("acme", …)</c> — belongs to
+/// the application's container rather than to this scheduler's registration, and is not replayed. That
+/// is a limit worth knowing rather than a gap to close: replaying arbitrary registrations from the
+/// application's collection would mean deciding which of them are this scheduler's, and nothing in a
+/// service descriptor says.
+/// </para>
+/// </remarks>
+/// <param name="Name">The name the scheduler was registered under, as it was spelled there.</param>
+/// <param name="Properties">
+/// The flat <c>quartz.*</c> bag the registration was seeded with, already checked. Empty for a
+/// registration that was given none, and ignored when <paramref name="Configuration" /> is set.
+/// </param>
+/// <param name="Configuration">
+/// The section the registration read, already resolved to whichever of the caller's section and its
+/// <c>Schedulers:{name}</c> child actually held the settings, or <see langword="null" /> for a
+/// registration that was configured with a property bag instead.
+/// </param>
+/// <param name="Configure">
+/// The caller's own callback. The container-wide delegates <c>ConfigureAllQuartzSchedulers</c> recorded
+/// are deliberately not folded in here: they are replayed from the registry a generation is built
+/// against, which is where a scheduler added at runtime gets them too.
+/// </param>
+internal sealed record SchedulerBlueprint(
+    string Name,
+    NameValueCollection Properties,
+    IConfiguration? Configuration,
+    Action<IQuartzBuilder>? Configure);

--- a/src/Quartz/Configuration/SchedulerGeneration.cs
+++ b/src/Quartz/Configuration/SchedulerGeneration.cs
@@ -159,6 +159,17 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
     public IScheduler? Scheduler { get; private set; }
 
     /// <summary>
+    /// The scheduler behind the facade, once it has been built.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than resolved on demand, because it is read after the scheduler has been shut
+    /// down and what is wanted then is <see cref="Core.QuartzScheduler.RunningWorkDrained" /> — the
+    /// answer that shutdown could not return to its caller, and the only thing that says whether a
+    /// second generation may safely start over the same store.
+    /// </remarks>
+    public QuartzScheduler? QuartzScheduler { get; private set; }
+
+    /// <summary>
     /// Builds one scheduler's container, without creating the scheduler.
     /// </summary>
     /// <remarks>
@@ -256,7 +267,31 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
             .ConfigureAwait(false);
 
         Scheduler = scheduler;
+        QuartzScheduler = Scoped.GetScheduler<QuartzScheduler>(SchedulerName);
         return scheduler;
+    }
+
+    /// <summary>
+    /// A part of this generation that a replayed recipe would hand to the next one unchanged, or
+    /// <see langword="null" /> when the recipe named a type or a factory instead.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The store and the pool are recorded at construction, because they are read after this
+    /// generation's container is gone. These two are not: they are only ever compared while both
+    /// generations are alive, which is the moment a restart decides whether the recipe can produce a
+    /// second set of instances at all.
+    /// </para>
+    /// <para>
+    /// Resolved rather than inspected, because "did the recipe close over an instance" is not a question
+    /// a service descriptor answers: <c>UseJobFactory(myFactory)</c> and <c>UseJobFactory&lt;T&gt;()</c>
+    /// both end as a keyed singleton, and the difference only shows in whether two containers produce the
+    /// same object.
+    /// </para>
+    /// </remarks>
+    public T? Part<T>() where T : class
+    {
+        return Scoped.GetSchedulerService<T>(SchedulerName);
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/SchedulerGeneration.cs
+++ b/src/Quartz/Configuration/SchedulerGeneration.cs
@@ -173,18 +173,28 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
     /// Builds one scheduler's container, without creating the scheduler.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Everything that can fail on bad configuration fails here, before anything has been bound or
     /// started: the property bag is checked, the recipe runs, the container is built, and the parts are
     /// constructed. What construction deliberately does not do is <em>initialize</em> them — a thread
     /// pool starts no thread and a database store opens no connection until <c>Initialize</c>, which is
     /// <see cref="Create" />'s to call.
+    /// </para>
+    /// <para>
+    /// <c>refuseInstanceParts</c> is set for every generation after the first, and is what makes
+    /// replaying a recipe safe: a recipe that closes over an object hands this generation the very object
+    /// the last one is using, and the refusal has to happen before a provider exists to own it. It is
+    /// <see langword="false" /> for a scheduler's first generation, where the object has not been used
+    /// yet and there is nothing to protect it from.
+    /// </para>
     /// </remarks>
     public static SchedulerGeneration Build(
         IServiceProvider application,
         string schedulerName,
         SchedulerAddOptions options,
         Action<IQuartzBuilder>? configure,
-        int number)
+        int number,
+        bool refuseInstanceParts)
     {
         ServiceCollection services = new();
 
@@ -222,6 +232,14 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
         }
 
         ThrowIfAJobIsRegisteredHere(services, schedulerName);
+
+        if (refuseInstanceParts)
+        {
+            // Before the provider exists, which is the whole point: a refusal after one has been built
+            // has to dispose it, and Microsoft's container disposes whatever a factory delegate returned
+            // - which for these overloads is the object the running scheduler is using.
+            ThrowIfAPartWasSuppliedAsAnInstance(services, schedulerName);
+        }
 
         foreach (Type containerWide in containerWideReads)
         {
@@ -371,6 +389,63 @@ internal sealed class SchedulerGeneration : IAsyncDisposable
         }
 
         return configured.ToFrozenSet();
+    }
+
+    /// <summary>
+    /// Refuses a recipe that hands this generation an object the last one is already using.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A recipe made of <c>Use…&lt;T&gt;()</c> and factory registrations produces a new set of instances
+    /// every time it runs. One that closes over an object — <c>UseJobStore(myStore)</c> — produces the
+    /// same object, and that object belongs to a scheduler that is still running. Re-initialising it is
+    /// what <c>#3297</c> refused; handing it to a second scheduler is the same mistake wearing a
+    /// different hat.
+    /// </para>
+    /// <para>
+    /// Answered by reading the collection rather than by comparing what two containers produced, because
+    /// the timing is the point. A refusal here has built nothing and disposes nothing. A refusal after
+    /// the provider exists has to release it, and Microsoft's container releases whatever a factory
+    /// delegate returned — so refusing at that stage would dispose the running scheduler's own store if
+    /// it happened to be <see cref="IDisposable" />, which is a worse outcome than the mistake being
+    /// reported. <c>QuartzBuilder</c> leaves the note; this reads it.
+    /// </para>
+    /// </remarks>
+    private static void ThrowIfAPartWasSuppliedAsAnInstance(IServiceCollection services, string schedulerName)
+    {
+        List<string> parts = [];
+        foreach (ServiceDescriptor descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(SchedulerInstancePart)
+                && Instance(descriptor) is { } part
+                && !parts.Contains(part.PartType.Name, StringComparer.Ordinal))
+            {
+                parts.Add(part.PartType.Name);
+            }
+        }
+
+        if (parts.Count == 0)
+        {
+            return;
+        }
+
+        parts.Sort(StringComparer.Ordinal);
+
+        Throw.SchedulerConfigException(
+            $"The recipe for scheduler '{schedulerName}' supplies {string.Join(" and ", parts)} as an instance "
+            + "— UseJobStore(IJobStore), UseThreadPool(IThreadPool), UseJobFactory(instance) or "
+            + "UseInstanceIdGenerator(instance) — so replaying it would hand the new scheduler the very object "
+            + "the old one is using, and a shut-down instance cannot be re-initialised. Register a type or a "
+            + "factory instead: UseJobStore<T>(), UseThreadPool<T>() and UseJobStore(provider => new …) each "
+            + "build a new instance every time the recipe runs. A factory must return a new instance per "
+            + $"generation rather than close over a shared one. Scheduler '{schedulerName}' was not touched.");
+
+        static SchedulerInstancePart? Instance(ServiceDescriptor descriptor)
+        {
+            return descriptor.IsKeyedService
+                ? descriptor.KeyedImplementationInstance as SchedulerInstancePart
+                : descriptor.ImplementationInstance as SchedulerInstancePart;
+        }
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/SchedulerInstancePart.cs
+++ b/src/Quartz/Configuration/SchedulerInstancePart.cs
@@ -1,0 +1,23 @@
+namespace Quartz.Configuration;
+
+/// <summary>
+/// A note in a scheduler's collection that one of its parts was supplied as an object rather than as a
+/// type or a factory.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Nothing resolves this. It exists so that "was this part handed to the recipe as an instance" can be
+/// answered by <em>reading</em> the collection, before anything has been built — because the only other
+/// way to answer it is to build a second generation and compare the parts by reference, and by then a
+/// refusal has to dispose the container it built. Microsoft's container disposes what a factory delegate
+/// returned, and for these four overloads that object is the one the <em>running</em> scheduler is using.
+/// A refusal that killed the scheduler it was protecting would be worse than the mistake it reports.
+/// </para>
+/// <para>
+/// One marker per part supplied that way, added beside the registration itself and only when that
+/// registration is the one that took — <c>TryAdd</c> is first-wins, and a marker for an instance nothing
+/// will ever resolve would refuse a restart that is perfectly replayable.
+/// </para>
+/// </remarks>
+/// <param name="PartType">The service the instance was supplied for, which is what a refusal names.</param>
+internal sealed record SchedulerInstancePart(Type PartType);

--- a/src/Quartz/Configuration/SchedulerNameRegistry.cs
+++ b/src/Quartz/Configuration/SchedulerNameRegistry.cs
@@ -18,6 +18,15 @@ internal sealed class SchedulerNameRegistry
     private readonly List<string> names = [];
 
     /// <summary>
+    /// What each named registration was told, kept so that its scheduler can be built again.
+    /// </summary>
+    /// <remarks>
+    /// Keyed the way <see cref="Find" /> compares, so a restart asked for under a different spelling
+    /// finds the recipe rather than reporting the name unknown.
+    /// </remarks>
+    private readonly Dictionary<string, SchedulerBlueprint> blueprints = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// The delegates <c>ConfigureAllQuartzSchedulers</c> has recorded, in the order they were recorded.
     /// </summary>
     private readonly List<Action<IQuartzBuilder>> configureAll = [];
@@ -92,6 +101,34 @@ internal sealed class SchedulerNameRegistry
         }
 
         names.Add(name);
+    }
+
+    /// <summary>
+    /// Records what a named registration was told, so that its scheduler can be built a second time.
+    /// </summary>
+    /// <remarks>
+    /// Recorded beside <see cref="Add" /> rather than instead of it: the list of names is what a
+    /// duplicate is caught against and what the listing reads, and it holds the default scheduler's
+    /// existence too, which has no recipe. A second recipe under one name cannot arrive, because
+    /// <see cref="Add" /> has already refused the name by the time this is called.
+    /// </remarks>
+    public void AddBlueprint(SchedulerBlueprint blueprint)
+    {
+        blueprints[blueprint.Name] = blueprint;
+    }
+
+    /// <summary>
+    /// The recipe a named registration was made with, or <see langword="null" /> when this collection
+    /// registered no scheduler under that name.
+    /// </summary>
+    /// <remarks>
+    /// The default scheduler has none, deliberately. Its parts are the container's unkeyed
+    /// registrations, indistinguishable from the application's own, so there is nothing to replay into a
+    /// container of its own — which is what <c>ISchedulerRuntime.Restart</c> says when it is asked.
+    /// </remarks>
+    public SchedulerBlueprint? Blueprint(string? name)
+    {
+        return name is not null && blueprints.TryGetValue(name, out SchedulerBlueprint? blueprint) ? blueprint : null;
     }
 
     /// <summary>

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -4,7 +4,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using Quartz.Core;
 using Quartz.Extensibility;
+using Quartz.Impl;
 using Quartz.Util;
 
 namespace Quartz.Configuration;
@@ -38,8 +40,25 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     private readonly ILogger<SchedulerRuntime> logger;
     private readonly IHostApplicationLifetime? applicationLifetime;
 
+    /// <summary>
+    /// What a restart waits for the outgoing scheduler's jobs when the caller says nothing.
+    /// </summary>
+    private static readonly TimeSpan defaultDrainTimeout = TimeSpan.FromSeconds(30);
+
     private readonly ConcurrentDictionary<string, SemaphoreSlim> gates = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, RuntimeUnit> units = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The container-registered schedulers this runtime has built a later generation of.
+    /// </summary>
+    /// <remarks>
+    /// A dictionary of their own, so that <see cref="QuerySchedulers" /> keeps calling them
+    /// <see cref="SchedulerOrigin.Container" />: they are the container's registrations, and a restart
+    /// changes which instances answer for a name rather than where the name came from. Everything else
+    /// treats the two kinds alike — one gate per name covers both, the host drains both, and disposal
+    /// releases both.
+    /// </remarks>
+    private readonly ConcurrentDictionary<string, RuntimeUnit> containerUnits = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Generations whose schedulers somebody else is shutting down, waiting to have their containers
@@ -148,7 +167,8 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 Name = schedulerName,
                 Options = options,
                 Configure = configure,
-                Generation = generation
+                Live = generation,
+                Number = generation.Number
             };
 
             logger.RuntimeSchedulerAdded(scheduler.SchedulerName, scheduler.SchedulerInstanceId);
@@ -188,7 +208,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
 
             try
             {
-                if (unit.Generation.Scheduler is { } scheduler)
+                if (unit.Live?.Scheduler is { } scheduler)
                 {
                     await scheduler.Shutdown(waitForJobsToComplete, cancellationToken).ConfigureAwait(false);
                 }
@@ -196,12 +216,131 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
             finally
             {
                 // Even when the shutdown threw: the container is this generation's, and leaking it would
-                // leak the thread pool, the job store and its database connections along with it.
-                await unit.Generation.DisposeAsync().ConfigureAwait(false);
+                // leak the thread pool, the job store and its database connections along with it. The
+                // abandoned one is a generation a restart shut down but could not prove had finished, and
+                // it is released here for the same reason - its jobs are somebody else's problem now, and
+                // there is nothing left that would ever come back for its container.
+                await Release(unit.Live).ConfigureAwait(false);
+                await Release(unit.Abandoned?.Owned).ConfigureAwait(false);
             }
 
             logger.RuntimeSchedulerRemoved(unit.Name);
             return true;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IScheduler> Restart(
+        string schedulerName,
+        SchedulerRestartOptions options = default,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schedulerName);
+
+        SemaphoreSlim gate = Gate(schedulerName);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            RuntimeUnit unit = UnitToRestart(schedulerName);
+
+            // Before anything is built or shut down: a restart that ran now would create its scheduler
+            // after the shutdown that would have stopped it, and would have shut the running one down on
+            // the way. Refusing here leaves the old scheduler for the host to drain.
+            ThrowIfTheHostIsStopping(unit.Name, "restarted");
+
+            TimeSpan drainTimeout = options.DrainTimeout ?? defaultDrainTimeout;
+            using CancellationTokenSource drain = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (drainTimeout != Timeout.InfiniteTimeSpan)
+            {
+                drain.CancelAfter(drainTimeout);
+            }
+
+            await ThrowIfAnEarlierRestartIsStillFinishing(unit, drainTimeout, drain.Token).ConfigureAwait(false);
+
+            // May be null, and that is not a failure: the scheduler was shut down by hand, by the host,
+            // or by a restart whose drain gave up, and there is simply nothing to stop before the next
+            // generation is built. Restarting something that is already down is starting it again.
+            Incumbent? live = Incumbent.Of(unit, application, repository);
+
+            SchedulerGeneration next = BuildNext(unit);
+
+            try
+            {
+                if (live is not null)
+                {
+                    // Read before the shutdown, because a shut-down scheduler reports Shutdown and would
+                    // make every restart leave the next generation in standby.
+                    ThrowIfTheRecipeSuppliesAnInstance(unit.Name, live, next);
+                }
+            }
+            catch
+            {
+                await Discard(next).ConfigureAwait(false);
+                throw;
+            }
+
+            bool wasRunning = live?.Facade.Status == SchedulerStatus.Running;
+            string? previousInstanceId = live?.Facade.SchedulerInstanceId;
+
+            if (live is not null)
+            {
+                logger.SchedulerRestarting(unit.Name, previousInstanceId!, live.JobsExecuting);
+
+                // Waiting is not optional. The next generation's first act is a recovery sweep over the
+                // whole scheduler name - triggers out of acquired and blocked, every fired-trigger row
+                // deleted - and it is unfiltered by instance id, so starting it beside a job the old
+                // generation is still running would tear that job's bookkeeping out from under it.
+                await live.Facade.Shutdown(waitForJobsToComplete: true, drain.Token).ConfigureAwait(false);
+
+                if (live.Drained != true)
+                {
+                    // Kept rather than forgotten: its jobs are still running, so the next attempt has to
+                    // wait for them before it may build anything, and the listing has to keep saying the
+                    // name is there with nothing running under it.
+                    unit.Live = null;
+                    unit.Abandoned = live;
+                    await Discard(next).ConfigureAwait(false);
+
+                    throw Abandoned(unit.Name, live.JobsExecuting, drainTimeout);
+                }
+
+                await Release(live.Owned).ConfigureAwait(false);
+                unit.Live = null;
+            }
+
+            IScheduler scheduler;
+            try
+            {
+                // Here, after the drain, and nowhere earlier: this is what initializes the store, takes
+                // the lock handler, runs the recovery sweep and applies the declared jobs and triggers.
+                scheduler = await next.Create(cancellationToken).ConfigureAwait(false);
+
+                if (options.Start ?? wasRunning)
+                {
+                    await scheduler.Start(cancellationToken).ConfigureAwait(false);
+                }
+
+                // Asked again for the reason Add asks again: building and starting is not instantaneous,
+                // and a host that began stopping in that window has already taken the schedulers it was
+                // going to drain.
+                ThrowIfTheHostIsStopping(unit.Name, "restarted");
+            }
+            catch
+            {
+                await Discard(next).ConfigureAwait(false);
+                throw;
+            }
+
+            unit.Live = next;
+            unit.Number = next.Number;
+            unit.Abandoned = null;
+
+            logger.SchedulerRestarted(unit.Name, previousInstanceId ?? "none", scheduler.SchedulerInstanceId);
+            return scheduler;
         }
         finally
         {
@@ -247,10 +386,17 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     /// rather than leaving them for container disposal, which happens after it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The units are taken rather than read, so a tenant is shut down once whoever gets to it first: the
     /// host through this, <see cref="Remove" /> through its gate, or <see cref="DisposeAsync" />. Their
     /// containers are kept back to be released when this is disposed, because the shutdown the caller is
     /// about to do has not happened yet.
+    /// </para>
+    /// <para>
+    /// A restarted container-registered scheduler is handed over too, and it has to be: the hosted
+    /// service resolved its schedulers when the host started, so what it holds under that name is the
+    /// generation the restart shut down. Nothing else would stop the one that replaced it.
+    /// </para>
     /// </remarks>
     internal List<IScheduler> TakeLiveSchedulers()
     {
@@ -259,23 +405,40 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         Interlocked.Exchange(ref draining, 1);
 
         List<IScheduler> live = [];
+
         foreach (string name in units.Keys)
         {
-            if (!units.TryRemove(name, out RuntimeUnit? unit))
-            {
-                continue;
-            }
-
-            drained.Enqueue(unit.Generation);
-
-            if (unit.Generation.Scheduler is { } scheduler)
+            if (units.TryRemove(name, out RuntimeUnit? unit) && Take(unit) is { } scheduler)
             {
                 logger.RuntimeSchedulerShutDownByHost(unit.Name);
                 live.Add(scheduler);
             }
         }
 
+        foreach (string name in containerUnits.Keys)
+        {
+            if (containerUnits.TryRemove(name, out RuntimeUnit? unit) && Take(unit) is { } scheduler)
+            {
+                live.Add(scheduler);
+            }
+        }
+
         return live;
+
+        IScheduler? Take(RuntimeUnit unit)
+        {
+            Keep(unit.Live);
+            Keep(unit.Abandoned?.Owned);
+            return unit.Live?.Scheduler;
+        }
+
+        void Keep(SchedulerGeneration? generation)
+        {
+            if (generation is not null)
+            {
+                drained.Enqueue(generation);
+            }
+        }
     }
 
     /// <summary>
@@ -302,16 +465,12 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
 
         try
         {
-            foreach (string name in units.Keys)
+            foreach (RuntimeUnit unit in Taken(units).Concat(Taken(containerUnits)))
             {
-                if (!units.TryRemove(name, out RuntimeUnit? unit))
-                {
-                    continue;
-                }
+                Retain(unit.Live);
+                Retain(unit.Abandoned?.Owned);
 
-                drained.Enqueue(unit.Generation);
-
-                if (unit.Generation.Scheduler is not { } scheduler)
+                if (unit.Live?.Scheduler is not { } scheduler)
                 {
                     continue;
                 }
@@ -347,6 +506,28 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         if (exceptions is not null)
         {
             throw new AggregateException("One or more runtime scheduler shutdowns failed.", exceptions);
+        }
+
+        List<RuntimeUnit> Taken(ConcurrentDictionary<string, RuntimeUnit> from)
+        {
+            List<RuntimeUnit> taken = [];
+            foreach (string name in from.Keys)
+            {
+                if (from.TryRemove(name, out RuntimeUnit? unit))
+                {
+                    taken.Add(unit);
+                }
+            }
+
+            return taken;
+        }
+
+        void Retain(SchedulerGeneration? generation)
+        {
+            if (generation is not null)
+            {
+                drained.Enqueue(generation);
+            }
         }
     }
 
@@ -414,6 +595,224 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     }
 
     /// <summary>
+    /// The unit a restart is about, creating one from the container's recipe the first time a registered
+    /// scheduler is restarted, and refusing every name that has no recipe to replay.
+    /// </summary>
+    /// <remarks>
+    /// The two dictionaries are asked before the registry is, because after one restart a
+    /// container-registered scheduler <em>is</em> a generation this runtime holds, and its next restart
+    /// has to be against that generation rather than against the recipe on its own.
+    /// </remarks>
+    private RuntimeUnit UnitToRestart(string schedulerName)
+    {
+        if (units.TryGetValue(schedulerName, out RuntimeUnit? added))
+        {
+            return added;
+        }
+
+        if (containerUnits.TryGetValue(schedulerName, out RuntimeUnit? restarted))
+        {
+            return restarted;
+        }
+
+        if (names.Blueprint(schedulerName) is { } blueprint)
+        {
+            RuntimeUnit unit = new()
+            {
+                Name = blueprint.Name,
+                Options = Recipe(blueprint),
+                Configure = blueprint.Configure,
+
+                // Generation one is the container's own keyed graph rather than anything this runtime
+                // built, so there is nothing to record but its number: what the restart shuts down is
+                // read from the repository, and its parts stay the container's to dispose.
+                Number = 1
+            };
+
+            return containerUnits.GetOrAdd(blueprint.Name, unit);
+        }
+
+        if (ContainerRegistration(schedulerName) is { } registered)
+        {
+            Throw.SchedulerConfigException(
+                $"Scheduler '{registered}' is registered without a name; its parts are the container's unkeyed "
+                + "registrations, so its recipe cannot be replayed — nothing can tell them apart from the "
+                + $"application's own. Register it with AddQuartz(\"{registered}\", …) to make it restartable; "
+                + "Standby()/Start() pause and resume it.");
+        }
+
+        throw new SchedulerNotFoundException(
+            schedulerName,
+            $"No scheduler named '{schedulerName}' is registered with this container or has been added at "
+            + "runtime, so there is no recipe to build one from. ISchedulerRuntime.Add(\"" + schedulerName
+            + "\", …) creates one.");
+    }
+
+    /// <summary>
+    /// The recipe a container registration was made with, in the form a generation is built from.
+    /// </summary>
+    /// <remarks>
+    /// One of the two, never both: a section says everything a property bag does, and
+    /// <see cref="SchedulerGeneration.Build" /> refuses a recipe that sets both rather than choosing
+    /// between them.
+    /// </remarks>
+    private static SchedulerAddOptions Recipe(SchedulerBlueprint blueprint)
+    {
+        if (blueprint.Configuration is not null)
+        {
+            return new SchedulerAddOptions { Configuration = blueprint.Configuration };
+        }
+
+        List<KeyValuePair<string, string?>> properties = [];
+        foreach (string? key in blueprint.Properties.AllKeys)
+        {
+            if (key is not null)
+            {
+                properties.Add(new KeyValuePair<string, string?>(key, blueprint.Properties[key]));
+            }
+        }
+
+        return new SchedulerAddOptions { Properties = properties };
+    }
+
+    /// <summary>
+    /// Builds the next generation's container, translating a configuration failure the way
+    /// <see cref="Add" /> does.
+    /// </summary>
+    /// <remarks>
+    /// Before the old scheduler is touched, so a recipe that no longer builds — a connection string
+    /// removed from configuration, a validator that has since been added — leaves the scheduler that is
+    /// running exactly where it was. Construction is not initialization: nothing here opens a connection
+    /// or starts a thread, which is what makes it safe to do beside a live generation.
+    /// </remarks>
+    private SchedulerGeneration BuildNext(RuntimeUnit unit)
+    {
+        try
+        {
+            return SchedulerGeneration.Build(application, unit.Name, unit.Options, unit.Configure, unit.Number + 1);
+        }
+        catch (OptionsValidationException e)
+        {
+            throw new SchedulerConfigException(string.Join(" ", e.Failures), e);
+        }
+    }
+
+    /// <summary>
+    /// Refuses a recipe that hands the next generation a part the last one is holding.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A recipe made of <c>Use…&lt;T&gt;()</c> and factory registrations produces a new set of instances
+    /// every time it is run. One that closes over an object — <c>UseJobStore(myStore)</c> — produces the
+    /// same object, and that object is about to be shut down. Nothing in a service descriptor says which
+    /// of the two a recipe is, so it is answered by building the next generation and comparing what came
+    /// out by reference.
+    /// </para>
+    /// <para>
+    /// Four parts, because these are the ones a recipe can be handed as an instance and that a scheduler
+    /// cannot work without. Plugins and listeners are supplied as instances too, and are deliberately not
+    /// checked: they are the application's to reason about, a plugin that tolerates a second
+    /// <c>Initialize</c> is perfectly legal, and refusing every recipe with a listener object in it would
+    /// leave almost nothing restartable.
+    /// </para>
+    /// </remarks>
+    private static void ThrowIfTheRecipeSuppliesAnInstance(string schedulerName, Incumbent live, SchedulerGeneration next)
+    {
+        string? shared = Shared(live.Store, next.StoreInstance, "a job store", "UseJobStore(IJobStore)")
+            ?? Shared(live.Pool, next.PoolInstance, "a thread pool", "UseThreadPool(IThreadPool)")
+            ?? Shared(live.JobFactory, next.Part<IJobFactory>(), "a job factory", "UseJobFactory(instance)")
+            ?? Shared(live.InstanceIdGenerator, next.Part<IInstanceIdGenerator>(), "an instance id generator", "UseInstanceIdGenerator(instance)");
+
+        if (shared is null)
+        {
+            return;
+        }
+
+        Throw.SchedulerConfigException(
+            $"The recipe for scheduler '{schedulerName}' supplies {shared}, so replaying it hands the new "
+            + "scheduler the object the old one is about to shut down, and a shut-down instance cannot be "
+            + "re-initialised. Register a type or a factory instead — the same recipe written as "
+            + "UseJobStore<T>(), UseThreadPool<T>() or UseJobStore(provider => …) builds a new instance each "
+            + $"time it runs. Scheduler '{schedulerName}' is still running and was not touched.");
+
+        static string? Shared<T>(T? current, T? candidate, string what, string how) where T : class
+        {
+            return current is not null && ReferenceEquals(current, candidate) ? $"{what} as an instance ({how})" : null;
+        }
+    }
+
+    /// <summary>
+    /// Refuses a restart while the generation an earlier one abandoned is still running its jobs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The count is read first because it cannot block: a pool that implements only the default
+    /// <see cref="IThreadPool.Drain" /> falls back to a wait that cannot be given up on, and asking it
+    /// while jobs are plainly still running would hang the retry rather than refuse it. Once the count
+    /// reads zero the pool is asked anyway, because the count goes to zero before the last job's store
+    /// update is issued and it is precisely that write the next generation must not start beside.
+    /// </para>
+    /// <para>
+    /// The built-in pool answers this truthfully after a drain it gave up on, which is what makes a
+    /// retry a plain second call rather than something that has to keep state of its own.
+    /// </para>
+    /// </remarks>
+    private async ValueTask ThrowIfAnEarlierRestartIsStillFinishing(
+        RuntimeUnit unit,
+        TimeSpan drainTimeout,
+        CancellationToken drainToken)
+    {
+        if (unit.Abandoned is not { } abandoned)
+        {
+            return;
+        }
+
+        if (abandoned.JobsExecuting == 0 && await abandoned.Pool.Drain(drainToken).ConfigureAwait(false))
+        {
+            await Release(abandoned.Owned).ConfigureAwait(false);
+            unit.Abandoned = null;
+            return;
+        }
+
+        throw Abandoned(unit.Name, abandoned.JobsExecuting, drainTimeout);
+    }
+
+    /// <summary>
+    /// The report that a generation's work outlived the drain, logged and thrown as one.
+    /// </summary>
+    private SchedulerRestartException Abandoned(string schedulerName, int jobsStillExecuting, TimeSpan drainTimeout)
+    {
+        logger.SchedulerRestartAbandoned(schedulerName, jobsStillExecuting, drainTimeout);
+
+        return new SchedulerRestartException(
+            schedulerName,
+            jobsStillExecuting,
+            drainTimeout,
+            $"Scheduler '{schedulerName}' was shut down, but its work had not finished when the {drainTimeout} "
+            + $"drain gave up on it ({jobsStillExecuting} job(s) still executing), so no new scheduler was built. "
+            + "The next generation's first act is a recovery sweep over the whole scheduler name — every "
+            + "acquired and blocked trigger back to waiting, every fired-trigger row deleted — and it does not "
+            + "filter by instance id, so running it now would tear that work's bookkeeping out from under it. "
+            + $"Call Restart(\"{schedulerName}\") again once the work has finished; nothing else is needed, and "
+            + "until then the name is listed with no status. ShutdownJobInterruption and [JobTimeout] are how a "
+            + "job is made to stop.");
+    }
+
+    /// <summary>
+    /// Releases a generation's container, if there is one to release.
+    /// </summary>
+    /// <remarks>
+    /// There is not, for the generation a container registration built: its parts are keyed singletons in
+    /// the application's container, disposed with it. That is the one asymmetry between restarting a
+    /// registered scheduler and restarting one this runtime added, and it costs one dead object graph
+    /// per registered scheduler ever restarted.
+    /// </remarks>
+    private static ValueTask Release(SchedulerGeneration? generation)
+    {
+        return generation?.DisposeAsync() ?? default;
+    }
+
+    /// <summary>
     /// Refuses a name while the schedulers are being taken away.
     /// </summary>
     /// <remarks>
@@ -422,12 +821,12 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     /// there still something that will shut it down" — and only the second one is about the scheduler
     /// that now exists.
     /// </remarks>
-    private void ThrowIfTheHostIsStopping(string schedulerName)
+    private void ThrowIfTheHostIsStopping(string schedulerName, string verb = "added")
     {
         if (Volatile.Read(ref draining) == 1 || applicationLifetime?.ApplicationStopping.IsCancellationRequested == true)
         {
             Throw.SchedulerConfigException(
-                $"The host is stopping, so scheduler '{schedulerName}' was not added: it would be created after "
+                $"The host is stopping, so scheduler '{schedulerName}' was not {verb}: it would be created after "
                 + "the shutdown that would have stopped it, and nothing would come back for it.");
         }
     }
@@ -508,9 +907,9 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     /// One scheduler this runtime holds: what built it, and what it built.
     /// </summary>
     /// <remarks>
-    /// The blueprint is kept rather than discarded after the generation exists, because a recipe that
-    /// has been run and thrown away can never be run again — which is what every comparable system found
-    /// out about restart, and what this leaves room for.
+    /// The recipe is kept rather than discarded after the generation exists, because a recipe that has
+    /// been run and thrown away can never be run again — which is what every comparable system found out
+    /// about restart, and what makes <see cref="Restart" /> a replay rather than a resurrection.
     /// </remarks>
     private sealed class RuntimeUnit
     {
@@ -520,6 +919,109 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
 
         public required Action<IQuartzBuilder>? Configure { get; init; }
 
-        public required SchedulerGeneration Generation { get; init; }
+        /// <summary>
+        /// Which generation of this name the runtime last built, counting the container's own as one.
+        /// </summary>
+        public required int Number { get; set; }
+
+        /// <summary>
+        /// The generation this runtime built and has not released, or <see langword="null" /> while the
+        /// live scheduler is the container's own — or while there is none at all.
+        /// </summary>
+        /// <remarks>
+        /// Null in three quite different situations, which is why nothing infers anything from it beyond
+        /// "there is no container of ours to release": a container-registered scheduler before its first
+        /// restart, one whose restart was abandoned, and one that has been shut down by hand.
+        /// </remarks>
+        public SchedulerGeneration? Live { get; set; }
+
+        /// <summary>
+        /// The generation a restart shut down but could not prove had finished its work.
+        /// </summary>
+        /// <remarks>
+        /// Kept so the next attempt can wait for it rather than build over it, and released as soon as it
+        /// answers that its work is done.
+        /// </remarks>
+        public Incumbent? Abandoned { get; set; }
+    }
+
+    /// <summary>
+    /// The generation a restart is replacing, as the restart needs to see it.
+    /// </summary>
+    /// <remarks>
+    /// One shape for two quite different things — a generation this runtime built, and the keyed graph a
+    /// container registration produced — because a restart does the same five things to either: read its
+    /// status, name its parts, shut it down, ask whether its work finished, and release what it owns.
+    /// The last of those is the only place the two differ, and <see cref="Owned" /> is where the
+    /// difference is written down.
+    /// </remarks>
+    private sealed record Incumbent(
+        IScheduler Facade,
+        QuartzScheduler? Core,
+        IJobStore Store,
+        IThreadPool Pool,
+        IJobFactory? JobFactory,
+        IInstanceIdGenerator? InstanceIdGenerator,
+        SchedulerGeneration? Owned)
+    {
+        /// <summary>
+        /// How many jobs this generation is still running, or was still running when it was last asked.
+        /// </summary>
+        public int JobsExecuting => Core?.NumberOfJobsExecutingHere ?? 0;
+
+        /// <summary>
+        /// Whether the shutdown's wait for this generation's work succeeded, or <see langword="null" />
+        /// when the answer cannot be read.
+        /// </summary>
+        /// <remarks>
+        /// Unreadable only for a facade that is not this library's — a scheduler bound into the
+        /// repository by hand, or a proxy to another process — and an unreadable answer is treated as a
+        /// refusal, because the whole point of asking is to know before writing to a shared store.
+        /// </remarks>
+        public bool? Drained => Core?.RunningWorkDrained;
+
+        /// <summary>
+        /// The generation a restart of <paramref name="unit" /> would replace, or <see langword="null" />
+        /// when nothing is running under that name.
+        /// </summary>
+        /// <remarks>
+        /// The parts are resolved here, while the scheduler is still alive: they are keyed singletons and
+        /// are therefore already constructed, and after the shutdown a runtime generation's container may
+        /// well be gone.
+        /// </remarks>
+        public static Incumbent? Of(RuntimeUnit unit, IServiceProvider application, ISchedulerRepository repository)
+        {
+            if (unit.Live is { Scheduler: { } tenant } generation)
+            {
+                return new Incumbent(
+                    tenant,
+                    generation.QuartzScheduler,
+                    generation.StoreInstance,
+                    generation.PoolInstance,
+                    generation.Part<IJobFactory>(),
+                    generation.Part<IInstanceIdGenerator>(),
+                    generation);
+            }
+
+            if (unit.Live is not null || repository.Lookup(unit.Name) is not { } registered)
+            {
+                // Either a generation of ours that was never created, or a registration nothing has built
+                // or something has already shut down. Both mean the same thing here: nothing to stop.
+                return null;
+            }
+
+            // The container's own graph. Resolving it constructs nothing that is not already there, since
+            // the scheduler the repository is holding was built out of it.
+            QuartzSchedulerResources resources = application.GetScheduler<QuartzSchedulerResources>(unit.Name);
+
+            return new Incumbent(
+                registered,
+                (registered as StdScheduler)?.scheduler,
+                JobStores.Unwrap(resources.JobStore),
+                resources.ThreadPool,
+                application.GetSchedulerService<IJobFactory>(unit.Name),
+                application.GetSchedulerService<IInstanceIdGenerator>(unit.Name),
+                Owned: null);
+        }
     }
 }

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -167,6 +167,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 Name = schedulerName,
                 Options = options,
                 Configure = configure,
+                FromContainer = false,
                 Live = generation,
                 Number = generation.Number
             };
@@ -625,6 +626,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 Name = blueprint.Name,
                 Options = Recipe(blueprint),
                 Configure = blueprint.Configure,
+                FromContainer = true,
 
                 // Generation one is the container's own keyed graph rather than anything this runtime
                 // built, so there is nothing to record but its number: what the restart shuts down is
@@ -940,6 +942,18 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         public required Action<IQuartzBuilder>? Configure { get; init; }
 
         /// <summary>
+        /// Whether the recipe came from a container registration rather than from a call to
+        /// <see cref="Add" />.
+        /// </summary>
+        /// <remarks>
+        /// It decides one thing: whether the scheduler bound in the repository under this name is this
+        /// unit's first generation. For a registration it is, and shutting it down is what a restart is;
+        /// for a name this runtime added, anything in the repository that is not a generation this
+        /// runtime holds is somebody else's scheduler and not this one's to stop.
+        /// </remarks>
+        public required bool FromContainer { get; init; }
+
+        /// <summary>
         /// Which generation of this name the runtime last built, counting the container's own as one.
         /// </summary>
         public required int Number { get; set; }
@@ -1030,10 +1044,14 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                     generation);
             }
 
-            if (unit.Live is not null || repository.Lookup(unit.Name) is not { } registered)
+            // The repository is asked only for a name the container registered, and only while this
+            // runtime holds no generation of its own under it. Any other reading of it would be somebody
+            // else's scheduler wearing the same name — one bound by hand, one AddQuartzHttpClient bound —
+            // and this is not the place to notice that, nor is it something to shut down on the way past.
+            if (unit.Live is not null || !unit.FromContainer || repository.Lookup(unit.Name) is not { } registered)
             {
-                // Either a generation of ours that was never created, or a registration nothing has built
-                // or something has already shut down. Both mean the same thing here: nothing to stop.
+                // A generation of ours that was never created, a registration nothing has built, or one
+                // something has already shut down. All of them mean the same thing here: nothing to stop.
                 return null;
             }
 

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -125,7 +125,16 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
             SchedulerGeneration generation;
             try
             {
-                generation = SchedulerGeneration.Build(application, schedulerName, options, configure, number: 1);
+                generation = SchedulerGeneration.Build(
+                    application,
+                    schedulerName,
+                    options,
+                    configure,
+                    number: 1,
+
+                    // A first generation may be handed an object: nothing has used it yet, and refusing
+                    // UseJobStore(myStore) at Add would be refusing an API that works.
+                    refuseInstanceParts: false);
             }
             catch (OptionsValidationException e)
             {
@@ -694,7 +703,16 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     {
         try
         {
-            return SchedulerGeneration.Build(application, unit.Name, unit.Options, unit.Configure, unit.Number + 1);
+            return SchedulerGeneration.Build(
+                application,
+                unit.Name,
+                unit.Options,
+                unit.Configure,
+                unit.Number + 1,
+
+                // Every generation after the first. The refusal it turns on happens before a provider
+                // exists, so a recipe that closes over an object costs the running scheduler nothing.
+                refuseInstanceParts: true);
         }
         catch (OptionsValidationException e)
         {
@@ -703,15 +721,23 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     }
 
     /// <summary>
-    /// Refuses a recipe that hands the next generation a part the last one is holding.
+    /// The second line: refuses a recipe whose <em>factory</em> handed the next generation the object
+    /// the last one is holding.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A recipe made of <c>Use…&lt;T&gt;()</c> and factory registrations produces a new set of instances
-    /// every time it is run. One that closes over an object — <c>UseJobStore(myStore)</c> — produces the
-    /// same object, and that object is about to be shut down. Nothing in a service descriptor says which
-    /// of the two a recipe is, so it is answered by building the next generation and comparing what came
-    /// out by reference.
+    /// The four <c>Use…(instance)</c> overloads are refused before a provider exists, by
+    /// <c>SchedulerGeneration.Build</c> reading the note <c>QuartzBuilder</c> left. This catches what
+    /// that cannot see: <c>UseJobStore(provider =&gt; sharedInstance)</c> is a factory registration by
+    /// its shape and an instance registration by its effect, and only comparing what two containers
+    /// produced tells them apart.
+    /// </para>
+    /// <para>
+    /// It is the second line rather than the first because it costs what the first one does not. By the
+    /// time it can answer, the next generation's container exists and holds the shared object, so
+    /// refusing means disposing a container that will take that object with it — which is why the
+    /// message says what it says, and why a factory that means to be replayed must return a new instance
+    /// each time it runs.
     /// </para>
     /// <para>
     /// Four parts, because these are the ones a recipe can be handed as an instance and that a scheduler
@@ -723,10 +749,10 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     /// </remarks>
     private static void ThrowIfTheRecipeSuppliesAnInstance(string schedulerName, Incumbent live, SchedulerGeneration next)
     {
-        string? shared = Shared(live.Store, next.StoreInstance, "a job store", "UseJobStore(IJobStore)")
-            ?? Shared(live.Pool, next.PoolInstance, "a thread pool", "UseThreadPool(IThreadPool)")
-            ?? Shared(live.JobFactory, next.Part<IJobFactory>(), "a job factory", "UseJobFactory(instance)")
-            ?? Shared(live.InstanceIdGenerator, next.Part<IInstanceIdGenerator>(), "an instance id generator", "UseInstanceIdGenerator(instance)");
+        string? shared = Shared(live.Store, next.StoreInstance, "job store", "UseJobStore(provider => …)")
+            ?? Shared(live.Pool, next.PoolInstance, "thread pool", "UseThreadPool(provider => …)")
+            ?? Shared(live.JobFactory, next.Part<IJobFactory>(), "job factory", "UseJobFactory(provider => …)")
+            ?? Shared(live.InstanceIdGenerator, next.Part<IInstanceIdGenerator>(), "instance id generator", "UseInstanceIdGenerator(provider => …)");
 
         if (shared is null)
         {
@@ -734,15 +760,16 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
         }
 
         Throw.SchedulerConfigException(
-            $"The recipe for scheduler '{schedulerName}' supplies {shared}, so replaying it hands the new "
-            + "scheduler the object the old one is about to shut down, and a shut-down instance cannot be "
-            + "re-initialised. Register a type or a factory instead — the same recipe written as "
-            + "UseJobStore<T>(), UseThreadPool<T>() or UseJobStore(provider => …) builds a new instance each "
-            + $"time it runs. Scheduler '{schedulerName}' is still running and was not touched.");
+            $"The recipe for scheduler '{schedulerName}' produced the same {shared} the running scheduler "
+            + "already has, so replaying it hands the new scheduler an object the old one is about to shut "
+            + "down, and a shut-down instance cannot be re-initialised. A factory registration is replayed "
+            + "once per generation and must return a new instance each time rather than close over a shared "
+            + "one — the container built for the refused generation is released, and it takes what the factory "
+            + $"returned with it. Scheduler '{schedulerName}' is still running and was not touched.");
 
         static string? Shared<T>(T? current, T? candidate, string what, string how) where T : class
         {
-            return current is not null && ReferenceEquals(current, candidate) ? $"{what} as an instance ({how})" : null;
+            return current is not null && ReferenceEquals(current, candidate) ? $"{what} ({how})" : null;
         }
     }
 

--- a/src/Quartz/Configuration/SchedulerRuntime.cs
+++ b/src/Quartz/Configuration/SchedulerRuntime.cs
@@ -259,7 +259,12 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 drain.CancelAfter(drainTimeout);
             }
 
-            await ThrowIfAnEarlierRestartIsStillFinishing(unit, drainTimeout, drain.Token).ConfigureAwait(false);
+            // Read before the abandoned generation is let go of. An attempt whose drain gave up shut a
+            // running scheduler down, and the attempt that finishes the job should leave the name the way
+            // it found it rather than in standby because the first one already did the shutting down.
+            bool abandonedWasRunning = unit.Abandoned?.WasRunning == true;
+
+            await ThrowIfAnEarlierRestartIsStillFinishing(unit, drainTimeout, drain.Token, cancellationToken).ConfigureAwait(false);
 
             // May be null, and that is not a failure: the scheduler was shut down by hand, by the host,
             // or by a restart whose drain gave up, and there is simply nothing to stop before the next
@@ -272,8 +277,6 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
             {
                 if (live is not null)
                 {
-                    // Read before the shutdown, because a shut-down scheduler reports Shutdown and would
-                    // make every restart leave the next generation in standby.
                     ThrowIfTheRecipeSuppliesAnInstance(unit.Name, live, next);
                 }
             }
@@ -283,7 +286,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 throw;
             }
 
-            bool wasRunning = live?.Facade.Status == SchedulerStatus.Running;
+            bool wasRunning = live?.WasRunning ?? abandonedWasRunning;
             string? previousInstanceId = live?.Facade.SchedulerInstanceId;
 
             if (live is not null)
@@ -742,39 +745,56 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     }
 
     /// <summary>
-    /// Refuses a restart while the generation an earlier one abandoned is still running its jobs.
+    /// Waits out the generation an earlier restart abandoned, and refuses this one if its work is still
+    /// not finished.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The count is read first because it cannot block: a pool that implements only the default
-    /// <see cref="IThreadPool.Drain" /> falls back to a wait that cannot be given up on, and asking it
-    /// while jobs are plainly still running would hang the retry rather than refuse it. Once the count
-    /// reads zero the pool is asked anyway, because the count goes to zero before the last job's store
-    /// update is issued and it is precisely that write the next generation must not start beside.
+    /// The pool is asked rather than the count of executing jobs, because a job leaves that count before
+    /// its job store update is issued and it is exactly that write the next generation must not start
+    /// beside. The built-in pool answers truthfully after a drain it gave up on — the completion the
+    /// first wait watched is the one this watches — which is what makes a retry a plain second call
+    /// rather than something that has to keep state of its own.
     /// </para>
     /// <para>
-    /// The built-in pool answers this truthfully after a drain it gave up on, which is what makes a
-    /// retry a plain second call rather than something that has to keep state of its own.
+    /// Bounded twice over: by the deadline on the token, which a pool of ours honours, and by
+    /// <see cref="TaskAsyncEnumerableExtensions" />' wait on the same token, because
+    /// <see cref="IThreadPool.Drain" />'s default implementation ends in a wait that cannot be given up
+    /// on. A pool that never overrode it would otherwise hang the retry rather than refuse it, and the
+    /// caller would have no way to learn that it had.
     /// </para>
     /// </remarks>
     private async ValueTask ThrowIfAnEarlierRestartIsStillFinishing(
         RuntimeUnit unit,
         TimeSpan drainTimeout,
-        CancellationToken drainToken)
+        CancellationToken drainToken,
+        CancellationToken cancellationToken)
     {
         if (unit.Abandoned is not { } abandoned)
         {
             return;
         }
 
-        if (abandoned.JobsExecuting == 0 && await abandoned.Pool.Drain(drainToken).ConfigureAwait(false))
+        bool finished;
+        try
         {
-            await Release(abandoned.Owned).ConfigureAwait(false);
-            unit.Abandoned = null;
-            return;
+            finished = await abandoned.Pool.Drain(drainToken).AsTask().WaitAsync(drainToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The deadline, not the caller. Reported as an answer for the same reason Drain reports it
+            // as one: giving up on the wait is a fact about the old generation, not a failure of this
+            // call, and the caller is the one that knows what to do about it.
+            finished = false;
         }
 
-        throw Abandoned(unit.Name, abandoned.JobsExecuting, drainTimeout);
+        if (!finished)
+        {
+            throw Abandoned(unit.Name, abandoned.JobsExecuting, drainTimeout);
+        }
+
+        await Release(abandoned.Owned).ConfigureAwait(false);
+        unit.Abandoned = null;
     }
 
     /// <summary>
@@ -954,10 +974,16 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
     /// status, name its parts, shut it down, ask whether its work finished, and release what it owns.
     /// The last of those is the only place the two differ, and <see cref="Owned" /> is where the
     /// difference is written down.
+    /// <para>
+    /// <c>WasRunning</c> is captured rather than read on demand, because it is the question a shutdown
+    /// destroys the answer to: after it, every scheduler reports <see cref="SchedulerStatus.Shutdown" />,
+    /// and the next generation's starting policy defaults to what this one was doing.
+    /// </para>
     /// </remarks>
     private sealed record Incumbent(
         IScheduler Facade,
         QuartzScheduler? Core,
+        bool WasRunning,
         IJobStore Store,
         IThreadPool Pool,
         IJobFactory? JobFactory,
@@ -996,6 +1022,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
                 return new Incumbent(
                     tenant,
                     generation.QuartzScheduler,
+                    tenant.Status == SchedulerStatus.Running,
                     generation.StoreInstance,
                     generation.PoolInstance,
                     generation.Part<IJobFactory>(),
@@ -1017,6 +1044,7 @@ internal sealed class SchedulerRuntime : ISchedulerRuntime, IAsyncDisposable, ID
             return new Incumbent(
                 registered,
                 (registered as StdScheduler)?.scheduler,
+                registered.Status == SchedulerStatus.Running,
                 JobStores.Unwrap(resources.JobStore),
                 resources.ThreadPool,
                 application.GetSchedulerService<IJobFactory>(unit.Name),

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -510,6 +510,29 @@ internal sealed class QuartzScheduler
     public bool Clustered => resources.JobStore.Clustered;
 
     /// <summary>
+    /// Whether the work this scheduler was running had finished by the time <see cref="Shutdown" />
+    /// stopped waiting for it, or <see langword="null" /> while no shutdown has run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Shutdown" /> always completes, whether or not the work it was waiting for did, because
+    /// everything after the wait — the job store, the plugins, the listeners — has to be told the
+    /// scheduler stopped regardless. The fact that the wait was abandoned is therefore recorded rather
+    /// than thrown, and this is where it is recorded.
+    /// </para>
+    /// <para>
+    /// It is not the same question as <see cref="NumberOfJobsExecutingHere" />: the barrier covers each
+    /// job's job store update as well as the job itself, and a job leaves that count before its update
+    /// is issued. Read by <c>SchedulerRuntime.Restart</c>, which must not build the next generation of a
+    /// scheduler over a store the previous one is still writing to — the recovery sweep a new generation
+    /// runs at start is unfiltered by instance id, so it would delete a still-running job's fired-trigger
+    /// row. Internal because it says something about a shutdown that has already happened, which only
+    /// whoever performed it is in a position to ask.
+    /// </para>
+    /// </remarks>
+    internal bool? RunningWorkDrained { get; private set; }
+
+    /// <summary>
     /// Halts the <see cref="QuartzScheduler" />'s firing of <see cref="ITrigger" />s,
     /// and cleans up all resources associated with the QuartzScheduler.
     /// <para>
@@ -585,7 +608,10 @@ internal sealed class QuartzScheduler
                 // that it gave up rather than throwing, so everything below still runs. The barrier
                 // covers each job's job store update as well as the job itself, because the pool was
                 // handed the whole of the execution, of which that update is the last act.
-                if (!await resources.ThreadPool.Drain(cancellationToken).ConfigureAwait(false))
+                bool drained = await resources.ThreadPool.Drain(cancellationToken).ConfigureAwait(false);
+                RunningWorkDrained = drained;
+
+                if (!drained)
                 {
                     logger.GaveUpWaitingForRunningJobs(resources.GetUniqueIdentifier());
                 }
@@ -597,6 +623,13 @@ internal sealed class QuartzScheduler
                 // from the absence of a completion. Counted before the pool is shut down, since that is
                 // what empties the list.
                 int stillExecuting = GetCurrentlyExecutingJobs().Count;
+
+                // The best this branch can say. Nothing was waited for, so "nothing was running when we
+                // looked" is the whole of the evidence — and it is evidence with a known hole in it, since
+                // a job leaves this count before its store update is issued. A caller that needs the
+                // stronger answer asks for the wait.
+                RunningWorkDrained = stillExecuting == 0;
+
                 if (stillExecuting > 0)
                 {
                     logger.ShuttingDownWithJobsStillExecuting(

--- a/src/Quartz/ISchedulerRuntime.cs
+++ b/src/Quartz/ISchedulerRuntime.cs
@@ -132,4 +132,64 @@ public interface ISchedulerRuntime : ISchedulerRegistry
         string schedulerName,
         bool waitForJobsToComplete = false,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Shuts a scheduler down and builds another one from the recipe that built it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Nothing is restarted, and the name is the only thing the two schedulers share. A scheduler's
+    /// thread pool, job store, connection provider, plugins and listeners are all one-way — every one of
+    /// them refuses work once it has been shut down — so a second generation is a second set of
+    /// instances, built by running the recipe again into a container of its own. That is what
+    /// <see cref="Add" /> does for a name the container never heard of, and it is what this does for a
+    /// name it did: <c>AddQuartz(name, …)</c> records what it was told, so a registered scheduler is
+    /// restartable too.
+    /// </para>
+    /// <para>
+    /// The order is build, drain, create — and each step is where it is for a reason. The new
+    /// generation's container is built <em>first</em>, so a recipe that no longer works leaves the old
+    /// scheduler running rather than nothing at all. The old scheduler is then shut down waiting for its
+    /// jobs, because a persistent store's recovery sweep runs over the whole scheduler name unfiltered
+    /// by instance id: a new generation that started while the old one's jobs ran would move their
+    /// triggers back to waiting and delete their fired-trigger rows underneath them. Only once that
+    /// drain has finished is the new scheduler created, which is when its store is initialized and its
+    /// declared jobs and triggers are applied.
+    /// </para>
+    /// <para>
+    /// A restart is observable from outside the process. With a fixed instance id the new generation
+    /// checks in under the same <c>SCHEDULER_STATE</c> row; with <c>AUTO</c> it takes a new one and the
+    /// old row expires the way a stopped node's does. Either way a clustered peer sees what it sees when
+    /// a node is restarted, because that is what this is. A job that outlives the drain is at-least-once:
+    /// the new generation's recovery re-fires it exactly as it would after a crash.
+    /// </para>
+    /// <para>
+    /// A name this runtime does not hold and the container did not register is a
+    /// <see cref="SchedulerNotFoundException" />. A name it holds but whose scheduler was shut down —
+    /// by hand, by the host, or by a restart whose drain gave up — is not an error: there is simply
+    /// nothing to shut down first, and this builds the next generation.
+    /// </para>
+    /// </remarks>
+    /// <param name="schedulerName">The scheduler's name.</param>
+    /// <param name="options">
+    /// How long to wait for the outgoing scheduler's jobs, and whether to start the new one. The default
+    /// waits thirty seconds and starts the new scheduler if the old one was running.
+    /// </param>
+    /// <param name="cancellationToken">The cancellation instruction.</param>
+    /// <returns>The new scheduler, created and bound.</returns>
+    /// <exception cref="SchedulerNotFoundException">
+    /// Neither this runtime nor the container holds a scheduler of that name.
+    /// </exception>
+    /// <exception cref="SchedulerConfigException">
+    /// The scheduler has no recipe that can be replayed — the default scheduler, or one whose recipe
+    /// supplies a part as an instance — or the recipe no longer builds. The old scheduler keeps running.
+    /// </exception>
+    /// <exception cref="SchedulerRestartException">
+    /// The outgoing scheduler's jobs were still running when the drain gave up. The old scheduler is
+    /// shut down and the new one was not built; ask again once the work has finished.
+    /// </exception>
+    ValueTask<IScheduler> Restart(
+        string schedulerName,
+        SchedulerRestartOptions options = default,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Quartz/Impl/DefaultSchedulerFactory.cs
+++ b/src/Quartz/Impl/DefaultSchedulerFactory.cs
@@ -288,15 +288,23 @@ internal sealed class DefaultSchedulerFactory : ISchedulerFactory
     /// shutdown is claimed and cannot be abandoned, so it refuses every call already, and handing it back
     /// hands back the same dead scheduler a moment earlier.
     /// </para>
+    /// <para>
+    /// What the message can now offer is <see cref="ISchedulerRuntime.Restart" />, which is the honest
+    /// form of what a caller asking for a shut-down scheduler wanted: not this one revived, but another
+    /// one built from the same registration into a container of its own.
+    /// </para>
     /// </remarks>
     private static void ThrowIfShutdown(bool isShutdown, string schedulerName)
     {
         if (isShutdown)
         {
             Throw.SchedulerException(
-                $"Scheduler '{schedulerName}' has been shut down. A scheduler cannot be restarted within "
-                + "the same service provider, because the container owns its components' lifetimes. Use "
-                + "Standby()/Start() to pause and resume, or build a new host/container for a fresh scheduler.");
+                $"Scheduler '{schedulerName}' has been shut down, and the components the container built for "
+                + "it are one-way: a thread pool and a job store that have been shut down cannot be "
+                + "re-initialised, so handing this one back would hand back something that looks alive and "
+                + "schedules nothing. Use Standby()/Start() to pause and resume, or "
+                + $"ISchedulerRuntime.Restart(\"{schedulerName}\") builds a new scheduler from the same "
+                + "registration.");
         }
     }
 

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -55,10 +55,11 @@ internal sealed class DeferredScheduler : IScheduler
         // The factory caches, so asking it again would be correct — but it takes a lock and a repository
         // lookup to say so, and this sits in front of every call a caller makes.
         var resolved = scheduler;
-        return resolved is not null ? new ValueTask<IScheduler>(resolved) : Create(cancellationToken);
+        return resolved is not null && !IsDown(resolved) ? new ValueTask<IScheduler>(resolved) : Create(cancellationToken);
 
         async ValueTask<IScheduler> Create(CancellationToken cancellationToken)
         {
+            Forget();
             return scheduler = await factory.GetScheduler(cancellationToken).ConfigureAwait(false);
         }
     }
@@ -77,9 +78,14 @@ internal sealed class DeferredScheduler : IScheduler
         get
         {
             var resolved = scheduler;
-            if (resolved is not null)
+            if (resolved is not null && !IsDown(resolved))
             {
                 return resolved;
+            }
+
+            if (resolved is not null)
+            {
+                Forget();
             }
 
             var pending = creation ??= factory.GetScheduler().AsTask();
@@ -95,6 +101,47 @@ internal sealed class DeferredScheduler : IScheduler
                 + "Resolve the scheduler after the host has started, or await any of its methods first — "
                 + "building a scheduler is asynchronous, and a property cannot wait for it.");
         }
+    }
+
+    /// <summary>
+    /// Whether the scheduler this handle remembers has stopped for good.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A handle outlives the scheduler it points at. <see cref="ISchedulerRuntime.Restart" /> shuts one
+    /// generation down and builds another under the same name, and every
+    /// <c>[FromKeyedServices("acme")] IScheduler</c> in the application holds one of these — so without
+    /// this check the whole application would go on injecting the dead generation while the repository,
+    /// the dashboard and the HTTP API all showed the live one. The registration is the identity here,
+    /// not the instance.
+    /// </para>
+    /// <para>
+    /// Asking the factory again is what finds the replacement: it answers from the repository, where the
+    /// new generation bound itself. With no live scheduler under the name it refuses exactly as it did
+    /// before, and says so — a shut-down scheduler is not silently rebuilt.
+    /// </para>
+    /// <para>
+    /// One volatile field read and one status read per forwarded call on the ordinary path, where the
+    /// status is a field on the scheduler this points at.
+    /// </para>
+    /// </remarks>
+    private static bool IsDown(IScheduler scheduler)
+    {
+        return scheduler.Status is SchedulerStatus.ShuttingDown or SchedulerStatus.Shutdown;
+    }
+
+    /// <summary>
+    /// Drops what this handle remembers, so the next use asks the factory rather than answering with a
+    /// scheduler that has stopped.
+    /// </summary>
+    /// <remarks>
+    /// The completed <see cref="creation" /> has to go with it: it holds the same dead scheduler, and a
+    /// synchronous member that only cleared the field would read it straight back out.
+    /// </remarks>
+    private void Forget()
+    {
+        scheduler = null;
+        creation = null;
     }
 
     public string SchedulerName => registrationName ?? options.Get(optionsName).InstanceName;

--- a/src/Quartz/SchedulerRestartException.cs
+++ b/src/Quartz/SchedulerRestartException.cs
@@ -1,0 +1,74 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// Thrown by <see cref="ISchedulerRuntime.Restart" /> when the outgoing scheduler's jobs were still
+/// running when the drain gave up on them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A type of its own rather than a bare <see cref="SchedulerException" />, because this is the one
+/// failure a caller can act on without changing anything: the work will finish, and asking again
+/// afterwards succeeds. Nothing was lost — the old scheduler is shut down, the new one was never built,
+/// and the scheduler's name is listed with no status until a restart completes.
+/// </para>
+/// <para>
+/// A <see cref="SchedulerConfigException" /> is the other outcome and means the opposite: the recipe
+/// cannot produce a second generation, so asking again will fail the same way.
+/// </para>
+/// </remarks>
+public sealed class SchedulerRestartException : SchedulerException
+{
+    internal SchedulerRestartException(
+        string schedulerName,
+        int jobsStillExecuting,
+        TimeSpan drainTimeout,
+        string message) : base(message)
+    {
+        SchedulerName = schedulerName;
+        JobsStillExecuting = jobsStillExecuting;
+        DrainTimeout = drainTimeout;
+    }
+
+    /// <summary>
+    /// The scheduler that was being restarted, so a caller can report it without parsing the message.
+    /// </summary>
+    public string SchedulerName { get; }
+
+    /// <summary>
+    /// How many of its jobs the outgoing scheduler was still running when the wait was given up on.
+    /// </summary>
+    /// <remarks>
+    /// A floor rather than a total. The drain waits for each job's job store update as well as the job,
+    /// and a job leaves this count before its update is issued — so zero here means the jobs have
+    /// finished and a write is still in flight, which is just as much a reason not to start a second
+    /// scheduler over the same store.
+    /// </remarks>
+    public int JobsStillExecuting { get; }
+
+    /// <summary>
+    /// The deadline that expired, as <see cref="SchedulerRestartOptions.DrainTimeout" /> gave it or
+    /// defaulted it.
+    /// </summary>
+    public TimeSpan DrainTimeout { get; }
+}

--- a/src/Quartz/SchedulerRestartOptions.cs
+++ b/src/Quartz/SchedulerRestartOptions.cs
@@ -1,0 +1,80 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+namespace Quartz;
+
+/// <summary>
+/// How long a restart waits for the outgoing scheduler's work, and what it leaves the new one doing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two settings, and both defaults say "as it was": wait long enough for a job to finish but not
+/// indefinitely, and leave the new scheduler running exactly if the old one was. So
+/// <see langword="default" /> — which is what omitting the argument gives — is a restart that changes
+/// nothing but the instances.
+/// </para>
+/// <para>
+/// There is no <c>WaitForJobsToComplete</c>. A restart always waits, because the next generation's first
+/// act is a recovery sweep over the whole scheduler name — it moves acquired and blocked triggers back
+/// to waiting and deletes every fired-trigger row — and running that while the previous generation's
+/// jobs are still writing would corrupt them. <see cref="DrainTimeout" /> is how long that wait may
+/// take, and giving up on it fails the restart rather than proceeding.
+/// </para>
+/// </remarks>
+/// <seealso cref="ISchedulerRuntime.Restart" />
+public readonly record struct SchedulerRestartOptions
+{
+    /// <summary>
+    /// Leave the new scheduler for the application to start, whatever the old one was doing. The name
+    /// for <c>new SchedulerRestartOptions { Start = false }</c>.
+    /// </summary>
+    public static SchedulerRestartOptions WithoutStarting => new() { Start = false };
+
+    /// <summary>
+    /// How long to wait for the outgoing scheduler's running jobs before giving up on the restart.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null" /> — the default — is thirty seconds.
+    /// <see cref="Timeout.InfiniteTimeSpan" /> waits until the jobs finish or the cancellation token
+    /// fires, whichever comes first. The wait covers each job's job store update as well as the job
+    /// itself, because the thread pool is handed the whole of an execution and that update is its last
+    /// act.
+    /// <para>
+    /// A wait that expires leaves the old scheduler shut down and the new one unbuilt, and reports a
+    /// <see cref="SchedulerRestartException" />. Ask again once the work has finished — nothing else is
+    /// needed, and until then the name is listed with no status. Long-running jobs that must be cut
+    /// short are what <see cref="ShutdownJobInterruption" /> and <see cref="JobTimeoutAttribute" /> are
+    /// for.
+    /// </para>
+    /// </remarks>
+    public TimeSpan? DrainTimeout { get; init; }
+
+    /// <summary>
+    /// Whether the new scheduler is started.
+    /// </summary>
+    /// <remarks>
+    /// <see langword="null" /> — the default — starts it if the old one was running, and leaves it
+    /// created if the old one was in standby, had never been started, or had already been shut down.
+    /// A restart that changed whether a scheduler fires would be a second decision hidden inside the
+    /// first. Say <see langword="true" /> or <see langword="false" /> to decide it deliberately.
+    /// </remarks>
+    public bool? Start { get; init; }
+}


### PR DESCRIPTION
`ISchedulerRuntime.Restart(name)` shuts a scheduler down and builds another one from the recipe that
built it — for a tenant `Add` created, and for one `AddQuartz(name, …)` registered, whose recipe is now
recorded at registration.

```csharp
ISchedulerRuntime runtime = app.Services.GetRequiredService<ISchedulerRuntime>();

IScheduler tenant = await runtime.Restart("acme", new SchedulerRestartOptions
{
    DrainTimeout = TimeSpan.FromMinutes(2)
});
```

Nothing is restarted in place, and that is not a limitation to work around — a scheduler's thread pool,
job store, connection provider, plugins and listeners all refuse work once they have been shut down, and
#3297 refused a restart precisely because re-initialising them hands back something that looks alive and
schedules nothing. So the second scheduler is a second set of instances, built by running the recipe
again into a container of its own, exactly as PR1 (#3725) already does for a name the container never
heard of. The name is the only thing the two schedulers share.

This is PR2 of #3338 and closes it.

## Build, drain, create

Each step is where it is for a reason, and the middle one is the reason this took a PR rather than a
method.

**Build first.** The next generation's container is built before the old scheduler is touched, so a
recipe that no longer works — a connection string gone from configuration, a validator a package added —
fails with `SchedulerConfigException` and leaves the running scheduler exactly where it was. Construction
is not initialization: nothing opens a connection or starts a thread until the last step, which PR1
established and this depends on.

**Drain second, and waiting is not optional.** A persistent scheduler's first act on `Start` is
`RecoverJobs`, which is crash recovery: acquired and blocked triggers back to waiting, triggers left in
`COMPLETE` deleted, every fired-trigger row deleted, none of it filtered by instance id. The wide
analysis on #3338 named this as the finding that blocked the whole design, and it is real — see the
failing-first test below. `QuartzScheduler` gained `internal bool? RunningWorkDrained`, because
`Shutdown` always completes whether or not its wait succeeded and the caller has no other way to learn
which. It is not the same question as `NumberOfJobsExecutingHere`: the pool's barrier covers each job's
store update, and a job leaves that count before its update is issued.

**Create last.** The store is initialized, its schema checked, the declared content applied and the sweep
run only once the drain has finished.

## The failing-first test

`SchedulerRuntimeDrainTest` runs over a SQLite **file**, because none of this is observable over a store
that goes away with its generation. It was written against a restart that shut the old scheduler down
without waiting — the obvious implementation, and the one the analysis predicted would corrupt in-flight
work:

```
Expected Recovered(log, mark) to be equal to {"Freed 0 triggers from 'acquired' / 'blocked' state.",
"Recovering 0 jobs that were in-progress at the time of the last shut-down.", "Removed 0 'complete'
triggers.", "Removed 0 stale fired job entries."} … but {…, "Removed 1 'complete' triggers.", …}
differs at index 2.
```

**The road the damage took is worth naming, because it is not the one the issue predicted.** The analysis
expected `DeleteFiredTriggers` to delete the running job's row directly. What actually happens first is
that a one-shot trigger is in `COMPLETE` from the moment it fires until the job running it finishes, so
the sweep deletes the *trigger* — and `DeleteTrigger` takes the fired-trigger row with it. A test
watching only `StaleFiredJobEntriesRemoved` reads `Removed 0` and passes while the corruption happens one
step earlier. The test watches all four counters `RecoverJobs` reports for that reason.

## Refusing an instance-supplied part before a provider exists

The four `Use…(instance)` overloads are refused by **reading the collection**, before
`BuildServiceProvider` has been called for the next generation. That timing is not a nicety. A refusal
reached by building and then comparing has to release the container it built, and Microsoft's container
releases whatever a factory delegate returned — which for these overloads is the object the *running*
scheduler is using. With the guard turned off, the test says so:

```
Expected shared.Disposed to be False because the refusal happens before a provider exists, so there is
no container to release — and one that had to be released would have taken the running scheduler's own
store with it, but found True.
```

`QuartzBuilder` leaves the note: the four instance overloads register exactly as they did and
additionally record a keyed `internal sealed record SchedulerInstancePart(Type PartType)` — only when
their registration is the one that takes, since registration is first-wins and a note about an instance
nothing resolves would refuse a restart that replays perfectly. `SchedulerGeneration.Build` reads those
notes when `refuseInstanceParts` is set, which is every generation after the first. **No public API
change, and no behaviour change for a scheduler that is never restarted.**

The reference comparison stays as the *second* line, because a collection cannot be read for
`UseJobStore(provider => sharedInstance)` — a factory by its shape, an instance by its effect. Its
message and the docs now say what follows from where it sits: a factory registration is replayed once per
generation and must return a new instance each time, because the container built for a refused generation
is released and takes what the factory returned with it.

## What a caller sees

| Outcome | What it means |
|---|---|
| `SchedulerNotFoundException` | Neither this runtime nor the container knows the name |
| `SchedulerConfigException` | The recipe cannot produce a second generation, or no longer builds. **The old scheduler keeps running** |
| `SchedulerRestartException` | The drain gave up. The old scheduler is **down**, the new one was **never built**, the name is listed with `Status: null`. Ask again once the work has finished — nothing has to be undone |

The refusals, verbatim:

> Scheduler '{name}' is registered without a name; its parts are the container's unkeyed registrations,
> so its recipe cannot be replayed — nothing can tell them apart from the application's own. Register it
> with `AddQuartz("{name}", …)` to make it restartable; `Standby()`/`Start()` pause and resume it.

> The recipe for scheduler '{name}' supplies IJobStore as an instance — `UseJobStore(IJobStore)`,
> `UseThreadPool(IThreadPool)`, `UseJobFactory(instance)` or `UseInstanceIdGenerator(instance)` — so
> replaying it would hand the new scheduler the very object the old one is using, and a shut-down
> instance cannot be re-initialised. Register a type or a factory instead: `UseJobStore<T>()`,
> `UseThreadPool<T>()` and `UseJobStore(provider => new …)` each build a new instance every time the
> recipe runs. A factory must return a new instance per generation rather than close over a shared one.
> Scheduler '{name}' was not touched.

> The recipe for scheduler '{name}' produced the same job store (`UseJobStore(provider => …)`) the
> running scheduler already has, so replaying it hands the new scheduler an object the old one is about
> to shut down, and a shut-down instance cannot be re-initialised. A factory registration is replayed
> once per generation and must return a new instance each time rather than close over a shared one — the
> container built for the refused generation is released, and it takes what the factory returned with it.
> Scheduler '{name}' is still running and was not touched.

> No scheduler named '{name}' is registered with this container or has been added at runtime, so there is
> no recipe to build one from. `ISchedulerRuntime.Add("{name}", …)` creates one.

> Scheduler '{name}' was shut down, but its work had not finished when the {timeout} drain gave up on it
> ({n} job(s) still executing), so no new scheduler was built. The next generation's first act is a
> recovery sweep over the whole scheduler name — every acquired and blocked trigger back to waiting,
> every fired-trigger row deleted — and it does not filter by instance id, so running it now would tear
> that work's bookkeeping out from under it. Call `Restart("{name}")` again once the work has finished;
> nothing else is needed, and until then the name is listed with no status. `ShutdownJobInterruption` and
> `[JobTimeout]` are how a job is made to stop.

> The host is stopping, so scheduler '{name}' was not restarted: it would be created after the shutdown
> that would have stopped it, and nothing would come back for it.

And `DefaultSchedulerFactory`'s refusal keeps `has been shut down` and `Standby()/Start()` — two tests
pin those — and now names what does build another one:

> Scheduler '{name}' has been shut down, and the components the container built for it are one-way: a
> thread pool and a job store that have been shut down cannot be re-initialised, so handing this one back
> would hand back something that looks alive and schedules nothing. Use `Standby()`/`Start()` to pause
> and resume, or `ISchedulerRuntime.Restart("{name}")` builds a new scheduler from the same registration.

## Blueprint capture

`AddQuartz(name, …)` records a `SchedulerBlueprint` — the property bag, the configuration section it
*resolved* (not the one it was handed, so a replay reads the same settings), and the caller's callback —
beside the name it already records. The default scheduler records none: its parts are the container's
unkeyed registrations and nothing can tell them apart from the application's own.

**Not replayed, documented and pinned:** anything written *beside* the call — a
`services.Configure<QuartzSchedulerOptions>("acme", …)`, a keyed registration made directly against the
application's collection, `AddQuartzHostedService("acme", …)`. Nothing in a service descriptor says which
scheduler an application wrote it for, so the alternative to this boundary is guessing.

## `DeferredScheduler`

The `IScheduler` a container hands out memoises the scheduler it resolves, and every
`[FromKeyedServices("acme")] IScheduler` in the application holds one. Without this the whole application
would go on injecting the dead generation while the repository, the dashboard and the HTTP API all showed
the live one — the trap the spike called "the one nobody would find in review". A handle whose remembered
scheduler reports `ShuttingDown` or `Shutdown` now forgets it (and the memoised creation task with it,
or a synchronous member reads the same dead scheduler straight back out) and asks the factory again,
which answers from the repository. With no live scheduler under the name it refuses exactly as before:
re-pointing must not become rebuilding. Cost on the ordinary path is one status read, which is a field.

## Public API

Additions only. No line was removed or changed in either baseline.

```csharp
public interface ISchedulerRuntime : ISchedulerRegistry
{
    ValueTask<IScheduler> Restart(string schedulerName, SchedulerRestartOptions options = default,
        CancellationToken cancellationToken = default);
}

public readonly record struct SchedulerRestartOptions
{
    public static SchedulerRestartOptions WithoutStarting { get; }
    public TimeSpan? DrainTimeout { get; init; }
    public bool? Start { get; init; }
}

public sealed class SchedulerRestartException : SchedulerException
{
    public string SchedulerName { get; }
    public int JobsStillExecuting { get; }
    public TimeSpan DrainTimeout { get; }
}
```

`PublicApiTest_Quartz.verified.txt` and `LogEventCatalogTest_Quartz.verified.txt` regenerated;
`log-events.md` regenerated by `dotnet fallout DocsLogEvents` (ids 4023–4025). The migration guide's
"Upgrading from 4.0 to 4.1" section gains three rows, beside the cron rows #3733 landed.

## Docs

`multi-tenancy.md` gains a "Restarting a scheduler" subsection with `sample_tenancy_restart`. Four pages
said a scheduler cannot be restarted and now say it is not restarted *in place*, naming what does build
another one: the honest-limits section, `tenancy-patterns.md`, the `standalone-scheduler.md` warning and
the `external-leader.md` note — which keeps its point, since losing a lease should cost a standby rather
than a new scheduler.

## Deviations from the spec, and why

1. **A retry after an abandoned drain awaits the abandoned generation's pool rather than refusing on
   `NumberOfJobsExecutingHere`.** The spec's algorithm refuses when that count is non-zero. Writing the
   retry test showed why that is wrong in both directions: the count goes to zero *before* the last
   job's store update is issued, so a caller retrying the instant its job signalled completion was both
   refused (a race on the count) and, had it not been, allowed to build over a write still in flight. The
   wait is bounded twice — by the deadline on the token, which a pool of ours honours, and by a
   `WaitAsync` on the same token, because `IThreadPool.Drain`'s default body ends in a wait that cannot
   be given up on and would otherwise hang the retry rather than refuse it.
2. **The abandoned generation remembers whether it was running.** Not in the spec, and the retry test
   caught it: the first attempt already did the shutting down, so `wasRunning` read from the live
   scheduler is `false` on the retry and the recovered scheduler would come back in standby. The attempt
   that finishes the job leaves the name the way the first attempt found it.
3. **`RuntimeUnit` carries `FromContainer`, and the repository is read for the incumbent only for a
   container registration.** Self-review, not the spec. For a name this runtime *added*, anything bound
   under it that is not a generation this runtime holds is somebody else's scheduler — one bound by hand,
   one `AddQuartzHttpClient` bound — and neither this runtime's to shut down nor something whose
   `QuartzSchedulerResources` the application container can be asked for.
4. **`Restart` reads the host-stopping signal before it builds, as well as after it starts.** The spec
   put the check only after. Reading it first means a host that is already stopping gets a refusal with
   the old scheduler still running for it to drain, rather than one with the name shut down.
5. **The instance-supplied refusal covers four parts, not two, and happens in two places.**
   `UseJobStore(IJobStore)` and `UseThreadPool(IThreadPool)` as the spec asked, plus
   `UseJobFactory(instance)` and `UseInstanceIdGenerator(instance)`, which the spec's message text
   already named. The spec put the whole check after the build; review moved the four readable spellings
   in front of it, for the disposal reason above. Plugins and listeners are deliberately *not* checked:
   a plugin that tolerates a second `Initialize` is legal, and refusing every recipe with a listener
   object in it would leave almost nothing restartable.
6. **`RunningWorkDrained`'s tests live in `Core/ShutdownDrainTest` rather than `Core/QuartzSchedulerTest`.**
   That file is already about what "the scheduler waited for its running jobs" is worth, and it owns the
   gated-job machinery the three cases need.
7. **The blueprint-capture commit's "not replayed" test is `Configuration/SchedulerBlueprintTest`**, which
   asserts against the recorded recipe directly, so that commit passes on its own without `Restart`
   existing. `SchedulerRuntimeRestartTest.OptionsConfiguredBesideAddQuartzAreNotReplayed` is the
   end-to-end half the spec named, and it is there too.
8. **`RestartOfARuntimeTenantIsANewSetOfInstances` asserts on distinct instances rather than distinct
   instance ids.** *This is a spec statement the code proves wrong*:
   `DefaultSchedulerFactory.GenerateInstanceId` short-circuits to `NON_CLUSTERED` when the store is not
   clustered, so two generations of a `RAMJobStore` scheduler cannot have different instance ids however
   the recipe is written. What the test asserts instead is the invariant that matters — a second
   `Initialize` never happens on the same store, proved by a factory-registered store recorded per
   generation.
9. **`SchedulerRuntimeRestartTest` builds its containers with `await using`.** Resolving the keyed
   `IScheduler` puts a `DeferredScheduler` into the container's disposable list, and MS DI refuses to
   dispose synchronously at all once it holds a service that is only `IAsyncDisposable`.

## For a reviewer to decide

- **`Restart` on a container registration leaves generation one's keyed singletons in the application
  container** — shut down, and released only when the container is. There is nowhere else for them to go;
  they are the container's. It costs one dead object graph per registered scheduler ever restarted.
- **`Remove` still refuses a container-registered name**, including one that has been restarted. The
  container owns those, and PR1's reasoning is unchanged.
- **A factory that returns a shared object is still refused only after the next generation's container
  exists**, so that refusal does release a container that holds the shared object. There is no way to
  read that case out of a collection, the message and the docs say so, and the four spellings that *can*
  be read are handled before anything is built.

## Verification

`build.cmd Compile UnitTest`:

```
Passed!  - Failed: 0, Passed: 6197, Skipped: 36, Total: 6233, Duration: 52 s - Quartz.Tests.Unit.dll
Passed!  - Failed: 0, Passed:  633, Skipped:  0, Total:  633, Duration: 16 s - Quartz.Tests.AspNetCore.dll
Restore Succeeded 0:01 · Compile Succeeded 0:08 · UnitTest Succeeded 1:14
```

`build.cmd Compile UnitTest IntegrationTest --database sqlite` (`QUARTZ_TEST_DATABASE=sqlite`):

```
Passed!  - Failed: 0, Passed:   15, Skipped:  0, Total:   15, Duration: 1 m 30 s - Quartz.Tests.Integration.dll
Passed!  - Failed: 0, Passed: 6197, Skipped: 36, Total: 6233, Duration:      52 s - Quartz.Tests.Unit.dll
Passed!  - Failed: 0, Passed:  633, Skipped:  0, Total:  633, Duration:       7 s - Quartz.Tests.AspNetCore.dll
Restore Succeeded 0:01 · Compile Succeeded 0:08 · IntegrationTest Succeeded 1:32 · UnitTest Succeeded 1:04
```

The other five dialect legs need a Docker daemon and none is running on this machine
(`open //./pipe/docker_engine: The system cannot find the file specified`), so only the SQLite leg was
run locally. `QUARTZ_TEST_DATABASE=sqlite` as an environment variable is *not* enough — `Build.cs` sets
that variable from the `--database` parameter, so without the flag the run attempts every dialect and
fails on Docker.

`dotnet fallout BenchmarkSmoke` succeeded (298 benchmarks); `dotnet fallout PublishTrimmed` succeeded —
the canary ran and reported nothing outside the recorded trim baseline.

Docs: `dotnet fallout DocsSnippets`, `dotnet fallout VerifyDocsSnippets` (115 markdown files up to date),
`npm run docs:check-links` (224 pages, 1421 links, 878 fragments — no dead links or anchors) and
`npm run docs:lint` (92 files, 0 errors) all pass. MD004 is *consistent*-style, so the new
`multi-tenancy.md` bullets use dashes to match what the file already had.

**One flake worth reporting:**
`StartupRefusalSqliteTest.StartingFromInsideAnEnlistmentScopeIsRefusedAndSaysSo` failed once in one
full-suite run and passed in the four runs before and after it, in isolation, and in five consecutive
runs of the three SQLite fixtures together. It is an ambient-transaction test in a fixture this PR does
not touch, and nothing here touches `AdoJobStoreBase` or `AmbientConnection` — but it failed on a run of
this branch, so it is said rather than left out.

Closes #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
