### PR TITLE
A node that leaves without waiting for its jobs costs the cluster no firing

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -708,8 +708,11 @@ entities changes.
 ### Shutdown has a deadline
 
 `WaitForJobsToComplete` is off by default, which means a shutdown returns while jobs are still
-running. Turning it on makes the scheduler wait — but not indefinitely, and the bound is not a
-Quartz setting:
+running. It is not quite instant even so: from Quartz 4.1 a shutdown that does not wait still stops
+firing before it closes its thread pool, and still gives the executions already in flight a couple of
+seconds to report their completions, so a job that was about to finish leaves nothing behind for a
+peer to recover. Turning `WaitForJobsToComplete` on makes the scheduler wait for the jobs themselves —
+but not indefinitely, and that bound is not a Quartz setting:
 
 <!-- snippet: sample_best_practices_shutdown -->
 ```csharp

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -58,7 +58,19 @@ newly possible, that change, and the two cron expressions 4.1 reads differently.
 | `QuartzDashboardOptions.IsJobTypeAllowed` | The same predicate for the dashboard's `IQuartzApiClient`, where a refused name raises `UnauthorizedAccessException` the way a scheduler the visitor may not see does. Enforced in the client rather than in the pages, as `ReadOnly` is. The two surfaces are configured separately because a deployment can map one and not the other — see [Narrowing which job types may be named](packages/dashboard.md#narrowing-which-job-types-may-be-named) |
 | `<execution-group>` and `<retry-policy>` in `job_scheduling_data_2_0.xsd` | The XML format catches up with JSON on the two trigger settings written since the schema was. The schema keeps its `2.0` version and its namespace: all three new elements are optional and sit between `<calendar-name>` and `<job-data-map>`, so a file written before they existed validates and means exactly what it meant. The three *trigger kinds* stay [frozen](packages/quartz-plugins.md#the-xml-trigger-kinds-are-frozen) |
 
-Four behaviours changed without a signature changing:
+Five behaviours changed without a signature changing:
+
+* **`Shutdown(waitForJobsToComplete: false)` no longer drops a firing, and settles what it can.** It
+  stops the scheduler's own firing loop and waits for it before closing the thread pool, so an
+  occurrence the loop had already committed to the store — `TriggersFired` has run and the trigger has
+  moved past it — is dispatched rather than refused and lost. It then gives the executions already in
+  flight up to two seconds to report their completions before the job store is torn down, because a
+  completion that arrives after the store has closed is refused and leaves the firing `EXECUTING` with
+  its trigger `BLOCKED` for a peer to recover a check-in timeout later. It is still not a wait for the
+  jobs: it returns the moment nothing is in flight, and a job still working when the window closes is
+  abandoned as before. What an application sees is a shutdown — the default one, since
+  `QuartzHostedServiceOptions.WaitForJobsToComplete` is off — that can take up to two seconds longer
+  when a job was running. See [When a node leaves](tutorial/advanced-enterprise-features.md#when-a-node-leaves).
 
 * **`HttpScheduler.UpdateTriggerDetails` works** rather than throwing `NotSupportedException`. It was the
   one `IScheduler` member the HTTP API had no route behind, and the API has one now:

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -68,10 +68,17 @@ has no variables, delete the block between the `BEGIN DROP TABLES` and `END DROP
 Once the schema is ahead of every node, replace the nodes one at a time. Three things happen as each
 one goes down and comes back that are worth knowing about in advance.
 
-**A clean shutdown gives its reservations back.** When the scheduling loop halts, every trigger it had
-acquired but not yet fired is released to `WAITING`, so another node picks it up on its next pass
-rather than waiting for the failure detector. A process that is killed rather than stopped does not do
-this, and its reservations wait for the check-in machinery below.
+**A clean shutdown gives its reservations back.** The scheduling loop is halted and waited for before
+anything else is torn down, so every trigger it had acquired but not yet fired is released to `WAITING`
+for another node to pick up on its next pass rather than waiting for the failure detector — and a
+firing it had already committed is dispatched rather than dropped. A process that is killed rather than
+stopped does neither, and what it left waits for the check-in machinery below.
+
+**A shutdown that does not wait still settles what it can.** Since 4.1 it gives the executions already
+in flight a couple of seconds to report their completions before the job store is closed, because a
+completion issued after that is refused and leaves the firing `EXECUTING` with its trigger `BLOCKED`.
+It is still not a wait for the jobs — a job still working when the window closes is abandoned, and
+what it leaves is a peer's to recover.
 
 **A clean shutdown does not delete the node's check-in row.** Nothing removes a `QRTZ_SCHEDULER_STATE`
 row on the way down; the row stays, with the timestamp the node last wrote, until a peer notices it has

--- a/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
+++ b/docs/documentation/quartz-4.x/tutorial/advanced-enterprise-features.md
@@ -195,6 +195,34 @@ The same listing is behind `GET /schedulers/{name}/nodes` in the
 [HTTP API](../packages/http-api.md#cluster-nodes) and the Cluster page of the
 [dashboard](../packages/dashboard.md).
 
+## When a node leaves
+
+A node that is shut down rather than killed hands back what it can, and the two kinds of shutdown now
+differ less than they used to.
+
+**It stops firing before it stops running jobs.** The scheduling loop is halted and waited for first, so
+every trigger it had reserved but not yet fired is released to `WAITING` for another node to pick up on
+its next pass, and a firing it had already committed — the fired-trigger row written, the trigger moved
+on to its next instant — is dispatched rather than dropped. This holds whether or not the shutdown waits
+for jobs; before 4.1 the unwaited kind could close the thread pool underneath its own loop and lose that
+occurrence outright, which nothing but `RequestRecovery` would ever get back.
+
+**It settles the firings it can, then leaves the rest.** `Shutdown(waitForJobsToComplete: true)` waits
+for its executions, so nothing is left over at all. `Shutdown(waitForJobsToComplete: false)` — what
+`AddQuartzHostedService` does unless told otherwise — does not wait for the jobs, but it does give the
+executions already in flight a couple of seconds to report their completions before the job store is
+closed, because a completion issued after that is refused: the firing stays `EXECUTING` and, for a
+`[DisallowConcurrentExecution]` job, its trigger stays `BLOCKED`. A job still working when the window
+closes is abandoned, and what it leaves is what a crashed node leaves — a peer settles it once the
+check-in lapses, which is `CheckinInterval + CheckinMisfireThreshold` and then a grace period for an
+execution that may still be alive.
+
+**It does not delete its check-in row.** Nothing removes a `QRTZ_SCHEDULER_STATE` row on the way down;
+it stays with the timestamp the node last wrote until a peer decides the node has failed and recovers
+it. So a node that leaves is declared failed on the same schedule as one that crashed — the argument
+for waiting for the jobs, and for the window above, is that a node with nothing left over has nothing
+to be recovered.
+
 ## Asking for recovery
 
 Failover recovers a dead node's *executions*, and only for jobs that asked. `RequestRecovery()` on the

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/UnwaitedShutdownClusteredPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/UnwaitedShutdownClusteredPostgresTest.cs
@@ -1,0 +1,288 @@
+using System.Collections.Concurrent;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Quartz.Tests.Integration.Impl.AdoJobStore;
+
+/// <summary>
+/// A node shuts down without waiting for its jobs while one of them is inside <c>Execute</c>, and the
+/// schedule it was halfway through still comes out having fired every instant exactly once — promptly,
+/// rather than after a peer has waited out the leaver's check-in (#3746).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The check-in misfire threshold is deliberately enormous — thirty seconds against a one-second
+/// check-in interval — so that cluster recovery cannot settle the leaver's residue within the window
+/// this fixture asserts over. Everything asserted below therefore has to be the leaving node's own
+/// doing: what it leaves behind when it goes is what the surviving node has to work with, and a
+/// fixture whose peer could recover in two seconds would pass whether or not the leaver settled
+/// anything.
+/// </para>
+/// <para>
+/// The trigger carries <see cref="SimpleTriggerMisfireInstruction.IgnoreMisfires"/>, which makes
+/// "fired exactly once" a statement about a fixed set of instants rather than about a count: a trigger
+/// with that instruction is exempt from the misfire handler and from acquisition's <c>NoEarlierThan</c>
+/// bound, so however far behind the nodes fall its fire times stay the series it was scheduled with.
+/// </para>
+/// </remarks>
+[Category("db-postgres")]
+[NonParallelizable]
+public sealed class UnwaitedShutdownClusteredPostgresTest : ClusteredPostgresTestBase
+{
+    private const string Group = "unwaitedShutdown";
+    private const string TriggerName = "unwaitedShutdownTrigger";
+    private const int FiringCount = 5;
+
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(1);
+
+    private static volatile ConcurrentBag<Firing> firings = new();
+    private static SemaphoreSlim jobParked = new(0);
+    private static SemaphoreSlim jobMayFinish = new(0);
+    private static SemaphoreSlim jobFinished = new(0);
+    private static int executions;
+
+    protected override string SchedulerName => "UnwaitedShutdownTest";
+
+    [SetUp]
+    public void ResetSignals()
+    {
+        Interlocked.Exchange(ref firings, new ConcurrentBag<Firing>());
+        jobParked = new SemaphoreSlim(0);
+        jobMayFinish = new SemaphoreSlim(0);
+        jobFinished = new SemaphoreSlim(0);
+        Interlocked.Exchange(ref executions, 0);
+    }
+
+    [TearDown]
+    public void DisposeSignals()
+    {
+        jobParked.Dispose();
+        jobMayFinish.Dispose();
+        jobFinished.Dispose();
+    }
+
+    [Test]
+    public async Task ANodeLeavingWithoutWaitingForItsJobsCostsTheClusterNoFiring()
+    {
+        IScheduler nodeA = await CreateScheduler("unwaitedNodeA", checkinMisfireThresholdMs: 30_000);
+        IScheduler nodeB = await CreateScheduler("unwaitedNodeB", checkinMisfireThresholdMs: 30_000);
+
+        TriggerKey triggerKey = new(TriggerName, Group);
+
+        try
+        {
+            // Only node A is running, so the firing that is interrupted is deterministically its.
+            await nodeA.Start();
+
+            IJobDetail job = JobBuilder.Create<ParkingJob>()
+                .WithIdentity("unwaitedShutdownJob", Group)
+                .StoreDurably()
+                .Build();
+            await nodeA.AddJob(job, new AddJobOptions { Replace = true });
+
+            DateTimeOffset start = DateTimeOffset.UtcNow.AddSeconds(2);
+            DateTimeOffset[] expected = new DateTimeOffset[FiringCount];
+            for (int i = 0; i < FiringCount; i++)
+            {
+                expected[i] = start + i * Interval;
+            }
+
+            await nodeA.ScheduleJob(TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .ForJob(job)
+                .StartAt(start)
+                .WithSimpleSchedule(schedule => schedule
+                    .WithInterval(Interval)
+                    .WithRepeatCount(FiringCount - 1)
+                    .WithMisfireInstruction(SimpleTriggerMisfireInstruction.IgnoreMisfires))
+                .Build());
+
+            (await jobParked.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the first firing has to be inside Execute before its node leaves");
+
+            // The peer joins while node A is holding the job, so the cluster never stops having a node
+            // that could fire the rest of the schedule.
+            await nodeB.Start();
+
+            TestContext.Out.WriteLine("State with the first firing parked on node A:\n" + await DumpDatabaseState());
+
+            // The firing ends of its own accord a fraction of a second after the node is told to come
+            // down, which is the ordinary shape of this: an execution in flight when the shutdown was
+            // asked for, finishing while it is still under way. Half a second is comfortably longer than
+            // the leaver's own teardown — a shutdown that does not wait for its jobs is over in tens of
+            // milliseconds, and on the unfixed path the store is closed by the time this fires — and
+            // comfortably shorter than the window the shutdown gives an execution to report itself.
+            Task release = Task.Run(async () =>
+            {
+                await Task.Delay(500);
+                jobMayFinish.Release();
+            });
+
+            // The case this fixture is about: the node comes down without waiting for the job it is
+            // running, so the completion that firing owes the store is issued by a scheduler that has
+            // already stopped.
+            long shutdownStarted = Stopwatch.GetTimestamp();
+            await nodeA.Shutdown(waitForJobsToComplete: false);
+            TimeSpan shutdownTook = Stopwatch.GetElapsedTime(shutdownStarted);
+
+            TestContext.Out.WriteLine(
+                $"Shutdown(waitForJobsToComplete: false) returned after {shutdownTook.TotalMilliseconds:F0} ms. "
+                + $"State:\n{await DumpDatabaseState()}");
+
+            await release;
+            (await jobFinished.WaitAsync(TimeSpan.FromSeconds(30)))
+                .Should().BeTrue("the interrupted execution still runs to the end on the leaver's own thread");
+
+            // The completion the leaver owed the store. It is issued the instant the job body returns, so
+            // ten seconds is a round trip's worth of slack — and it is a third of the check-in misfire
+            // threshold, so nothing a peer does can be what satisfies it.
+            await WaitForCondition(
+                async () => await CountFiredTriggerRows("unwaitedNodeA") == 0,
+                timeoutMs: 10_000,
+                async () => "the leaver's fired-trigger row to be gone. A firing that ran to completion has "
+                            + "to be recorded as complete by the node that ran it, whether or not that node "
+                            + "waited for it, or the row sits there until a peer's cluster recovery — which "
+                            + $"here is thirty seconds away. State:\n{await DumpDatabaseState()}");
+
+            // Not compared with WAITING: the survivor is running, so by the time this reads the row it
+            // may legitimately have acquired or even fired the trigger again. BLOCKED is the one answer
+            // that can only mean the leaver's execution is still recorded as holding the job.
+            (await TriggerState(triggerKey)).Should().NotBe("BLOCKED",
+                "the execution that was holding the trigger has finished, so nothing is holding it any "
+                + "more — a trigger left BLOCKED by a departed node is a schedule that stops dead until a "
+                + "peer times the leaver out");
+
+            // Everything from here on is the survivor's, and it has to be all of it.
+            await WaitForCondition(
+                () => Task.FromResult(firings.Count >= FiringCount),
+                timeoutMs: 20_000,
+                async () => $"the survivor to finish the schedule alone; {firings.Count} of {FiringCount} "
+                            + $"firings arrived ({NodeFiringCounts()}). State:\n{await DumpDatabaseState()}");
+
+            Firing[] recorded = firings.ToArray();
+            TestContext.Out.WriteLine("Firings: " + string.Join(", ", recorded
+                .OrderBy(x => x.ScheduledFireTimeUtc)
+                .Select(x => $"{x.ScheduledFireTimeUtc:O}@{x.InstanceId}")));
+
+            DateTimeOffset[] missing = expected.Except(recorded.Select(x => x.ScheduledFireTimeUtc)).OrderBy(x => x).ToArray();
+            missing.Should().BeEmpty(
+                "a node that leaves without waiting costs the cluster no firing — the trigger has {0} "
+                + "scheduled instants whether or not the node that started the schedule saw it through; "
+                + "missing: [{1}]", FiringCount, Format(missing));
+
+            DateTimeOffset[] doubled = recorded
+                .GroupBy(x => x.ScheduledFireTimeUtc)
+                .Where(x => x.Count() > 1)
+                .Select(x => x.Key)
+                .OrderBy(x => x)
+                .ToArray();
+            doubled.Should().BeEmpty(
+                "and it gains the cluster none either: a scheduled instant belongs to exactly one node, "
+                + "and a second firing of one would mean the survivor re-fired what the leaver had already "
+                + "run; doubled: [{0}]", Format(doubled));
+
+            recorded.Should().ContainSingle(x => string.Equals(x.InstanceId, "unwaitedNodeA", StringComparison.Ordinal),
+                "the leaver ran exactly the one firing it was parked on, and a scheduler that has shut "
+                + "down acquires nothing");
+
+            (await CountFiredTriggerRows(instanceId: null)).Should().Be(0,
+                "every firing of the run has been accounted for, so nothing is left claiming to be in "
+                + "flight");
+        }
+        finally
+        {
+            jobMayFinish.Release();
+            await nodeA.Shutdown(waitForJobsToComplete: false);
+            await nodeB.Shutdown(waitForJobsToComplete: false);
+        }
+    }
+
+    /// <summary>
+    /// How many fired-trigger rows this fixture's scheduler has, optionally for one node only.
+    /// </summary>
+    private async Task<int> CountFiredTriggerRows(string instanceId)
+    {
+        if (instanceId is null)
+        {
+            return await CountRows(
+                "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName",
+                ("schedulerName", SchedulerName));
+        }
+
+        return await CountRows(
+            "SELECT COUNT(*) FROM QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName AND INSTANCE_NAME = @instanceName",
+            ("schedulerName", SchedulerName),
+            ("instanceName", instanceId));
+    }
+
+    /// <summary>
+    /// The trigger's stored state, read from the row rather than through <c>GetTriggerState</c>, which
+    /// maps several stored states onto one answer and so cannot tell BLOCKED from WAITING.
+    /// </summary>
+    private async Task<string> TriggerState(TriggerKey triggerKey)
+    {
+        using DbConnection connection = Database.CreateConnection();
+        await connection.OpenAsync();
+
+        using DbCommand command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName "
+            + "AND TRIGGER_NAME = @triggerName AND TRIGGER_GROUP = @triggerGroup";
+        AddParameter(command, "schedulerName", SchedulerName);
+        AddParameter(command, "triggerName", triggerKey.Name);
+        AddParameter(command, "triggerGroup", triggerKey.Group);
+
+        return (string) await command.ExecuteScalarAsync();
+
+        static void AddParameter(DbCommand command, string name, string value)
+        {
+            DbParameter parameter = command.CreateParameter();
+            parameter.ParameterName = name;
+            parameter.Value = value;
+            command.Parameters.Add(parameter);
+        }
+    }
+
+    private static string NodeFiringCounts()
+        => string.Join(", ", firings
+            .GroupBy(x => x.InstanceId, StringComparer.Ordinal)
+            .OrderBy(x => x.Key, StringComparer.Ordinal)
+            .Select(x => $"{x.Key}={x.Count()}"));
+
+    private static string Format(IEnumerable<DateTimeOffset> instants)
+        => string.Join(", ", instants.Select(x => x.ToString("O", CultureInfo.InvariantCulture)));
+
+    private sealed record Firing(string InstanceId, DateTimeOffset ScheduledFireTimeUtc);
+
+    /// <summary>
+    /// Parks its first execution until the test lets it go, so that the shutdown under test always
+    /// lands mid-execution; every later firing records itself and returns.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DisallowConcurrentExecutionAttribute"/> is what makes the interrupted firing hold the
+    /// trigger: the store blocks the job's triggers for as long as an execution is inside, and the
+    /// completion that never arrived is the only thing that would have unblocked them.
+    /// </remarks>
+    [DisallowConcurrentExecution]
+    public sealed class ParkingJob : IJob
+    {
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.Increment(ref executions) == 1)
+            {
+                jobParked.Release();
+
+                // Deliberately not the job's own token: the node shutting down mid-run is what is under
+                // test, and a firing that turned into a cancellation here would be one the totals could
+                // not count.
+                await jobMayFinish.WaitAsync(TimeSpan.FromSeconds(60), CancellationToken.None).ConfigureAwait(false);
+                firings.Add(new Firing(context.Scheduler.SchedulerInstanceId, context.ScheduledFireTimeUtc!.Value));
+                jobFinished.Release();
+                return;
+            }
+
+            firings.Add(new Firing(context.Scheduler.SchedulerInstanceId, context.ScheduledFireTimeUtc!.Value));
+        }
+    }
+}

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/UnwaitedShutdownClusteredPostgresTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/UnwaitedShutdownClusteredPostgresTest.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Data.Common;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -145,10 +144,11 @@ public sealed class UnwaitedShutdownClusteredPostgresTest : ClusteredPostgresTes
                             + "waited for it, or the row sits there until a peer's cluster recovery — which "
                             + $"here is thirty seconds away. State:\n{await DumpDatabaseState()}");
 
