### PR TITLE
A remote scheduler's status and instance id can be read without blocking a thread

### DIFF
--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -50,6 +50,8 @@ expressions it reads differently.
 | `ISchedulerRuntime.Restart` | `Restart(schedulerName, options, cancellationToken)` shuts a scheduler down and builds another from the recipe that built it — for a tenant this runtime added, and for one `AddQuartz(name, …)` registered, whose recipe is now recorded at registration. Nothing is restarted in place: the name is the only thing the two schedulers share |
 | `SchedulerRestartOptions` | `DrainTimeout` — how long to wait for the outgoing scheduler's jobs, thirty seconds by default — and `Start`, which defaults to "as the old one was". A `readonly record struct` whose `default` is a restart that changes nothing but the instances |
 | `SchedulerRestartException` | Thrown when the outgoing scheduler's jobs outlived the drain. Carries `SchedulerName`, `JobsStillExecuting` and `DrainTimeout`. The old scheduler is down and the new one was never built; ask again once the work has finished |
+| `IScheduler.GetStatus` | The asynchronous twin of `Status`, as a **default interface member** answering the property — so an `IScheduler` implemented outside this repository compiles unchanged and reports what it already reported. `HttpScheduler` overrides it: the same one round trip the property makes, awaited rather than blocked on. See [Blocking members](packages/http-client.md#blocking-members) |
+| `IScheduler.GetSchedulerInstanceId` | The asynchronous twin of `SchedulerInstanceId`, likewise a **default interface member** answering the property and likewise overridden by `HttpScheduler`. The two properties stay, and stay blocking over HTTP; these are the members to call on a request path |
 
 Four behaviours changed without a signature changing:
 

--- a/docs/documentation/quartz-4.x/packages/http-client.md
+++ b/docs/documentation/quartz-4.x/packages/http-client.md
@@ -235,8 +235,23 @@ thread for the round trip. `SchedulerName` is the one that is free — the clien
 `Status` is one request for the whole lifecycle, where the `IsStarted` / `InStandbyMode` / `IsShutdown`
 it replaces were three requests to the same endpoint, each reading a different field of the same answer.
 
-Do not touch them on a request path. `GetMetadata()` is the async member that answers most of the same
-questions in one call:
+Do not touch the two properties on a request path. Both have an asynchronous twin on `IScheduler` —
+`GetStatus()` and `GetSchedulerInstanceId()` — which ask the same question in the same one request and
+await the answer instead of holding a thread while it arrives. These are the members to call:
+
+<!-- snippet: sample_httpclient_status -->
+```csharp
+SchedulerStatus status = await scheduler.GetStatus(cancellationToken);
+string instanceId = await scheduler.GetSchedulerInstanceId(cancellationToken);
+```
+<!-- endSnippet -->
+
+They are default interface members that answer the property, so a scheduler in this process reports
+exactly what it did before and pays nothing for the indirection; only a proxy overrides them. The
+properties stay, and stay blocking — `IScheduler` declares them, and a property cannot be awaited.
+
+`GetMetadata()` answers both and the rest of the scheduler's details in one request, so prefer it where
+more than the status is wanted:
 
 <!-- snippet: sample_httpclient_metadata -->
 ```csharp

--- a/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/HttpClientSamples.cs
@@ -112,6 +112,16 @@ public static class HttpClientSamples
         #endregion
     }
 
+    public static async ValueTask StatusWithoutBlocking(IScheduler scheduler, CancellationToken cancellationToken)
+    {
+        #region sample_httpclient_status
+
+        SchedulerStatus status = await scheduler.GetStatus(cancellationToken);
+        string instanceId = await scheduler.GetSchedulerInstanceId(cancellationToken);
+
+        #endregion
+    }
+
     public static async ValueTask QueryTriggers(IScheduler scheduler, CancellationToken cancellationToken)
     {
         #region sample_httpclient_query_triggers

--- a/src/Quartz.HttpClient/HttpScheduler.cs
+++ b/src/Quartz.HttpClient/HttpScheduler.cs
@@ -107,10 +107,24 @@ public sealed class HttpScheduler : IScheduler
     /// <inheritdoc />
     /// <remarks>
     /// One round trip, and a blocking one: <see cref="IScheduler" /> declares this a property, and a
-    /// property cannot be awaited. Prefer <see cref="GetMetadata" /> where the calling code can await —
-    /// it answers this and the rest of the scheduler's details in the same request.
+    /// property cannot be awaited. Prefer <see cref="GetSchedulerInstanceId" />, which asks the same
+    /// question in the same one request without holding a thread while it is answered, or
+    /// <see cref="GetMetadata" /> where the whole of the scheduler's details is wanted.
     /// </remarks>
     public string SchedulerInstanceId => GetSchedulerDetailsSync().SchedulerInstanceId;
+
+    /// <summary>
+    /// The remote scheduler's instance Id, read over the network without blocking the calling thread.
+    /// </summary>
+    /// <remarks>
+    /// One round trip, the same one <see cref="SchedulerInstanceId" /> makes and the same one
+    /// <see cref="GetMetadata" /> makes. This is the member to call from a request path.
+    /// </remarks>
+    public async ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default)
+    {
+        var schedulerDto = await GetSchedulerDetails(cancellationToken).ConfigureAwait(false);
+        return schedulerDto.SchedulerInstanceId;
+    }
 
     /// <summary>
     /// The system clock, which is the only honest answer a proxy can give.
@@ -130,9 +144,25 @@ public sealed class HttpScheduler : IScheduler
     /// </summary>
     /// <remarks>
     /// One round trip, where the three booleans this replaces were three - each asking the same endpoint
-    /// the same question and reading a different field of the answer.
+    /// the same question and reading a different field of the answer. A blocking round trip, though:
+    /// prefer <see cref="GetStatus" />, which asks the same question without holding a thread while it
+    /// is answered.
     /// </remarks>
     public SchedulerStatus Status => GetSchedulerDetailsSync().Status;
+
+    /// <summary>
+    /// The remote scheduler's lifecycle state, read over the network without blocking the calling
+    /// thread.
+    /// </summary>
+    /// <remarks>
+    /// One round trip, the same one <see cref="Status" /> makes. This is the member to call from a
+    /// request path.
+    /// </remarks>
+    public async ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default)
+    {
+        var schedulerDto = await GetSchedulerDetails(cancellationToken).ConfigureAwait(false);
+        return schedulerDto.Status;
+    }
 
     /// <summary>
     /// Not supported. The context belongs to the scheduler's own process: it is a live, writable

--- a/src/Quartz.Tests.AspNetCore/HttpApi/HttpSchedulerStatusTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/HttpSchedulerStatusTest.cs
@@ -28,6 +28,65 @@ public class HttpSchedulerStatusTest
     }
 
     [Test]
+    public async Task GetStatusIsTheSameRoundTripWithoutBlockingAThread()
+    {
+        CountingHandler handler = new(Body(SchedulerStatus.Standby));
+        HttpScheduler scheduler = new("TestScheduler", new HttpClient(handler) { BaseAddress = new Uri("http://quartz.test/") });
+
+        SchedulerStatus status = await scheduler.GetStatus();
+
+        status.Should().Be(SchedulerStatus.Standby,
+            "the asynchronous member reads the same field of the same answer the property does");
+        handler.Requests.Should().Be(1,
+            "awaiting the answer rather than blocking for it does not make it a second request");
+    }
+
+    [Test]
+    public async Task GetSchedulerInstanceIdIsOneRoundTrip()
+    {
+        CountingHandler handler = new(Body(SchedulerStatus.Running));
+        HttpScheduler scheduler = new("TestScheduler", new HttpClient(handler) { BaseAddress = new Uri("http://quartz.test/") });
+
+        string instanceId = await scheduler.GetSchedulerInstanceId();
+
+        instanceId.Should().Be("NON_CLUSTERED");
+        handler.Requests.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The two asynchronous members answer what the two properties answer, which is the whole of their
+    /// contract — they exist to cost a thread less, not to say anything different.
+    /// </summary>
+    [Test]
+    public async Task TheAsynchronousMembersAnswerWhatThePropertiesAnswer()
+    {
+        CountingHandler handler = new(Body(SchedulerStatus.Running));
+        HttpScheduler scheduler = new("TestScheduler", new HttpClient(handler) { BaseAddress = new Uri("http://quartz.test/") });
+
+        (await scheduler.GetStatus()).Should().Be(scheduler.Status);
+        (await scheduler.GetSchedulerInstanceId()).Should().Be(scheduler.SchedulerInstanceId);
+    }
+
+    /// <summary>
+    /// And the cancellation token reaches the request, which is the other thing a property could not do.
+    /// </summary>
+    [Test]
+    public async Task ACancelledTokenStopsTheRequestRatherThanTheAnswer()
+    {
+        CountingHandler handler = new(Body(SchedulerStatus.Running));
+        HttpScheduler scheduler = new("TestScheduler", new HttpClient(handler) { BaseAddress = new Uri("http://quartz.test/") });
+
+        using CancellationTokenSource cancellation = new();
+        await cancellation.CancelAsync();
+
+        Func<Task> act = async () => await scheduler.GetStatus(cancellation.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a caller that gave up on the answer should not go on waiting for the round trip");
+        handler.Requests.Should().Be(0);
+    }
+
+    [Test]
     public async Task MetadataReportsTheSameStatusTheSchedulerDoes()
     {
         CountingHandler handler = new(Body(SchedulerStatus.ShuttingDown));
@@ -70,6 +129,8 @@ public class HttpSchedulerStatusTest
 
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             Interlocked.Increment(ref requests);
 
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)

--- a/src/Quartz.Tests.Unit/Impl/SchedulerAsyncStatusTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/SchedulerAsyncStatusTest.cs
@@ -1,0 +1,126 @@
+#nullable enable
+
+using FakeItEasy;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Impl;
+
+/// <summary>
+/// <see cref="IScheduler.GetStatus" /> and <see cref="IScheduler.GetSchedulerInstanceId" /> answer what
+/// <see cref="IScheduler.Status" /> and <see cref="IScheduler.SchedulerInstanceId" /> answer.
+/// </summary>
+/// <remarks>
+/// The pair exists for the one implementation that cannot answer a property without blocking a thread —
+/// a proxy for a scheduler in another process. Everywhere else they have to be indistinguishable from
+/// the properties, or code that moved to them to stop blocking would be reading a different scheduler.
+/// </remarks>
+[NonParallelizable]
+public sealed class SchedulerAsyncStatusTest
+{
+    /// <summary>
+    /// The scheduler a factory builds in this process, across the lifecycle transitions the status is
+    /// there to report.
+    /// </summary>
+    [Test]
+    public async Task ASchedulerInThisProcessAnswersTheSameEitherWay()
+    {
+        await using ServiceProvider provider = Container(services => services.AddQuartz(q => q.UseInMemoryStore()));
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        scheduler.Should().BeOfType<StdScheduler>(
+            "this is the implementation every in-process scheduler is reached through");
+
+        (await scheduler.GetSchedulerInstanceId()).Should().Be(scheduler.SchedulerInstanceId,
+            "the instance id is one string, and which member asked for it cannot change it");
+
+        (await scheduler.GetStatus()).Should().Be(scheduler.Status).And.Be(SchedulerStatus.Created);
+
+        await scheduler.Start();
+        (await scheduler.GetStatus()).Should().Be(scheduler.Status).And.Be(SchedulerStatus.Running);
+
+        await scheduler.Standby();
+        (await scheduler.GetStatus()).Should().Be(scheduler.Status).And.Be(SchedulerStatus.Standby);
+
+        await scheduler.Shutdown();
+        (await scheduler.GetStatus()).Should().Be(scheduler.Status).And.Be(SchedulerStatus.Shutdown,
+            "a scheduler that has stopped still reports where it got to");
+    }
+
+    /// <summary>
+    /// The handle a container hands out, which builds its scheduler on first use.
+    /// </summary>
+    [Test]
+    public async Task TheHandleAContainerInjectsAnswersForTheSchedulerItBuilds()
+    {
+        await using ServiceProvider provider = Container(services => services.AddQuartz("acme", q => q.UseInMemoryStore()));
+        IScheduler handle = provider.GetRequiredKeyedService<IScheduler>("acme");
+
+        handle.Should().BeOfType<DeferredScheduler>();
+
+        (await handle.GetStatus()).Should().Be(SchedulerStatus.Created,
+            "the handle builds the scheduler it points at rather than answering for one of its own");
+        (await handle.GetSchedulerInstanceId()).Should().Be(handle.SchedulerInstanceId);
+
+        await handle.Start();
+
+        (await handle.GetStatus()).Should().Be(handle.Status).And.Be(SchedulerStatus.Running);
+
+        await handle.Shutdown();
+    }
+
+    /// <summary>
+    /// A decorator hands both on, rather than letting the interface's default body answer from the
+    /// property on the decorator itself.
+    /// </summary>
+    /// <remarks>
+    /// The fake answers a different value from each member, which no real scheduler does: it is the only
+    /// way to tell "forwarded the call" from "ran the default, which read the forwarded property".
+    /// </remarks>
+    [Test]
+    public async Task ADecoratorHandsBothOnRatherThanDecomposingThem()
+    {
+        IScheduler inner = A.Fake<IScheduler>();
+        A.CallTo(() => inner.Status).Returns(SchedulerStatus.Standby);
+        A.CallTo(() => inner.GetStatus(A<CancellationToken>._)).Returns(SchedulerStatus.Running);
+        A.CallTo(() => inner.SchedulerInstanceId).Returns("read-from-the-property");
+        A.CallTo(() => inner.GetSchedulerInstanceId(A<CancellationToken>._)).Returns("forwarded");
+
+        DelegatingScheduler scheduler = new(inner);
+
+        (await scheduler.GetStatus()).Should().Be(SchedulerStatus.Running,
+            "the decorator asks the scheduler behind it the question it was asked, and an inner "
+            + "implementation that answers this member specially is the reason the member exists");
+        (await scheduler.GetSchedulerInstanceId()).Should().Be("forwarded");
+    }
+
+    /// <summary>
+    /// The default bodies, on a scheduler written outside this repository that declares neither.
+    /// </summary>
+    [Test]
+    public async Task ASchedulerThatDeclaresNeitherAnswersFromItsProperties()
+    {
+        IScheduler scheduler = A.Fake<IScheduler>();
+        A.CallTo(() => scheduler.Status).Returns(SchedulerStatus.ShuttingDown);
+        A.CallTo(() => scheduler.SchedulerInstanceId).Returns("NON_CLUSTERED");
+        A.CallTo(() => scheduler.GetStatus(A<CancellationToken>._)).CallsBaseMethod();
+        A.CallTo(() => scheduler.GetSchedulerInstanceId(A<CancellationToken>._)).CallsBaseMethod();
+
+        (await scheduler.GetStatus()).Should().Be(SchedulerStatus.ShuttingDown,
+            "the default implementation is what lets an implementation outside this repository compile "
+            + "unchanged, so it has to report what that implementation already reports");
+        (await scheduler.GetSchedulerInstanceId()).Should().Be("NON_CLUSTERED");
+    }
+
+    private static ServiceProvider Container(Action<IServiceCollection> register)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging();
+        register(services);
+        return services.BuildServiceProvider();
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.HttpClient.verified.txt
@@ -39,6 +39,8 @@ namespace Quartz
         public System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.SchedulerMetadata> GetMetadata(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<string> GetSchedulerInstanceId(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<Quartz.SchedulerStatus> GetStatus(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.ITrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ITrigger>> GetTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -661,6 +661,8 @@ namespace Quartz
         System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.SchedulerMetadata> GetMetadata(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.ValueTask<string> GetSchedulerInstanceId(System.Threading.CancellationToken cancellationToken = default); // default implementation
+        System.Threading.Tasks.ValueTask<Quartz.SchedulerStatus> GetStatus(System.Threading.CancellationToken cancellationToken = default); // default implementation
         System.Threading.Tasks.ValueTask<Quartz.ITrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ITrigger>> GetTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default);
@@ -3240,6 +3242,8 @@ namespace Quartz.Impl
         public virtual System.Threading.Tasks.ValueTask<Quartz.IJobDetail?> GetJobDetail(Quartz.JobKey jobKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.IJobDetail>> GetJobDetails(System.Collections.Generic.IReadOnlyCollection<Quartz.JobKey> jobKeys, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.SchedulerMetadata> GetMetadata(System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<string> GetSchedulerInstanceId(System.Threading.CancellationToken cancellationToken = default) { }
+        public virtual System.Threading.Tasks.ValueTask<Quartz.SchedulerStatus> GetStatus(System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.ITrigger?> GetTrigger(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<Quartz.TriggerState> GetTriggerState(Quartz.TriggerKey triggerKey, System.Threading.CancellationToken cancellationToken = default) { }
         public virtual System.Threading.Tasks.ValueTask<System.Collections.Generic.List<Quartz.ITrigger>> GetTriggers(System.Collections.Generic.IReadOnlyCollection<Quartz.TriggerKey> triggerKeys, System.Threading.CancellationToken cancellationToken = default) { }

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -122,6 +122,23 @@ public interface IScheduler : IAsyncDisposable
     string SchedulerInstanceId { get; }
 
     /// <summary>
+    /// The instance Id of the <see cref="IScheduler" />, asked asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The asynchronous twin of <see cref="SchedulerInstanceId" />, and the member to call from a
+    /// request path. A scheduler in this process answers with the same string either way. A proxy for a
+    /// scheduler in another process — <c>HttpScheduler</c> — has to ask it, and the property can only do
+    /// that by blocking the calling thread for the round trip; this one awaits it.
+    /// </para>
+    /// <para>
+    /// A default implementation answers <see cref="SchedulerInstanceId" />, so a scheduler written
+    /// outside this repository needs no change and reports what the property does.
+    /// </para>
+    /// </remarks>
+    ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default) => new(SchedulerInstanceId);
+
+    /// <summary>
     /// The clock this scheduler reads: what it calls "now" when it decides a trigger is due, and what a
     /// trigger built for it should compute its fire times from.
     /// </summary>
@@ -160,6 +177,27 @@ public interface IScheduler : IAsyncDisposable
     /// <seealso cref="Standby" />
     /// <seealso cref="Shutdown(bool, CancellationToken)" />
     SchedulerStatus Status { get; }
+
+    /// <summary>
+    /// Where the <see cref="IScheduler" /> is in its lifecycle, asked asynchronously.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The asynchronous twin of <see cref="Status" />, and the member to call from a request path. A
+    /// scheduler in this process answers with the same value either way, and the answer is as
+    /// instantaneous a snapshot here as it is there. A proxy for a scheduler in another process —
+    /// <c>HttpScheduler</c> — has to ask it, and the property can only do that by blocking the calling
+    /// thread for the round trip; this one awaits it.
+    /// </para>
+    /// <para>
+    /// A default implementation answers <see cref="Status" />, so a scheduler written outside this
+    /// repository needs no change and reports what the property does.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Start" />
+    /// <seealso cref="Standby" />
+    /// <seealso cref="Shutdown(bool, CancellationToken)" />
+    ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default) => new(Status);
 
     /// <summary>
     /// Get a <see cref="SchedulerMetadata" /> object describing the settings

--- a/src/Quartz/Impl/DeferredScheduler.cs
+++ b/src/Quartz/Impl/DeferredScheduler.cs
@@ -149,6 +149,19 @@ internal sealed class DeferredScheduler : IScheduler
     public string SchedulerInstanceId => Resolved.SchedulerInstanceId;
 
     /// <summary>
+    /// The instance Id of the scheduler this handle points at, building it first if nothing has yet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Resolve" /> rather than <see cref="Resolved" />: this member can wait for a scheduler
+    /// to be built, so it answers where the property would have to refuse.
+    /// </remarks>
+    public async ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.GetSchedulerInstanceId(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// The built scheduler's clock, or the system clock while there is no scheduler yet.
     /// </summary>
     /// <remarks>
@@ -162,6 +175,20 @@ internal sealed class DeferredScheduler : IScheduler
     public SchedulerContext Context => Resolved.Context;
 
     public SchedulerStatus Status => Resolved.Status;
+
+    /// <summary>
+    /// Where the scheduler this handle points at is in its lifecycle, building it first if nothing has
+    /// yet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Resolve" /> rather than <see cref="Resolved" />: this member can wait for a scheduler
+    /// to be built, so it answers where the property would have to refuse.
+    /// </remarks>
+    public async ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default)
+    {
+        var target = await Resolve(cancellationToken).ConfigureAwait(false);
+        return await target.GetStatus(cancellationToken).ConfigureAwait(false);
+    }
 
     public IListenerManager ListenerManager => Resolved.ListenerManager;
 

--- a/src/Quartz/Impl/DelegatingScheduler.cs
+++ b/src/Quartz/Impl/DelegatingScheduler.cs
@@ -36,6 +36,12 @@ public class DelegatingScheduler : IScheduler
     public virtual string SchedulerInstanceId => scheduler.SchedulerInstanceId;
 
     /// <inheritdoc />
+    public virtual ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetSchedulerInstanceId(cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual TimeProvider TimeProvider => scheduler.TimeProvider;
 
     /// <inheritdoc />
@@ -43,6 +49,12 @@ public class DelegatingScheduler : IScheduler
 
     /// <inheritdoc />
     public virtual SchedulerStatus Status => scheduler.Status;
+
+    /// <inheritdoc />
+    public virtual ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default)
+    {
+        return scheduler.GetStatus(cancellationToken);
+    }
 
     /// <inheritdoc />
     public virtual ValueTask<SchedulerMetadata> GetMetadata(CancellationToken cancellationToken = default)

--- a/src/Quartz/Impl/StdScheduler.cs
+++ b/src/Quartz/Impl/StdScheduler.cs
@@ -58,6 +58,14 @@ internal sealed class StdScheduler : IScheduler
     public string SchedulerInstanceId => scheduler.SchedulerInstanceId;
 
     /// <summary>
+    /// The proxied <see cref="QuartzScheduler" />'s instance Id, which is already in this process.
+    /// </summary>
+    public ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default)
+    {
+        return new ValueTask<string>(scheduler.SchedulerInstanceId);
+    }
+
+    /// <summary>
     /// The clock the proxied <see cref="QuartzScheduler" /> was built with.
     /// </summary>
     public TimeProvider TimeProvider => scheduler.resources.TimeProvider;
@@ -100,6 +108,15 @@ internal sealed class StdScheduler : IScheduler
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.
     /// </summary>
     public SchedulerStatus Status => scheduler.Status;
+
+    /// <summary>
+    /// Reads the same field of the proxied <see cref="QuartzScheduler" /> that <see cref="Status" />
+    /// does, since nothing has to be waited for to answer here.
+    /// </summary>
+    public ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default)
+    {
+        return new ValueTask<SchedulerStatus>(scheduler.Status);
+    }
 
     /// <summary>
     /// Calls the equivalent method on the 'proxied' <see cref="QuartzScheduler" />.


### PR DESCRIPTION
`IScheduler.Status` and `IScheduler.SchedulerInstanceId` are properties, and a property cannot be awaited. For a scheduler in this process that costs nothing; for `HttpScheduler` it means each read blocks the calling thread for an HTTP round trip, which is caveat 8 of beta.1 and what `packages/http-client.md#blocking-members` warns about.

## What changed

Two additive members on `IScheduler`, both **default interface members** answering the property they twin:

```csharp
ValueTask<string> GetSchedulerInstanceId(CancellationToken cancellationToken = default) => new(SchedulerInstanceId);
ValueTask<SchedulerStatus> GetStatus(CancellationToken cancellationToken = default) => new(Status);
```

A scheduler implemented outside this repository therefore compiles unchanged and reports exactly what it already reported. `HttpScheduler` overrides both through the `GetSchedulerDetails(cancellationToken)` it already had — the same one request the properties make, awaited rather than blocked on, and with the caller''s cancellation token reaching the wire.

`StdScheduler`, `DelegatingScheduler` and `DeferredScheduler` each **declare** both, per the forwarder rule: a member a forwarder omits runs the interface default *on the forwarder*, which asks the inner instance a different question. `DelegatingForwardingTest` sweeps for that and already covered the two new members without being changed.

One behaviour falls out of this rather than being designed: `DeferredScheduler` — the handle `[FromKeyedServices("acme")] IScheduler` injects — resolves *asynchronously* for the pair, so they answer for a scheduler the container has not built yet, where `Status` and `SchedulerInstanceId` have to throw. That is strictly more than the properties can do, and it is what an asynchronous member is for.

The properties stay, and stay blocking over HTTP. Nothing is deprecated.

## Docs

`packages/http-client.md` "Blocking members" now names the two members as the ones to call on a request path (new `sample_httpclient_status` snippet) and keeps the property caveat; `GetMetadata()` remains the recommendation where more than the status is wanted. Two rows added to the "Upgrading from 4.0 to 4.1" table, marked as default interface members.

## Baselines

Additions only, reviewed and accepted through the Verify workflow:

- `PublicApiTest_Quartz.verified.txt` — the two `IScheduler` members (marked `// default implementation`) and the two `DelegatingScheduler` overrides.
- `PublicApiTest_Quartz.HttpClient.verified.txt` — the two `HttpScheduler` overrides.

## Verification

- `dotnet build Quartz.slnx` — Build succeeded, 0 Warning(s), 0 Error(s)
- `dotnet test src/Quartz.Tests.Unit` — Failed: 0, Passed: 6220, Skipped: 36, Total: 6256
- `dotnet test src/Quartz.Tests.AspNetCore` — Failed: 0, Passed: 653, Skipped: 0, Total: 653
- `dotnet fallout DocsSnippets` — up to date (115 markdown files checked)
- `npm run docs:check-links` — 224 pages, 1429 internal links, 883 fragments, no dead links or anchors
- `npm run docs:lint` — 0 error(s)

Integration tests were not run: they need a Docker daemon, and nothing here reaches a job store.

## For a reviewer to decide

Nothing blocking, but two calls worth a look:

1. **`DeferredScheduler` answers before the scheduler is built.** The properties refuse in that window; the new members build it and answer. Deliberate — see above — but it is a difference between a property and its twin, on one implementation.
2. **`CountingHandler` in `HttpSchedulerStatusTest` now observes its cancellation token.** It has to, for the cancellation assertion to mean anything; it changes no existing test.

Closes #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK