### PR TITLE
Quartz depends on the logging abstractions rather than the logging package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,8 @@ updates:
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "Microsoft.Extensions.Logging"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "Microsoft.Extensions.Logging.Console"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "Microsoft.Extensions.Options.ConfigurationExtensions"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -111,11 +111,19 @@
     moving the floor instead would hand the demand to every consumer. Nothing that ships may do it, which
     PackageDependencyTest holds.
 
-    Two of the ids here are not floors themselves. Microsoft.Extensions.Hosting and
-    Microsoft.Extensions.Logging.Console ship in nothing and are referenced only by tests and examples,
-    but dotnet/runtime versions the family in lockstep: 10.0.11 of either demands 10.0.11 of a floored
-    id, and CentralPackageTransitivePinningEnabled has already pinned that at the floor, so restore
-    fails. They sit with the floors so the family stays one line rather than two that disagree.
+    Three of the ids here are not floors themselves. Microsoft.Extensions.Hosting,
+    Microsoft.Extensions.Logging and Microsoft.Extensions.Logging.Console ship in nothing and are
+    referenced only by tests and examples, but dotnet/runtime versions the family in lockstep: 10.0.11
+    of any of them demands 10.0.11 of a floored id, and CentralPackageTransitivePinningEnabled has
+    already pinned that at the floor, so restore fails. They sit with the floors so the family stays one
+    line rather than two that disagree.
+
+    Microsoft.Extensions.Logging is the newest of the three and used to be a floor: Quartz referenced it
+    for one call, services.AddLogging(), and every shipped package inherited it. Quartz references
+    Microsoft.Extensions.Logging.Abstractions instead as of 4.1 (#3730), so no nuspec names the
+    implementation package any more — but Microsoft.Extensions.Hosting and
+    Microsoft.Extensions.Logging.Console both pull it in transitively, and it is pinned here for the
+    same lockstep reason they are.
 
     That pinning is also why several of these ids reach nuspecs that name none of them: Quartz.Jobs
     references nothing but Quartz, and carries all six of Quartz's framework extensions as dependencies of
@@ -136,6 +144,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     <!--

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -40,8 +40,9 @@ The rest of this guide is written as one statement about 3.x and 4.0, with no bu
 ## Upgrading from 4.0 to 4.1
 
 Nothing in the 4.0 public surface moved and the database schema did not either, so an application on
-4.0 compiles on 4.1 unchanged. What is here is what 4.1 makes newly possible, and the two cron
-expressions it reads differently.
+4.0 compiles on 4.1 unchanged — unless it was using a package it took transitively from `Quartz` and
+`Quartz` no longer carries, which is the one dependency change below. What is here is what 4.1 makes
+newly possible, that change, and the two cron expressions 4.1 reads differently.
 
 | Added | What it is |
 |---|---|
@@ -83,6 +84,32 @@ Four behaviours changed without a signature changing:
 
 The mechanics, the refusals and the recipes are in
 [Multi-Tenancy](multi-tenancy.md#adding-a-tenant-while-the-process-is-running).
+
+One dependency changed, and a consumer can see it: **`Quartz` depends on
+`Microsoft.Extensions.Logging.Abstractions` rather than `Microsoft.Extensions.Logging`.** Quartz writes
+log events, and building the pipeline that carries them is the application's job — the implementation
+package was referenced for exactly one call, `AddLogging()` inside `AddQuartz`, and it is not made any
+more. Nothing in the public surface moves, and an application under a host, or one that calls
+`services.AddLogging(…)` on either side of `AddQuartz`, sees no difference at all: Quartz logs through
+whatever `ILoggerFactory` the container holds, as it always has.
+
+What changes is a project that used `LoggerFactory`, `AddLogging` or another
+`Microsoft.Extensions.Logging` type without ever referencing the package, taking it transitively through
+`Quartz`. That project references it:
+
+```shell
+dotnet add package Microsoft.Extensions.Logging
+```
+
+Two consequences follow, and a hosted application meets neither. A container that configured no logging
+at all now holds no `ILoggerFactory`: `AddQuartz` used to register one, and registering one now would
+beat the `services.AddLogging(logging => logging.AddConsole())` written on the line after it and drop
+the application's providers in silence. Such a container still builds and runs a scheduler, and its
+lines go to `LogProvider` — where everything Quartz cannot inject a logger into already writes. And
+`QuartzSchedulerBuilder` refuses at `Build()` a container holding `ILoggerProvider` registrations with
+no `ILoggerFactory` to read them, which used to work because Quartz's own `AddLogging()` supplied the
+factory; register the provider the ordinary way, `Services.AddLogging(logging =>
+logging.AddProvider(…))`, which brings a factory with it.
 
 Two cron expressions change what they mean, and neither can be reported to you — both parse on 4.1:
 

--- a/src/Quartz.Benchmark/Quartz.Benchmark.csproj
+++ b/src/Quartz.Benchmark/Quartz.Benchmark.csproj
@@ -36,6 +36,12 @@
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="MySqlConnector" />
     <PackageReference Include="Npgsql" />
+    <!--
+      Those drivers drag in Microsoft.Extensions.Caching.Memory, pinned centrally at 10.0.10, which asks
+      for a Microsoft.Extensions.Logging.Abstractions above the 10.0.0 floor Quartz ships. Raised for
+      this project alone, which inherits nothing to anybody.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Examples.Aspire.AppHost/Quartz.Examples.Aspire.AppHost.csproj
+++ b/src/Quartz.Examples.Aspire.AppHost/Quartz.Examples.Aspire.AppHost.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />
     <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />

--- a/src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj
+++ b/src/Quartz.Examples.Wolverine/Quartz.Examples.Wolverine.csproj
@@ -50,6 +50,12 @@
     <PackageReference Include="WolverineFx.Postgresql" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <!--
+      Npgsql drags in Microsoft.Extensions.Caching.Memory, pinned centrally at 10.0.10, which asks for a
+      Microsoft.Extensions.Logging.Abstractions above the 10.0.0 floor Quartz ships. Raised for this
+      project alone, which inherits nothing to anybody.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/Quartz.Examples/Quartz.Examples.csproj
+++ b/src/Quartz.Examples/Quartz.Examples.csproj
@@ -23,6 +23,13 @@
     <!-- The clustering example's database driver. Quartz names a provider rather than referencing
          one, so without this the example fails at startup with a missing assembly. -->
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <!--
+      The driver above drags in Microsoft.Extensions.Caching.Memory, pinned centrally at 10.0.10, which
+      asks for a Microsoft.Extensions.Logging.Abstractions above the 10.0.0 floor Quartz ships. Raised
+      for this project alone, which inherits nothing to anybody - a floor is a demand made of every
+      consumer, and no consumer should inherit a driver's servicing schedule.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="NLog.Extensions.Logging" />
     <PackageReference Include="Serilog" />

--- a/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
+++ b/src/Quartz.Extensions.Redis/Quartz.Extensions.Redis.csproj
@@ -25,6 +25,23 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <!--
+      The one shipped project that does not restate Quartz's floors in its own nuspec, and the reason is
+      StackExchange.Redis. Transitive pinning turns every centrally versioned id in the graph into a
+      direct dependency at exactly the central version, and NuGet resolves a direct reference in
+      preference to a deeper one whichever way round the versions are - so pinning
+      Microsoft.Extensions.Logging.Abstractions at the 10.0.0 floor while StackExchange.Redis 3.0.0 asks
+      for 10.0.5 is a package downgrade (NU1109) rather than a floor being raised to meet a demand.
+
+      The alternatives were worse. Raising the floor to 10.0.5 would hand StackExchange.Redis' servicing
+      schedule to every consumer of Quartz itself, which is the mistake #3717 was about; a
+      VersionOverride would write a floor into this nuspec where neither Directory.Packages.props nor
+      Dependabot can see it, which PackageDependencyTest refuses on any shipped project. Turning the
+      pinning off leaves this package's nuspec saying what it actually depends on - Quartz and
+      StackExchange.Redis - and a consumer inherits Quartz's floors through Quartz, which is where they
+      are declared and checked. Same reasoning as src/QuartzShimPackage.props, for the same mechanism.
+    -->
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />

--- a/src/Quartz.Tests.Integration.Seeder/Quartz.Tests.Integration.Seeder.csproj
+++ b/src/Quartz.Tests.Integration.Seeder/Quartz.Tests.Integration.Seeder.csproj
@@ -34,6 +34,13 @@
     -->
     <PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.4" />
 
+    <!--
+      The drivers below drag in Microsoft.Extensions.Caching.Memory, pinned centrally at 10.0.10, which
+      asks for a Microsoft.Extensions.Logging.Abstractions above the 10.0.0 floor Quartz ships. Raised
+      here for the same reason as the pins above: a scratch process inherits nothing to anyone.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
+
     <!-- The six providers 3.20's DbProvider loads by assembly name, one per dialect it can seed. -->
     <PackageReference Include="FirebirdSql.Data.FirebirdClient" />
     <PackageReference Include="Microsoft.Data.SqlClient" />

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -55,6 +55,12 @@
       host up around a scheduler needs the host, which is this package.
     -->
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <!--
+      The ADO.NET drivers drag in Microsoft.Extensions.Caching.Memory, pinned centrally at 10.0.10,
+      which asks for a Microsoft.Extensions.Logging.Abstractions above the 10.0.0 floor Quartz ships.
+      Raised for this project alone, which inherits nothing to anybody.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MySqlConnector" />

--- a/src/Quartz.Tests.Unit/Configuration/LoggingRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LoggingRegistrationTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 using Quartz.Diagnostics;
+using Quartz.Extensibility;
 
 namespace Quartz.Tests.Unit.Configuration;
 
@@ -82,6 +83,36 @@ public sealed class LoggingRegistrationTest
         (await scheduler.GetStatus()).Should().Be(SchedulerStatus.Running,
             "a container that was never told where logging goes is still a container a scheduler builds "
             + "and runs out of - nothing about logging may be a precondition for scheduling");
+    }
+
+    /// <summary>
+    /// (i, continued) A component of your own, built by Quartz in that same container, still gets
+    /// everything its constructor asks for — an <see cref="ILoggerFactory" /> included.
+    /// </summary>
+    /// <remarks>
+    /// It has always been satisfiable, because <c>AddQuartz</c> used to call <c>AddLogging()</c>. Now
+    /// the factory comes from the provider Quartz activates through rather than from a registration, so
+    /// this holds the two together: the ambient bridge arrives, and the keyed parameter beside it still
+    /// resolves the way the container would have resolved it.
+    /// </remarks>
+    [Test]
+    public void AComponentBuiltInThatContainerStillGetsAnILoggerFactory()
+    {
+        ServiceCollection services = new();
+        services.AddKeyedSingleton("audit", new AuditSink());
+        services.AddQuartz(quartz => quartz.UseInstanceIdGenerator<DemandingInstanceIdGenerator>());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        DemandingInstanceIdGenerator generator = provider.GetRequiredService<IInstanceIdGenerator>()
+            .Should().BeOfType<DemandingInstanceIdGenerator>().Subject;
+
+        generator.LoggerFactory.Should().BeOfType<LogProviderLoggerFactory>(
+            "'you configured no logging, so your component cannot be built' is not an answer, and the "
+            + "ambient bridge is where the rest of Quartz already writes when nothing was configured");
+        generator.Sink.Should().NotBeNull(
+            "and the provider Quartz activates through has to stay an ordinary one for everything else, "
+            + "keyed constructor parameters included");
     }
 
     /// <summary>
@@ -250,6 +281,33 @@ public sealed class LoggingRegistrationTest
 
         await scheduler.Start();
         return scheduler;
+    }
+
+    /// <summary>
+    /// Something for a keyed constructor parameter to be, so that the component below asks the
+    /// activating provider for two different kinds of thing at once.
+    /// </summary>
+    private sealed class AuditSink;
+
+    /// <summary>
+    /// A component of the shape an application writes: it takes a logger factory, and something else
+    /// the container holds under a key.
+    /// </summary>
+    private sealed class DemandingInstanceIdGenerator : IInstanceIdGenerator
+    {
+        public DemandingInstanceIdGenerator(
+            ILoggerFactory loggerFactory,
+            [FromKeyedServices("audit")] AuditSink sink)
+        {
+            LoggerFactory = loggerFactory;
+            Sink = sink;
+        }
+
+        public ILoggerFactory LoggerFactory { get; }
+
+        public AuditSink Sink { get; }
+
+        public ValueTask<string> GenerateInstanceId(CancellationToken cancellationToken = default) => new("demanding");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Configuration/LoggingRegistrationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LoggingRegistrationTest.cs
@@ -1,0 +1,304 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Tests.Unit.Configuration;
+
+/// <summary>
+/// Where a Quartz log line ends up, for every order the two calls that decide it can be written in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Quartz registers <see cref="ILogger{T}" /> and deliberately no <see cref="ILoggerFactory" />
+/// (#3730). The reason is the whole of this file: every registration in this area is a <c>TryAdd</c>,
+/// so the first one wins, and a factory registered by <c>AddQuartz</c> would beat the
+/// <c>services.AddLogging(b =&gt; b.AddConsole())</c> an application writes on the next line — the
+/// providers would be registered, never consumed, and nothing would say so. An application that
+/// configured logging must reach Quartz's lines whichever side of <c>AddQuartz</c> it configured them
+/// on, and one that configured none must still get a scheduler.
+/// </para>
+/// <para>
+/// Seven arrangements, which is every way the two decisions combine that behaves differently: no
+/// logging at all, either order in one container, a host that configured it before user code ran, the
+/// standalone builder's ambient bridge, an application that registered a factory instance rather than
+/// calling <c>AddLogging</c>, and a scheduler added to a container after it was built.
+/// </para>
+/// </remarks>
+public sealed class LoggingRegistrationTest
+{
+    private const string SchedulerCategory = "Quartz.Core.QuartzScheduler";
+
+    private readonly List<IScheduler> started = [];
+
+    [TearDown]
+    public async Task ShutDownWhateverStarted()
+    {
+        foreach (IScheduler scheduler in started)
+        {
+            try
+            {
+                await scheduler.Shutdown();
+            }
+            catch (SchedulerException)
+            {
+                // Already shut down by the test itself.
+            }
+        }
+
+        started.Clear();
+    }
+
+    /// <summary>
+    /// (i) Nothing but <c>AddQuartz</c>.
+    /// </summary>
+    [Test]
+    public async Task AContainerToldNothingAboutLoggingStillRunsAScheduler()
+    {
+        SignallingJob.Fired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        ServiceCollection services = new();
+        services.AddQuartz(quartz => quartz.ScheduleJob<SignallingJob>(
+            trigger => trigger.WithIdentity("now").StartNow(),
+            job => job.WithIdentity("signalling")));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        provider.GetService<ILoggerFactory>().Should().BeNull(
+            "Quartz registers no logger factory, which is the whole reason an application's later "
+            + "AddLogging is still the one that decides where lines go");
+
+        IScheduler scheduler = await Start(provider);
+
+        await SignallingJob.Fired.Task.WaitAsync(TimeSpan.FromSeconds(30));
+
+        (await scheduler.GetStatus()).Should().Be(SchedulerStatus.Running,
+            "a container that was never told where logging goes is still a container a scheduler builds "
+            + "and runs out of - nothing about logging may be a precondition for scheduling");
+    }
+
+    /// <summary>
+    /// (ii) <c>AddQuartz</c> first, then the application's logging. The case the ruling protects: a
+    /// factory registered by Quartz would have won this one, and the provider below would never be read.
+    /// </summary>
+    [Test]
+    public async Task LoggingConfiguredAfterAddQuartzStillReceivesQuartzsLines()
+    {
+        RecordingLoggerProvider recorder = new();
+
+        ServiceCollection services = new();
+        services.AddQuartz();
+        services.AddLogging(logging => logging.AddProvider(recorder));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        await Start(provider);
+
+        recorder.Categories.Should().Contain(SchedulerCategory,
+            "AddLogging registers its factory with TryAdd, so anything Quartz registered for that "
+            + "service would have silently taken the application's providers out of the picture");
+    }
+
+    /// <summary>
+    /// (iii) The other order, which is the one every sample writes.
+    /// </summary>
+    [Test]
+    public async Task LoggingConfiguredBeforeAddQuartzReceivesQuartzsLines()
+    {
+        RecordingLoggerProvider recorder = new();
+
+        ServiceCollection services = new();
+        services.AddLogging(logging => logging.AddProvider(recorder));
+        services.AddQuartz();
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        await Start(provider);
+
+        recorder.Categories.Should().Contain(SchedulerCategory,
+            "the two orders are the same arrangement written twice, and a difference between them "
+            + "would be a difference nobody could see until production");
+    }
+
+    /// <summary>
+    /// (iv) A host, which configures logging for itself before any application code runs.
+    /// </summary>
+    [Test]
+    public async Task AHostsOwnLoggingReceivesQuartzsLines()
+    {
+        RecordingLoggerProvider recorder = new();
+
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder();
+        builder.Logging.AddProvider(recorder);
+        builder.Services.AddQuartz();
+
+        using IHost host = builder.Build();
+        await Start(host.Services);
+
+        recorder.Categories.Should().Contain(SchedulerCategory,
+            "a hosted application never calls AddLogging itself, and the host's Logger<T> registration "
+            + "is what wins the open generic here rather than Quartz's");
+    }
+
+    /// <summary>
+    /// (v) The standalone builder, whose container has no providers of its own and forwards to
+    /// <see cref="LogProvider" />.
+    /// </summary>
+    [Test]
+    [NonParallelizable]
+    public async Task AStandaloneSchedulerStillLogsThroughTheAmbientFactory()
+    {
+        RecordingLoggerProvider recorder = new();
+        using ILoggerFactory ambient = new LoggerFactory();
+        ambient.AddProvider(recorder);
+
+        LogProvider.SetLogProvider(ambient);
+        try
+        {
+            await using StandaloneSchedulerFactory factory = QuartzSchedulerBuilder
+                .Create(quartz => quartz.ConfigureScheduler(options => options.InstanceName = "ambient-bridge"))
+                .Build();
+
+            started.Add(await factory.GetScheduler());
+
+            recorder.Categories.Should().Contain(SchedulerCategory,
+                "the bridge is how a console application says where its logging goes, and dropping the "
+                + "logging package must not have taken it with it");
+        }
+        finally
+        {
+            LogProvider.SetLogProvider(NullLoggerFactory.Instance);
+        }
+    }
+
+    /// <summary>
+    /// (v, continued) A provider registered on the standalone builder without a factory to read it.
+    /// </summary>
+    /// <remarks>
+    /// It used to work, because <c>AddQuartz</c> called <c>AddLogging()</c> and so there was always a
+    /// factory to consume the provider. There is not any more, and the two answers left are to write the
+    /// caller's lines somewhere they did not ask for or to say so — so it says so.
+    /// </remarks>
+    [Test]
+    public void AStandaloneBuilderRefusesAProviderWithNoFactoryToReadIt()
+    {
+        Action build = () => QuartzSchedulerBuilder
+            .Create(quartz => quartz.Services.AddSingleton<ILoggerProvider>(new RecordingLoggerProvider()))
+            .Build();
+
+        build.Should().Throw<SchedulerConfigException>()
+            .WithMessage("*AddLogging*",
+                "the message has to name the one-line fix, because the mistake is invisible otherwise: "
+                + "the scheduler runs, and the lines the caller asked for go to the ambient bridge");
+    }
+
+    /// <summary>
+    /// (vi) An application that registered a factory of its own rather than calling <c>AddLogging</c>,
+    /// which is what a container assembled by hand around an existing factory looks like.
+    /// </summary>
+    [Test]
+    public async Task AnApplicationsOwnLoggerFactoryIsTheOneQuartzUses()
+    {
+        RecordingLoggerProvider recorder = new();
+        using ILoggerFactory application = LoggerFactory.Create(logging => logging.AddProvider(recorder));
+
+        ServiceCollection services = new();
+        services.AddSingleton(application);
+        services.AddQuartz();
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+        await Start(provider);
+
+        recorder.Categories.Should().Contain(SchedulerCategory,
+            "there is one question - what ILoggerFactory does this container hold - and Quartz asks it "
+            + "rather than caring how the answer got there");
+    }
+
+    /// <summary>
+    /// (vii) A scheduler added to a container that has already been built, which registers its own
+    /// object graph in a container of its own and is handed the application's factory as an instance.
+    /// </summary>
+    [Test]
+    public async Task ASchedulerAddedAtRuntimeLogsThroughTheApplicationsFactory()
+    {
+        RecordingLoggerProvider recorder = new();
+
+        ServiceCollection services = new();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddLogging(logging => logging.AddProvider(recorder));
+        services.AddQuartz(quartz => quartz.ConfigureScheduler(options => options.InstanceName = "landlord"));
+
+        await using ServiceProvider provider = services.BuildServiceProvider();
+
+        IScheduler tenant = await provider.GetRequiredService<ISchedulerRuntime>().Add("tenant", _ => { });
+        started.Add(tenant);
+
+        recorder.Messages.Should().Contain(message => message.Contains("Scheduler tenant_$_", StringComparison.Ordinal),
+            "a tenant's container registers Quartz's shared services all over again, and the one thing "
+            + "it must not register a second copy of is where log lines go");
+    }
+
+    private async Task<IScheduler> Start(IServiceProvider provider)
+    {
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        started.Add(scheduler);
+
+        await scheduler.Start();
+        return scheduler;
+    }
+
+    /// <summary>
+    /// Signals through a static because the job factory builds it from its parameterless constructor.
+    /// </summary>
+    public sealed class SignallingJob : IJob
+    {
+        internal static TaskCompletionSource Fired = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Fired.TrySetResult();
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Records the category and rendered message of every line, which is how "this reached the
+    /// application's providers" is observable without pinning the words a type happens to log.
+    /// </summary>
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<(string Category, string Message)> entries = new();
+
+        public IReadOnlyCollection<string> Categories => [.. entries.Select(x => x.Category)];
+
+        public IReadOnlyCollection<string> Messages => [.. entries.Select(x => x.Message)];
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(this, categoryName);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class RecordingLogger(RecordingLoggerProvider provider, string category) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                provider.entries.Enqueue((category, formatter(state, exception)));
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SharedServiceForwardingTest.cs
@@ -58,9 +58,25 @@ public sealed class SharedServiceForwardingTest
         [typeof(Microsoft.Extensions.Options.IOptionsMonitorCache<>)] = OptionsFramework,
 
         [typeof(Microsoft.Extensions.Logging.ILogger<>)] = Logging,
-        [typeof(Microsoft.Extensions.Logging.ILoggerFactory)] = Logging,
-        [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfigurationFactory)] = Logging,
-        [typeof(Microsoft.Extensions.Logging.Configuration.ILoggerProviderConfiguration<>)] = Logging,
+    };
+
+    /// <summary>
+    /// The other direction: a service a generation is handed that the shared registration deliberately
+    /// does not make, and why.
+    /// </summary>
+    /// <remarks>
+    /// One entry, and it is the exception that proves the rule the test below states. Everything else
+    /// forwarded is something <c>AddQuartzSharedServices</c> would otherwise register a second copy of;
+    /// this one is something nobody registers at all, and forwarding it is how a tenant reaches it.
+    /// </remarks>
+    private static readonly Dictionary<Type, string> forwardedWithoutRegistration = new()
+    {
+        [typeof(Microsoft.Extensions.Logging.ILoggerFactory)] =
+            "Quartz registers no logger factory - a TryAdd of one would beat the AddLogging an "
+            + "application writes after AddQuartz and drop its providers in silence (#3730). It is "
+            + "still forwarded, because where a tenant's log lines go is the application's decision "
+            + "and its factory is the whole of that decision; an application that made none forwards "
+            + "nothing, and the tenant falls back to the ambient bridge exactly as the application does",
     };
 
     private const string ContainerWide =
@@ -72,8 +88,10 @@ public sealed class SharedServiceForwardingTest
         + "generation reads its own options through its own";
 
     private const string Logging =
-        "AddLogging()'s registrations, which follow the ILoggerFactory that is forwarded - the factory "
-        + "is what decides where a log line goes, and it is the application's";
+        "the logger follows the ILoggerFactory that is forwarded - the factory is what decides where a "
+        + "log line goes, and it is the application's. A generation registers its own QuartzLogger<T>, "
+        + "which reads the forwarded factory, so a tenant's lines land where the application's do "
+        + "without a second registration to keep in step";
 
     [Test]
     public void EverySharedServiceIsEitherForwardedOrExcused()
@@ -111,9 +129,13 @@ public sealed class SharedServiceForwardingTest
             registered.Add(descriptor.ServiceType);
         }
 
-        SchedulerGeneration.ForwardedServiceTypes.Should().OnlyContain(x => registered.Contains(x),
-            "the list drifts in both directions: a service that stopped being registered here is one a "
-            + "generation is still trying to carry across, which is a forward of nothing at all");
+        SchedulerGeneration.ForwardedServiceTypes
+            .Where(x => !forwardedWithoutRegistration.ContainsKey(x))
+            .Should().OnlyContain(x => registered.Contains(x),
+                "the list drifts in both directions: a service that stopped being registered here is one "
+                + "a generation is still trying to carry across, which is a forward of nothing at all - "
+                + "unless it is one nobody registers, in which case say so in "
+                + nameof(forwardedWithoutRegistration));
     }
 
     [Test]
@@ -122,6 +144,9 @@ public sealed class SharedServiceForwardingTest
         excused.Should().OnlyContain(x => !string.IsNullOrWhiteSpace(x.Value),
             "an excuse without a reason is a service somebody classified in a hurry, and the next reader "
             + "has no way to tell whether it was thought about");
+
+        forwardedWithoutRegistration.Should().OnlyContain(x => !string.IsNullOrWhiteSpace(x.Value),
+            "and the same for the other direction, where the reason is the whole of the classification");
     }
 
     private static bool IsClassified(Type serviceType)

