### PR TITLE
Release gate G5: a 30-minute PostgreSQL soak with a runtime-added tenant restarted throughout

### DIFF
--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -830,8 +830,41 @@ share of them is one statement: `SelectJobForTrigger` now selects `IS_NONCONCURR
 `IS_UPDATE_DATA`, so that a process without the job's class still reads the job's attribute flags
 (#3705). Rescheduling, editing and deleting a trigger are what reach it, and the soak's workload does
 none of the three — it schedules its triggers once and then runs. The other commit is
-`QuartzHostedService`'s stop path, which the fixture never enters, because it builds each node from
-`QuartzSchedulerBuilder` rather than from a host. The figures above therefore stand for the release.
+`QuartzHostedService`'s stop path, which the fixture never enters, because it builds its nodes into
+containers of its own rather than from a host. The figures above therefore stand for the release.
+
+**A runtime-added tenant was put through the same half hour** — 30 minutes on `b67f0faa9a`, on
+2026-09-09 — because 4.1 is the first release in which a scheduler can arrive after the container was
+built, and nothing had asked what a hundred rebuilds against a real database leave behind. Beside the
+two nodes, a third scheduler was added to node A's container through
+[`ISchedulerRuntime.Add`](multi-tenancy.md), storing under its own `SCHED_NAME` in the same
+tables, with a `[DisallowConcurrentExecution]` job firing every two seconds and an ordinary one every
+second. It was restarted through `ISchedulerRuntime.Restart` with a thirty-second drain every three
+minutes, and removed and added again from the same recipe every seven: twelve rebuilds, thirteen
+generations.
+
+It passed, and the cluster beside it landed firing for firing where the 4.0 runs left it — peak
+observed concurrency **1** over 2,645 firings of the serial job, 890 simple, 591
+daily-time-interval, 444 calendar-interval, 354 cron and 296 recurrence, 534 attempts at the failing
+job of which 356 were the retry policy's, 178 overruns interrupted, and the survivor replaying the
+killed node's one interrupted firing a second after the kill. The tenant's own numbers are the new
+ones. Its ordinary trigger had **1,796 scheduled fire times and fired every one of them exactly
+once**: a rebuild is a gap of under a second, far inside the misfire threshold, so each new
+generation caught the missed occurrences up rather than letting them go, and none was skipped. Its
+serial job's peak observed concurrency was **1** over 898 firings across all thirteen generations —
+`[DisallowConcurrentExecution]` is a claim about the job rather than about the generation running it,
+and the trigger rows carry the block over a rebuild. No drain was abandoned, and every rebuild was
+firing again within 0.9 s against a budget of ten. It ended as the cluster did: nothing `ACQUIRED` or
+`BLOCKED` under either scheduler name, `QRTZ_FIRED_TRIGGERS` empty for both, and a live heap of 5 MB
+behind 629–656 handles across all thirty samples.
+
+One thing the run settled rather than measured: **a non-clustered scheduler's instance id is
+`NON_CLUSTERED` in every generation**, because the id generator is not called for a store that shares
+its database with nobody. So the instance id cannot tell one generation of a restarted tenant from
+the next, and anything that has to correlate a record with the generation that wrote it needs
+something else — the fixture stamps an ordinal into the scheduler's `SchedulerContext` as the recipe
+runs, which says the stronger thing anyway, since the number only advances when the recipe is
+replayed.
 
 The harness is `ClusteredSoakTestBase` in `Quartz.Tests.Integration`; it is opt-in
 (`[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`) and is run before a tag rather than in CI.

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredJobStoreTestBase.cs
@@ -4,6 +4,8 @@ using System.Data.Common;
 using System.Globalization;
 using System.Text;
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 
 /// <summary>
@@ -93,7 +95,62 @@ public abstract class ClusteredJobStoreTestBase
         Action<NameValueCollection> configure = null,
         Action<IQuartzBuilder> configureBuilder = null)
     {
-        var properties = new NameValueCollection
+        NameValueCollection properties = NodeProperties(instanceId, checkinIntervalMs, checkinMisfireThresholdMs, configure);
+
+        // Cluster nodes share the scheduler (instance) name, and a factory's repository lookup is
+        // name-only — but each factory owns its own repository, so every call here builds a genuinely
+        // separate node rather than handing back the first one.
+        ISchedulerFactory factory = QuartzSchedulerBuilder.Create(configureBuilder).UseProperties(properties).Build();
+        return await factory.GetScheduler();
+    }
+
+    /// <summary>
+    /// Builds one node of this fixture's cluster into a container the caller keeps hold of, rather than
+    /// into the one <see cref="QuartzSchedulerBuilder" /> creates and hides.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Same scheduler, same flat properties, same callback — <c>AddQuartz(properties, configure)</c> is
+    /// what the standalone builder calls into. What the caller gets in addition is the
+    /// <see cref="IServiceProvider" />, which is the only way to reach the container-wide services a
+    /// node shares with the application that hosts it: <see cref="ISchedulerRuntime" /> above all, since
+    /// a scheduler added at run time is added to <em>a container</em>, and
+    /// <see cref="StandaloneSchedulerFactory" /> deliberately exposes none.
+    /// </para>
+    /// <para>
+    /// The container is the caller's to dispose, and disposing it shuts down whatever it still holds. A
+    /// fixture that only needs a node uses <see cref="CreateScheduler" />.
+    /// </para>
+    /// </remarks>
+    /// <inheritdoc cref="CreateScheduler" path="/param" />
+    protected async Task<SchedulerHost> CreateSchedulerHost(
+        string instanceId,
+        int checkinIntervalMs = 1000,
+        int checkinMisfireThresholdMs = 2000,
+        Action<NameValueCollection> configure = null,
+        Action<IQuartzBuilder> configureBuilder = null)
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(
+            NodeProperties(instanceId, checkinIntervalMs, checkinMisfireThresholdMs, configure),
+            configureBuilder);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        IScheduler scheduler = await provider.GetRequiredService<ISchedulerFactory>().GetScheduler();
+        return new SchedulerHost(provider, scheduler);
+    }
+
+    /// <summary>
+    /// The flat properties one node of this fixture's cluster is configured from, whichever of the two
+    /// doors above builds it.
+    /// </summary>
+    private NameValueCollection NodeProperties(
+        string instanceId,
+        int checkinIntervalMs,
+        int checkinMisfireThresholdMs,
+        Action<NameValueCollection> configure)
+    {
+        NameValueCollection properties = new()
         {
             ["quartz.scheduler.instanceName"] = SchedulerName,
             ["quartz.scheduler.instanceId"] = instanceId,
@@ -114,13 +171,18 @@ public abstract class ClusteredJobStoreTestBase
         };
 
         configure?.Invoke(properties);
-
-        // Cluster nodes share the scheduler (instance) name, and a factory's repository lookup is
-        // name-only — but each factory owns its own repository, so every call here builds a genuinely
-        // separate node rather than handing back the first one.
-        ISchedulerFactory factory = QuartzSchedulerBuilder.Create(configureBuilder).UseProperties(properties).Build();
-        return await factory.GetScheduler();
+        return properties;
     }
+
+    /// <summary>
+    /// A node and the container it was built from.
+    /// </summary>
+    /// <remarks>
+    /// The pair rather than the scheduler alone, because the interesting half is the container: it is
+    /// what an application hosting this node would have, and what the services a scheduler does not own
+    /// — the repository, the registry, the runtime — are resolved from.
+    /// </remarks>
+    protected sealed record SchedulerHost(ServiceProvider Services, IScheduler Scheduler);
 
     protected static Task WaitForCondition(
         Func<Task<bool>> condition,

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.Tenant.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.Tenant.cs
@@ -1,0 +1,900 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// The soak's third scheduler: one nobody registered, added to node A's container after that container
+/// was built, and taken apart and put back together throughout the run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What it is for.</b> The two clustered nodes are a deployment that starts once and runs. A
+/// multi-tenant process is not: tenants arrive, are reconfigured, and go, and each of those is a
+/// scheduler being built or shut down beside schedulers that are firing. <see cref="ISchedulerRuntime" />
+/// is the door for that, and its unit tests answer the questions a unit test can — the order of build,
+/// drain and create, and what each refusal protects. What they cannot answer is what a hundred rebuilds
+/// against a real database over half an hour leave behind, which is this.
+/// </para>
+/// <para>
+/// <b>It is a tenant, not a third node.</b> It has its own <c>SCHED_NAME</c> in the same tables, which
+/// is the arrangement <c>SharedDatabaseTenancyTestBase</c> pins and the one multi-tenancy is built on,
+/// and its store is not clustered — so every generation's first act is the recovery sweep over the whole
+/// scheduler name that <see cref="ISchedulerRuntime.Restart" /> orders its steps around. The cluster's
+/// own assertions are scoped to <c>ClusterSoakTest</c> and this scheduler's rows are under
+/// <c>soak-tenant</c>, so "the cluster is unaffected" is asserted rather than assumed.
+/// </para>
+/// <para>
+/// <b>Its store is registered by type and by factory, never as an instance.</b> A recipe that closes
+/// over an <see cref="Extensibility.IJobStore" />, an <see cref="Extensibility.IThreadPool" />, a job
+/// factory or an instance-id generator cannot be replayed — the second generation would be handed the
+/// object the first is using — and <c>Restart</c> refuses it by name. That refusal is not what this
+/// gate is here to exercise, so <see cref="ConfigureTenant" /> stays on the replayable side of it.
+/// </para>
+/// </remarks>
+public abstract partial class ClusteredSoakTestBase
+{
+    /// <summary>
+    /// The tenant's name, which is also its instance name and therefore its <c>SCHED_NAME</c>.
+    /// </summary>
+    private const string TenantName = "soak-tenant";
+
+    private const string TenantGroup = "clusterSoakTenant";
+
+    /// <summary>
+    /// The scheduler-context key each generation is stamped with as the recipe runs.
+    /// </summary>
+    /// <remarks>
+    /// A non-clustered scheduler's instance id is <c>NON_CLUSTERED</c> in every generation —
+    /// <c>DefaultSchedulerFactory</c> does not call the id generator for a store that shares its
+    /// database with nobody, whatever <c>GenerateInstanceId</c> says — so the id alone cannot say which
+    /// generation answered. The ordinal can, and it says something the id could not anyway: the number
+    /// only advances when the recipe is <em>run again</em>, which is what a restart has to have done.
+    /// </remarks>
+    private const string TenantGenerationKey = "soak.generation";
+
+    /// <summary>
+    /// The tenant's pool. Bigger than the workload needs on purpose: what the drain waits for should be
+    /// the jobs themselves rather than a queue behind a pool of one.
+    /// </summary>
+    private const int TenantMaxConcurrency = 4;
+
+    private static readonly TimeSpan TenantSteadyInterval = TimeSpan.FromSeconds(1);
+
+    private static readonly TimeSpan TenantSerialInterval = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// How long a restart may wait for the outgoing generation's jobs. Thirty seconds against a longest
+    /// job of 300 ms, so a drain that gives up has found something rather than merely been unlucky.
+    /// </summary>
+    private static readonly TimeSpan TenantDrainTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How soon after a rebuild the tenant has to be firing again for the rebuild to count as clean.
+    /// </summary>
+    private static readonly TimeSpan TenantFireAgainBudget = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// How long the run waits for that firing before giving up on it. Longer than the budget
+    /// deliberately: a rebuild that took twelve seconds should be <em>measured</em> at twelve and fail
+    /// the assertion saying so, not recorded as "never fired" because the wait stopped at ten.
+    /// </summary>
+    private static readonly TimeSpan TenantFireAgainPatience = TimeSpan.FromSeconds(30);
+
+    private ISchedulerRuntime runtime;
+
+    private IScheduler tenant;
+
+    /// <summary>How many times the tenant's recipe has been run, which is how many generations there are.</summary>
+    private int tenantGenerations;
+
+    /// <summary>
+    /// The instant the steady trigger starts from, which is the origin of the grid its scheduled fire
+    /// times sit on — and so the thing the end assertions do their arithmetic against.
+    /// </summary>
+    private DateTimeOffset tenantWorkloadStart;
+
+    private readonly List<TenantRebuild> tenantRebuilds = [];
+
+    /// <summary>
+    /// The tenant's rows are under its own <c>SCHED_NAME</c>, which the base class's teardown does not
+    /// name, and <see cref="ISchedulerRuntime" /> deliberately deletes nothing when a tenant goes.
+    /// </summary>
+    [TearDown]
+    public Task CleanUpTenantState()
+    {
+        return ExecuteStatements(
+            [
+                "DELETE FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SIMPLE_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SIMPROP_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_BLOB_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_JOB_DETAILS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_PAUSED_TRIGGER_GRPS WHERE SCHED_NAME = @schedulerName",
+                "DELETE FROM QRTZ_SCHEDULER_STATE WHERE SCHED_NAME = @schedulerName",
+            ],
+            ("schedulerName", TenantName));
+    }
+
+    /// <summary>
+    /// Adds the tenant to node A's container and gives it a schedule of its own.
+    /// </summary>
+    private async Task StartTenant(SchedulerHost host, List<string> timeline, DateTimeOffset started)
+    {
+        runtime = host.Services.GetRequiredService<ISchedulerRuntime>();
+
+        // Far enough out that the whole workload is stored before any of it is due, so the first
+        // scheduled fire time is one the tenant was running for.
+        tenantWorkloadStart = started.AddSeconds(5);
+
+        tenant = await runtime.Add(TenantName, ConfigureTenant);
+        AttachRecorder(tenant);
+
+        await ScheduleTenantWorkload(tenant);
+
+        Note(timeline, DateTimeOffset.UtcNow,
+            $"tenant '{TenantName}' added at run time on '{NodeA}'s container as {TenantIdentity(tenant)}");
+    }
+
+    /// <summary>
+    /// The recipe, run again in full for every generation.
+    /// </summary>
+    /// <remarks>
+    /// The store is chosen through <c>UsePersistentStore</c> with a data source described in options and
+    /// a driver delegate built by a factory, so replaying this produces a second set of instances rather
+    /// than the first set handed over — which is what <c>Restart</c> requires and what it refuses a
+    /// recipe for otherwise. The misfire threshold is the cluster's, so that the tenant and the nodes
+    /// agree about how late is late.
+    /// </remarks>
+    private void ConfigureTenant(IQuartzBuilder quartz)
+    {
+        // Here rather than inside the callback: this counts the times the recipe has been replayed,
+        // which is once per generation, and an options callback runs when its container reads the
+        // options rather than when the recipe is written down.
+        string generation = Interlocked.Increment(ref tenantGenerations).ToString(CultureInfo.InvariantCulture);
+
+        quartz.ConfigureScheduler(options =>
+        {
+            options.Context[TenantGenerationKey] = generation;
+            options.IdleWaitTime = TimeSpan.FromSeconds(2);
+            options.MaxBatchSize = TenantMaxConcurrency;
+        });
+
+        quartz.UseDefaultThreadPool(TenantMaxConcurrency);
+
+        quartz.UsePersistentStore(store =>
+        {
+            store.UseDataSource(source =>
+            {
+                source.Provider = Database.Provider;
+                source.ConnectionString = Database.ConnectionString;
+            });
+
+            // A factory rather than an instance: it has to answer with a new delegate every time the
+            // recipe runs, which is the whole difference between a restartable recipe and a refused one.
+            store.UseDriverDelegate(_ => Database.CreateDriverDelegate());
+
+            store.ConfigureStore(options => options.MisfireThreshold = MisfireThreshold);
+        });
+    }
+
+    /// <summary>
+    /// The tenant's own two jobs: one that must never overlap itself, and one that fires often enough
+    /// that a gap in it is visible to the second.
+    /// </summary>
+    /// <remarks>
+    /// Scheduled once, at the start, and never again. Every later generation inherits these rows, which
+    /// is what makes the schedule a single grid running the length of the soak rather than one that
+    /// resets each time the tenant is rebuilt — and a grid is the only thing "fired exactly once or was
+    /// skipped" can be said about.
+    /// </remarks>
+    private async Task ScheduleTenantWorkload(IScheduler scheduler)
+    {
+        // A run that fell over leaves its rows under this SCHED_NAME, and nothing removes a tenant's
+        // data when the tenant goes. Scheduling onto them would inherit the earlier run's grid.
+        await scheduler.DeleteJob(new JobKey(TenantJobs.Steady, TenantGroup));
+        await scheduler.DeleteJob(new JobKey(TenantJobs.Serial, TenantGroup));
+
+        IJobDetail steady = JobBuilder.Create<SoakTenantSteadyJob>()
+            .WithIdentity(TenantJobs.Steady, TenantGroup)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(steady, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(TenantTriggers.Steady, TenantGroup)
+            .ForJob(steady)
+            .StartAt(tenantWorkloadStart)
+            .WithSimpleSchedule(x => x.RepeatForever().WithInterval(TenantSteadyInterval))
+            .Build());
+
+        IJobDetail serial = JobBuilder.Create<SoakTenantSerialJob>()
+            .WithIdentity(TenantJobs.Serial, TenantGroup)
+            .StoreDurably()
+            .Build();
+        await scheduler.AddJob(serial, new AddJobOptions { Replace = true });
+
+        await scheduler.ScheduleJob(TriggerBuilder.Create()
+            .WithIdentity(TenantTriggers.Serial, TenantGroup)
+            .ForJob(serial)
+            .StartAt(tenantWorkloadStart)
+            .WithSimpleSchedule(x => x.RepeatForever().WithInterval(TenantSerialInterval))
+            .Build());
+    }
+
+    /// <summary>
+    /// Rebuilds the tenant, either by restarting it or by removing it and adding it again from the same
+    /// recipe, and records what that cost.
+    /// </summary>
+    /// <remarks>
+    /// The two are different questions. <c>Restart</c> is the runtime doing the whole thing — build the
+    /// next generation, drain the outgoing one, create — with the ordering it promises; remove and add
+    /// is an application doing it by hand, with the tenant genuinely absent in between. A deployment
+    /// does both, so the soak does both.
+    /// </remarks>
+    private async Task RebuildTenant(List<string> timeline, TenantRebuildKind kind)
+    {
+        DateTimeOffset openedAt = DateTimeOffset.UtcNow;
+        string previousIdentity = TenantIdentity(tenant);
+        int executing = TenantLedger.InFlight;
+
+        IScheduler next = null;
+        string outcome;
+
+        try
+        {
+            if (kind == TenantRebuildKind.Restart)
+            {
+                next = await runtime.Restart(
+                    TenantName,
+                    new SchedulerRestartOptions { DrainTimeout = TenantDrainTimeout });
+                outcome = "drained";
+            }
+            else
+            {
+                bool removed = await runtime.Remove(TenantName, waitForJobsToComplete: true);
+                outcome = removed ? "removed and added" : "nothing to remove, added";
+                next = await runtime.Add(TenantName, ConfigureTenant);
+            }
+        }
+        catch (SchedulerRestartException e)
+        {
+            // Reported rather than swallowed. In a workload whose longest job is 300 ms a drain that
+            // gave up has found something, and AssertTenantRebuilds fails on it — but the run goes on,
+            // because the next rebuild starts the tenant again and the rest of the half hour is still
+            // worth watching. A soak that stops at the first surprise throws away the other twenty-five
+            // minutes of evidence.
+            outcome = $"ABANDONED after {e.DrainTimeout} with {e.JobsStillExecuting} job(s) still executing";
+            TenantLedger.RecordAbandonedDrain(e);
+        }
+
+        tenant = next;
+        DateTimeOffset returnedAt = DateTimeOffset.UtcNow;
+
+        TenantFiring firedAgain = null;
+        if (next is not null)
+        {
+            AttachRecorder(next);
+            firedAgain = await WaitForTenantFiringAfter(returnedAt, TenantFireAgainPatience);
+        }
+
+        tenantRebuilds.Add(new TenantRebuild
+        {
+            Number = tenantRebuilds.Count + 1,
+            Kind = kind,
+            OpenedAt = openedAt,
+            ReturnedAt = returnedAt,
+            PreviousIdentity = previousIdentity,
+            NextIdentity = TenantIdentity(next),
+            JobsExecuting = executing,
+            Outcome = outcome,
+            FiredAgainAt = firedAgain?.Start,
+        });
+
+        Note(timeline, openedAt,
+            $"tenant {kind.ToString().ToLowerInvariant()}: {previousIdentity} -> {TenantIdentity(next)} "
+            + $"({outcome}, {executing} executing)");
+    }
+
+    /// <summary>
+    /// How a generation of the tenant is named in the report: its instance id and which run of the
+    /// recipe built it.
+    /// </summary>
+    private static string TenantIdentity(IScheduler scheduler)
+    {
+        if (scheduler is null)
+        {
+            return "none";
+        }
+
+        string generation = scheduler.Context.TryGetValue(TenantGenerationKey, out object value)
+            ? Convert.ToString(value, CultureInfo.InvariantCulture)
+            : "?";
+
+        return $"{scheduler.SchedulerInstanceId}#{generation}";
+    }
+
+    /// <summary>
+    /// Takes the tenant away at the end of the run, waiting for its jobs so that the "nothing left
+    /// behind" assertion is about a tenant that finished rather than one that was cut off.
+    /// </summary>
+    private async Task StopTenant(List<string> timeline)
+    {
+        if (runtime is null)
+        {
+            return;
+        }
+
+        try
+        {
+            bool removed = await runtime.Remove(TenantName, waitForJobsToComplete: true);
+            Note(timeline, DateTimeOffset.UtcNow,
+                removed ? $"tenant '{TenantName}' removed" : $"tenant '{TenantName}' was already gone");
+        }
+        catch (Exception e)
+        {
+            // This runs inside a finally that still has a cluster to shut down and a report to print, so
+            // a failure here is recorded and asserted on afterwards rather than thrown from here.
+            TenantLedger.RecordTeardownFailure(e);
+            Note(timeline, DateTimeOffset.UtcNow, $"tenant '{TenantName}' could not be removed: {e.Message}");
+        }
+        finally
+        {
+            tenant = null;
+        }
+    }
+
+    /// <summary>
+    /// Waits for the tenant's next steady firing, answering with it or with <see langword="null" /> if
+    /// the patience runs out. It does not fail the run: how long a rebuild took to fire again is a
+    /// measurement the report carries and the end assertions judge, and failing here would end the soak
+    /// at the first slow rebuild.
+    /// </summary>
+    private static async Task<TenantFiring> WaitForTenantFiringAfter(DateTimeOffset after, TimeSpan patience)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + patience;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            TenantFiring firing = TenantLedger.FirstSteadyFiringAfter(after);
+            if (firing is not null)
+            {
+                return firing;
+            }
+
+            await Task.Delay(100);
+        }
+
+        return TenantLedger.FirstSteadyFiringAfter(after);
+    }
+
+    /// <summary>
+    /// What a tenant that has been rebuilt a dozen times and then removed leaves in the tables.
+    /// </summary>
+    /// <remarks>
+    /// Polled for the reason the cluster's own version is: <c>Remove</c> returns once the scheduler has
+    /// stopped and its jobs have finished, but the last completions write on their own connections.
+    /// </remarks>
+    private async Task AssertTenantLeftNothingBehind()
+    {
+        await WaitForCondition(
+            async () => await CountTenantRows("QRTZ_FIRED_TRIGGERS") == 0,
+            timeoutMs: 60_000,
+            async () =>
+                $"QRTZ_FIRED_TRIGGERS to drain for '{TenantName}'. Every generation of this tenant swept the "
+                + "whole scheduler name on startup and the last one was removed waiting for its jobs, so a row "
+                + $"here is a firing nothing ever completed. State:\n{await DumpTenantState()}");
+
+        int reserved = await CountRows(
+            "SELECT COUNT(*) FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_STATE IN ('ACQUIRED', 'BLOCKED')",
+            ("schedulerName", TenantName));
+
+        reserved.Should().Be(0,
+            "an ACQUIRED row is one a generation reserved and never fired and a BLOCKED row is the serial job's "
+            + "sibling never unblocked — a rebuild that left either would have left the next generation a trigger "
+            + "that only a recovery can move");
+    }
+
+    /// <summary>
+    /// The property the tenant exists to demonstrate: a schedule that survives being rebuilt.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The steady trigger repeats indefinitely under <c>SmartPolicy</c>, which
+    /// <c>SimpleTriggerImpl.UpdateAfterMisfire</c> resolves to
+    /// <c>RescheduleNextWithRemainingCount</c> for an indefinite repeat: the next fire time becomes the
+    /// next occurrence <em>on the original grid</em> after now, so a misfire skips occurrences and never
+    /// moves them. Every scheduled fire time this run sees is therefore
+    /// <c>start + n × 1 s</c>, and the question is only which of those <c>n</c> fired.
+    /// </para>
+    /// <para>
+    /// That makes the count exact rather than approximate. Between the first and last firing there are
+    /// <c>(last − first) / 1 s + 1</c> occurrences; each one fired exactly once or was skipped, and each
+    /// skipped one has to fall inside a window when the tenant was being rebuilt. No band, no tolerance:
+    /// a second firing of one occurrence and a gap nothing accounts for are both simply wrong.
+    /// </para>
+    /// </remarks>
+    private void AssertTenantKeptItsSchedule()
+    {
+        SteadySchedule schedule = AnalyseSteadySchedule();
+
+        schedule.Firings.Should().NotBeEmpty(
+            "the tenant's ordinary trigger fires every second for the whole run; none at all means the tenant "
+            + "never ran, which makes every other assertion here vacuous");
+
+        schedule.OffGrid.Should().BeEmpty(
+            "a simple trigger's occurrences are start + n × interval, and misfire handling under SmartPolicy "
+            + "moves the next fire time to the next occurrence on that grid rather than off it. A scheduled "
+            + "fire time that is not on the grid is a trigger that was rewritten rather than caught up");
+
+        schedule.Repeated.Should().BeEmpty(
+            "one occurrence, one firing. A second firing of the same scheduled fire time is a rebuild replaying "
+            + "work the previous generation had already completed — which is what the drain before the next "
+            + "generation's recovery sweep exists to prevent");
+
+        (schedule.Firings.Count + schedule.Skipped.Count).Should().Be(schedule.Expected,
+            "the occurrences between the first firing and the last are exactly {0}, and each of them either "
+            + "fired once or was skipped — {1} fired and {2} were skipped, so the sum saying anything else is "
+            + "an occurrence that fired twice",
+            schedule.Expected, schedule.Firings.Count, schedule.Skipped.Count);
+
+        schedule.Unexplained.Should().BeEmpty(
+            "an occurrence is only allowed to be skipped while the tenant is being rebuilt: between the rebuild "
+            + "being asked for and the new generation firing again, the scheduler is not there to fire it and "
+            + "its misfire instruction lets it go. One skipped outside every such window is a firing lost while "
+            + "the tenant was up");
+
+        TenantLedger.SerialPeakConcurrency.Should().Be(1,
+            "[DisallowConcurrentExecution] is a claim about the job, not about the generation running it. A "
+            + "rebuild hands the same trigger rows to a new set of instances, and two firings at once across "
+            + "that boundary would be the store failing to carry the block over it");
+
+        TenantLedger.SerialOverlaps.Should().BeEmpty(
+            "the same statement listed rather than counted, so a failure names the firings that overlapped");
+
+        TenantLedger.FiringsOf(TenantJobs.Serial).Should().NotBeEmpty(
+            "the serial job is what the overlap check watches; it has to have run for the check to mean anything");
+    }
+
+    /// <summary>
+    /// That every rebuild finished, and that the tenant was firing again promptly afterwards.
+    /// </summary>
+    private void AssertTenantRebuilds()
+    {
+        TenantLedger.TeardownFailures.Should().BeEmpty(
+            "removing the tenant at the end of the run is the ordinary path, and a failure there is one an "
+            + "application shutting a tenant down would meet too");
+
+        TenantLedger.AbandonedDrains.Should().BeEmpty(
+            "a restart's drain waits {0} for jobs whose longest is 300 ms. Giving up on that is either a job "
+            + "that never completed or a completion the scheduler never noticed, and both leave the tenant shut "
+            + "down with nothing built in its place",
+            TenantDrainTimeout);
+
+        tenantRebuilds.Should().NotBeEmpty(
+            "the run rebuilds the tenant on a timer; none at all means the phases never fired and the whole "
+            + "tenant half of this gate asserted nothing");
+
+        foreach (TenantRebuild rebuild in tenantRebuilds)
+        {
+            rebuild.NextIdentity.Should().NotBe(rebuild.PreviousIdentity,
+                "rebuild #{0} ({1}) has to have produced a second set of instances. The ordinal only advances "
+                + "when the recipe is run again, so an unchanged identity is a scheduler that was resumed "
+                + "rather than rebuilt — which every part of it refuses to be, having been shut down",
+                rebuild.Number, rebuild.Kind);
+
+            rebuild.FiredAgainAt.Should().NotBeNull(
+                "rebuild #{0} ({1}, {2}) has to leave a scheduler that fires. Nothing within {3} of it means the "
+                + "new generation was built and bound but never acquired anything — a tenant that is listed, "
+                + "reports itself running, and does no work",
+                rebuild.Number, rebuild.Kind, rebuild.Outcome, TenantFireAgainPatience);
+
+            rebuild.FiredAgainAfter.Value.Should().BeLessThanOrEqualTo(TenantFireAgainBudget,
+                "rebuild #{0} ({1}) left the tenant idle for {2:F1} s. A trigger due every second should be "
+                + "picked up by the next generation as soon as its store is initialized; a longer gap is the "
+                + "recovery sweep, the schema check or the first acquisition costing more than a restart should",
+                rebuild.Number, rebuild.Kind, rebuild.FiredAgainAfter.Value.TotalSeconds);
+        }
+    }
+
+    /// <summary>
+    /// Reads the steady trigger's firings as a grid: which occurrences fired, which were skipped, and
+    /// which of the skipped ones no rebuild accounts for.
+    /// </summary>
+    /// <remarks>
+    /// Shared by the report and the assertions, so that what the run prints and what it fails on are the
+    /// same numbers rather than two calculations that could disagree.
+    /// </remarks>
+    private SteadySchedule AnalyseSteadySchedule()
+    {
+        List<TenantFiring> firings = TenantLedger.FiringsOf(TenantJobs.Steady)
+            .Where(x => x.ScheduledFireTimeUtc is not null)
+            .OrderBy(x => x.ScheduledFireTimeUtc.Value)
+            .ToList();
+
+        if (firings.Count == 0)
+        {
+            return new SteadySchedule(firings, [], [], [], [], 0);
+        }
+
+        List<TenantFiring> repeated = firings
+            .GroupBy(x => x.ScheduledFireTimeUtc.Value)
+            .Where(group => group.Count() > 1)
+            .SelectMany(group => group)
+            .ToList();
+
+        HashSet<DateTimeOffset> fired = firings.Select(x => x.ScheduledFireTimeUtc.Value).ToHashSet();
+
+        List<DateTimeOffset> offGrid = fired
+            .Where(at => (at - tenantWorkloadStart).Ticks % TenantSteadyInterval.Ticks != 0)
+            .OrderBy(at => at)
+            .ToList();
+
+        DateTimeOffset first = firings[0].ScheduledFireTimeUtc.Value;
+        DateTimeOffset last = firings[^1].ScheduledFireTimeUtc.Value;
+
+        List<DateTimeOffset> skipped = [];
+        for (DateTimeOffset at = first; at <= last; at += TenantSteadyInterval)
+        {
+            if (!fired.Contains(at))
+            {
+                skipped.Add(at);
+            }
+        }
+
+        List<DateTimeOffset> unexplained = skipped
+            .Where(at => !tenantRebuilds.Any(rebuild => rebuild.Covers(at, TenantSteadyInterval)))
+            .ToList();
+
+        int expected = (int) ((last - first).Ticks / TenantSteadyInterval.Ticks) + 1;
+
+        return new SteadySchedule(firings, repeated, skipped, unexplained, offGrid, expected);
+    }
+
+    /// <summary>
+    /// The tenant's half of the run's report: what it fired, and what each rebuild cost.
+    /// </summary>
+    private string TenantReport()
+    {
+        SteadySchedule schedule = AnalyseSteadySchedule();
+        List<TenantFiring> serial = TenantLedger.FiringsOf(TenantJobs.Serial);
+
+        StringBuilder report = new();
+        report.AppendLine(CultureInfo.InvariantCulture, $"Runtime tenant '{TenantName}':");
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"  {"steady (every 1 s)",-28} {schedule.Firings.Count} fired, {schedule.Skipped.Count} skipped, "
+            + $"{schedule.Expected} occurrences, {schedule.Unexplained.Count} unexplained");
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"  {"serial (max concurrent)",-28} {serial.Count} ({TenantLedger.SerialPeakConcurrency})");
+        report.AppendLine(CultureInfo.InvariantCulture,
+            $"  {"rebuilds",-28} {tenantRebuilds.Count}");
+
+        foreach (TenantRebuild rebuild in tenantRebuilds)
+        {
+            report.AppendLine(CultureInfo.InvariantCulture,
+                $"  #{rebuild.Number,-2} {rebuild.Kind,-7} {rebuild.OpenedAt:HH:mm:ss}  "
+                + $"{rebuild.PreviousIdentity} -> {rebuild.NextIdentity}  {rebuild.Outcome}; "
+                + $"{rebuild.JobsExecuting} executing; fired again after {Describe(rebuild.FiredAgainAfter)}");
+        }
+
+        foreach (DateTimeOffset at in schedule.Skipped)
+        {
+            report.AppendLine(CultureInfo.InvariantCulture,
+                $"  skipped {at:HH:mm:ss}  {(schedule.Unexplained.Contains(at) ? "OUTSIDE EVERY REBUILD WINDOW" : "in a rebuild window")}");
+        }
+
+        foreach (string abandoned in TenantLedger.AbandonedDrains)
+        {
+            report.AppendLine("  abandoned drain: " + abandoned);
+        }
+
+        foreach (string failure in TenantLedger.TeardownFailures)
+        {
+            report.AppendLine("  teardown failure: " + failure);
+        }
+
+        return report.ToString();
+
+        static string Describe(TimeSpan? elapsed)
+        {
+            return elapsed is null
+                ? "never"
+                : string.Create(CultureInfo.InvariantCulture, $"{elapsed.Value.TotalSeconds:F1} s");
+        }
+    }
+
+    private Task<int> CountTenantRows(string table)
+    {
+        return CountRows(
+            $"SELECT COUNT(*) FROM {table} WHERE SCHED_NAME = @schedulerName",
+            ("schedulerName", TenantName));
+    }
+
+    /// <summary>
+    /// The tenant's trigger and fired-trigger rows, for a failed assertion to say what it was looking at.
+    /// The base class's dump is scoped to the cluster's scheduler name, which is not this one.
+    /// </summary>
+    private async Task<string> DumpTenantState()
+    {
+        int triggers = await CountTenantRows("QRTZ_TRIGGERS");
+        int fired = await CountTenantRows("QRTZ_FIRED_TRIGGERS");
+        int state = await CountTenantRows("QRTZ_SCHEDULER_STATE");
+
+        return string.Create(CultureInfo.InvariantCulture,
+            $"{TenantName}: {triggers} trigger row(s), {fired} fired-trigger row(s), {state} scheduler-state row(s)");
+    }
+
+    /// <summary>Which of the two ways the tenant was taken apart and put back together.</summary>
+    private enum TenantRebuildKind
+    {
+        /// <summary><see cref="ISchedulerRuntime.Restart" />: the runtime orders build, drain and create.</summary>
+        Restart,
+
+        /// <summary><see cref="ISchedulerRuntime.Remove" /> then <see cref="ISchedulerRuntime.Add" />, by hand.</summary>
+        Recycle,
+    }
+
+    /// <summary>One rebuild, and everything about it a reader of the report would want.</summary>
+    private sealed record TenantRebuild
+    {
+        public required int Number { get; init; }
+
+        public required TenantRebuildKind Kind { get; init; }
+
+        /// <summary>When the rebuild was asked for, which is when the tenant stopped being able to fire.</summary>
+        public required DateTimeOffset OpenedAt { get; init; }
+
+        /// <summary>When the call came back with a scheduler, or came back without one.</summary>
+        public required DateTimeOffset ReturnedAt { get; init; }
+
+        /// <summary>
+        /// The outgoing generation, as its instance id and the run of the recipe that built it.
+        /// </summary>
+        public required string PreviousIdentity { get; init; }
+
+        /// <summary>The incoming generation, named the same way, or <c>none</c> if none was built.</summary>
+        public required string NextIdentity { get; init; }
+
+        /// <summary>
+        /// How many of the tenant's jobs were in flight when the rebuild was asked for — which is what
+        /// the drain then had to wait for.
+        /// </summary>
+        public required int JobsExecuting { get; init; }
+
+        public required string Outcome { get; init; }
+
+        /// <summary>When the tenant next fired, or <see langword="null" /> if it never did.</summary>
+        public required DateTimeOffset? FiredAgainAt { get; init; }
+
+        /// <summary>How long the new generation took to fire, measured from the call coming back.</summary>
+        public TimeSpan? FiredAgainAfter => FiredAgainAt is null ? null : FiredAgainAt.Value - ReturnedAt;
+
+        /// <summary>
+        /// Whether an occurrence that never fired falls inside this rebuild's window.
+        /// </summary>
+        /// <remarks>
+        /// The window opens one interval early on purpose: an occurrence due in the interval before the
+        /// rebuild was asked for may have been acquired and not yet fired when the drain began, and the
+        /// shutdown releases it back to waiting. It closes at the first firing of the next generation,
+        /// which is the moment the tenant demonstrably works again — a fixed slack would be a number
+        /// picked to make the run pass.
+        /// </remarks>
+        public bool Covers(DateTimeOffset at, TimeSpan slack)
+        {
+            return at >= OpenedAt - slack && at <= (FiredAgainAt ?? DateTimeOffset.MaxValue);
+        }
+    }
+
+    /// <summary>
+    /// The steady trigger's grid, read out of the ledger.
+    /// </summary>
+    private sealed record SteadySchedule(
+        List<TenantFiring> Firings,
+        List<TenantFiring> Repeated,
+        List<DateTimeOffset> Skipped,
+        List<DateTimeOffset> Unexplained,
+        List<DateTimeOffset> OffGrid,
+        int Expected);
+
+    /// <summary>
+    /// One firing of one of the tenant's jobs, as the gate asked for it: which firing, which occurrence
+    /// it was, which generation ran it, and when it began and ended.
+    /// </summary>
+    private sealed record TenantFiring(
+        string Job,
+        string FireInstanceId,
+        DateTimeOffset? ScheduledFireTimeUtc,
+        string Node,
+        DateTimeOffset Start,
+        DateTimeOffset End);
+
+    /// <summary>The tenant's job names, in one place.</summary>
+    private static class TenantJobs
+    {
+        public const string Steady = "tenantSteadyJob";
+
+        public const string Serial = "tenantSerialJob";
+    }
+
+    /// <summary>The tenant's trigger names, in one place.</summary>
+    private static class TenantTriggers
+    {
+        public const string Steady = "tenant-steady";
+
+        public const string Serial = "tenant-serial";
+    }
+
+    /// <summary>
+    /// Everything the tenant did, in statics because its jobs are constructed by whichever generation is
+    /// alive and the fixture never sees them.
+    /// </summary>
+    private static class TenantLedger
+    {
+        private static ConcurrentQueue<TenantFiring> firings = new();
+
+        private static int inFlight;
+        private static int serialInFlight;
+        private static int serialPeak;
+
+        public static ConcurrentQueue<string> SerialOverlaps { get; private set; } = new();
+
+        public static ConcurrentQueue<string> AbandonedDrains { get; private set; } = new();
+
+        public static ConcurrentQueue<string> TeardownFailures { get; private set; } = new();
+
+        /// <summary>
+        /// How many of the tenant's jobs are running right now, which is what a rebuild's drain is about
+        /// to wait for.
+        /// </summary>
+        public static int InFlight => Volatile.Read(ref inFlight);
+
+        public static int SerialPeakConcurrency => Volatile.Read(ref serialPeak);
+
+        public static void Reset()
+        {
+            firings = new ConcurrentQueue<TenantFiring>();
+            SerialOverlaps = new ConcurrentQueue<string>();
+            AbandonedDrains = new ConcurrentQueue<string>();
+            TeardownFailures = new ConcurrentQueue<string>();
+            Interlocked.Exchange(ref inFlight, 0);
+            Interlocked.Exchange(ref serialInFlight, 0);
+            Interlocked.Exchange(ref serialPeak, 0);
+        }
+
+        public static void Enter(IJobExecutionContext context, bool serial)
+        {
+            Interlocked.Increment(ref inFlight);
+
+            if (!serial)
+            {
+                return;
+            }
+
+            int inside = Interlocked.Increment(ref serialInFlight);
+            RecordSerialPeak(inside);
+
+            if (inside > 1)
+            {
+                SerialOverlaps.Enqueue(string.Create(CultureInfo.InvariantCulture,
+                    $"{inside} concurrent firings of the tenant's serial job; this one on "
+                    + $"'{context.Scheduler.SchedulerInstanceId}' as {context.FireInstanceId}"));
+            }
+        }
+
+        public static void Exit(string job, IJobExecutionContext context, DateTimeOffset start, bool serial)
+        {
+            if (serial)
+            {
+                Interlocked.Decrement(ref serialInFlight);
+            }
+
+            Interlocked.Decrement(ref inFlight);
+
+            firings.Enqueue(new TenantFiring(
+                job,
+                context.FireInstanceId,
+                context.ScheduledFireTimeUtc,
+                context.Scheduler.SchedulerInstanceId,
+                start,
+                DateTimeOffset.UtcNow));
+        }
+
+        public static void RecordAbandonedDrain(SchedulerRestartException exception)
+        {
+            AbandonedDrains.Enqueue(string.Create(CultureInfo.InvariantCulture,
+                $"'{exception.SchedulerName}' had {exception.JobsStillExecuting} job(s) executing when the "
+                + $"{exception.DrainTimeout} drain gave up: {exception.Message}"));
+        }
+
+        public static void RecordTeardownFailure(Exception exception) => TeardownFailures.Enqueue(exception.ToString());
+
+        public static List<TenantFiring> FiringsOf(string job)
+        {
+            return firings.Where(x => string.Equals(x.Job, job, StringComparison.Ordinal)).ToList();
+        }
+
+        /// <summary>
+        /// The earliest steady firing that began after <paramref name="after" />, which is how a rebuild
+        /// learns that the generation it built is doing work.
+        /// </summary>
+        public static TenantFiring FirstSteadyFiringAfter(DateTimeOffset after)
+        {
+            TenantFiring earliest = null;
+            foreach (TenantFiring firing in firings)
+            {
+                if (!string.Equals(firing.Job, TenantJobs.Steady, StringComparison.Ordinal) || firing.Start <= after)
+                {
+                    continue;
+                }
+
+                if (earliest is null || firing.Start < earliest.Start)
+                {
+                    earliest = firing;
+                }
+            }
+
+            return earliest;
+        }
+
+        private static void RecordSerialPeak(int inside)
+        {
+            int observed = Volatile.Read(ref serialPeak);
+            while (inside > observed)
+            {
+                int previous = Interlocked.CompareExchange(ref serialPeak, inside, observed);
+                if (previous == observed)
+                {
+                    return;
+                }
+
+                observed = previous;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The tenant's ordinary job. A firing a second, doing just enough work that its start and end are
+    /// different instants and that a drain has something to wait for.
+    /// </summary>
+    public sealed class SoakTenantSteadyJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            DateTimeOffset start = DateTimeOffset.UtcNow;
+            TenantLedger.Enter(context, serial: false);
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                TenantLedger.Exit(TenantJobs.Steady, context, start, serial: false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The tenant's serial job. It holds its slot long enough that a second firing would have to overlap
+    /// it rather than merely follow it — including a second firing acquired by a later generation.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class SoakTenantSerialJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            DateTimeOffset start = DateTimeOffset.UtcNow;
+            TenantLedger.Enter(context, serial: true);
+            try
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(300), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                TenantLedger.Exit(TenantJobs.Serial, context, start, serial: true);
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/ClusteredSoakTestBase.cs
@@ -9,7 +9,8 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// <summary>
 /// Two clustered nodes carrying every kind of work the scheduler can be asked to do, for half an hour,
 /// with the failures a cluster meets in production induced along the way — and then asked what they
-/// left behind.
+/// left behind. A third scheduler is added to node A's container at run time and rebuilt throughout,
+/// because a tenant that comes and goes is the other thing a long-lived process does to a database.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -51,8 +52,15 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// <c>LAST_CHECKIN_TIME</c>, and a node with a fake clock is a node in a cluster that does not exist.
 /// Where the test needs the past it moves a row, with <c>BackdateCheckin</c>.
 /// </para>
+/// <para>
+/// <b>The runtime tenant is the other half</b>, and lives in <c>ClusteredSoakTestBase.Tenant.cs</c>:
+/// a third scheduler added through <see cref="ISchedulerRuntime" /> to the container node A was built
+/// from, storing under its own <c>SCHED_NAME</c> in the same tables, restarted and recycled throughout
+/// the run. Its assertions are its own; the cluster's are unchanged by its presence, which is itself
+/// something the run is asked to show.
+/// </para>
 /// </remarks>
-public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
+public abstract partial class ClusteredSoakTestBase : ClusteredJobStoreTestBase
 {
     private const string Group = "clusterSoak";
     private const string NodeA = "soak-node-a";
@@ -103,11 +111,18 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
     {
         TimeSpan duration = SoakDuration();
         SoakRecorder.Reset();
+        TenantLedger.Reset();
 
         List<ResourceSample> samples = [];
         List<string> timeline = [];
 
-        IScheduler nodeA = await CreateSoakScheduler(NodeA);
+        // Node A is built into a container this fixture keeps hold of, because the tenant below is added
+        // to that container: ISchedulerRuntime is a service of the container a scheduler was built from,
+        // and the standalone builder hides its own. Node B has no such need and is built the way every
+        // other clustered fixture builds a node — which also keeps one of the two nodes on the path the
+        // earlier soak runs took.
+        SchedulerHost hostA = await CreateSoakHost(NodeA);
+        IScheduler nodeA = hostA.Scheduler;
         IScheduler nodeB = await CreateSoakScheduler(NodeB);
 
         try
@@ -123,6 +138,8 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
 
             Note(timeline, started, $"workload scheduled; running for {duration}");
 
+            await StartTenant(hostA, timeline, started);
+
             // The phases, as fractions of the run, so a five-minute smoke exercises the same sequence a
             // half-hour gate does. Each one is a failure a cluster meets in production.
             DateTimeOffset standbyAt = started + duration * 0.25;
@@ -130,6 +147,14 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
             DateTimeOffset killAt = started + duration * 0.55;
             DateTimeOffset replaceAt = started + duration * 0.70;
             DateTimeOffset deadline = started + duration;
+
+            // The tenant's own phases, expressed the same way: at the half hour this gate runs for they
+            // are a restart every three minutes and a remove-and-add every seven, which is what the gate
+            // asks for, and a shorter run scales both rather than skipping them entirely.
+            TimeSpan restartEvery = duration / 10;
+            TimeSpan recycleEvery = duration * 7 / 30;
+            DateTimeOffset tenantRestartAt = started + restartEvery;
+            DateTimeOffset tenantRecycleAt = started + recycleEvery;
 
             // Long enough that a sample is a settled heap rather than a moment in a collection, short
             // enough that a five-minute smoke still produces a series to read a trend off.
@@ -192,6 +217,24 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
                     Note(timeline, now, $"'{NodeB}' replaced and rejoined the cluster");
                 }
 
+                // Its own chain, because the tenant's life is independent of the cluster's failures: it
+                // is a scheduler beside them rather than one of them, and a run that only rebuilt it
+                // while nothing else was happening would be the easy half of the question.
+                if (now >= tenantRecycleAt)
+                {
+                    await RebuildTenant(timeline, TenantRebuildKind.Recycle);
+
+                    // Both clocks. A recycle is a rebuild too, so restarting a moment after one would
+                    // measure the same thing twice and shorten the interval the gate asked for.
+                    tenantRecycleAt = DateTimeOffset.UtcNow + recycleEvery;
+                    tenantRestartAt = DateTimeOffset.UtcNow + restartEvery;
+                }
+                else if (now >= tenantRestartAt)
+                {
+                    await RebuildTenant(timeline, TenantRebuildKind.Restart);
+                    tenantRestartAt = DateTimeOffset.UtcNow + restartEvery;
+                }
+
                 if (now >= sampleAt)
                 {
                     samples.Add(ResourceSample.Take(now - started));
@@ -206,6 +249,10 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
         }
         finally
         {
+            // The tenant first, so that its own shutdown is not racing node A's — and so that a failure
+            // in it cannot leave the cluster running, which the catch inside StopTenant is there for.
+            await StopTenant(timeline);
+
             // Waiting for the jobs is the point rather than politeness: the "nothing left behind"
             // assertions below are about a cluster that finished its work, not one that was cut off
             // mid-firing.
@@ -215,10 +262,13 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
                 await nodeB.Shutdown(waitForJobsToComplete: true);
             }
 
+            await hostA.Services.DisposeAsync();
+
             // Here rather than at the end of the run, so that a soak which fell over halfway through
             // still says how far it got and what it had seen. That is most of what a run this long is
             // for, and it is exactly the run that will not reach the end.
             TestContext.Out.WriteLine(Report(timeline, samples, duration));
+            TestContext.Out.WriteLine(TenantReport());
         }
 
         await AssertNothingLeftBehind();
@@ -226,6 +276,10 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
         AssertNoOverlap();
         AssertNoUnobservedFailures();
         AssertResourcesFlat(samples);
+
+        await AssertTenantLeftNothingBehind();
+        AssertTenantKeptItsSchedule();
+        AssertTenantRebuilds();
     }
 
     /// <summary>
@@ -266,14 +320,31 @@ public abstract class ClusteredSoakTestBase : ClusteredJobStoreTestBase
             instanceId,
             checkinIntervalMs: 2000,
             checkinMisfireThresholdMs: 15_000,
-            configure: properties =>
-            {
-                properties["quartz.threadPool.maxConcurrency"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
-                properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
-                properties["quartz.jobStore.misfireThreshold"] =
-                    ((int) MisfireThreshold.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
-            },
+            configure: ConfigureSoakNode,
             configureBuilder: quartz => quartz.AddJobTimeout());
+    }
+
+    /// <summary>
+    /// The same node, built into a container this fixture keeps — which is what
+    /// <see cref="ISchedulerRuntime" /> is resolved from, and therefore what the runtime tenant is added
+    /// to. Only node A needs it.
+    /// </summary>
+    private Task<SchedulerHost> CreateSoakHost(string instanceId)
+    {
+        return CreateSchedulerHost(
+            instanceId,
+            checkinIntervalMs: 2000,
+            checkinMisfireThresholdMs: 15_000,
+            configure: ConfigureSoakNode,
+            configureBuilder: quartz => quartz.AddJobTimeout());
+    }
+
+    private static void ConfigureSoakNode(NameValueCollection properties)
+    {
+        properties["quartz.threadPool.maxConcurrency"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
+        properties["quartz.scheduler.batchTriggerAcquisitionMaxCount"] = MaxConcurrency.ToString(CultureInfo.InvariantCulture);
+        properties["quartz.jobStore.misfireThreshold"] =
+            ((int) MisfireThreshold.TotalMilliseconds).ToString(CultureInfo.InvariantCulture);
     }
 
     /// <summary>


### PR DESCRIPTION
Release gate G5 for 4.1: **30 minutes against PostgreSQL on `b67f0faa9a`, 2026-09-09. It passed.**

The clustered soak now carries a third scheduler that nobody registered — one added to node A's
container after that container was built, storing under its own `SCHED_NAME` in the same tables, and
taken apart and put back together throughout the half hour the two nodes are running.

## The run

```
Soak over 00:30:00:
  06:18:34 workload scheduled; running for 00:30:00
  06:18:35 tenant 'soak-tenant' added at run time on 'soak-node-a's container as NON_CLUSTERED#1
  06:21:34 tenant restart: NON_CLUSTERED#1 -> NON_CLUSTERED#2 (drained, 1 executing)
  06:24:35 tenant restart: NON_CLUSTERED#2 -> NON_CLUSTERED#3 (drained, 1 executing)
  06:25:34 tenant recycle: NON_CLUSTERED#3 -> NON_CLUSTERED#4 (removed and added, 0 executing)
  06:26:04 both nodes in standby for 00:00:30 to induce misfires
  06:26:34 both nodes resumed
  06:28:35 tenant restart: NON_CLUSTERED#4 -> NON_CLUSTERED#5 (drained, 0 executing)
  06:31:36 tenant restart: NON_CLUSTERED#5 -> NON_CLUSTERED#6 (drained, 0 executing)
  06:32:35 tenant recycle: NON_CLUSTERED#6 -> NON_CLUSTERED#7 (removed and added, 0 executing)
  06:35:04 'soak-node-b' killed mid-flight, leaving an EXECUTING row behind
  06:35:05 survivor recovered the killed node's work
  06:35:36 tenant restart: NON_CLUSTERED#7 -> NON_CLUSTERED#8 (drained, 0 executing)
  06:38:37 tenant restart: NON_CLUSTERED#8 -> NON_CLUSTERED#9 (drained, 0 executing)
  06:39:34 'soak-node-b' replaced and rejoined the cluster
  06:39:36 tenant recycle: NON_CLUSTERED#9 -> NON_CLUSTERED#10 (removed and added, 0 executing)
  06:42:37 tenant restart: NON_CLUSTERED#10 -> NON_CLUSTERED#11 (drained, 1 executing)
  06:45:38 tenant restart: NON_CLUSTERED#11 -> NON_CLUSTERED#12 (drained, 0 executing)
  06:46:37 tenant recycle: NON_CLUSTERED#12 -> NON_CLUSTERED#13 (removed and added, 1 executing)
  06:48:34 run complete, shutting the cluster down
  06:48:34 tenant 'soak-tenant' removed
Firings:
  family-calendarInterval      444
  family-cron                  354
  family-dailyTimeInterval     591
  family-recurrence            296
  family-simple                890
  serial (max concurrent)      2645 (1)
  failing (attempts)           534, of which 356 were retries
  timed out                    178
  recovered                    1

Runtime tenant 'soak-tenant':
  steady (every 1 s)           1796 fired, 0 skipped, 1796 occurrences, 0 unexplained
  serial (max concurrent)      898 (1)
  rebuilds                     12
  #1  Restart 06:21:34  NON_CLUSTERED#1  -> NON_CLUSTERED#2   drained; 1 executing; fired again after 0.9 s
  #2  Restart 06:24:35  NON_CLUSTERED#2  -> NON_CLUSTERED#3   drained; 1 executing; fired again after 0.7 s
  #3  Recycle 06:25:34  NON_CLUSTERED#3  -> NON_CLUSTERED#4   removed and added; 0 executing; fired again after 0.7 s
  #4  Restart 06:28:35  NON_CLUSTERED#4  -> NON_CLUSTERED#5   drained; 0 executing; fired again after 0.6 s
  #5  Restart 06:31:36  NON_CLUSTERED#5  -> NON_CLUSTERED#6   drained; 0 executing; fired again after 0.9 s
  #6  Recycle 06:32:35  NON_CLUSTERED#6  -> NON_CLUSTERED#7   removed and added; 0 executing; fired again after 0.4 s
  #7  Restart 06:35:36  NON_CLUSTERED#7  -> NON_CLUSTERED#8   drained; 0 executing; fired again after 0.6 s
  #8  Restart 06:38:37  NON_CLUSTERED#8  -> NON_CLUSTERED#9   drained; 0 executing; fired again after 0.4 s
  #9  Recycle 06:39:36  NON_CLUSTERED#9  -> NON_CLUSTERED#10  removed and added; 0 executing; fired again after 0.8 s
  #10 Restart 06:42:37  NON_CLUSTERED#10 -> NON_CLUSTERED#11  drained; 1 executing; fired again after 0.7 s
  #11 Restart 06:45:38  NON_CLUSTERED#11 -> NON_CLUSTERED#12  drained; 0 executing; fired again after 0.5 s
  #12 Recycle 06:46:37  NON_CLUSTERED#12 -> NON_CLUSTERED#13  removed and added; 1 executing; fired again after 0.7 s
```

Resources across all thirty samples: heap **5 MB** throughout, **629–656** handles, 59–65 threads.

The cluster landed firing for firing where the 4.0 runs left it (890/591/444/354/296 against
890/591/444/355/296 on the beta.1 PostgreSQL run; 2,645 serial firings against 2,662; 356 retries and
178 overruns in both). `QRTZ_FIRED_TRIGGERS` was empty for **both** scheduler names at the end, with
nothing `ACQUIRED` or `BLOCKED` under either, no unexpected scheduler error and no unobserved task
exception.

The tenant's numbers are the new ones: **1,796 scheduled fire times, every one fired exactly once,
none skipped.** A rebuild is a gap of well under a second, far inside the misfire threshold, so each
new generation caught the missed occurrences up rather than letting them go — the misfire branch of
the assertion was therefore never taken, which is worth knowing rather than worth forcing.

## What the fixture adds

A tenant, not a third node. `ISchedulerRuntime.Add("soak-tenant", …)` on node A's container, with a
`[DisallowConcurrentExecution]` job every two seconds and an ordinary one every second, both writing
`(fireInstanceId, scheduledFireTime, generation, start, end)` into a ledger. Restarted through
`ISchedulerRuntime.Restart` with a 30-second drain on one timer and removed and added again on
another — three and seven minutes at the gate's half hour, expressed as fractions of the run so a
five-minute smoke exercises the same sequence, as the existing phases already are.

Its store is registered by data source and driver-delegate factory rather than as an instance, so the
recipe replays and `Restart`'s instance-part refusal does not trip. It is deliberately **not**
clustered: a non-clustered store's first act on start is the recovery sweep over the whole scheduler
name, unfiltered by instance id, which is the exact hazard `Restart`'s build-drain-create ordering
exists to protect against.

## What it asserts

Arithmetic rather than banded. A simple trigger repeating indefinitely resolves `SmartPolicy` to
`RescheduleNextWithRemainingCount` (`SimpleTriggerImpl.UpdateAfterMisfire`), which moves the next fire
time to the next occurrence **on the original grid** — so every scheduled fire time is
`start + n × 1 s`, and between the first firing and the last there are exactly
`(last − first) / 1 s + 1` of them. Then:

- every occurrence fired exactly once, or was skipped and falls inside a window when the tenant was
  being rebuilt (the report lists which, and whether each is accounted for);
- `fired + skipped == occurrences`, which is "exactly once" written as arithmetic;
- every observed scheduled fire time is on the grid;
- the serial job's peak observed concurrency across every generation is 1;
- no restart's drain was abandoned — a `SchedulerRestartException` is recorded and failed on rather
  than swallowed, and the run continues so the rest of the half hour is still evidence;
- every rebuild produced a genuinely new generation, and the tenant was firing again within 10 s of
  the call returning;
- `QRTZ_FIRED_TRIGGERS` is empty for the tenant's `SCHED_NAME` at the end, and nothing is `ACQUIRED`
  or `BLOCKED`;
- the cluster's own assertions are unchanged and still hold with the tenant present.

## What the run found

**A non-clustered scheduler's instance id is `NON_CLUSTERED` in every generation.**
`DefaultSchedulerFactory.GenerateInstanceId` returns the default id for a store that shares its
database with nobody, whatever `GenerateInstanceId` says — so the instance id cannot tell one
generation of a restarted tenant from the next, and anything correlating a record with the generation
that wrote it needs something else. That is deliberate and documented on the member; it is recorded
in `operations.md` because it is the first thing anyone building tenant-restart tooling will trip on.
The fixture names a generation by its instance id **and** an ordinal the recipe stamps into
`SchedulerContext` as it runs, which says the stronger thing anyway: the number only advances when
the recipe is replayed, so `#n -> #n+1` is the proof a restart built a second set of instances.

Nothing else. No assertion was widened, no tolerance introduced, and no product change was needed.

## For a reviewer to decide

- **Node A now comes from a container the fixture owns.** `ISchedulerRuntime` is a service of the
  container a scheduler was built from, and `StandaloneSchedulerFactory` deliberately exposes none —
  so `ClusteredJobStoreTestBase` grew `CreateSchedulerHost`, which is `AddQuartz(properties, configure)`
  over the same property bag `CreateScheduler` builds. `CreateScheduler` is unchanged and node B still
  takes it, so one of the two nodes stays on exactly the path the earlier soak runs took.
- **The rebuild windows close at the first firing of the next generation**, not at a fixed slack, and
  open one interval early — an occurrence due in the interval before the shutdown may have been
  acquired and not yet fired. Both are argued on `TenantRebuild.Covers`; a fixed slack would be a
  number picked to make the run pass.
- **There is no issue for this gate to close**, so the PR closes none.

## Verification

- `QUARTZ_SOAK_MINUTES=30 dotnet test src/Quartz.Tests.Integration -c Release --filter "FullyQualifiedName~ClusteredSoakPostgresTest"` — **passed, 30.1 min**
- `dotnet build Quartz.slnx` — **0 warnings, 0 errors**
- `dotnet test src/Quartz.Tests.Unit` — **6242 passed, 0 failed, 36 skipped**
- `dotnet fallout DocsSnippets` (no drift), `VerifyDocsSnippets`, `npm run docs:check-links`
  (224 pages, 1449 links, 898 fragments, none dead), `npm run docs:lint` (0 errors)

Test-only. `[Category("LongRunning")]`, `QUARTZ_SOAK_MINUTES`, excluded from every integration leg,
run by hand before a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
