### PR TITLE
The 3.x line's untagged builds say 3.22

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
-    <VersionPrefix>3.21.0</VersionPrefix>
+    <VersionPrefix>3.22.0</VersionPrefix>
 
     <CLSCompliant>True</CLSCompliant>
     <ComVisible>False</ComVisible>


### PR DESCRIPTION
3.21.0 is tagged at 5650bf2e87; the feedz previews the branch pushes on every build would sort below it until the prefix moves past, so 3.21.0 → 3.22.0, as #3710 and #3712 did after the two previous 3.x releases. Merge after the v3.21.0 publish run has finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK