### PR TITLE
The API reference links name the host that serves it

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ use this file except in compliance with the License. You may obtain a copy
 of the License [here](http://www.apache.org/licenses/LICENSE-2.0).
 
 For API documentation, please refer to the
-[4.x API reference](https://docs.quartz-scheduler.net/apidoc/4.x/), which is generated from the XML
+[4.x API reference](https://www.quartz-scheduler.net/apidoc/4.x/), which is generated from the XML
 documentation comments of the shipped packages and rolls forward with every 4.x minor release. The
-3.x set stays at [/apidoc/3.0](https://docs.quartz-scheduler.net/apidoc/3.0/html).
+3.x set stays at [/apidoc/3.0](https://docs.quartz-scheduler.net/apidoc/3.0).

--- a/apidoc/docfx.json
+++ b/apidoc/docfx.json
@@ -1,4 +1,4 @@
-// The docfx project behind https://docs.quartz-scheduler.net/apidoc/4.x/.
+// The docfx project behind https://www.quartz-scheduler.net/apidoc/4.x/.
 //
 // It sits at the repository root rather than under `docs/`, which is VuePress's source directory:
 // every `.md` under there becomes a site page, is link-checked by `npm run docs:check-links` and

--- a/apidoc/index.md
+++ b/apidoc/index.md
@@ -8,7 +8,7 @@ start, tutorial, configuration, how-tos - lives on the
 maps the 3.x names onto these.
 
 This set rolls forward with every 4.x minor release. The 3.x reference stays at
-[/apidoc/3.0](https://docs.quartz-scheduler.net/apidoc/3.0/html).
+[/apidoc/3.0](https://docs.quartz-scheduler.net/apidoc/3.0).
 
 ## Where to start
 

--- a/docs/.vuepress/configs/sidebar/en.ts
+++ b/docs/.vuepress/configs/sidebar/en.ts
@@ -57,7 +57,7 @@ export const sidebarEn: SidebarConfig = [
         // Generated with docfx by `dotnet fallout ApiDoc` and deployed with the site; the folder is
         // 4.x rather than a version because the set rolls forward with every 4.x minor release.
         text: "API Documentation",
-        link: "https://docs.quartz-scheduler.net/apidoc/4.x/",
+        link: "https://www.quartz-scheduler.net/apidoc/4.x/",
       },
     ],
   },


### PR DESCRIPTION
The reference #3740 generates is deployed with the site, to https://www.quartz-scheduler.net/apidoc/4.x/ (200 as of this PR), and that is where it answers. `docs.quartz-scheduler.net` is a different host: it carries the hand-made 3.0 set at `/apidoc/3.0` and nothing the docs workflow pushes, so the sidebar entry, the README and the reference's own landing page pointed at a 404 the moment they were published. The 3.0 links lose the `/html` segment, which that host no longer serves either.

Not touched: the 2.0 and 1.0 sidebar links also 404 on that host today (`/apidoc/2.0/html`, `/apidoc/1.0/html`) — pre-existing, and whatever serves `docs.quartz-scheduler.net` is not in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK