### PR TITLE
Two schedulers locking through Redis are proven not to double-fire

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,10 @@ Integration tests provision their database dependencies through Testcontainers f
   The values are `postgres`, `sqlserver`, `mysql`, `oracle`, `firebird`, `sqlite`, `redis`, `basic`
   (everything that needs no database) and `all`, and they set both the test-category filter and the
   `QUARTZ_TEST_DATABASE` variable the Testcontainers fixture reads. Naming none means `all`, which
-  starts seven containers — two for SQL Server, and one of them Oracle — before a single test runs.
+  starts seven containers before a single test runs — one each for PostgreSQL, MySQL, Oracle, Firebird
+  and Redis, and two for SQL Server; the Oracle one is what makes that wait long. `redis` starts two:
+  its own, and a PostgreSQL for the two schedulers of `RedisTwoNodeTest` to share, because Redis there
+  is the lock rather than the store.
 
 This builds and runs tests the way the CI server does. `IntegrationTest` is skipped on one machine
 only: a Windows or macOS CI leg, neither of which has a Docker daemon. It runs on yours.

--- a/src/Quartz.Tests.Integration/Redis/RedisClusterTestBase.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisClusterTestBase.cs
@@ -1,0 +1,487 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+using Quartz.Extensions.Redis;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Tests.Integration.Impl.AdoJobStore;
+
+namespace Quartz.Tests.Integration.Impl.Redis;
+
+/// <summary>
+/// The arrangement <c>Quartz.Extensions.Redis</c> exists for, actually running: two schedulers of one
+/// cluster, one persistent store between them, and a Redis key as the only thing that keeps them out
+/// of each other's way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The store is PostgreSQL rather than a SQLite file, which is what an in-process two-node fixture
+/// would otherwise reach for. SQLite cannot carry this case at all: <c>AdoJobStoreBase.Initialize</c>
+/// throws outright for a clustered SQLite store, and — before it gets that far — it replaces whatever
+/// lock handler was configured with <c>SqliteLockHandler</c>, because a single file has one writer and
+/// the global in-process gate is what makes it work. A fixture on SQLite would therefore either not
+/// start or not be locking through Redis, and either way would prove nothing. So the Redis CI leg
+/// starts a PostgreSQL container beside its Redis one; see <c>TestcontainersDatabaseEnvironment</c>.
+/// </para>
+/// <para>
+/// Every trigger here carries <see cref="SimpleTriggerMisfireInstruction.IgnoreMisfires" />, which is
+/// what makes "fired exactly once" a statement about a fixed set of instants rather than about a count.
+/// A trigger with that instruction is exempt from the misfire handler and from acquisition's
+/// <c>NoEarlierThan</c> bound, so its fire times stay the arithmetic series it was scheduled with
+/// however far behind the nodes fall — a slow CI runner makes the test slower, never differently
+/// scheduled.
+/// </para>
+/// </remarks>
+public abstract class RedisClusterTestBase : ClusteredJobStoreTestBase
+{
+    /// <summary>
+    /// The group every job and trigger a fixture here schedules belongs to.
+    /// </summary>
+    protected const string Group = "redisCluster";
+
+    /// <summary>
+    /// The trigger of the job with no concurrency constraint.
+    /// </summary>
+    protected const string OrdinaryTriggerName = "ordinaryTrigger";
+
+    /// <summary>
+    /// The trigger of the <c>[DisallowConcurrentExecution]</c> job.
+    /// </summary>
+    protected const string SerialTriggerName = "serialTrigger";
+
+    /// <summary>
+    /// How long one execution of the <c>[DisallowConcurrentExecution]</c> job takes.
+    /// </summary>
+    /// <remarks>
+    /// Not zero, because an overlap is only observable while two executions are both inside. It is the
+    /// window a second node's execution would have to land in for
+    /// <see cref="PeakConcurrentSerialExecutions" /> to see it, and it is also what the recorded
+    /// entry/exit pairs are intervals of.
+    /// </remarks>
+    private static readonly TimeSpan SerialJobDuration = TimeSpan.FromMilliseconds(10);
+
+    private static volatile ConcurrentBag<FiringRecord> firings = new();
+    private static int concurrentSerialExecutions;
+    private static int peakConcurrentSerialExecutions;
+
+    private string keyPrefix;
+
+    protected RedisClusterTestBase() : base(TestConstants.PostgresProvider)
+    {
+    }
+
+    /// <summary>
+    /// Every firing both nodes recorded, in no particular order.
+    /// </summary>
+    internal static ConcurrentBag<FiringRecord> Firings => firings;
+
+    /// <summary>
+    /// The most executions of the <c>[DisallowConcurrentExecution]</c> job that were ever inside
+    /// <see cref="SerialJob.Execute" /> at the same moment. One, or the guarantee is broken.
+    /// </summary>
+    protected static int PeakConcurrentSerialExecutions => Volatile.Read(ref peakConcurrentSerialExecutions);
+
+    /// <summary>
+    /// Fresh state, and a Redis key namespace of this test's own.
+    /// </summary>
+    /// <remarks>
+    /// The prefix is per test rather than per fixture so that a lock a crashed run left behind — the
+    /// keys carry a time to live, but it is thirty seconds — cannot make the next run wait for it.
+    /// </remarks>
+    [SetUp]
+    public void ResetRedisClusterState()
+    {
+        Interlocked.Exchange(ref firings, new ConcurrentBag<FiringRecord>());
+        Volatile.Write(ref concurrentSerialExecutions, 0);
+        Volatile.Write(ref peakConcurrentSerialExecutions, 0);
+        keyPrefix = $"quartz:test:{Guid.NewGuid():N}:";
+    }
+
+    /// <summary>
+    /// Builds one node of this fixture's cluster: its own container, its own scheduler, and a Redis
+    /// lock handler pointed at the fixture's server.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A container per node, because the two nodes share a scheduler name and the container keys a
+    /// scheduler's parts by that name — two nodes in one container would be one node asked for twice.
+    /// </para>
+    /// <para>
+    /// The two settings that matter to the proof are on <c>ConfigureStore</c>, applied after
+    /// <c>UseClustering</c> so that they win: <c>UseDbLocks</c> is off, so no <c>QRTZ_LOCKS</c> row is
+    /// ever taken and Redis is the only mutual exclusion there is, and
+    /// <c>AcquireTriggersWithinLock</c> is on, so every acquisition cycle goes through it rather than
+    /// only the batched ones.
+    /// </para>
+    /// </remarks>
+    internal async Task<RedisNode> CreateNode(string instanceId)
+    {
+        ServiceCollection services = new();
+
+        services.AddQuartz(quartz =>
+        {
+            quartz.ConfigureScheduler(options =>
+            {
+                options.InstanceName = SchedulerName;
+                options.InstanceId = instanceId;
+                options.IdleWaitTime = TimeSpan.FromSeconds(1);
+
+                // One at a time, deliberately. Both triggers are due at the same instants, so a node
+                // batching would take both rows every cycle and could hold the whole schedule while its
+                // peer found nothing — and a fixture where one node fires everything proves nothing
+                // about a lock. At one, both nodes reach for the same earliest row on every cycle,
+                // which is the contention a broken lock turns into a double fire, and the loser of each
+                // race still has the other trigger to fire.
+                options.MaxBatchSize = 1;
+            });
+
+            quartz.UseDefaultThreadPool(maxConcurrency: 10);
+
+            quartz.UsePersistentStore(store =>
+            {
+                store.UsePostgres(Database.ConnectionString);
+                store.UseSystemTextJsonSerializer();
+
+                store.UseClustering(cluster =>
+                {
+                    cluster.CheckinInterval = TimeSpan.FromSeconds(1);
+                    cluster.CheckinMisfireThreshold = TimeSpan.FromSeconds(5);
+                });
+
+                store.UseRedisLockHandler(redis =>
+                {
+                    redis.RedisConfiguration = RedisTestEnvironment.ConnectionString;
+                    redis.KeyPrefix = keyPrefix;
+
+                    // The shipped default is 100 ms, which is a tenth of a second of latency for the
+                    // node that lost the race. This fixture schedules a firing every 100 ms, which no
+                    // deployment does, so the poll is tightened to match rather than the workload
+                    // loosened to hide it.
+                    redis.LockRetryInterval = TimeSpan.FromMilliseconds(20);
+                });
+
+                store.ConfigureStore(options =>
+                {
+                    options.TablePrefix = "QRTZ_";
+
+                    // UseClustering turned this on, because clustering has never worked without a
+                    // cluster-wide lock. Here the cluster-wide lock is the Redis key, so the database
+                    // one is turned back off: what is being proved is that Redis alone is enough, and
+                    // a row lock underneath would prove it whatever Redis did.
+                    options.UseDbLocks = false;
+
+                    // Load-bearing, and the reason MaxBatchSize can stay at one: acquisition takes the
+                    // lock when it asks for more than one trigger *or* when this is set, so without it
+                    // a one-at-a-time node would acquire lock-free and the Redis key would guard
+                    // nothing that matters here.
+                    options.AcquireTriggersWithinLock = true;
+                });
+            });
+        });
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        AdoJobStoreBase store = (AdoJobStoreBase) provider.GetRequiredService<IJobStore>();
+
+        return new RedisNode(provider, scheduler, store);
+    }
+
+    /// <summary>
+    /// Adds the durable job both triggers fire, and the two triggers themselves.
+    /// </summary>
+    /// <remarks>
+    /// Scheduled on one node; the other reaches them through the store, which is the point.
+    /// </remarks>
+    protected static async Task<DateTimeOffset[]> ScheduleOrdinaryTrigger(
+        IScheduler scheduler,
+        DateTimeOffset start,
+        int firingCount,
+        TimeSpan interval)
+    {
+        IJobDetail job = JobBuilder.Create<OrdinaryJob>()
+            .WithIdentity("ordinary", Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+
+        return await Schedule(scheduler, job, OrdinaryTriggerName, start, firingCount, interval);
+    }
+
+    /// <summary>
+    /// The same, for the job that may only ever have one execution anywhere in the cluster.
+    /// </summary>
+    protected static async Task<DateTimeOffset[]> ScheduleSerialTrigger(
+        IScheduler scheduler,
+        DateTimeOffset start,
+        int firingCount,
+        TimeSpan interval)
+    {
+        IJobDetail job = JobBuilder.Create<SerialJob>()
+            .WithIdentity("serial", Group)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(job, new AddJobOptions { Replace = true });
+
+        return await Schedule(scheduler, job, SerialTriggerName, start, firingCount, interval);
+    }
+
+    private static async Task<DateTimeOffset[]> Schedule(
+        IScheduler scheduler,
+        IJobDetail job,
+        string triggerName,
+        DateTimeOffset start,
+        int firingCount,
+        TimeSpan interval)
+    {
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(triggerName, Group)
+            .ForJob(job)
+            .StartAt(start)
+            .WithSimpleSchedule(schedule => schedule
+                .WithInterval(interval)
+                .WithRepeatCount(firingCount - 1)
+                .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+            .Build());
+
+        // The same arithmetic SimpleTriggerImpl does, which is the whole of a simple trigger's schedule
+        // once misfires are out of the picture.
+        DateTimeOffset[] expected = new DateTimeOffset[firingCount];
+        for (int i = 0; i < firingCount; i++)
+        {
+            expected[i] = start + i * interval;
+        }
+
+        return expected;
+    }
+
+    /// <summary>
+    /// The property the whole fixture exists for: the trigger's scheduled fire times are exactly the
+    /// ones it was given, each of them fired, and none of them fired twice.
+    /// </summary>
+    /// <remarks>
+    /// Stated as three assertions rather than one set comparison so that a failure says which of the
+    /// three went wrong, and names the instants involved. A doubled fire time means two nodes fired the
+    /// same row; a missing one means a row was acquired and dropped.
+    /// </remarks>
+    protected static void AssertFiredExactlyOnce(string triggerName, DateTimeOffset[] expected)
+    {
+        FiringRecord[] recorded = Firings.Where(x => x.TriggerKey.Name == triggerName).ToArray();
+
+        DateTimeOffset[] doubled = recorded
+            .GroupBy(x => x.ScheduledFireTimeUtc)
+            .Where(x => x.Count() > 1)
+            .Select(x => x.Key)
+            .OrderBy(x => x)
+            .ToArray();
+
+        doubled.Should().BeEmpty(
+            "a scheduled fire time belongs to exactly one node, so a repeat means both acquired the "
+            + "same row through the Redis lock; doubled: [{0}]", Format(doubled));
+
+        DateTimeOffset[] missing = expected.Except(recorded.Select(x => x.ScheduledFireTimeUtc)).OrderBy(x => x).ToArray();
+
+        missing.Should().BeEmpty(
+            "every scheduled fire time of '{0}' has to fire — a missing one is a firing that was "
+            + "acquired and then dropped, which is the other half of what a broken lock produces; "
+            + "missing: [{1}]", triggerName, Format(missing));
+
+        DateTimeOffset[] unexpected = recorded.Select(x => x.ScheduledFireTimeUtc).Except(expected).OrderBy(x => x).ToArray();
+
+        unexpected.Should().BeEmpty(
+            "the misfire instruction is IgnoreMisfires, so nothing reschedules '{0}' and its fire times "
+            + "stay the series it was scheduled with; unexpected: [{1}]", triggerName, Format(unexpected));
+
+        recorded.Select(x => x.FireInstanceId).Should().OnlyHaveUniqueItems(
+            "a fire instance id names one firing, and two firings that shared one would make every "
+            + "count above agree with itself while the store had fired twice");
+    }
+
+    /// <summary>
+    /// That the <c>[DisallowConcurrentExecution]</c> job was never running twice at once, said twice:
+    /// by the counter the executions themselves keep, and by the entry/exit instants they recorded.
+    /// </summary>
+    /// <remarks>
+    /// The counter is what actually catches an overlap — it is incremented and decremented inside the
+    /// execution, so it cannot miss one. The interval check is what makes a failure readable: it names
+    /// the two firings and the nodes they ran on.
+    /// </remarks>
+    protected static void AssertSerialJobNeverOverlapped()
+    {
+        PeakConcurrentSerialExecutions.Should().Be(1,
+            "[DisallowConcurrentExecution] is a cluster-wide guarantee, and the store keeps it by "
+            + "blocking the trigger while an execution holds the job — a peak above one means two nodes "
+            + "were inside the same job at the same moment");
+
+        FiringRecord[] ordered = Firings
+            .Where(x => x.TriggerKey.Name == SerialTriggerName)
+            .OrderBy(x => x.Entered)
+            .ToArray();
+
+        for (int i = 1; i < ordered.Length; i++)
+        {
+            FiringRecord previous = ordered[i - 1];
+            FiringRecord current = ordered[i];
+
+            current.Entered.Should().BeOnOrAfter(previous.Exited,
+                "one execution of the job has to finish before the next begins; {0} on {1} entered at "
+                + "{2:O} while {3} on {4} was still inside until {5:O}",
+                current.FireInstanceId, current.InstanceId, current.Entered,
+                previous.FireInstanceId, previous.InstanceId, previous.Exited);
+        }
+    }
+
+    /// <summary>
+    /// Writes what the run actually produced, so that a green leg still reports its numbers.
+    /// </summary>
+    protected static void ReportFirings()
+    {
+        TestContext.Out.WriteLine("Firings per node: " + NodeFiringCounts());
+
+        TestContext.Out.WriteLine("Firings per trigger: " + string.Join(", ", Firings
+            .GroupBy(x => x.TriggerKey.Name)
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => $"{x.Key}={x.Count()}")));
+
+        TestContext.Out.WriteLine(
+            "Peak concurrent executions of the [DisallowConcurrentExecution] job: "
+            + PeakConcurrentSerialExecutions.ToString(CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Both nodes fired, which is what says the lock rotated rather than one node holding it throughout.
+    /// </summary>
+    protected static void AssertBothNodesFired(params string[] instanceIds)
+    {
+        Firings.Select(x => x.InstanceId).Distinct().Should().BeEquivalentTo(instanceIds,
+            "a lock that never changes hands would let one node fire everything, and every assertion "
+            + "about double firing would pass against a cluster that was not one");
+    }
+
+    protected static int FiringCount() => Firings.Count;
+
+    /// <summary>
+    /// How many firings the named node recorded.
+    /// </summary>
+    protected static int NodeFiringCount(string instanceId)
+        => Firings.Count(x => string.Equals(x.InstanceId, instanceId, StringComparison.Ordinal));
+
+    /// <summary>
+    /// The per-node tally, for the message a timed-out wait fails with: "no firings arrived" and "one
+    /// node took them all" are different failures and want telling apart.
+    /// </summary>
+    protected static string NodeFiringCounts()
+        => string.Join(", ", Firings
+            .GroupBy(x => x.InstanceId)
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => $"{x.Key}={x.Count()}"));
+
+    private static string Format(IEnumerable<DateTimeOffset> instants)
+        => string.Join(", ", instants.Select(x => x.ToString("O", CultureInfo.InvariantCulture)));
+
+    private static void Record(IJobExecutionContext context, DateTimeOffset entered, DateTimeOffset exited)
+    {
+        Firings.Add(new FiringRecord(
+            context.FireInstanceId,
+            context.Scheduler.SchedulerInstanceId,
+            context.Trigger.Key,
+            context.ScheduledFireTimeUtc!.Value,
+            entered,
+            exited));
+    }
+
+    /// <summary>
+    /// One firing, as the assertions need to see it: which firing it was, which node ran it, which
+    /// trigger and scheduled instant it was for, and the window it occupied.
+    /// </summary>
+    internal sealed record FiringRecord(
+        string FireInstanceId,
+        string InstanceId,
+        TriggerKey TriggerKey,
+        DateTimeOffset ScheduledFireTimeUtc,
+        DateTimeOffset Entered,
+        DateTimeOffset Exited);
+
+    /// <summary>
+    /// The job with no concurrency constraint at all: whatever exactly-once holds for it is the store's
+    /// doing rather than a queue's.
+    /// </summary>
+    public sealed class OrdinaryJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            Record(context, now, now);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// The job that may only have one execution in the whole cluster at a time.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class SerialJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            DateTimeOffset entered = DateTimeOffset.UtcNow;
+
+            int inside = Interlocked.Increment(ref concurrentSerialExecutions);
+            int peak = Volatile.Read(ref peakConcurrentSerialExecutions);
+            while (inside > peak && Interlocked.CompareExchange(ref peakConcurrentSerialExecutions, inside, peak) != peak)
+            {
+                peak = Volatile.Read(ref peakConcurrentSerialExecutions);
+            }
+
+            try
+            {
+                // Deliberately not the job's own token. A node shutting down mid-run is one of the
+                // things under test, and a firing that turned into a cancellation there would be a
+                // firing the totals could not count.
+                await Task.Delay(SerialJobDuration, CancellationToken.None).ConfigureAwait(false);
+            }
+            finally
+            {
+                Record(context, entered, DateTimeOffset.UtcNow);
+                Interlocked.Decrement(ref concurrentSerialExecutions);
+            }
+        }
+    }
+
+    /// <summary>
+    /// One node of the cluster, and everything a test has to reach into it for: the scheduler, the
+    /// store it was built with, and the lock handler that store settled on.
+    /// </summary>
+    internal sealed class RedisNode : IAsyncDisposable
+    {
+        private readonly ServiceProvider provider;
+
+        internal RedisNode(ServiceProvider provider, IScheduler scheduler, AdoJobStoreBase store)
+        {
+            this.provider = provider;
+            Scheduler = scheduler;
+            Store = store;
+        }
+
+        public IScheduler Scheduler { get; }
+
+        internal AdoJobStoreBase Store { get; }
+
+        /// <summary>
+        /// The handler the store is actually locking through, which is the premise every assertion in
+        /// these fixtures rests on.
+        /// </summary>
+        internal RedisLockHandler LockHandler => (RedisLockHandler) Store.LockHandler;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (Scheduler.Status is not (SchedulerStatus.ShuttingDown or SchedulerStatus.Shutdown))
+            {
+                await Scheduler.Shutdown(waitForJobsToComplete: false);
+            }
+
+            await provider.DisposeAsync();
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Redis/RedisLockHandlerShutdownUnderLoadTest.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisLockHandlerShutdownUnderLoadTest.cs
@@ -1,0 +1,121 @@
+using StackExchange.Redis;
+
+using Quartz.Extensions.Redis;
+
+namespace Quartz.Tests.Integration.Impl.Redis;
+
+/// <summary>
+/// A node leaves a running cluster: it closes the Redis connection it opened, it fires nothing more,
+/// and the schedule it was halfway through still comes out having fired every instant exactly once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>RedisLockHandlerTest.ShuttingDownClosesTheConnectionItOpened</c> is the same #3639 path with
+/// nothing else going on — a handler that took one lock, handled directly. This is that path where it
+/// actually matters: the handler is the store's, the store is mid-acquisition, a peer is contending
+/// for the very key being released, and the connection being closed is one the scheduler has been
+/// locking through for thousands of round trips.
+/// </para>
+/// <para>
+/// The workload is <see cref="RedisTwoNodeTest" />'s, shorter. It keeps the
+/// <c>[DisallowConcurrentExecution]</c> trigger because a node that vanishes while holding a job is
+/// the case that leaves a <c>BLOCKED</c> trigger behind for the survivor's cluster recovery to unblock,
+/// and that unblocking is part of what "costs the cluster no firing" means.
+/// </para>
+/// </remarks>
+[Category("db-redis")]
+[NonParallelizable]
+public sealed class RedisLockHandlerShutdownUnderLoadTest : RedisClusterTestBase
+{
+    private const int OrdinaryFirings = 100;
+    private const int SerialFirings = 60;
+
+    /// <summary>
+    /// How much of the schedule has to be behind the cluster before one node leaves, so that the
+    /// leaving genuinely happens mid-run.
+    /// </summary>
+    private const int FiringsBeforeLeaving = 20;
+
+    private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(100);
+
+    protected override string SchedulerName => "redis-shutdown-load";
+
+    [Test]
+    public async Task ANodeLeavingMidRunClosesItsConnectionAndCostsTheClusterNoFiring()
+    {
+        await using RedisNode nodeA = await CreateNode("nodeA");
+        await using RedisNode nodeB = await CreateNode("nodeB");
+
+        nodeA.Store.LockHandler.Should().BeOfType<RedisLockHandler>(
+            "the connection this test watches close is one the store opened for its own locking, so a "
+            + "store locking through anything else would make every assertion below vacuous");
+        nodeB.Store.LockHandler.Should().BeOfType<RedisLockHandler>();
+
+        await nodeA.Scheduler.Start();
+        await nodeB.Scheduler.Start();
+
+        DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(3);
+        DateTimeOffset[] ordinary = await ScheduleOrdinaryTrigger(nodeA.Scheduler, start, OrdinaryFirings, Interval);
+        DateTimeOffset[] serial = await ScheduleSerialTrigger(nodeB.Scheduler, start, SerialFirings, Interval);
+
+        // Both nodes have to have taken the lock and fired through it, or "one node left" would be
+        // "one node never joined" and the survivor would simply carry on as it always had.
+        await WaitForCondition(
+            () => Task.FromResult(FiringCount() >= FiringsBeforeLeaving && NodeFiringCount("nodeA") > 0 && NodeFiringCount("nodeB") > 0),
+            timeoutMs: 60_000,
+            async () => $"both nodes to be firing, with at least {FiringsBeforeLeaving} firings behind "
+                        + $"them ({NodeFiringCounts()}). State:\n{await DumpDatabaseState()}");
+
+        RedisLockHandler leaving = nodeA.LockHandler;
+        IConnectionMultiplexer opened = leaving.Connection;
+
+        opened.Should().NotBeNull("the node has been locking through Redis, which is what opens the connection");
+        opened.IsConnected.Should().BeTrue("the node was talking to this server a moment ago");
+
+        int nodeBBeforeLeaving = NodeFiringCount("nodeB");
+
+        await nodeA.Scheduler.Shutdown(waitForJobsToComplete: false);
+
+        opened.IsConnected.Should().BeFalse(
+            "the multiplexer belongs to the handler and the handler to the store, so a scheduler that "
+            + "has shut down leaves no Redis connection and no heartbeat behind (#3639) — and it has to "
+            + "hold with a peer still contending for the very key this node was releasing");
+        leaving.Connection.Should().BeNull("the handler has let go of what it closed");
+
+        // A firing already dispatched when the halt landed still records itself, so the leaver's count
+        // is taken after that has had time to happen rather than at the instant of the shutdown.
+        await Task.Delay(2000);
+        int nodeAAfterLeaving = NodeFiringCount("nodeA");
+
+        // Generous, because the survivor may first have to notice its peer is gone: a node that leaves
+        // does not delete its own SCHEDULER_STATE row, so anything it was holding waits on the other
+        // node's cluster recovery — one check-in interval plus the misfire threshold.
+        await WaitForCondition(
+            () => Task.FromResult(FiringCount() >= OrdinaryFirings + SerialFirings),
+            timeoutMs: 90_000,
+            async () => $"the survivor to finish the schedule alone; {FiringCount()} of "
+                        + $"{OrdinaryFirings + SerialFirings} firings arrived ({NodeFiringCounts()}). "
+                        + $"State:\n{await DumpDatabaseState()}");
+
+        await Task.Delay(3000);
+
+        ReportFirings();
+
+        NodeFiringCount("nodeB").Should().BeGreaterThan(nodeBBeforeLeaving,
+            "the survivor has to take over the whole schedule — a cluster whose remaining node stopped "
+            + "firing when its peer left would be worse than one that never had a peer");
+
+        NodeFiringCount("nodeA").Should().Be(nodeAAfterLeaving,
+            "a scheduler that has shut down acquires nothing, so every firing from here on is the "
+            + "survivor's");
+
+        AssertFiredExactlyOnce(OrdinaryTriggerName, ordinary);
+        AssertFiredExactlyOnce(SerialTriggerName, serial);
+        AssertSerialJobNeverOverlapped();
+
+        FiringCount().Should().Be(OrdinaryFirings + SerialFirings,
+            "a node leaving costs the cluster no firing and gains it none — the two triggers have {0} "
+            + "scheduled instants whether or not both nodes saw them through",
+            OrdinaryFirings + SerialFirings);
+    }
+}

--- a/src/Quartz.Tests.Integration/Redis/RedisTestEnvironment.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisTestEnvironment.cs
@@ -12,6 +12,10 @@ public class RedisTestEnvironment
     [OneTimeSetUp]
     public async Task SetUp()
     {
+        // redis:7 is what the CI leg runs and what the package is supported against. The handler speaks
+        // nothing but SET NX PX, GET, DEL and one EVAL, so another RESP server — Garnet, suggested on the
+        // 4.0.0 announcement — is an image name away; that has not been run here, so it is an invitation
+        // rather than a claim, and the default stays where support is.
         container = new RedisBuilder("redis:7").Build();
         await container.StartAsync();
         ConnectionString = container.GetConnectionString();

--- a/src/Quartz.Tests.Integration/Redis/RedisTwoNodeTest.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisTwoNodeTest.cs
@@ -1,0 +1,92 @@
+using Quartz.Extensions.Redis;
+
+namespace Quartz.Tests.Integration.Impl.Redis;
+
+/// <summary>
+/// Two schedulers, one store, and a Redis key between them: every scheduled firing happens on exactly
+/// one of them, and the job that forbids concurrency never runs twice at once.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>RedisLockHandlerTest</c> proves the handler keeps its own contract — re-entry, cancellation,
+/// expiry, ownership. None of that says a cluster locking through it cannot double-fire, because that
+/// is a property of the handler <em>and</em> of everything the store does under it. This is the case
+/// that says it, and it is the reason the package exists.
+/// </para>
+/// <para>
+/// The two nodes contend for the same two trigger rows two hundred and fifty times over, with database
+/// row locking switched off, so there is nothing but the Redis key keeping them apart. A lock that
+/// granted itself twice would show up as a scheduled fire time fired by both nodes; one that lost a
+/// release would show up as a fire time that never fired at all. Both are asserted, by name.
+/// </para>
+/// </remarks>
+[Category("db-redis")]
+[NonParallelizable]
+public sealed class RedisTwoNodeTest : RedisClusterTestBase
+{
+    private const int OrdinaryFirings = 150;
+    private const int SerialFirings = 100;
+
+    private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(100);
+
+    protected override string SchedulerName => "redis-two-node";
+
+    [Test]
+    public async Task TwoNodesLockingThroughRedisFireEveryScheduledTimeExactlyOnce()
+    {
+        await using RedisNode nodeA = await CreateNode("nodeA");
+        await using RedisNode nodeB = await CreateNode("nodeB");
+
+        // The premise, asserted rather than assumed: a store that had quietly built a lock handler of
+        // its own would pass everything below without Redis being involved at all.
+        nodeA.Store.LockHandler.Should().BeOfType<RedisLockHandler>(
+            "UseRedisLockHandler registers the handler the store then locks through, and everything "
+            + "this fixture asserts is about that handler");
+        nodeB.Store.LockHandler.Should().BeOfType<RedisLockHandler>();
+
+        nodeA.Store.UseDbLocks.Should().BeFalse(
+            "a QRTZ_LOCKS row underneath would keep the two nodes apart whatever Redis did, and the "
+            + "proof would be of the database's locking rather than of this package's");
+        nodeB.Store.UseDbLocks.Should().BeFalse();
+
+        await nodeA.Scheduler.Start();
+        await nodeB.Scheduler.Start();
+
+        // Far enough out that both triggers are stored, and both nodes awake, before either is due.
+        DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(3);
+
+        // Due at the same instants, so both nodes reach for the same earliest row on every cycle. Two
+        // of them rather than one so that the loser of each race still has something to fire: a node
+        // that never fired would make the exactly-once assertions true of a cluster of one.
+        DateTimeOffset[] ordinary = await ScheduleOrdinaryTrigger(nodeA.Scheduler, start, OrdinaryFirings, Interval);
+        DateTimeOffset[] serial = await ScheduleSerialTrigger(nodeB.Scheduler, start, SerialFirings, Interval);
+
+        await WaitForCondition(
+            () => Task.FromResult(FiringCount() >= OrdinaryFirings + SerialFirings),
+            timeoutMs: 90_000,
+            async () => $"all {OrdinaryFirings + SerialFirings} firings; {FiringCount()} arrived "
+                        + $"({NodeFiringCounts()}). State:\n{await DumpDatabaseState()}");
+
+        // Absence cannot be polled for. A duplicate that lost its race by a few hundred milliseconds
+        // arrives after the last legitimate firing rather than before it, so the wait above would end
+        // just as happily either way.
+        await Task.Delay(3000);
+
+        ReportFirings();
+
+        AssertFiredExactlyOnce(OrdinaryTriggerName, ordinary);
+        AssertFiredExactlyOnce(SerialTriggerName, serial);
+        AssertSerialJobNeverOverlapped();
+        AssertBothNodesFired("nodeA", "nodeB");
+
+        FiringCount().Should().Be(OrdinaryFirings + SerialFirings,
+            "the two triggers have {0} scheduled firings between them and no other trigger exists, so "
+            + "any other total is a firing this fixture cannot account for", OrdinaryFirings + SerialFirings);
+
+        // The last statement rather than the first, because a trigger that has run out of repeats is
+        // deleted: "Complete or None" cannot tell a finished schedule from one that never existed, and
+        // is only worth asserting once the firings above have said which of the two this is.
+        await WaitForTriggerCompletion(nodeB.Scheduler, new TriggerKey(OrdinaryTriggerName, Group), 10_000);
+        await WaitForTriggerCompletion(nodeB.Scheduler, new TriggerKey(SerialTriggerName, Group), 10_000);
+    }
+}

--- a/src/Quartz.Tests.Integration/TestcontainersDatabaseEnvironment.cs
+++ b/src/Quartz.Tests.Integration/TestcontainersDatabaseEnvironment.cs
@@ -57,8 +57,8 @@ internal static class TestcontainersDatabaseEnvironment
             string targetDatabase = Environment.GetEnvironmentVariable("QUARTZ_TEST_DATABASE")?.ToLowerInvariant();
             bool startAll = string.IsNullOrEmpty(targetDatabase) || targetDatabase == "all";
 
-            // No database containers needed for basic, sqlite, or redis tests (redis has its own container via RedisTestEnvironment)
-            if (targetDatabase is "basic" or "sqlite" or "redis")
+            // No database containers needed for basic or sqlite tests.
+            if (targetDatabase is "basic" or "sqlite")
             {
                 initialized = true;
                 return;
@@ -66,7 +66,13 @@ internal static class TestcontainersDatabaseEnvironment
 
             try
             {
-                if (startAll || targetDatabase == "postgres")
+                // The Redis leg brings its own Redis through RedisTestEnvironment, and takes a
+                // PostgreSQL besides. Redis there is the *lock*, not the store, so proving that two
+                // schedulers locking through it never double-fire needs a store they can cluster over —
+                // and SQLite, the one engine that needs no container, refuses clustering outright and
+                // substitutes its own lock handler for whatever was configured. See
+                // RedisClusterTestBase.
+                if (startAll || targetDatabase is "postgres" or "redis")
                 {
                     await StartPostgreSqlContainerAsync(await ReadScriptAsync("database", "tables", "tables_postgres.sql"));
                 }


### PR DESCRIPTION
`Quartz.Extensions.Redis` was the least exercised package that 4.0.0 shipped: one unit test and one
Testcontainers fixture, all of it about `RedisLockHandler` in isolation. `RedisLockHandlerTest` proves
the handler keeps its own contract — re-entry answers `false`, a cancelled wait throws rather than
lying, a lock expires, a non-owner cannot release. None of that says a *cluster* locking through it
cannot fire a trigger twice, because that is a property of the handler **and** of everything the store
does under it.

Two fixtures, both test-only, under the existing `db-redis` category so `pr-integration-redis.yml`
runs them.

## `RedisTwoNodeTest`

Two schedulers of one cluster, one persistent store between them, `UseDbLocks` off so no `QRTZ_LOCKS`
row is ever taken, and `AcquireTriggersWithinLock` on so every acquisition cycle of both nodes goes
through the Redis key. 250 scheduled firings over two triggers due at the same instants — 150 of an
ordinary job, 100 of a `[DisallowConcurrentExecution]` one — scheduled from opposite nodes.

It asserts, by name:

* every scheduled fire time fired, and none of them twice (a doubled instant means two nodes acquired
  one row; a missing one means a row was acquired and dropped);
* no fire time outside the series the triggers were scheduled with;
* the `[DisallowConcurrentExecution]` job never had two executions inside it at once, said twice — by
  the counter the executions themselves keep, and by their recorded entry/exit intervals. Both nodes
  are in one process, so that counter observes cluster-wide concurrency directly;
* both nodes fired, so the lock actually changed hands. Without this the other assertions would pass
  against a cluster that was not one.

Two design choices are load-bearing rather than incidental, and both are commented where they are made:

* **`IgnoreMisfires` on both triggers.** Such a trigger is exempt from the misfire handler and from
  acquisition's `NoEarlierThan` bound, so its fire times stay the arithmetic series it was scheduled
  with however far behind the nodes fall. A slow runner makes the test slower, never differently
  scheduled — which is what lets "fired exactly once" be a statement about a fixed set of instants
  rather than about a count.
* **`MaxBatchSize = 1`.** Both triggers are due at the same instants, so a node that batched would take
  both rows every cycle and could hold the whole schedule while its peer found nothing — and a proof in
  which one node fires everything says nothing about a lock. At one, both nodes reach for the same
  earliest row on every cycle, which is the contention a broken lock turns into a double fire, and the
  loser of each race still has the other trigger to fire. `AcquireTriggersWithinLock` is what keeps the
  Redis key in the path, since acquisition locks when it asks for more than one trigger *or* when that
  is set.

The fixture writes its per-node and per-trigger tallies and the peak concurrent execution count to the
test output, so a green leg still reports its numbers.

## `RedisLockHandlerShutdownUnderLoadTest`

The #3639 shutdown path where it matters. `RedisLockHandlerTest.ShuttingDownClosesTheConnectionItOpened`
runs it on a handler that took one lock, held directly. Here the handler is the store's, the store is
mid-acquisition, a peer is contending for the very key being released, and the connection is one the
scheduler has been locking through for thousands of round trips. One node leaves mid-run; the
multiplexer closes and the handler lets go of it, the leaver fires nothing more, the survivor takes
over the whole schedule, and every instant is still fired exactly once.

It keeps the `[DisallowConcurrentExecution]` trigger, because a node that vanishes while holding that
job leaves a `BLOCKED` trigger for the survivor's cluster recovery to unblock, and that unblocking is
part of what "costs the cluster no firing" has to mean.

## The store is PostgreSQL, not a SQLite file — reviewer decision

The issue offers "SQLite file or the PostgreSQL fixture". **SQLite cannot carry this case at all**, and
that is worth a reviewer's eye:

* `AdoJobStoreBase.Initialize` throws `InvalidConfigurationException("SQLite cannot be used as
  clustered mode due to locking problems")` for a clustered SQLite store; and
* before it gets that far it replaces *whatever lock handler was configured* with `SqliteLockHandler`
  — `if (Delegate is SQLiteDelegate && LockHandler is not SqliteLockHandler)` — because one file has
  one writer and the global in-process gate is what makes it work.

So a fixture on SQLite would either not start or not be locking through Redis, and either way would
prove nothing. Neither is a bug: both are deliberate and documented. The consequence is that the Redis
CI leg now starts a PostgreSQL container beside its own Redis one — the `redis` leg's wall time grows
by one `postgres:15.1` start, against a 10-minute budget it currently uses a fraction of. If that cost
is unwanted, the alternative is dropping the two-node proof, because there is no third store that runs
without a container.

`CONTRIBUTING.md`'s sentence counting what `all` starts named six of its seven containers — the total
was right, Redis was the one not named. It now names all seven and says what `redis` starts.

## Verification

Docker is not running on this machine (`docker info`: *failed to connect to the docker API at
`npipe:////./pipe/docker_engine`*), so **the CI leg is the run** — I have not seen these two tests
execute. What I did see:

```
dotnet build Quartz.slnx          → Build succeeded. 0 Warning(s), 0 Error(s)
dotnet test Quartz.Tests.Unit     → Passed! Failed: 0, Passed: 6232, Skipped: 36, Total: 6268, 53 s
dotnet test Quartz.Tests.AspNetCore → Passed! Failed: 0, Passed: 671, Skipped: 0, Total: 671, 7 s
dotnet fallout VerifyDocsSnippets → Documentation snippets are up to date (115 markdown files checked)
dotnet test --list-tests --filter "TestCategory=db-redis&TestCategory!=LongRunning"
    → lists TwoNodesLockingThroughRedisFireEveryScheduledTimeExactlyOnce
      and ANodeLeavingMidRunClosesItsConnectionAndCostsTheClusterNoFiring
      beside the thirteen existing db-redis tests
```

The numbers the proof produces — firings per node, per trigger, and the peak concurrent execution
count — land in the leg's test output.

## Not done

The issue's optional Garnet check ("if that is free to check") was not free without a daemon, so
`RedisTestEnvironment` carries a note saying `redis:7` is where support is and that another RESP
server is an image name away, explicitly as an invitation rather than as a claim that it passes. The
default image is unchanged.

Closes #3722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