-            // Not compared with WAITING: the survivor is running, so by the time this reads the row it
-            // may legitimately have acquired or even fired the trigger again. BLOCKED is the one answer
-            // that can only mean the leaver's execution is still recorded as holding the job.
-            (await TriggerState(triggerKey)).Should().NotBe("BLOCKED",
+            // Asked as "is it BLOCKED" rather than "is it WAITING": the survivor is running, so by the
+            // time this reads the row it may legitimately have acquired or even fired the trigger again.
+            // BLOCKED is the one answer that can only mean the leaver's execution is still recorded as
+            // holding the job.
+            (await CountBlockedTriggerRows(triggerKey)).Should().Be(0,
                 "the execution that was holding the trigger has finished, so nothing is holding it any "
                 + "more — a trigger left BLOCKED by a departed node is a schedule that stops dead until a "
                 + "peer times the leaver out");
@@ -217,31 +217,18 @@ public sealed class UnwaitedShutdownClusteredPostgresTest : ClusteredPostgresTes
     }
 
     /// <summary>
-    /// The trigger's stored state, read from the row rather than through <c>GetTriggerState</c>, which
-    /// maps several stored states onto one answer and so cannot tell BLOCKED from WAITING.
+    /// Whether the trigger's row says BLOCKED, asked of the row rather than through
+    /// <c>GetTriggerState</c>, which maps several stored states onto one answer and so cannot tell
+    /// BLOCKED from WAITING.
     /// </summary>
-    private async Task<string> TriggerState(TriggerKey triggerKey)
+    private async Task<int> CountBlockedTriggerRows(TriggerKey triggerKey)
     {
-        using DbConnection connection = Database.CreateConnection();
-        await connection.OpenAsync();
-
-        using DbCommand command = connection.CreateCommand();
-        command.CommandText =
-            "SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName "
-            + "AND TRIGGER_NAME = @triggerName AND TRIGGER_GROUP = @triggerGroup";
-        AddParameter(command, "schedulerName", SchedulerName);
-        AddParameter(command, "triggerName", triggerKey.Name);
-        AddParameter(command, "triggerGroup", triggerKey.Group);
-
-        return (string) await command.ExecuteScalarAsync();
-
-        static void AddParameter(DbCommand command, string name, string value)
-        {
-            DbParameter parameter = command.CreateParameter();
-            parameter.ParameterName = name;
-            parameter.Value = value;
-            command.Parameters.Add(parameter);
-        }
+        return await CountRows(
+            "SELECT COUNT(*) FROM QRTZ_TRIGGERS WHERE SCHED_NAME = @schedulerName "
+            + "AND TRIGGER_NAME = @triggerName AND TRIGGER_GROUP = @triggerGroup AND TRIGGER_STATE = 'BLOCKED'",
+            ("schedulerName", SchedulerName),
+            ("triggerName", triggerKey.Name),
+            ("triggerGroup", triggerKey.Group));
     }
 
     private static string NodeFiringCounts()

--- a/src/Quartz.Tests.Integration/Redis/RedisLockHandlerShutdownUnderLoadTest.cs
+++ b/src/Quartz.Tests.Integration/Redis/RedisLockHandlerShutdownUnderLoadTest.cs
@@ -22,6 +22,11 @@ namespace Quartz.Tests.Integration.Impl.Redis;
 /// the case that leaves a <c>BLOCKED</c> trigger behind for the survivor's cluster recovery to unblock,
 /// and that unblocking is part of what "costs the cluster no firing" means.
 /// </para>
+/// <para>
+/// It runs twice, once for each kind of leave. The promise is the same for both — a shutdown that does
+/// not wait for its jobs is what a host stopping does by default — and the two differ only in what the
+/// leaver still owes when it goes.
+/// </para>
 /// </remarks>
 [Category("db-redis")]
 [NonParallelizable]
@@ -40,8 +45,33 @@ public sealed class RedisLockHandlerShutdownUnderLoadTest : RedisClusterTestBase
 
     protected override string SchedulerName => "redis-shutdown-load";
 
+    /// <summary>
+    /// A graceful leave: the node stops taking work, lets the firing it is running finish, and only
+    /// then closes its store and its Redis connection.
+    /// </summary>
     [Test]