--- a/src/Quartz.Tests.Unit/Diagnostics/InjectedLoggingTest.cs
+++ b/src/Quartz.Tests.Unit/Diagnostics/InjectedLoggingTest.cs
@@ -23,6 +23,7 @@ public sealed class InjectedLoggingTest
     public void TheSchedulersResourcesCarryTheContainersLoggerFactory()
     {
         ServiceCollection services = new();
+        services.AddLogging();
         services.AddQuartz();
 
         using ServiceProvider provider = services.BuildServiceProvider();
@@ -34,20 +35,25 @@ public sealed class InjectedLoggingTest
     }
 
     /// <remarks>
-    /// Asked of the resolver rather than of a scheduler built without a logger factory, because there is
-    /// no such scheduler to build: <c>AddQuartz</c> calls <c>AddLogging</c>, and taking the factory back
-    /// out leaves <c>ILogger&lt;T&gt;</c> unresolvable, so the graph fails before any component could
-    /// fall back to anything. This is the rule the resources are filled in from.
+    /// Quartz registers no <see cref="ILoggerFactory" />, so this is every container that was never told
+    /// where logging goes rather than an exotic one assembled by hand — including the one this test
+    /// builds, which calls <c>AddQuartz</c> and nothing else.
     /// </remarks>
     [Test]
     public void AContainerWithNoLoggerFactoryFallsBackToTheAmbientOne()
     {
         ServiceCollection services = new();
+        services.AddQuartz();
+
         using ServiceProvider provider = services.BuildServiceProvider();
 
         provider.GetSchedulerLoggerFactory()
             .Should().BeOfType<LogProviderLoggerFactory>(
                 "falling silent is the one answer a component that used to log has no business giving");
+
+        provider.GetRequiredService<QuartzSchedulerResources>().LoggerFactory
+            .Should().BeOfType<LogProviderLoggerFactory>(
+                "and the resources are filled in from that rule, so a scheduler still builds");
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
+++ b/src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
@@ -55,10 +55,15 @@
       Directory.Packages.props sets for what Quartz ships. VersionOverride raises them here and nowhere
       else, so the shipped packages keep asking their consumers for 10.0.0 - which is the whole point
       of the floor - while the test host runs on what the fake logger needs.
+
+      Microsoft.Extensions.Logging.Abstractions is the same thing one level down: 10.0.11 of
+      Microsoft.Extensions.Logging above asks for 10.0.11 of it, and transitive pinning would hold it at
+      the floor and call the difference a downgrade.
     -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Quartz/Configuration/AmbientLoggerFactoryProvider.cs
+++ b/src/Quartz/Configuration/AmbientLoggerFactoryProvider.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Diagnostics;
+
+namespace Quartz.Configuration;
+
+/// <summary>
+/// The provider Quartz constructs a component from when the container it was given holds no
+/// <see cref="ILoggerFactory" />: everything resolves as it would have, and a request for a factory is
+/// answered with the ambient one rather than refused.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Quartz registers no <see cref="ILoggerFactory" /> — a <c>TryAdd</c> of one would beat the
+/// <c>services.AddLogging(…)</c> an application writes after <c>AddQuartz</c> and drop its providers in
+/// silence (#3730). But a component Quartz builds may well ask for one: a job store of your own
+/// registered with <c>UseJobStore&lt;T&gt;()</c>, a serializer, a connection provider, a listener. Those
+/// constructors are the application's, they have always been satisfiable, and "you configured no
+/// logging, so your job store cannot be built" is not an answer.
+/// </para>
+/// <para>
+/// So the fallback lives here, on the construction path, rather than in the container: it is reached
+/// only while Quartz is activating something, and it cannot shadow a registration because it is not
+/// one. <see cref="ActivatorUtilities" /> asks <see cref="IServiceProviderIsService" /> which
+/// constructor it can satisfy before resolving anything, so that is answered too — without it a
+/// component with a second, shorter constructor would quietly get that one instead.
+/// </para>
+/// <para>
+/// Applied by <see cref="SchedulerScopedServiceProvider.For" />, and only when the container really has
+/// nothing: an application on a host, one that called <c>AddLogging</c> either side of
+/// <c>AddQuartz</c>, and a standalone <see cref="QuartzSchedulerBuilder" /> all have a factory by the
+/// time anything is built, and are handed their own provider unwrapped.
+/// </para>
+/// </remarks>
+internal sealed class AmbientLoggerFactoryProvider
+    : IKeyedServiceProvider, IServiceProviderIsKeyedService
+{
+    private readonly IServiceProvider inner;
+
+    public AmbientLoggerFactoryProvider(IServiceProvider inner)
+    {
+        this.inner = inner;
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(ILoggerFactory))
+        {
+            return LogProviderLoggerFactory.Instance;
+        }
+
+        // A component handed "the container" keeps the fallback with it, because what it resolves later
+        // is built the same way - the content initializer is the case that shows it, since the listeners
+        // and middleware an application registered by type are activated from the provider it holds.
+        if (serviceType == typeof(IServiceProvider)
+            || serviceType == typeof(IServiceProviderIsService)
+            || serviceType == typeof(IServiceProviderIsKeyedService))
+        {
+            return this;
+        }
+
+        return inner.GetService(serviceType);
+    }
+
+    public object? GetKeyedService(Type serviceType, object? serviceKey)
+    {
+        return inner.GetKeyedService(serviceType, serviceKey);
+    }
+
+    public object GetRequiredKeyedService(Type serviceType, object? serviceKey)
+    {
+        return inner.GetRequiredKeyedService(serviceType, serviceKey);
+    }
+
+    public bool IsService(Type serviceType)
+    {
+        return serviceType == typeof(ILoggerFactory)
+            || serviceType == typeof(IServiceProvider)
+            || serviceType == typeof(IServiceProviderIsService)
+            || serviceType == typeof(IServiceProviderIsKeyedService)
+            || (inner.GetService<IServiceProviderIsService>()?.IsService(serviceType) ?? false);
+    }
+
+    public bool IsKeyedService(Type serviceType, object? serviceKey)
+    {
+        return inner.GetService<IServiceProviderIsKeyedService>()?.IsKeyedService(serviceType, serviceKey) ?? false;
+    }
+}

--- a/src/Quartz/Configuration/PersistentStoreBuilder.cs
+++ b/src/Quartz/Configuration/PersistentStoreBuilder.cs
@@ -147,7 +147,9 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
 
         if (schedulerKey is null)
         {
-            Services.AddSingleton(factory);
+            // See RegisterScoped: the wrapper is what lets a connection provider of your own take an
+            // ILoggerFactory in a container that was never told where logging goes.
+            Services.AddSingleton(provider => factory(SchedulerScopedServiceProvider.For(provider, key: null)));
         }
         else
         {
@@ -379,7 +381,10 @@ internal sealed class PersistentStoreBuilder : IPersistentStoreBuilder
     {
         if (schedulerKey is null)
         {
-            Services.TryAddSingleton(factory);
+            // Through the same wrapper as the keyed branch, although the default scheduler's parts need
+            // no redirecting: it is what supplies an ILoggerFactory to a component that asks for one in
+            // a container that has none, which Quartz no longer registers (#3730).
+            Services.TryAddSingleton(provider => factory(SchedulerScopedServiceProvider.For(provider, key: null)));
         }
         else
         {

--- a/src/Quartz/Configuration/QuartzServiceRegistration.cs
+++ b/src/Quartz/Configuration/QuartzServiceRegistration.cs
@@ -51,7 +51,18 @@ internal static class QuartzServiceRegistration
     public static IServiceCollection AddQuartzSharedServices(this IServiceCollection services)
     {
         services.AddQuartzOptionsValidation();
-        services.AddLogging();
+
+        // The logger a Quartz component is injected, and nothing else from the logging stack. This used
+        // to be AddLogging(), which also registers ILoggerFactory -> LoggerFactory and the filter
+        // options behind it; Quartz references only Microsoft.Extensions.Logging.Abstractions now, and
+        // could not register that factory even if it wanted to (#3730).
+        //
+        // Nor should it. Every registration here is a TryAdd, so the first one wins, and a factory
+        // registered by AddQuartz would beat the services.AddLogging(b => b.AddConsole()) an application
+        // writes after it — the providers would be dropped and nothing would say so. Where log lines go
+        // is the application's to decide, whichever line it decides it on; QuartzLogger<T> reads the
+        // decision when it is constructed rather than requiring it to have been made first.
+        services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(QuartzLogger<>)));
 
         // Job execution metrics. Built from the container's IMeterFactory when it has one — every
         // application on the generic host calls AddMetrics() for itself — so the measurements belong to
@@ -402,11 +413,13 @@ internal static class QuartzServiceRegistration
     /// Resolves the factory a scheduler's own parts create their loggers from.
     /// </summary>
     /// <remarks>
-    /// <see cref="AddQuartzSharedServices" /> calls <c>AddLogging()</c>, so this is the application's
-    /// factory in every container Quartz assembles. The fallback is for a container put together by
-    /// hand that has none: logging through <see cref="LogProvider" /> is what those components did
-    /// before they were injected a factory at all, so it is what they keep doing rather than falling
-    /// silent.
+    /// The application's, whenever the application has one — a generic host, or any
+    /// <c>services.AddLogging(…)</c> before or after <c>AddQuartz</c>. Quartz registers no
+    /// <see cref="ILoggerFactory" /> of its own, because a <c>TryAdd</c> of one would beat the
+    /// application's later call and drop its providers (#3730), so this is a <c>GetService</c> and not a
+    /// <c>GetRequiredService</c>. The fallback is for the container that was told nothing: logging
+    /// through <see cref="LogProvider" /> is what those components did before they were injected a
+    /// factory at all, so it is what they keep doing rather than falling silent.
     /// </remarks>
     internal static ILoggerFactory GetSchedulerLoggerFactory(this IServiceProvider provider)
     {

--- a/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
+++ b/src/Quartz/Configuration/SchedulerScopedServiceProvider.cs
@@ -3,9 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using Quartz.Core;
+using Quartz.Diagnostics;
 using Quartz.Impl;
 using Quartz.Impl.AdoJobStore;
 using Quartz.Impl.AdoJobStore.Common;
@@ -215,9 +217,18 @@ internal sealed class SchedulerScopedServiceProvider
     /// </remarks>
     public static IServiceProvider For(IServiceProvider provider, object? key)
     {
-        return key is null
-            ? provider
-            : new SchedulerScopedServiceProvider(provider, key, provider.GetService<ApplicationLink>());
+        if (key is not null)
+        {
+            return new SchedulerScopedServiceProvider(provider, key, provider.GetService<ApplicationLink>());
+        }
+
+        // The default scheduler's parts are unkeyed, so nothing needs redirecting - with one exception.
+        // Quartz registers no ILoggerFactory (#3730), and a component whose constructor asks for one has
+        // to be handed the ambient bridge rather than refused. The check is a singleton lookup made once
+        // per component built, and answers "yes" in every application that configured logging at all.
+        return provider.GetService<ILoggerFactory>() is null
+            ? new AmbientLoggerFactoryProvider(provider)
+            : provider;
     }
 
     public object? GetService(Type serviceType)
@@ -233,6 +244,15 @@ internal sealed class SchedulerScopedServiceProvider
         if (serviceType == typeof(TimeProvider))
         {
             return inner.GetKeyedService(serviceType, key) ?? inner.GetService(serviceType);
+        }
+
+        // Quartz registers no ILoggerFactory, so a container that was never told where logging goes has
+        // none to inject into a component that asks for one - a custom job store, a serializer, a
+        // listener. The ambient bridge is the answer there, for the same reason a scheduler's own parts
+        // fall back to it (#3730).
+        if (serviceType == typeof(ILoggerFactory))
+        {
+            return inner.GetService(serviceType) ?? LogProviderLoggerFactory.Instance;
         }
 
         // The trigger persistence delegates are one service type registered several times, so they
@@ -495,6 +515,12 @@ internal sealed class SchedulerScopedServiceProvider
         {
             return IsKeyedService(serviceType, key)
                 || (inner.GetService<IServiceProviderIsService>()?.IsService(serviceType) ?? false);
+        }
+
+        // Always, because GetService always answers it: the container's factory or the ambient bridge.
+        if (serviceType == typeof(ILoggerFactory))
+        {
+            return true;
         }
 
         if (NamedOptions(serviceType) is not null

--- a/src/Quartz/Diagnostics/QuartzLogger.cs
+++ b/src/Quartz/Diagnostics/QuartzLogger.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Diagnostics;
+
+/// <summary>
+/// The <see cref="ILogger{T}" /> a Quartz component is injected in a container that was never told
+/// where logging goes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AddQuartz</c> registers this for the open <see cref="ILogger{T}" />, and registers no
+/// <see cref="ILoggerFactory" /> at all. That second half is the point, and it is what
+/// <see cref="Microsoft.Extensions.Logging.Logger{T}" /> — which takes a factory the ordinary way and
+/// so needs one registered — cannot do on its own: Quartz must not be the thing that answers "where do
+/// log lines go", because every registration in this area is a <c>TryAdd</c> and the first one wins. A
+/// factory registered by <c>AddQuartz</c> would beat the <c>services.AddLogging(b =&gt; b.AddConsole())</c>
+/// an application writes on the line after it, and the application's providers would be dropped in
+/// silence.
+/// </para>
+/// <para>
+/// So the factory is read from the container when the logger is constructed, and only then: an
+/// application that configured logging before or after <c>AddQuartz</c>, or through a host that
+/// configured it before either, has an <see cref="ILoggerFactory" /> by the time anything is resolved,
+/// and this hands out its loggers. One that configured none gets <see cref="LogProviderLoggerFactory" />,
+/// which is where the rest of Quartz already sends a line it cannot inject a logger for.
+/// </para>
+/// <para>
+/// It also loses, deliberately, wherever it can: <c>AddLogging</c> registers
+/// <see cref="Microsoft.Extensions.Logging.Logger{T}" /> for the same open generic with its own
+/// <c>TryAdd</c>, so in a container where logging was configured first — every generic host — that is
+/// the type resolved and this one is never constructed. The two behave identically when a factory is
+/// registered; this one only adds an answer for when there is none.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The type the log category is named for.</typeparam>
+internal sealed class QuartzLogger<T> : Logger<T>
+{
+    public QuartzLogger(IServiceProvider provider)
+        : base(provider.GetService<ILoggerFactory>() ?? LogProviderLoggerFactory.Instance)
+    {
+    }
+}

--- a/src/Quartz/Quartz.csproj
+++ b/src/Quartz/Quartz.csproj
@@ -93,7 +93,15 @@
     -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <!--
+      The abstractions, not Microsoft.Extensions.Logging itself. Quartz writes log events and never
+      builds the pipeline that carries them: ILogger, ILoggerFactory, ILoggerProvider, the
+      [LoggerMessage] partials and NullLoggerFactory all live here, and LoggerFactory — the
+      implementation, and the AddLogging() that registers it — belongs to whoever composes the
+      application. So AddQuartz registers ILogger<> and no ILoggerFactory at all, and every place
+      Quartz needs a factory asks the container for one and falls back if there is none (issue #3730).
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
   </ItemGroup>
 

--- a/src/Quartz/QuartzSchedulerBuilder.cs
+++ b/src/Quartz/QuartzSchedulerBuilder.cs
@@ -276,19 +276,42 @@ public sealed class QuartzSchedulerBuilder
     /// </para>
     /// <para>
     /// Skipped as soon as a logging provider has been registered on
-    /// <see cref="IQuartzBuilder.Services" />, because then the caller has said where logging goes and
-    /// the container's own factory is the answer.
+    /// <see cref="IQuartzBuilder.Services" /> <em>and</em> there is a factory to consume it, because
+    /// then the caller has said where logging goes and the container's own factory is the answer. Both
+    /// halves are checked because Quartz registers no <see cref="ILoggerFactory" /> any more (#3730): a
+    /// provider on its own used to be enough, since <c>AddQuartz</c> called <c>AddLogging()</c> and so
+    /// there was always something to consume it, and now it is a half-configured container that would
+    /// write nowhere. That is refused out loud rather than bridged in silence, because a caller who
+    /// registered a provider has said where the lines go and sending them somewhere else is the one
+    /// answer that helps nobody.
     /// </para>
     /// </remarks>
+    /// <exception cref="SchedulerConfigException">
+    /// Logging providers are registered with no <see cref="ILoggerFactory" /> to consume them.
+    /// </exception>
     private void BridgeLoggingToLogProvider()
     {
-        if (services.Any(static descriptor => descriptor.ServiceType == typeof(ILoggerProvider)))
+        bool providers = services.Any(static descriptor => descriptor.ServiceType == typeof(ILoggerProvider));
+        bool factory = services.Any(static descriptor => descriptor.ServiceType == typeof(ILoggerFactory));
+
+        if (providers)
         {
-            return;
+            if (factory)
+            {
+                return;
+            }
+
+            throw new SchedulerConfigException(
+                "Logging providers are registered on the builder's Services, but no ILoggerFactory is, "
+                + "so nothing would read them. Quartz registers no factory of its own — that would beat "
+                + "an application's own AddLogging and drop its providers. Register the provider through "
+                + "logging configuration instead: Services.AddLogging(logging => logging.AddProvider(…)), "
+                + "which brings a factory with it. To log through LogProvider.SetLogProvider instead, "
+                + "register no provider here at all.");
         }
 
         // Replace rather than TryAdd: a caller who called AddLogging() without adding a provider has
-        // already registered the factory this stands in for.
+        // registered a factory with nothing behind it, which is the thing this stands in for.
         services.Replace(ServiceDescriptor.Singleton<ILoggerFactory>(LogProviderLoggerFactory.Instance));
     }
 }

--- a/src/Quartz/README.md
+++ b/src/Quartz/README.md
@@ -12,11 +12,15 @@ dotnet add package Quartz
 That is everything a scheduler needs: dependency injection, hosting, the scheduler health check and
 System.Text.Json serialization are part of this package, where Quartz 3 shipped them separately.
 
-Two things Quartz deliberately does not bring. The host below is Microsoft's — a project that has no
+Three things Quartz deliberately does not bring. The host below is Microsoft's — a project that has no
 `Microsoft.Extensions.Hosting` reference yet (a plain `console` one; the `worker` and `web` templates
-already have it) adds `dotnet add package Microsoft.Extensions.Hosting`. And a persistent store loads
-its ADO.NET driver by name, so `UseSqlServer` needs `Microsoft.Data.SqlClient` referenced,
-`UsePostgres` needs `Npgsql`, and so on.
+already have it) adds `dotnet add package Microsoft.Extensions.Hosting`. Quartz writes log events and
+leaves deciding where they go to the application, so it references
+`Microsoft.Extensions.Logging.Abstractions` rather than `Microsoft.Extensions.Logging` — a host brings
+the implementation with it, and a project that builds an `ILoggerFactory` itself adds
+`dotnet add package Microsoft.Extensions.Logging`. And a persistent store loads its ADO.NET driver by
+name, so `UseSqlServer` needs `Microsoft.Data.SqlClient` referenced, `UsePostgres` needs `Npgsql`, and
+so on.
 
 ## Quick start
 


### PR DESCRIPTION
`Quartz` referenced `Microsoft.Extensions.Logging` for exactly one call — `services.AddLogging()` in
`AddQuartzSharedServices`. Every `[LoggerMessage]` site, every `ILogger<T>`, `NullLogger` and the
`LogProvider` bridge compile against `Microsoft.Extensions.Logging.Abstractions`, and swapping the
reference produced exactly one compile error, which was that call. So the reference moves, and the
implementation package leaves every consumer's graph.

Closes #3730

## `Quartz`'s nuspec, before and after

Measured by packing, not assumed.

```diff
   <dependency id="Microsoft.Extensions.DependencyInjection" version="10.0.0" />
   <dependency id="Microsoft.Extensions.Diagnostics.HealthChecks" version="10.0.0" />
   <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.Logging" version="10.0.0" />
+  <dependency id="Microsoft.Extensions.Logging.Abstractions" version="10.0.0" />
   <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.0" />
   <dependency id="Microsoft.Extensions.Configuration.Binder" version="10.0.0" />
```

One id swapped, still six, still all floored at the major. `Microsoft.Extensions.Logging.Abstractions`
is a leaf: it drags in nothing, where `Microsoft.Extensions.Logging` brought
`Microsoft.Extensions.Options` and the DI abstractions with it. The satellite packages carry the same
delta, since transitive pinning writes `Quartz`'s floors into each of their nuspecs — `Quartz.Jobs`,
which references nothing but `Quartz`, was checked as well.

## What replaces `AddLogging()`

`AddQuartz` registers `ILogger<>` → `QuartzLogger<T>`, which is `Logger<T>` reading the container's
`ILoggerFactory` when it is constructed and `LogProviderLoggerFactory` when the container holds none.

**Quartz registers no `ILoggerFactory` at all**, and that is the load-bearing half. Every registration
here is a `TryAdd`, so the first one wins: a factory registered by `AddQuartz` would beat the
`services.AddLogging(logging => logging.AddConsole())` an application writes on the line after it, and
the application's providers would be registered, never consumed, and nothing would say so.

`LoggingRegistrationTest` is that guarantee written down — nine cases covering no logging at all, either
order of the two calls in one container, a host, the standalone builder, a factory instance registered
rather than `AddLogging` called, a runtime tenant, and a component of your own whose constructor asks
for a factory. Two of them fail the moment anything registers an `ILoggerFactory` from inside
`AddQuartz`, which was checked by doing it.

A component Quartz builds may still take an `ILoggerFactory` — a job store of your own registered with
`UseJobStore<T>()`, a serializer, a connection provider, a listener; the migration guide's `SlowJobStore`
sample is one. Those constructors have always been satisfiable and still are:
`AmbientLoggerFactoryProvider` sits on the construction path rather than in the container, where it
cannot shadow a registration, and answers a factory request with the ambient bridge when the container
has none. It answers `IServiceProviderIsService` too, because `ActivatorUtilities` asks which
constructor it can satisfy before it resolves anything.

## Two things a reviewer should decide

**1. `Quartz.Extensions.Redis` turns central transitive pinning off.** Adding
`Microsoft.Extensions.Logging.Abstractions` to `Directory.Packages.props` makes it a *direct* dependency
of every project in the repository, pinned at exactly the central version — and NuGet prefers a direct
reference to a deeper one whichever way round the versions are. `StackExchange.Redis 3.0.0` asks for
`10.0.5`, so pinning the floor at `10.0.0` there is `NU1109`, a package downgrade.

The three ways out, and why this one:

* raising the floor to `10.0.5` hands StackExchange.Redis' servicing schedule to every consumer of
  `Quartz` itself, which is the mistake #3717 was about, and `MicrosoftFloorIsTheMajorItself` refuses it;
* a `VersionOverride` writes a floor into a shipped nuspec where neither `Directory.Packages.props` nor
  Dependabot can see it, which `ShippedProjectOverridesNoVersion` refuses;
* turning the pinning off leaves that package's nuspec saying what it actually depends on.

The nuspec effect is visible, so it is worth eyes:

```diff
   <dependency id="Quartz" version="4.1.0" />
   <dependency id="StackExchange.Redis" version="3.0.0" />
-  <dependency id="Microsoft.Extensions.Configuration.Binder" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.DependencyInjection" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.Diagnostics.HealthChecks" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.Hosting.Abstractions" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.Logging" version="10.0.0" />
-  <dependency id="Microsoft.Extensions.Options.ConfigurationExtensions" version="10.0.0" />
```

Nothing a consumer restores changes: those six are `Quartz`'s own nuspec floors and arrive through the
`Quartz` dependency above them. It is the same mechanism, and the same reasoning,
`src/QuartzShimPackage.props` already uses. The alternative is to accept a `10.0.5` floor on `Quartz`,
which I did not think was mine to choose.

Eight projects that ship nothing raise the abstractions with `VersionOverride` instead, which is the
documented mechanism and needs no decision — but it is worth knowing *why* there are eight where the
other floors need five in total: `Microsoft.Extensions.Logging.Abstractions` is the most depended-on
leaf in the family, so anything modern in a graph asks for a newer patch of it. `bunit` asks for
`10.0.10`, Aspire for `10.0.11`, and `Microsoft.Extensions.Caching.Memory` — which the ADO.NET drivers
pull in — for `10.0.10`. Expect a Dependabot bump of any `Microsoft.Extensions.*` in a test or example
project to need one more of these.

**2. `QuartzSchedulerBuilder` refuses a half-configured container.** Its bridge asked whether an
`ILoggerProvider` was registered and skipped if one was, which was sound while `AddQuartz` called
`AddLogging()` — a provider then always had a factory behind it. It does not any more, so the guard asks
for both, and a provider registered with no factory to read it now throws `SchedulerConfigException` at
`Build()` naming the one-line fix, rather than being bridged to `LogProvider` in silence. That case used
to work. It cannot be made to work again without the package, and the alternative is losing an
application's logs quietly.

## What a consumer sees

Documented in the migration guide's 4.0 → 4.1 section, plainly, because this is the one thing in 4.1 an
application can be broken by without a signature having changed: a project that called
`LoggerFactory.Create` or `AddLogging` while referencing neither logging package was compiling against a
transitive reference, and now references it itself. The package readme's "two things Quartz deliberately
does not bring" is three.

## Verification

| | |
|---|---|
| `dotnet build Quartz.slnx` | succeeded, 0 warnings |
| `dotnet test src/Quartz.Tests.Unit` | 6242 passed, 0 failed, 36 skipped |
| `dotnet test src/Quartz.Tests.AspNetCore` | 671 passed, 0 failed |
| `dotnet fallout PublishTrimmed` | succeeded — the canary's SQLite store schedules, fires and reads back |
| `dotnet fallout ExamplesSmoke` | succeeded — every example, including the two that log through a host |
| `dotnet fallout BenchmarkSmoke` | succeeded, 298 benchmarks |
| `dotnet fallout VerifyDocsSnippets` | up to date, 115 markdown files |
| `npm run docs:check-links` | 224 pages, 1448 links, 898 fragments, none dead |
| `dotnet pack` | nuspecs above, read out of the packages |

`Quartz.Tests.Integration` was **not** run: no Docker daemon on this machine. It compiles as part of the
solution build.

Public API baselines are unchanged — `QuartzLogger<T>` and `AmbientLoggerFactoryProvider` are internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