-    public async Task ANodeLeavingMidRunClosesItsConnectionAndCostsTheClusterNoFiring()
+    public Task ANodeLeavingMidRunClosesItsConnectionAndCostsTheClusterNoFiring()
+    {
+        return ANodeLeavingMidRunCostsTheClusterNoFiring(waitForJobsToComplete: true);
+    }
+
+    /// <summary>
+    /// The same leave without the wait, which is what a host stopping does by default.
+    /// </summary>
+    /// <remarks>
+    /// The firing the node is running goes on running on its own thread, and the completion it owes the
+    /// store is issued after the scheduler has stopped — which is where this used to cost the cluster
+    /// exactly one of its 160 firings (#3746). It promises what the graceful case does because a
+    /// shutdown that does not wait still stops firing before it closes the thread pool, and still gives
+    /// the executions it has dispatched a moment to report themselves.
+    /// </remarks>
+    [Test]
+    public Task ANodeLeavingWithoutWaitingCostsTheClusterNoFiring()
+    {
+        return ANodeLeavingMidRunCostsTheClusterNoFiring(waitForJobsToComplete: false);
+    }
+
+    private async Task ANodeLeavingMidRunCostsTheClusterNoFiring(bool waitForJobsToComplete)
     {
         await using RedisNode nodeA = await CreateNode("nodeA");
         await using RedisNode nodeB = await CreateNode("nodeB");
@@ -74,15 +104,11 @@ public sealed class RedisLockHandlerShutdownUnderLoadTest : RedisClusterTestBase
 
         int nodeBBeforeLeaving = NodeFiringCount("nodeB");
 
-        // A graceful leave: the node stops taking work, lets the firing it is running finish, and only
-        // then closes its store and its Redis connection. That is what "costs the cluster no firing"
-        // can promise. A node that shuts down without waiting is a different case with a different
-        // answer: the firing it was executing runs to completion on its own thread, but the store the
-        // completion reports to is already closed, so the trigger's bookkeeping is left for a peer's
-        // cluster recovery to settle, and neither job here requests recovery. On CI that lost exactly
-        // one of 160 firings once (#3746); this fixture proves the graceful case and that issue owns
-        // the other.
-        await nodeA.Scheduler.Shutdown(waitForJobsToComplete: true);
+        // Both kinds of leave have to cost the cluster nothing, which is why this fixture runs twice.
+        // The waiting one lets the firing it is running finish before it closes its store; the other
+        // does not, and the firing it was executing then reports its completion to a scheduler that has
+        // already stopped — which is where an unwaited leave used to lose a firing (#3746).
+        await nodeA.Scheduler.Shutdown(waitForJobsToComplete);
 
         opened.IsConnected.Should().BeFalse(
             "the multiplexer belongs to the handler and the handler to the store, so a scheduler that "

--- a/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
+++ b/src/Quartz.Tests.Unit/Core/ShutdownDrainTest.cs
@@ -182,8 +182,9 @@ public class ShutdownDrainTest
     }
 
     /// <summary>
-    /// A shutdown that did not wait answers from the count of executing jobs, which is the only evidence
-    /// it has.
+    /// A shutdown that did not wait answers from the short window it gives the executions already in
+    /// flight — see <c>UnwaitedShutdownTest</c> — and a job that is still working when that window
+    /// closes is abandoned, which is what this asks about.
     /// </summary>
     [Test]
     public async Task AShutdownThatDidNotWaitSaysWhetherAnythingWasStillRunning()
@@ -202,6 +203,9 @@ public class ShutdownDrainTest
         await GatedJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
 
         await scheduler.Shutdown(waitForJobsToComplete: false);
+
+        scheduler.Status.Should().Be(SchedulerStatus.Shutdown,
+            "the window bounds an unwaited shutdown, it does not turn it into one that waits for its jobs");
 
         Drained(scheduler).Should().BeFalse(
             "a shutdown that abandoned a running job did not drain, and saying it had would license a second "

--- a/src/Quartz.Tests.Unit/Core/UnwaitedShutdownTest.cs
+++ b/src/Quartz.Tests.Unit/Core/UnwaitedShutdownTest.cs
@@ -1,0 +1,338 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Core;
+using Quartz.Extensibility;
+using Quartz.Impl;
+
+namespace Quartz.Tests.Unit.Core;
+
+/// <summary>
+/// What a shutdown that does not wait for its jobs still owes the schedule (#3746).
+/// </summary>
+/// <remarks>
+/// Two firings are at stake and they are different firings. One has been committed to the job store —
+/// <c>TriggersFired</c> has run, the trigger has moved past it — but not yet handed to the thread pool;
+/// dropping that one loses an occurrence outright, because nothing but a job asking for recovery ever
+/// gets it back. The other is already executing, and what it owes the store is the completion that
+/// unblocks its trigger and deletes its fired-trigger row; losing that one leaves a schedule stopped
+/// until a peer times the departed node out, which on a default cluster is half a minute and outside a
+/// cluster is until the node next starts.
+/// </remarks>
+[NonParallelizable]
+public class UnwaitedShutdownTest
+{
+    [SetUp]
+    public void ResetJobs()
+    {
+        CountingJob.Reset();
+        ParkingJob.Reset();
+    }
+
+    /// <summary>
+    /// The scheduler's own firing loop is stopped before the thread pool is closed to new work, so a
+    /// firing it has already committed to the store is still dispatched.
+    /// </summary>
+    /// <remarks>
+    /// The store double parks the loop between <c>TriggersFired</c> and the dispatch, which is the
+    /// window the loss lived in: it is a real window, not a contrived one, because the acquisition
+    /// cycle takes the cluster lock and a database round trip while a shutdown running on another
+    /// thread needs neither.
+    /// </remarks>
+    [Test]
+    public async Task AShutdownThatDidNotWaitStillRunsTheFiringItHadAlreadyCommitted()
+    {
+        GateAfterFiringStore store = null!;
+        RecordingThreadPool pool = new(new DefaultThreadPool());
+
+        IScheduler scheduler = await QuartzSchedulerBuilder
+            .Create(q => q
+                .ConfigureScheduler(options => options.InstanceName = "unwaited-shutdown-keeps-the-firing")
+                .UseThreadPool(pool)
+                .UseJobStore(provider =>
+                {
+                    store = new GateAfterFiringStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                    return store;
+                }))
+            .BuildScheduler();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<CountingJob>().WithIdentity("counted").Build(),
+            TriggerBuilder.Create().WithIdentity("counted").StartNow().Build());
+
+        await scheduler.Start();
+
+        // The firing is now in the store — the trigger has been advanced past it and its fired-trigger
+        // row written — and the loop is holding it, one statement short of handing it to the pool.
+        await store.FiringCommitted.WaitAsync(TimeSpan.FromSeconds(30));
+
+        Task shutdown = scheduler.Shutdown(waitForJobsToComplete: false).AsTask();
+
+        // Released the moment the pool is closed to new work, which is what the loop used to wake up
+        // to and be refused by; where the loop is stopped first, no such call comes and the short
+        // delay is what lets it finish its cycle instead.
+        await Task.WhenAny(pool.ClosedToNewWork, Task.Delay(TimeSpan.FromSeconds(1)));
+        store.ReleaseFiring();
+
+        await shutdown.WaitAsync(TimeSpan.FromSeconds(30));
+
+        CountingJob.Executions.Should().Be(1,
+            "TriggersFired has already committed this firing and advanced the trigger, so a shutdown "
+            + "that refuses to dispatch it loses the occurrence outright — the trigger will not offer "
+            + "it again, and only a job that asked for recovery would ever get it back");
+    }
+
+    /// <summary>
+    /// An execution that ends while the shutdown is still under way reports its completion to a store
+    /// that is still open, rather than to one that has already been torn down.
+    /// </summary>
+    /// <remarks>
+    /// Stated as an ordering rather than as a state, because the state a lost completion leaves is the
+    /// job store's business and every store leaves a different one: the in-memory store shrugs it off,
+    /// the ADO store answers "JobStore is shutdown" and leaves the trigger BLOCKED with its
+    /// fired-trigger row in place. What is common to all of them is that the update has to reach the
+    /// store before the store is told to close.
+    /// </remarks>
+    [Test]
+    public async Task AShutdownThatDidNotWaitLetsAnInFlightCompletionReachTheStore()
+    {
+        RecordingJobStore store = null!;
+
+        IScheduler scheduler = await QuartzSchedulerBuilder
+            .Create(q => q
+                .ConfigureScheduler(options => options.InstanceName = "unwaited-shutdown-settles-its-books")
+                .UseJobStore(provider =>
+                {
+                    store = new RecordingJobStore(ActivatorUtilities.CreateInstance<RAMJobStore>(provider));
+                    return store;
+                }))
+            .BuildScheduler();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<ParkingJob>().WithIdentity("parked").Build(),
+            TriggerBuilder.Create().WithIdentity("parked").StartNow().Build());
+
+        await scheduler.Start();
+        await ParkingJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        // The job ends a fraction of a second after the node is told to come down, which is the
+        // ordinary shape of an interrupted firing: it was already running, and it finishes while the
+        // shutdown is still working through its steps.
+        Task release = Task.Run(async () =>
+        {
+            await Task.Delay(200);
+            ParkingJob.Release();
+        });
+
+        await scheduler.Shutdown(waitForJobsToComplete: false);
+        await release;
+
+        store.Events.Should().Equal([RecordingJobStore.CompletionRecorded, RecordingJobStore.StoreShutDown],
+            "a firing that ran to completion has to be recorded as complete by the node that ran it, "
+            + "whether or not that node waited for it — a completion issued after the store has closed "
+            + "is refused, and the firing's bookkeeping is left for somebody else to do");
+
+        Drained(scheduler).Should().BeTrue(
+            "the execution settled inside the window the shutdown gave it, and the barrier covers the "
+            + "store update as well as the job");
+    }
+
+    private static bool? Drained(IScheduler scheduler)
+    {
+        return ((StdScheduler) scheduler).scheduler.RunningWorkDrained;
+    }
+
+    /// <summary>
+    /// Counts what actually ran.
+    /// </summary>
+    private sealed class CountingJob : IJob
+    {
+        private static int executions;
+
+        public static int Executions => Volatile.Read(ref executions);
+
+        public static void Reset() => Interlocked.Exchange(ref executions, 0);
+
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref executions);
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Runs until the test lets it stop, so that a shutdown can be asked for while it is inside.
+    /// </summary>
+    private sealed class ParkingJob : IJob
+    {
+        private static TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task Started => started.Task;
+
+        public static void Reset()
+        {
+            started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void Release() => release.TrySetResult();
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            started.TrySetResult();
+
+            // Deliberately not the job's own token: what is under test is a node coming down while a
+            // firing is in flight, and a firing that turned into a cancellation here would be a
+            // different case with a different answer.
+            await release.Task.ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Holds the scheduler's firing loop between the firing and the dispatch, which is the only place a
+    /// committed occurrence can still be dropped.
+    /// </summary>
+    private sealed class GateAfterFiringStore : DelegatingJobStore
+    {
+        private readonly TaskCompletionSource firingCommitted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource releaseFiring = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public GateAfterFiringStore(IJobStore jobStore) : base(jobStore)
+        {
+        }
+
+        public Task FiringCommitted => firingCommitted.Task;
+
+        public void ReleaseFiring() => releaseFiring.TrySetResult();
+
+        public override async ValueTask<List<TriggerFiredResult>> TriggersFired(
+            IReadOnlyCollection<IOperableTrigger> triggers,
+            CancellationToken cancellationToken = default)
+        {
+            List<TriggerFiredResult> fired = await base.TriggersFired(triggers, cancellationToken).ConfigureAwait(false);
+
+            if (fired.Exists(x => x.TriggerFiredBundle is not null))
+            {
+                firingCommitted.TrySetResult();
+                await releaseFiring.Task.ConfigureAwait(false);
+            }
+
+            return fired;
+        }
+    }
+
+    /// <summary>
+    /// Records the two events whose order is the promise: the completion of the firing that was in
+    /// flight, and the store being told to close.
+    /// </summary>
+    private sealed class RecordingJobStore : DelegatingJobStore
+    {
+        public const string CompletionRecorded = "completion recorded";
+        public const string StoreShutDown = "job store shut down";
+
+        private readonly List<string> events = [];
+
+        public RecordingJobStore(IJobStore jobStore) : base(jobStore)
+        {
+        }
+
+        public override bool SupportsPersistence => true;
+
+        public List<string> Events
+        {
+            get
+            {
+                lock (events)
+                {
+                    return [.. events];
+                }
+            }
+        }
+
+        public override async ValueTask TriggeredJobComplete(
+            IOperableTrigger trigger,
+            IJobDetail jobDetail,
+            SchedulerInstruction triggerInstructionCode,
+            CancellationToken cancellationToken = default)
+        {
+            await base.TriggeredJobComplete(trigger, jobDetail, triggerInstructionCode, cancellationToken).ConfigureAwait(false);
+            Record(CompletionRecorded);
+        }
+
+        public override ValueTask Shutdown(CancellationToken cancellationToken = default)
+        {
+            Record(StoreShutDown);
+            return base.Shutdown(cancellationToken);
+        }
+
+        private void Record(string what)
+        {
+            lock (events)
+            {
+                events.Add(what);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Says when the pool stopped accepting work, which is the instant a firing the loop still holds
+    /// becomes undispatchable.
+    /// </summary>
+    private sealed class RecordingThreadPool : IThreadPool
+    {
+        private readonly IThreadPool inner;
+        private readonly TaskCompletionSource closedToNewWork = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public RecordingThreadPool(IThreadPool inner)
+        {
+            this.inner = inner;
+        }
+
+        public Task ClosedToNewWork => closedToNewWork.Task;
+
+        public int PoolSize => inner.PoolSize;
+
+        public ValueTask Initialize(CancellationToken cancellationToken = default) => inner.Initialize(cancellationToken);
+
+        public ValueTask<int> WaitForAvailableThreads(CancellationToken cancellationToken = default)
+            => inner.WaitForAvailableThreads(cancellationToken);
+
+        public ValueTask<bool> TryRun(Func<ValueTask> action, CancellationToken cancellationToken = default)
+            => inner.TryRun(action, cancellationToken);
+
+        public ValueTask Shutdown(bool waitForJobsToComplete = true, CancellationToken cancellationToken = default)
+        {
+            closedToNewWork.TrySetResult();
+            return inner.Shutdown(waitForJobsToComplete, cancellationToken);
+        }
+
+        public ValueTask<bool> Drain(CancellationToken cancellationToken = default)
+        {
+            closedToNewWork.TrySetResult();
+            return inner.Drain(cancellationToken);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Core/UnwaitedShutdownTest.cs
+++ b/src/Quartz.Tests.Unit/Core/UnwaitedShutdownTest.cs
@@ -42,7 +42,7 @@ namespace Quartz.Tests.Unit.Core;
 /// cluster is until the node next starts.
 /// </remarks>
 [NonParallelizable]
-public class UnwaitedShutdownTest
+public sealed class UnwaitedShutdownTest
 {
     [SetUp]
     public void ResetJobs()

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
@@ -1,0 +1,206 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// A firing that ends while an unwaited shutdown is still under way is recorded by the node that ran
+/// it, rather than left in the database for somebody else to settle (#3746).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ADO store is where the loss is visible, because it is the store that refuses a late completion:
+/// <c>RetryExecuteInLocalTransactionLock</c> loops <c>while (!shutdown)</c> and throws
+/// <c>JobStore is shutdown - aborting retry</c> without attempting the write. What is left behind is a
+/// fired-trigger row that still says <c>EXECUTING</c> and, for a
+/// <see cref="DisallowConcurrentExecutionAttribute" /> job, a trigger still <c>BLOCKED</c> — which
+/// outside a cluster nothing settles until the node next starts, and inside one nothing settles until
+/// the leaver's check-in lapses.
+/// </para>
+/// <para>
+/// The clustered two-node case is <c>UnwaitedShutdownClusteredPostgresTest</c>. This is the same claim
+/// at unit cost: SQLite is a file, so a whole persistent store is a temporary path, and the rows are
+/// read back with SQL rather than through the store that wrote them.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class UnwaitedShutdownSqliteTest
+{
+    private static readonly JobKey jobKey = new("parked", "unwaited");
+    private static readonly TriggerKey triggerKey = new("t-parked", "unwaited");
+
+    private string databaseFile = null!;
+    private string connectionString = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-unwaited-shutdown-{Guid.NewGuid():N}.db");
+        connectionString = $"Data Source={databaseFile}";
+        ParkingJob.Reset();
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        SqliteConnection.ClearAllPools();
+
+        if (File.Exists(databaseFile))
+        {
+            File.Delete(databaseFile);
+        }
+    }
+
+    [Test]
+    public async Task AnUnwaitedShutdownRecordsTheCompletionOfAFiringThatEndsOnTheWayOut()
+    {
+        await using ServiceProvider container = BuildContainer();
+        IScheduler scheduler = await container.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<ParkingJob>().WithIdentity(jobKey).Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .StartNow()
+                // Repeating, so that the trigger row is still there to be read afterwards — and so that
+                // the state it is left in is one that matters to a schedule with firings still to come.
+                .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+                .Build());
+
+        await scheduler.Start();
+        await ParkingJob.Started.WaitAsync(TimeSpan.FromSeconds(30));
+
+        (await FiredTriggerStates()).Should().Equal(["EXECUTING"],
+            "the premise: the firing is in flight and the store knows it, so what the shutdown leaves "
+            + "behind is a question about this row");
+
+        // The firing ends a fraction of a second after the node is told to come down, which is the
+        // ordinary shape of it: it was already running, and it finishes while the shutdown is still
+        // working through its steps.
+        Task release = Task.Run(async () =>
+        {
+            await Task.Delay(200);
+            ParkingJob.Release();
+        });
+
+        await scheduler.Shutdown(waitForJobsToComplete: false);
+        await release;
+
+        (await FiredTriggerStates()).Should().BeEmpty(
+            "a firing that ran to completion has to be recorded as complete by the node that ran it, "
+            + "whether or not that node waited for it — a fired-trigger row left behind is one a peer "
+            + "has to time the leaver out to clear, and outside a cluster nobody clears it until this "
+            + "node next starts");
+
+        (await TriggerState()).Should().Be("WAITING",
+            "the execution that was holding the trigger has finished, and the completion is what "
+            + "unblocks a DisallowConcurrentExecution job's triggers — a trigger left BLOCKED is a "
+            + "schedule that stops dead");
+    }
+
+    private async Task<List<string>> FiredTriggerStates()
+    {
+        return await ReadColumn("SELECT STATE FROM QRTZ_FIRED_TRIGGERS");
+    }
+
+    private async Task<string> TriggerState()
+    {
+        List<string> states = await ReadColumn(
+            $"SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE TRIGGER_NAME = '{triggerKey.Name}'");
+
+        return states.Should().ContainSingle("the trigger repeats for ever, so its row is still there").Subject;
+    }
+
+    private async Task<List<string>> ReadColumn(string sql)
+    {
+        await using SqliteConnection connection = new(connectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        List<string> values = [];
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    private ServiceProvider BuildContainer()
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "unwaited-shutdown-sqlite";
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.ProvisionSchema();
+            });
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Holds the trigger — which is what <see cref="DisallowConcurrentExecutionAttribute" /> makes the
+    /// store do while an execution is inside — until the test lets it go.
+    /// </summary>
+    [DisallowConcurrentExecution]
+    public sealed class ParkingJob : IJob
+    {
+        private static TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private static TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public static Task Started => started.Task;
+
+        public static void Reset()
+        {
+            started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public static void Release() => release.TrySetResult();
+
+        public async ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            started.TrySetResult();
+
+            // Deliberately not the job's own token: what is under test is a node coming down while a
+            // firing is in flight, and a firing that turned into a cancellation would be a different
+            // case with a different answer.
+            await release.Task.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
@@ -55,19 +55,24 @@ public sealed class UnwaitedShutdownSqliteTest
     private string databaseFile = null!;
     private string connectionString = null!;
 
+    /// <remarks>
+    /// Pooling is off, which is what lets this fixture clean up after itself without
+    /// <see cref="SqliteConnection.ClearAllPools" />: that call is global, the assembly runs its
+    /// fixtures in parallel, and Microsoft.Data.Sqlite's pool hands out the underlying handle rather
+    /// than a copy — so clearing it disposes connections another fixture is in the middle of using. An
+    /// unpooled connection closes its handle when it is disposed, so the file is deletable anyway.
+    /// </remarks>
     [SetUp]
     public void CreateEmptyDatabase()
     {
         databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-unwaited-shutdown-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        connectionString = $"Data Source={databaseFile};Pooling=False";
         ParkingJob.Reset();
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
         if (File.Exists(databaseFile))
         {
             File.Delete(databaseFile);

--- a/src/Quartz.Tests.Unit/SchedulerTest.cs
+++ b/src/Quartz.Tests.Unit/SchedulerTest.cs
@@ -31,15 +31,21 @@ public class SchedulerTest
     {
         public const string ExecutingWaitHandleKey = "ExecutingWaitHandle";
         public const string CompletedWaitHandleKey = "CompletedWaitHandle";
+        public const string DelayKey = "Delay";
 
         public static TimeSpan Delay = TimeSpan.FromMilliseconds(200);
 
-        public static JobDataMap CreateJobDataMap(ManualResetEvent executing, ManualResetEvent completed)
+        /// <param name="delay">
+        /// How long the job takes, for a test that needs one longer than the window a shutdown gives its
+        /// executions to settle. Defaults to <see cref="Delay" />.
+        /// </param>
+        public static JobDataMap CreateJobDataMap(ManualResetEvent executing, ManualResetEvent completed, TimeSpan? delay = null)
         {
             return new JobDataMap
             {
                 { ExecutingWaitHandleKey, executing },
-                { CompletedWaitHandleKey, completed }
+                { CompletedWaitHandleKey, completed },
+                { DelayKey, delay ?? Delay }
             };
         }
 
@@ -53,7 +59,7 @@ public class SchedulerTest
             var signalExecuting = (ManualResetEvent) executing;
             signalExecuting.Set();
 
-            Thread.Sleep(Delay);
+            Thread.Sleep(context.JobDetail.JobDataMap.TryGetValue(DelayKey, out var delay) ? (TimeSpan) delay : Delay);
 
             if (!context.JobDetail.JobDataMap.TryGetValue(CompletedWaitHandleKey, out var completed))
             {
@@ -329,9 +335,17 @@ public class SchedulerTest
         });
     }
 
+    /// <remarks>
+    /// The job outlasts the short window an unwaited shutdown gives its executions to report their
+    /// completions (see <c>UnwaitedShutdownTest</c>), because that window is exactly what could be
+    /// mistaken for the wait this test says does not happen. A job that ends inside it is one the
+    /// shutdown does linger for — briefly, and to settle its bookkeeping rather than to see it through.
+    /// </remarks>
     [Test]
     public void TestShutdownWithoutWaitShouldNotBlockUntilAllTasksHaveCompleted()
     {
+        TimeSpan jobDuration = TimeSpan.FromSeconds(10);
+
         var schedulerName = Guid.NewGuid().ToString();
         var executing = new ManualResetEvent(false);
         var completed = new ManualResetEvent(false);
@@ -346,7 +360,7 @@ public class SchedulerTest
         scheduler.Start().GetAwaiter().GetResult();
 
         var job = JobBuilder.Create<TestJobWithDelay>()
-            .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed))
+            .UsingJobData(TestJobWithDelay.CreateJobDataMap(executing, completed, jobDuration))
             .Build();
         IOperableTrigger trigger = (IOperableTrigger) TriggerBuilder.Create()
             .WithSimpleSchedule(x => x.WithRepeatCount(0))
@@ -364,13 +378,13 @@ public class SchedulerTest
 
         stopwatch.Stop();
 
-        Assert.Multiple(() =>
-        {
-            // Shutdown should be fast since we're not waiting for tasks to complete
-            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(TestJobWithDelay.Delay.TotalMilliseconds - 50));
-            // The task should still be executing
-            Assert.That(completed.WaitOne(0), Is.False);
-        });
+        stopwatch.Elapsed.Should().BeLessThan(jobDuration,
+            "a shutdown that was told not to wait for its jobs must come back long before the job it "
+            + "abandoned does");
+
+        completed.WaitOne(0).Should().BeFalse(
+            "the job is still running, which is what 'did not wait' means — it is left to finish on its "
+            + "own thread");
     }
 
     [Test]

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -542,12 +542,12 @@ internal sealed class QuartzScheduler
     /// dispatched report their completions before the job store is torn down.
     /// </summary>
     /// <remarks>
-    /// A store round trip's worth, and no more. The window exists because a completion the store has
-    /// closed to leaves a firing's bookkeeping for somebody else to do — see <see cref="Shutdown" /> —
-    /// and it is short because anything longer would be waiting for the jobs themselves, which is what
-    /// <c>waitForJobsToComplete: true</c> is. Deliberately not configurable: an application that needs
-    /// its executions to finish asks for the wait, and one that needs out now is not made to wait on a
-    /// job by this.
+    /// A store round trip's worth, and no more. The window exists because a completion issued to a store
+    /// that has already closed is refused, and leaves a firing's bookkeeping for somebody else to do —
+    /// see <see cref="Shutdown" /> — and it is short because anything longer would be waiting for the
+    /// jobs themselves, which is what <c>waitForJobsToComplete: true</c> is. Deliberately not
+    /// configurable: an application that needs its executions to finish asks for the wait, and one that
+    /// needs out now is not made to wait on a job by this.
     /// </remarks>
     private static readonly TimeSpan DispatchedExecutionSettleWindow = TimeSpan.FromSeconds(2);
 
@@ -637,12 +637,16 @@ internal sealed class QuartzScheduler
     /// </summary>
     /// <param name="waitForJobsToComplete">
     /// if <see langword="true" /> the scheduler will not allow this method
-    /// to return until all currently executing jobs have completed.
+    /// to return until all currently executing jobs have completed. If <see langword="false" /> it waits
+    /// for no job, but still gives the executions already in flight
+    /// <see cref="DispatchedExecutionSettleWindow" /> to report their completions, so that a firing
+    /// which ends on the way out is recorded rather than left for a peer to recover.
     /// </param>
     /// <param name="cancellationToken">
-    /// Bounds the wait for running jobs, and nothing else. Cancelling it stops the scheduler waiting —
-    /// it does not cancel the jobs, and it does not abandon the shutdown, which always runs to the end
-    /// so that the job store, the plugins and the listeners are all told the scheduler has stopped.
+    /// Bounds the wait for running jobs, and nothing else — the window above included. Cancelling it
+    /// stops the scheduler waiting; it does not cancel the jobs, and it does not abandon the shutdown,
+    /// which always runs to the end so that the job store, the plugins and the listeners are all told
+    /// the scheduler has stopped.
     /// </param>
     public async ValueTask Shutdown(
         bool waitForJobsToComplete = false,

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -529,8 +529,104 @@ internal sealed class QuartzScheduler
     /// row. Internal because it says something about a shutdown that has already happened, which only
     /// whoever performed it is in a position to ask.
     /// </para>
+    /// <para>
+    /// A shutdown that did not wait answers from the same barrier, over the window it gives dispatched
+    /// executions to settle — so a job that finished within it makes this <see langword="true" /> rather
+    /// than the count of executing jobs deciding, which never covered the store update.
+    /// </para>
     /// </remarks>
     internal bool? RunningWorkDrained { get; private set; }
+
+    /// <summary>
+    /// How long a shutdown that is not waiting for its jobs lets the executions it has already
+    /// dispatched report their completions before the job store is torn down.
+    /// </summary>
+    /// <remarks>
+    /// A store round trip's worth, and no more. The window exists because a completion the store has
+    /// closed to leaves a firing's bookkeeping for somebody else to do — see <see cref="Shutdown" /> —
+    /// and it is short because anything longer would be waiting for the jobs themselves, which is what
+    /// <c>waitForJobsToComplete: true</c> is. Deliberately not configurable: an application that needs
+    /// its executions to finish asks for the wait, and one that needs out now is not made to wait on a
+    /// job by this.
+    /// </remarks>
+    private static readonly TimeSpan DispatchedExecutionSettleWindow = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// The executions this scheduler has handed to the thread pool and that have not finished.
+    /// </summary>
+    /// <remarks>
+    /// "Finished" is the whole of a firing — the job, its listeners, and the job store update that
+    /// completes the trigger — because what the pool is handed is the whole run shell. That is what
+    /// makes this a different question from <see cref="NumberOfJobsExecutingHere" />, which a job leaves
+    /// before its store update is issued. Kept here rather than read off the thread pool because
+    /// <see cref="IThreadPool.Drain" />'s default implementation waits however long the jobs take, and
+    /// an unwaited shutdown must not become a waiting one because of which pool is installed.
+    /// </remarks>
+    private int dispatchedExecutions;
+
+    /// <summary>
+    /// Completed when <see cref="dispatchedExecutions" /> next reaches zero. Only a shutdown that is
+    /// waiting for that ever installs one.
+    /// </summary>
+    private TaskCompletionSource? dispatchedExecutionsSettled;
+
+    /// <summary>
+    /// Counts an execution the scheduler thread is about to hand to the thread pool.
+    /// </summary>
+    internal void ExecutionDispatched()
+    {
+        Interlocked.Increment(ref dispatchedExecutions);
+    }
+
+    /// <summary>
+    /// Counts an execution out again, once everything it does — its job store update included — is done.
+    /// </summary>
+    internal void ExecutionSettled()
+    {
+        if (Interlocked.Decrement(ref dispatchedExecutions) == 0)
+        {
+            Volatile.Read(ref dispatchedExecutionsSettled)?.TrySetResult();
+        }
+    }
+
+    /// <summary>
+    /// Waits out <see cref="DispatchedExecutionSettleWindow" /> for the executions in flight, and says
+    /// whether they finished.
+    /// </summary>
+    /// <remarks>
+    /// Reports rather than throws, exactly as the waiting branch's drain does: the rest of the shutdown
+    /// has to run whether or not the work it gave a moment to took it.
+    /// </remarks>
+    private async ValueTask<bool> SettleDispatchedExecutions(CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref dispatchedExecutions) == 0)
+        {
+            return true;
+        }
+
+        TaskCompletionSource settled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        Volatile.Write(ref dispatchedExecutionsSettled, settled);
+
+        // Read again now that there is something to complete: an execution that finished between the
+        // check above and the assignment decremented against no source at all, and nothing else would
+        // ever complete this one.
+        if (Volatile.Read(ref dispatchedExecutions) == 0)
+        {
+            settled.TrySetResult();
+        }
+
+        try
+        {
+            await settled.Task
+                .WaitAsync(DispatchedExecutionSettleWindow, resources.TimeProvider, cancellationToken)
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception e) when (e is TimeoutException or OperationCanceledException)
+        {
+            return false;
+        }
+    }
 
     /// <summary>
     /// Halts the <see cref="QuartzScheduler" />'s firing of <see cref="ITrigger" />s,
@@ -574,7 +670,19 @@ internal sealed class QuartzScheduler
             // neither running nor shut down. The token bounds the wait for running jobs and nothing else.
             await StopFiring(CancellationToken.None).ConfigureAwait(false);
 
-            await schedThread.Halt(waitForJobsToComplete).ConfigureAwait(false);
+            await schedThread.Halt(wait: false).ConfigureAwait(false);
+
+            // The firing loop is brought to a full stop here, before anything it depends on is torn
+            // down, and not — as it used to be — after the thread pool has been closed to new work.
+            // TriggersFired commits a firing to the job store and advances the trigger before the
+            // execution is handed to the pool, so a dispatch the pool refuses in between is an
+            // occurrence that never happens and that nothing afterwards recovers: the trigger has
+            // moved past it, and only a job asking for recovery would ever get it back (#3746). The
+            // wait itself is not new — the same await ran a few lines further down — and it cannot
+            // stall on the pool, since the loop waits for a free thread on its own token, which Halt
+            // has just cancelled. What is new is that a shutdown which does not wait for its jobs now
+            // gets the same guarantee one that does always had through Halt(wait: true).
+            await schedThread.Shutdown().ConfigureAwait(false);
 
             await NotifySchedulerListenersShuttingDown(CancellationToken.None).ConfigureAwait(false);
 
@@ -618,18 +726,24 @@ internal sealed class QuartzScheduler
             }
             else
             {
+                // Not a wait for the jobs — that is what the other branch is for, and this returns the
+                // instant nothing is in flight — but the executions already dispatched are given a short
+                // window to report what they did. A completion issued after the job store has closed is
+                // refused by it: the ADO store answers one that arrives after Shutdown with "JobStore is
+                // shutdown", so a firing that ran to completion is left with its fired-trigger row in
+                // place and, for a DisallowConcurrentExecution job, its trigger BLOCKED — which only a
+                // peer's cluster recovery settles, a check-in timeout later, and which nothing settles at
+                // all outside a cluster until this node next starts (#3746). A job that is genuinely
+                // still working is abandoned exactly as before once the window closes; its residue is
+                // then a peer's to recover, which is the same answer a crashed node gets.
+                bool drained = await SettleDispatchedExecutions(cancellationToken).ConfigureAwait(false);
+                RunningWorkDrained = drained;
+
                 // Loud, because this is a shutdown that abandoned work. The default is 3.x's and stays,
                 // but "the process stopped and four jobs were half-done" is not something to find out
-                // from the absence of a completion. Counted before the pool is shut down, since that is
-                // what empties the list.
+                // from the absence of a completion. Counted after the window rather than before it, so
+                // that it names what was actually abandoned rather than what was merely in flight.
                 int stillExecuting = GetCurrentlyExecutingJobs().Count;
-
-                // The best this branch can say. Nothing was waited for, so "nothing was running when we
-                // looked" is the whole of the evidence — and it is evidence with a known hole in it, since
-                // a job leaves this count before its store update is issued. A caller that needs the
-                // stronger answer asks for the wait.
-                RunningWorkDrained = stillExecuting == 0;
-
                 if (stillExecuting > 0)
                 {
                     logger.ShuttingDownWithJobsStillExecuting(
@@ -638,11 +752,6 @@ internal sealed class QuartzScheduler
 
                 await resources.ThreadPool.Shutdown(waitForJobsToComplete: false, CancellationToken.None).ConfigureAwait(false);
             }
-
-            // Scheduler thread may have be waiting for the fire time of an acquired
-            // trigger and need time to release the trigger once halted, so make sure
-            // the thread is dead before continuing to shutdown the job store.
-            await schedThread.Shutdown().ConfigureAwait(false);
 
             // Same reasoning as the pool shutdown above: in hosted shutdown the caller's token is
             // the graceful-deadline token, which by design may already have fired while waiting for

--- a/src/Quartz/Core/QuartzScheduler.cs
+++ b/src/Quartz/Core/QuartzScheduler.cs
@@ -542,12 +542,19 @@ internal sealed class QuartzScheduler
     /// dispatched report their completions before the job store is torn down.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A store round trip's worth, and no more. The window exists because a completion issued to a store
     /// that has already closed is refused, and leaves a firing's bookkeeping for somebody else to do —
     /// see <see cref="Shutdown" /> — and it is short because anything longer would be waiting for the
     /// jobs themselves, which is what <c>waitForJobsToComplete: true</c> is. Deliberately not
     /// configurable: an application that needs its executions to finish asks for the wait, and one that
     /// needs out now is not made to wait on a job by this.
+    /// </para>
+    /// <para>
+    /// Measured on the scheduler's own <see cref="TimeProvider" />, as every other wait here is — so a
+    /// fixture that hands the scheduler a fake clock and then shuts down with a job parked has to
+    /// advance that clock, or the window it is waiting out never elapses.
+    /// </para>
     /// </remarks>
     private static readonly TimeSpan DispatchedExecutionSettleWindow = TimeSpan.FromSeconds(2);
 

--- a/src/Quartz/Core/QuartzSchedulerThread.cs
+++ b/src/Quartz/Core/QuartzSchedulerThread.cs
@@ -581,6 +581,12 @@ internal sealed class QuartzSchedulerThread
                             // will see accurate in-flight counts immediately
                             runningExecutionGroupCounts.AddOrUpdate(normalizedGroup, 1, (_, c) => c + 1);
 
+                            // Counted the same way, and for the shutdown's benefit: a firing is in flight
+                            // from here until the run shell's last act, the job store update that
+                            // completes it. A shutdown that is not waiting for its jobs still gives these
+                            // a moment to land, because the store refuses a completion once it has closed.
+                            qs.ExecutionDispatched();
+
                             Func<ValueTask> jobRunner = async () =>
                             {
                                 try
@@ -590,17 +596,21 @@ internal sealed class QuartzSchedulerThread
                                 finally
                                 {
                                     DecrementExecutionGroupCount(normalizedGroup);
+                                    qs.ExecutionSettled();
                                 }
                             };
 
                             // Deliberately not this thread's token: TriggersFired has already committed
                             // this firing to the job store and advanced the trigger, so refusing to dispatch
-                            // now loses the occurrence entirely. Only the pool's own shutdown may say no.
+                            // now loses the occurrence entirely. Only the pool's own shutdown may say no —
+                            // and a shutdown stops this loop before it closes the pool, so that a firing
+                            // this thread has already committed is never one nobody runs (#3746).
                             var threadPoolRunResult = await qsRsrcs.ThreadPool.TryRun(jobRunner, CancellationToken.None).ConfigureAwait(false);
                             if (!threadPoolRunResult)
                             {
-                                // The lambda never ran - decrement the count we pre-incremented
+                                // The lambda never ran - decrement the counts we pre-incremented
                                 DecrementExecutionGroupCount(normalizedGroup);
+                                qs.ExecutionSettled();
 
                                 // Check if the scheduler is being shutdown
                                 if (halted || cancellationTokenSource.Token.IsCancellationRequested)

--- a/src/Quartz/IScheduler.cs
+++ b/src/Quartz/IScheduler.cs
@@ -361,10 +361,18 @@ public interface IScheduler : IAsyncDisposable
     /// pass through <see cref="SchedulerStatus.Standby" /> on the way, and no listener is told it stood
     /// down: a scheduler being torn down is not one waiting to be started again.
     /// </para>
+    /// <para>
+    /// Firing stops before anything is torn down, so a trigger this scheduler had reserved is released
+    /// for another node and one it had already fired is still run. What it does about the executions
+    /// under way is <paramref name="waitForJobsToComplete" />'s answer.
+    /// </para>
     /// </remarks>
     /// <param name="waitForJobsToComplete">
     /// if <see langword="true" /> the scheduler will not allow this method
-    /// to return until all currently executing jobs have completed.
+    /// to return until all currently executing jobs have completed. If <see langword="false" /> it waits
+    /// for no job, but still gives the executions already in flight a couple of seconds to report their
+    /// completions, so that a firing which ends on the way out is recorded rather than left for a peer
+    /// to recover; one still working when that window closes is abandoned.
     /// </param>
     /// <param name="cancellationToken">
     /// Bounds the wait for running jobs, so that a shutdown can be given a deadline. Cancelling it stops


### PR DESCRIPTION
A node that shuts down without waiting for its jobs left two different firings behind, and only one of them was the one the issue's fixture noticed.

## What the reproduction found

`UnwaitedShutdownClusteredPostgresTest` is two clustered PostgreSQL nodes with one `[DisallowConcurrentExecution]` job on a five-instant `IgnoreMisfires` trigger. Node A fires the first instant, parks inside `Execute`, node B joins, node A runs `Shutdown(waitForJobsToComplete: false)`, and the parked firing ends half a second later. The check-in misfire threshold is thirty seconds, so nothing a peer does can be what settles the residue inside the window the fixture asserts over.

Before the change, on that fixture:

```
State with the first firing parked on node A:
TRIGGER: unwaitedShutdownTrigger state=BLOCKED next=639245548359415108
STATE:   unwaitedNodeA lastCheckin=639245548349026270 interval=1000
STATE:   unwaitedNodeB lastCheckin=639245548349969841 interval=1000
FIRED:   unwaitedShutdownTrigger instance=unwaitedNodeA state=EXECUTING entry=unwaitedNodeA2858952242822

Shutdown(waitForJobsToComplete: false) returned after 8 ms. State:
TRIGGER: unwaitedShutdownTrigger state=BLOCKED next=639245548359415108
FIRED:   unwaitedShutdownTrigger instance=unwaitedNodeA state=EXECUTING entry=unwaitedNodeA2858952242822
```

and ten seconds after the job had run to completion the rows were unchanged. After it, the same shutdown returns after 532 ms, the trigger is `WAITING`, no fired-trigger row remains, and all five instants fire exactly once — one on node A, four on node B.

### The issue's questions

1. **Which firing is lost.** Not the one that was executing: that one runs to completion on the leaver's own thread and is recorded. Two things are lost, and they are different.

   * **An occurrence the store had already been told about.** `QuartzSchedulerThread` calls `TriggersFired` — which writes the fired-trigger row and advances the trigger past the occurrence — and only then hands the execution to the thread pool. `Shutdown` halted that loop *without waiting for it* (`Halt(waitForJobsToComplete)`) and then closed the pool to new work, so a loop caught between those two statements met a pool that said no. `ThreadPool.TryRun() returned false due to scheduler shutdown, completing trigger` is the log line; the completion it then issues unblocks the job but leaves the trigger where firing had put it, one occurrence further on. Nothing recovers that firing: the trigger will not offer it again, and only `RequestsRecovery` would replay it. This is the one that costs a count, and it fits `nodeA=20, nodeB=139` — 159 of 160, the missing instant one node A had committed and never ran.
   * **The completion of the firing that was executing.** It is issued after `JobStore.Shutdown`, and `AdoJobStoreBase` refuses it: `RetryExecuteInLocalTransactionLock` loops `while (!shutdown)` and throws `JobStore is shutdown - aborting retry` without attempting the write. So the fired-trigger row stays `EXECUTING` and the trigger stays `BLOCKED` — the state dumped above. With `IgnoreMisfires` that costs time rather than a count; with a misfire instruction that drops occurrences it costs those too.

2. **Node A's `SCHEDULER_STATE` row survives a clean shutdown** — `ClusterManager.Shutdown` cancels the check-in loop and deletes nothing. The row above is still there with its check-in frozen at the instant the node left, while node B's advances. So the survivor settles the residue through the ordinary failed-instance path rather than through orphan detection (which only runs on a node's *first* check-in), and it cannot start before `LAST_CHECKIN_TIME + max(interval, elapsed) + CheckinMisfireThreshold`, plus a further grace period for an `EXECUTING` row of a `[DisallowConcurrentExecution]` job (`CanDeferRecovery`, #2817). On defaults that is roughly half a minute; against the fixture's thirty-second threshold it did not happen at all within the test.

3. **`RequestsRecovery`** is unchanged and stays what it was: without it an interrupted execution is not re-fired. Nothing here re-fires anything — what is fixed is a firing that never happened and a trigger left stuck, which is a different thing from replaying one that did.

## The change

**The firing loop is stopped completely before anything it depends on is torn down.** `QuartzScheduler.Shutdown` now signals the halt and immediately awaits the loop, where it used to await it only when `waitForJobsToComplete` was true and otherwise carry on to close the pool underneath it. The wait is not new — the same `schedThread.Shutdown()` ran a few lines further down, after the pool teardown — and it cannot stall on the pool, because the loop waits for a free thread on its own token, which `Halt` has just cancelled. What is new is that an unwaited shutdown gets the guarantee a waiting one always had.

**An unwaited shutdown gives the executions it has already dispatched a two-second window to report their completions**, before the plugins and the job store are shut down. It is not a wait for the jobs: it returns the instant nothing is in flight, and a job still working when the window closes is abandoned exactly as before — its residue a peer's to recover, which is the answer a crashed node gets. `RunningWorkDrained` now answers from that barrier, which covers each firing's job store update where the count of executing jobs never did.

The barrier counts the executions the scheduler dispatched rather than reading the thread pool, because `IThreadPool.Drain`'s default implementation waits however long the jobs take, and an unwaited shutdown must not become a waiting one because of which pool is installed.

### What was rejected

* **Releasing what the node holds on the way down** — moving its `BLOCKED` triggers back to `WAITING` and deleting its fired-trigger rows, so a peer picks them up without waiting for a check-in timeout. Unsafe for the very case the issue is about: the execution is *still running* on the leaving node, and unblocking its job invites a peer to start a second one. `CanDeferRecovery` exists to avoid exactly that. It would be safe only for firings that have already completed — which are precisely the ones the window above lets settle properly instead.
* **Deleting, or backdating, the node's `SCHEDULER_STATE` row on shutdown** so peers recover it promptly. Same objection, plus two of its own: orphan detection only runs on a node's first check-in, so a deleted row is settled no sooner than a stale one, and `CanDeferRecovery` derives its grace period from the check-in history the row carries, so removing it makes recovery *less* careful about a node that may still be alive.
* **A `QuartzSchedulerOptions` member for the window.** An application that needs its executions to finish asks for `waitForJobsToComplete: true`, and one that needs out now is not made to wait on a job by this. The window is a store round trip's worth and is documented where it is declared.

## Behaviour change

`Shutdown(waitForJobsToComplete: false)` — which is what `AddQuartzHostedService` does by default — can now take up to two seconds longer when a job is in flight, and returns as soon as the in-flight executions have reported themselves. It still never waits for a job to finish.

## Tests

* `UnwaitedShutdownTest.AShutdownThatDidNotWaitStillRunsTheFiringItHadAlreadyCommitted` — a store double parks the loop between `TriggersFired` and the dispatch; without the change the job never runs (`Executions` 0 of 1).
* `UnwaitedShutdownTest.AShutdownThatDidNotWaitLetsAnInFlightCompletionReachTheStore` — the completion has to reach the store before the store is told to close; without the change only `job store shut down` is recorded.
* `UnwaitedShutdownSqliteTest` — the same claim against a real ADO store on a SQLite file, asserting the rows rather than the ordering: `QRTZ_FIRED_TRIGGERS` empty and the trigger `WAITING` rather than `BLOCKED`. Unit cost, no container, and it is the ADO store's own refusal that it pins.
* `UnwaitedShutdownClusteredPostgresTest` — the clustered PostgreSQL reproduction above.
* `RedisLockHandlerShutdownUnderLoadTest` runs both leaves now — the graceful one it was changed to in #3747, and the ungraceful one it had before that, restored as `ANodeLeavingWithoutWaitingCostsTheClusterNoFiring`. Locally, against a Redis and a PostgreSQL container, the ungraceful one comes out `nodeA=10, nodeB=150` — 160 of 160, `ordinaryTrigger=100`, `serialTrigger=60`, peak concurrent executions of the serial job 1.
* `SchedulerTest.TestShutdownWithoutWaitShouldNotBlockUntilAllTasksHaveCompleted` keeps its promise and gets a job that outlasts the window, because the window is exactly what could be mistaken for the wait it says does not happen.

Closes #3746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
