### PR TITLE
SQLite test fixtures own their databases instead of clearing every connection pool

### DIFF
--- a/src/Quartz.Tests.AspNetCore/HttpApi/StoreFixtures.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/StoreFixtures.cs
@@ -14,44 +14,30 @@ namespace Quartz.Tests.AspNetCore.HttpApi;
 /// </remarks>
 internal sealed class SqliteStores : IDisposable
 {
-    private readonly ConcurrentDictionary<string, string> files = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, SqliteTestDatabase> databases = new(StringComparer.Ordinal);
     private readonly string prefix;
 
     public SqliteStores(string prefix) => this.prefix = prefix;
 
     public void Configure(IQuartzBuilder builder, string schedulerName)
     {
-        string file = files.GetOrAdd(
-            schedulerName,
-            _ => Path.Combine(Path.GetTempPath(), $"quartz-{prefix}-{Guid.NewGuid():N}.db"));
+        SqliteTestDatabase database = databases.GetOrAdd(schedulerName, _ => new SqliteTestDatabase(prefix));
 
         builder.UsePersistentStore(store =>
         {
-            store.UseSqlite(SqliteFactory.Instance, $"Data Source={file}");
+            store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
             store.ProvisionSchema();
         });
     }
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
-
-        foreach (string file in files.Values)
+        foreach (SqliteTestDatabase database in databases.Values)
         {
-            if (File.Exists(file))
-            {
-                try
-                {
-                    File.Delete(file);
-                }
-                catch (IOException)
-                {
-                    // A file the store has not finished letting go of is a temp file, not a failure.
-                }
-            }
+            database.Dispose();
         }
 
-        files.Clear();
+        databases.Clear();
     }
 }
 

--- a/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
+++ b/src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
@@ -20,6 +20,12 @@
       both rather than copied into either.
     -->
     <Compile Include="..\Quartz.Tests.Unit\PublicApiRendering.cs" Link="PublicApiRendering.cs" />
+    <!--
+      A SQLite file a fixture owns, with pooling off so that no teardown anywhere has to reach for the
+      process-global SqliteConnection.ClearAllPools (#3755). Shared by source with the two other test
+      projects, because the fixtures that needed it are spread across all three.
+    -->
+    <Compile Include="..\Quartz.Tests.Unit\SqliteTestDatabase.cs" Link="SqliteTestDatabase.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Core/SchedulerAcrossDstTransitionTest.cs
@@ -113,32 +113,13 @@ public sealed class SchedulerAcrossDstTransitionTest
 
     private static readonly ConcurrentDictionary<string, FireCollector> collectors = new(StringComparer.Ordinal);
 
-    private string databaseFile;
+    private SqliteTestDatabase database;
 
     [TearDown]
     public void DeleteDatabaseFile()
     {
-        if (databaseFile is null)
-        {
-            return;
-        }
-
-        // Pools first, or the handle the store left behind keeps the file locked on Windows.
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving one behind is not worth failing a passing test over
-            }
-        }
-
-        databaseFile = null;
+        database?.Dispose();
+        database = null;
     }
 
     public static IEnumerable<TestCaseData> Cases()
@@ -380,11 +361,11 @@ public sealed class SchedulerAcrossDstTransitionTest
         }).Build();
     }
 
-    private string ConnectionString => $"Data Source={databaseFile};";
+    private string ConnectionString => database.ConnectionString;
 
     private void PrepareDatabase()
     {
-        databaseFile = $"dst-scheduler-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("dst-scheduler");
 
         using SqliteConnection connection = new SqliteConnection(ConnectionString);
         connection.Open();

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreLoggingTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStoreLoggingTest.cs
@@ -47,14 +47,14 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 [NonParallelizable]
 public sealed class AdoJobStoreLoggingTest
 {
-    private string dbFileName = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public async Task SetUp()
     {
-        dbFileName = $"test-store-logging-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("store-logging");
 
-        await using SqliteConnection connection = new($"Data Source={dbFileName};");
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         await using SqliteCommand command = new(LoadSqliteTableScript(), connection);
         await command.ExecuteNonQueryAsync();
@@ -63,19 +63,7 @@ public sealed class AdoJobStoreLoggingTest
     [TearDown]
     public void TearDown()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(dbFileName))
-        {
-            try
-            {
-                File.Delete(dbFileName);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving it behind is not worth failing a test over
-            }
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -93,7 +81,7 @@ public sealed class AdoJobStoreLoggingTest
             quartz.ConfigureScheduler(options => options.InstanceName = "logging-store");
             quartz.UsePersistentStore(store =>
             {
-                store.UseSqlite($"Data Source={dbFileName};");
+                store.UseSqlite(database.ConnectionString);
                 store.UseSystemTextJsonSerializer();
             });
         });

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/AdoJobStorePagingTest.cs
@@ -54,6 +54,8 @@ public class AdoJobStorePagingTest
 
     private readonly List<IScheduler> createdSchedulers = [];
 
+    private SqliteTestDatabase database;
+
     [Test]
     [Category("db-sqlserver")]
     public Task TestSqlServer()
@@ -99,23 +101,16 @@ public class AdoJobStorePagingTest
     [Category("db-sqlite")]
     public async Task TestSQLiteMicrosoft()
     {
-        string dbFileName = "test-paging-sqlite-ms.db";
-        if (File.Exists(dbFileName))
-        {
-            SqliteConnection.ClearAllPools();
-            File.Delete(dbFileName);
-        }
+        database = new SqliteTestDatabase("paging-sqlite-ms");
 
-        string connectionString = $"Data Source={dbFileName};";
-
-        await using (SqliteConnection connection = new SqliteConnection(connectionString))
+        await using (SqliteConnection connection = new SqliteConnection(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using SqliteCommand command = new SqliteCommand(LoadSqliteTableScript(), connection);
             await command.ExecuteNonQueryAsync();
         }
 
-        await RunPagingTest("SQLite-Microsoft", connectionString, typeof(SQLiteDelegate));
+        await RunPagingTest("SQLite-Microsoft", database.ConnectionString, typeof(SQLiteDelegate));
     }
 
     private static string LoadSqliteTableScript()
@@ -522,5 +517,9 @@ public class AdoJobStorePagingTest
         }
 
         createdSchedulers.Clear();
+
+        // Only the SQLite case has one, and it goes after the shutdown so nothing is still holding it.
+        database?.Dispose();
+        database = null;
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/EnlistedTransactionTest.cs
@@ -566,8 +566,8 @@ public class EnlistedTransactionTest
     /// </summary>
     private TestProvider Sqlite()
     {
-        sqliteFile = Path.Combine(Path.GetTempPath(), $"quartz-enlisted-{Guid.NewGuid():N}.db");
-        string connectionString = $"Data Source={sqliteFile}";
+        sqliteDatabase = new SqliteTestDatabase("enlisted");
+        string connectionString = sqliteDatabase.ConnectionString;
 
         return new TestProvider(
             DataSourceOptions.Providers.Sqlite,
@@ -591,24 +591,13 @@ public class EnlistedTransactionTest
         return connectionString;
     }
 
-    private string sqliteFile;
+    private SqliteTestDatabase sqliteDatabase;
 
     [TearDown]
     public void DeleteSqliteDatabase()
     {
-        if (sqliteFile is null)
-        {
-            return;
-        }
-
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(sqliteFile))
-        {
-            File.Delete(sqliteFile);
-        }
-
-        sqliteFile = null;
+        sqliteDatabase?.Dispose();
+        sqliteDatabase = null;
     }
 
     [DisallowConcurrentExecution]

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigrationScriptTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MigrationScriptTest.cs
@@ -904,37 +904,15 @@ public class MigrationScriptTest
     /// </summary>
     internal static async Task WithSqliteAsync(Func<SqliteConnection, string, Task> body)
     {
-        string file = Path.Combine(Path.GetTempPath(), $"quartz-migration-{Guid.NewGuid():N}.db");
-        string connectionString = $"Data Source={file};";
+        using SqliteTestDatabase database = new SqliteTestDatabase("migration");
 
-        try
-        {
-            await using (SqliteConnection connection = new SqliteConnection(connectionString))
-            {
-                await connection.OpenAsync();
+        await using SqliteConnection connection = new SqliteConnection(database.ConnectionString);
+        await connection.OpenAsync();
 
-                // The fresh schema the migrated one has to end up matching. The other dialects get
-                // this from the test environment, which creates it when the container starts.
-                await ExecuteScriptAsync(connection, CurrentTableScript("sqlite"), "sqlite");
+        // The fresh schema the migrated one has to end up matching. The other dialects get this from
+        // the test environment, which creates it when the container starts.
+        await ExecuteScriptAsync(connection, CurrentTableScript("sqlite"), "sqlite");
 
-                await body(connection, connectionString);
-            }
-        }
-        finally
-        {
-            SqliteConnection.ClearAllPools();
-
-            try
-            {
-                if (File.Exists(file))
-                {
-                    File.Delete(file);
-                }
-            }
-            catch (IOException)
-            {
-                // the file is only test scratch space, leaving it behind is not worth failing over
-            }
-        }
+        await body(connection, database.ConnectionString);
     }
 }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/MisfireBatchRecoveryTest.cs
@@ -25,7 +25,7 @@ public class MisfireBatchRecoveryTest
     private const string DataSourceName = "misfire-batch-sqlite";
     private const string SchedulerName = "MisfireBatchRecoveryTest";
 
-    private string dbFileName;
+    private SqliteTestDatabase database;
     private IDbProvider dbProvider;
     private CountingSQLiteDelegate.Counter commandCounter;
     private readonly List<TestLocalTransactionJobStore> jobStores = [];
@@ -34,9 +34,9 @@ public class MisfireBatchRecoveryTest
     public async Task SetUp()
     {
         jobStores.Clear();
-        dbFileName = $"test-misfire-batch-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("misfire-batch");
 
-        await using (var connection = new SqliteConnection($"Data Source={dbFileName};"))
+        await using (var connection = new SqliteConnection(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using var command = new SqliteCommand(LoadSqliteTableScript(), connection);
@@ -45,7 +45,7 @@ public class MisfireBatchRecoveryTest
 
         // The store reads through the provider it is constructed with, so the test only has to build
         // one — there is no registry to publish it to.
-        dbProvider = new DbProvider("SQLite-Microsoft", $"Data Source={dbFileName};");
+        dbProvider = new DbProvider("SQLite-Microsoft", database.ConnectionString);
 
         commandCounter = new CountingSQLiteDelegate.Counter();
         CountingSQLiteDelegate.CurrentCounter = commandCounter;
@@ -63,18 +63,7 @@ public class MisfireBatchRecoveryTest
 
         CountingSQLiteDelegate.CurrentCounter = null;
 
-        SqliteConnection.ClearAllPools();
-        if (File.Exists(dbFileName))
-        {
-            try
-            {
-                File.Delete(dbFileName);
-            }
-            catch (IOException)
-            {
-                // the file is only test scratch space, leaving it behind is not worth failing over
-            }
-        }
+        database.Dispose();
     }
 
     [Test]

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SchemaProvisioningTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SchemaProvisioningTest.cs
@@ -445,35 +445,13 @@ public class SchemaProvisioningTest
     /// </summary>
     private static async Task WithSqliteAsync(Func<SqliteConnection, string, Task> body)
     {
-        string file = Path.Combine(Path.GetTempPath(), $"quartz-provisioning-{Guid.NewGuid():N}.db");
-        string connectionString = $"Data Source={file};";
+        using SqliteTestDatabase database = new SqliteTestDatabase("provisioning");
 
-        try
-        {
-            await using (SqliteConnection connection = new SqliteConnection(connectionString))
-            {
-                await connection.OpenAsync();
+        await using SqliteConnection connection = new SqliteConnection(database.ConnectionString);
+        await connection.OpenAsync();
 
-                await CreateFreshSqliteSchemaAsync(connection);
-                await body(connection, connectionString);
-            }
-        }
-        finally
-        {
-            SqliteConnection.ClearAllPools();
-
-            try
-            {
-                if (File.Exists(file))
-                {
-                    File.Delete(file);
-                }
-            }
-            catch (IOException)
-            {
-                // the file is only test scratch space, leaving it behind is not worth failing over
-            }
-        }
+        await CreateFreshSqliteSchemaAsync(connection);
+        await body(connection, database.ConnectionString);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancySqliteTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SharedDatabaseTenancySqliteTest.cs
@@ -12,7 +12,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 [NonParallelizable]
 public sealed class SharedDatabaseTenancySqliteTest : SharedDatabaseTenancyTestBase
 {
-    private string databaseFile;
+    private SqliteTestDatabase database;
 
     protected override void UseDatabase(IPersistentStoreBuilder store)
     {
@@ -21,7 +21,7 @@ public sealed class SharedDatabaseTenancySqliteTest : SharedDatabaseTenancyTestB
 
     protected override async Task PrepareDatabase()
     {
-        databaseFile = $"tenancy-shared-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("tenancy-shared");
 
         await using SqliteConnection connection = new SqliteConnection(ConnectionString);
         await connection.OpenAsync();
@@ -32,26 +32,13 @@ public sealed class SharedDatabaseTenancySqliteTest : SharedDatabaseTenancyTestB
 
     protected override Task CleanUpDatabase()
     {
-        // The file is this fixture's alone, so it goes rather than its rows. Pools have to be cleared
-        // first or the handle the store left behind keeps the file locked on Windows.
-        SqliteConnection.ClearAllPools();
-
-        if (databaseFile is not null && File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving one behind is not worth failing a passing test over
-            }
-        }
+        // The file is this fixture's alone, so it goes rather than its rows.
+        database?.Dispose();
 
         return Task.CompletedTask;
     }
 
-    private string ConnectionString => $"Data Source={databaseFile};";
+    private string ConnectionString => database.ConnectionString;
 
     private static string LoadTableScript()
     {

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/SqliteFileJobStoreContractTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/SqliteFileJobStoreContractTest.cs
@@ -36,7 +36,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 /// </remarks>
 public abstract class SqliteFileJobStoreContractTest : AdoJobStoreContractTest
 {
-    private string dbFileName;
+    private SqliteTestDatabase database;
 
     protected override string DbProviderName => "SQLite-Microsoft";
 
@@ -44,34 +44,21 @@ public abstract class SqliteFileJobStoreContractTest : AdoJobStoreContractTest
 
     protected override async ValueTask<string> PrepareDatabase()
     {
-        dbFileName = $"test-store-contract-{Guid.NewGuid():N}.db";
-        string connectionString = $"Data Source={dbFileName};";
+        database = new SqliteTestDatabase("store-contract");
 
-        await using (SqliteConnection connection = new SqliteConnection(connectionString))
+        await using (SqliteConnection connection = new SqliteConnection(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using SqliteCommand command = new SqliteCommand(LoadSqliteTableScript(), connection);
             await command.ExecuteNonQueryAsync();
         }
 
-        return connectionString;
+        return database.ConnectionString;
     }
 
     protected override ValueTask DisposeStore()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(dbFileName))
-        {
-            try
-            {
-                File.Delete(dbFileName);
-            }
-            catch (IOException)
-            {
-                // the file is only test scratch space, leaving it behind is not worth failing over
-            }
-        }
+        database.Dispose();
 
         return default;
     }

--- a/src/Quartz.Tests.Integration/Impl/AdoJobStore/TraceContextThroughAdoStoreTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/AdoJobStore/TraceContextThroughAdoStoreTest.cs
@@ -47,7 +47,7 @@ namespace Quartz.Tests.Integration.Impl.AdoJobStore;
 [NonParallelizable]
 public sealed class TraceContextThroughAdoStoreTest
 {
-    private string databaseFile;
+    private SqliteTestDatabase database;
     private ActivityListener listener;
     private readonly List<Activity> stoppedActivities = [];
 
@@ -81,20 +81,8 @@ public sealed class TraceContextThroughAdoStoreTest
     {
         listener?.Dispose();
 
-        // Pools first, or the handle the store left behind keeps the file locked on Windows.
-        SqliteConnection.ClearAllPools();
-
-        if (databaseFile is not null && File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving one behind is not worth failing a passing test over
-            }
-        }
+        database?.Dispose();
+        database = null;
     }
 
     [Test]
@@ -198,11 +186,11 @@ public sealed class TraceContextThroughAdoStoreTest
         return null;
     }
 
-    private string ConnectionString => $"Data Source={databaseFile};";
+    private string ConnectionString => database.ConnectionString;
 
     private async Task PrepareDatabase()
     {
-        databaseFile = $"trace-context-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("trace-context");
 
         await using SqliteConnection connection = new SqliteConnection(ConnectionString);
         await connection.OpenAsync();

--- a/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
+++ b/src/Quartz.Tests.Integration/Impl/MisfireAcrossDstTransitionTest.cs
@@ -65,14 +65,14 @@ public sealed class MisfireAcrossDstTransitionTest
     /// <summary>Anything overdue by more than five minutes has misfired.</summary>
     private static readonly TimeSpan MisfireThreshold = TimeSpan.FromMinutes(5);
 
-    private string databaseFile;
+    private SqliteTestDatabase database;
     private IDbProvider dbProvider;
     private RecoverableJobStore adoJobStore;
 
     [SetUp]
     public async Task CreateDatabase()
     {
-        databaseFile = $"dst-misfire-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("dst-misfire");
 
         await using (SqliteConnection connection = new SqliteConnection(ConnectionString))
         {
@@ -93,21 +93,8 @@ public sealed class MisfireAcrossDstTransitionTest
             adoJobStore = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (databaseFile is not null && File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving one behind is not worth failing a passing test over
-            }
-        }
-
-        databaseFile = null;
+        database?.Dispose();
+        database = null;
     }
 
     /// <summary>
@@ -335,7 +322,7 @@ public sealed class MisfireAcrossDstTransitionTest
         return value is long ticks ? new DateTimeOffset(ticks, TimeSpan.Zero) : null;
     }
 
-    private string ConnectionString => $"Data Source={databaseFile};";
+    private string ConnectionString => database.ConnectionString;
 
     private static string LoadTableScript()
     {

--- a/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
+++ b/src/Quartz.Tests.Integration/Quartz.Tests.Integration.csproj
@@ -14,6 +14,12 @@
     <Compile Include="..\Quartz.Tests.Unit\TestConstants.cs" />
     <Compile Include="..\Quartz.Tests.Unit\TestJobStores.cs" />
     <!--
+      A SQLite file a fixture owns, with pooling off so that no teardown anywhere has to reach for the
+      process-global SqliteConnection.ClearAllPools (#3755). Shared by source with the two other test
+      projects, because the fixtures that needed it are spread across all three.
+    -->
+    <Compile Include="..\Quartz.Tests.Unit\SqliteTestDatabase.cs" />
+    <!--
       The zones and walk helpers the daylight saving time tests are written against. Shared rather
       than copied so that both projects state a transition premise the same way, and so a zone that
       moves is corrected in one place.

--- a/src/Quartz.Tests.Integration/Scenarios/BusIntegrationScenarioTest.cs
+++ b/src/Quartz.Tests.Integration/Scenarios/BusIntegrationScenarioTest.cs
@@ -22,7 +22,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
@@ -118,7 +117,7 @@ public sealed class BusIntegrationScenarioTest
     private readonly List<Activity> executeActivities = [];
 
     private string run;
-    private string databaseFile;
+    private SqliteTestDatabase database;
     private FakeTimeProvider clock;
     private BusRecorder recorder;
     private ActivityListener listener;
@@ -141,7 +140,7 @@ public sealed class BusIntegrationScenarioTest
         {
             // Nothing creates the file and nothing runs a script against it: the store provisions its
             // own schema the first time it is built, which is step 1's business.
-            databaseFile = $"bus-scenario-{run}.db";
+            database = new SqliteTestDatabase($"bus-scenario-{run}");
         }
 
         lock (executeActivities)
@@ -196,27 +195,8 @@ public sealed class BusIntegrationScenarioTest
 
         scheduler = null;
 
-        if (databaseFile is null)
-        {
-            return;
-        }
-
-        // Pools first, or the handle the store left behind keeps the file locked on Windows.
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // scratch space; leaving one behind is not worth failing a passing test over
-            }
-        }
-
-        databaseFile = null;
+        database?.Dispose();
+        database = null;
     }
 
     /// <summary>
@@ -742,7 +722,7 @@ public sealed class BusIntegrationScenarioTest
 
     private string SchedulerName => $"bus-{run}";
 
-    private string ConnectionString => $"Data Source={databaseFile};";
+    private string ConnectionString => database.ConnectionString;
 
     private DateTimeOffset Now => clock.GetUtcNow();
 

--- a/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeDrainTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulerRuntimeDrainTest.cs
@@ -44,14 +44,12 @@ public sealed class SchedulerRuntimeDrainTest
     /// </remarks>
     private static readonly int[] recoveryCounters = [3018, 3019, 3021, 3022];
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-runtime-drain-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("runtime-drain");
         GatedJob.Reset();
     }
 
@@ -59,20 +57,7 @@ public sealed class SchedulerRuntimeDrainTest
     public void DeleteDatabase()
     {
         GatedJob.Release();
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                // A connection pool that has not finished closing. The file is in the temp directory and
-                // the test has already said what it had to say.
-            }
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -242,7 +227,7 @@ public sealed class SchedulerRuntimeDrainTest
     {
         builder.UsePersistentStore(store =>
         {
-            store.UseSqlite(SqliteFactory.Instance, connectionString);
+            store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
             store.ProvisionSchema();
         });
     }

--- a/src/Quartz.Tests.Unit/Configuration/SchedulingDuplicatesSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/SchedulingDuplicatesSqliteTest.cs
@@ -47,25 +47,18 @@ public sealed class SchedulingDuplicatesSqliteTest
 {
     private static readonly JobKey jobKey = new("declared", "declared-group");
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-scheduling-duplicates-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("scheduling-duplicates");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -141,7 +134,7 @@ public sealed class SchedulingDuplicatesSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
 

--- a/src/Quartz.Tests.Unit/Configuration/TypeLoaderAliasTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/TypeLoaderAliasTest.cs
@@ -34,25 +34,18 @@ public sealed class TypeLoaderAliasTest
     /// </summary>
     private const string StoredName = "Acme.Jobs.NightlyReport, Acme.Jobs";
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-alias-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("alias");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -245,7 +238,7 @@ public sealed class TypeLoaderAliasTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
 
@@ -265,7 +258,7 @@ public sealed class TypeLoaderAliasTest
 
     private async Task<int> Execute(string sql)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();
@@ -276,7 +269,7 @@ public sealed class TypeLoaderAliasTest
 
     private async Task<string?> Scalar(string sql)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdministrationNodeSqliteTest.cs
@@ -64,8 +64,7 @@ public sealed class AdministrationNodeSqliteTest
     private static readonly TriggerKey PlainTrigger = new("nightly-report", "acme");
     private static readonly TriggerKey GatedTrigger = new("message-cleanup", "acme");
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     private StandaloneSchedulerFactory workerFactory = null!;
     private StandaloneSchedulerFactory adminFactory = null!;
@@ -81,8 +80,7 @@ public sealed class AdministrationNodeSqliteTest
     {
         WorkerJobs.Reset();
 
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-admin-node-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("admin-node");
 
         workerFactory = QuartzSchedulerBuilder.Create(q =>
         {
@@ -106,7 +104,7 @@ public sealed class AdministrationNodeSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         }).Build();
@@ -141,7 +139,7 @@ public sealed class AdministrationNodeSqliteTest
             q.UseThreadPool<ZeroSizeThreadPool>();
             q.UseTypeLoader<UnknownJobTypeLoader>();
 
-            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, connectionString));
+            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, database.ConnectionString));
         }).Build();
 
         admin = await adminFactory.GetScheduler();
@@ -159,32 +157,7 @@ public sealed class AdministrationNodeSqliteTest
         adminFactory.Dispose();
         workerFactory.Dispose();
 
-        SqliteConnection.ClearAllPools();
-
-        DeleteDatabaseFile();
-    }
-
-    /// <summary>
-    /// Deletes the file, giving the last connection a moment to let go of it.
-    /// </summary>
-    /// <remarks>
-    /// The two schedulers have been shut down and the pools cleared by the time this runs, but on
-    /// Windows a handle that was closed a microsecond ago can still fail the delete, and a fixture that
-    /// leaves a stray temporary file behind is worse than one that waits.
-    /// </remarks>
-    private void DeleteDatabaseFile()
-    {
-        for (int attempt = 0; attempt < 20 && File.Exists(databaseFile); attempt++)
-        {
-            try
-            {
-                File.Delete(databaseFile);
-            }
-            catch (IOException)
-            {
-                Thread.Sleep(50);
-            }
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -466,7 +439,7 @@ public sealed class AdministrationNodeSqliteTest
     /// </summary>
     private async Task<string> StoredTriggerState(TriggerKey key)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();
@@ -483,7 +456,7 @@ public sealed class AdministrationNodeSqliteTest
     /// </summary>
     private async Task<(bool NonConcurrent, bool UpdateData)> StoredJobFlags(JobKey key)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoCancellationSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoCancellationSqliteTest.cs
@@ -49,27 +49,20 @@ public sealed class AdoCancellationSqliteTest
 {
     private const string Group = "cancellation";
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private CancellingSqliteDelegate driverDelegate = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-cancellation-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("cancellation");
         driverDelegate = new CancellingSqliteDelegate();
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -240,7 +233,7 @@ public sealed class AdoCancellationSqliteTest
                 // Registered before the dialect is chosen, because UseSqlite registers SQLiteDelegate
                 // with TryAdd and the first registration is the one that wins.
                 store.UseDriverDelegate(_ => driverDelegate);
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
             });
         });
 
@@ -268,7 +261,7 @@ public sealed class AdoCancellationSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 // #3550: the store creates the schema it needs, so the test needs no script of its own.
                 store.ProvisionSchema();
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoGroupDeleteSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoGroupDeleteSqliteTest.cs
@@ -48,25 +48,18 @@ public sealed class AdoGroupDeleteSqliteTest
     private const string SagaGroup = "saga-17";
     private const string OtherGroup = "saga-18";
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-group-delete-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("group-delete");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -160,7 +153,7 @@ public sealed class AdoGroupDeleteSqliteTest
 
     private async Task<int> CountOfPausedJobGroups()
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();
@@ -200,7 +193,7 @@ public sealed class AdoGroupDeleteSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 // #3550: the store creates the schema it needs, so the test needs no script of its own.
                 store.ProvisionSchema();
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/Common/TypeFreeDbProviderTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/Common/TypeFreeDbProviderTest.cs
@@ -44,16 +44,14 @@ public sealed class TypeFreeDbProviderTest
         BindByName = true,
     };
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public async Task CreateSchema()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-type-free-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("type-free");
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         SqliteCommand command = connection.CreateCommand();
@@ -64,15 +62,14 @@ public sealed class TypeFreeDbProviderTest
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-        File.Delete(databaseFile);
+        database.Dispose();
     }
 
     [Test]
     public async Task AFactoryProviderRunsAScheduleWithNoTypeNamed()
     {
         DbMetadata metadata = TypeFreeSqlite;
-        IDbProvider provider = new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, connectionString);
+        IDbProvider provider = new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, database.ConnectionString);
 
         await ScheduleFireAndReadBack(provider, nameof(AFactoryProviderRunsAScheduleWithNoTypeNamed));
     }
@@ -81,7 +78,7 @@ public sealed class TypeFreeDbProviderTest
     public async Task ADataSourceProviderRunsAScheduleWithNoTypeNamed()
     {
         DbMetadata metadata = TypeFreeSqlite;
-        await using SqliteDataSource dataSource = new(connectionString);
+        await using SqliteDataSource dataSource = new(database.ConnectionString);
         IDbProvider provider = new DataSourceDbProvider(metadata, dataSource);
 
         await ScheduleFireAndReadBack(provider, nameof(ADataSourceProviderRunsAScheduleWithNoTypeNamed));
@@ -94,7 +91,7 @@ public sealed class TypeFreeDbProviderTest
     [Test]
     public void NeitherProviderIsBuiltOnTheReflectiveOne()
     {
-        using SqliteDataSource dataSource = new(connectionString);
+        using SqliteDataSource dataSource = new(database.ConnectionString);
 
         typeof(ProviderFactoryDbProvider).Should().NotBeAssignableTo<DbProvider>();
         typeof(DataSourceDbProvider).Should().NotBeAssignableTo<DbProvider>(

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConfiguredTypeNamesResolveTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ConfiguredTypeNamesResolveTest.cs
@@ -25,7 +25,6 @@ using System.Collections.Specialized;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.DependencyInjection;
 
 using Quartz.Documentation.Samples.HowTos;
@@ -64,25 +63,18 @@ public sealed class ConfiguredTypeNamesResolveTest
 
     private const string ExternalTransactionJobStoreName = "Quartz.Impl.AdoJobStore.ExternalTransactionJobStore, Quartz";
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-delegate-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("delegate");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -224,7 +216,7 @@ public sealed class ConfiguredTypeNamesResolveTest
         ServiceCollection chosenInCode = new();
         chosenInCode.AddQuartz(q => q.UsePersistentStore(store =>
         {
-            store.UseSqlite(connectionString);
+            store.UseSqlite(database.ConnectionString);
             store.UseAmbientTransactions();
         }));
         using ServiceProvider fromCode = chosenInCode.BuildServiceProvider();
@@ -255,7 +247,7 @@ public sealed class ConfiguredTypeNamesResolveTest
             ["quartz.jobStore.dataSource"] = "default",
             ["quartz.jobStore.schemaProvisioning"] = nameof(SchemaProvisioning.CreateIfMissing),
             ["quartz.dataSource.default.provider"] = "SQLite-Microsoft",
-            ["quartz.dataSource.default.connectionString"] = connectionString
+            ["quartz.dataSource.default.connectionString"] = database.ConnectionString
         };
     }
 

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/CustomCalendarSerializerSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/CustomCalendarSerializerSqliteTest.cs
@@ -51,25 +51,18 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class CustomCalendarSerializerSqliteTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-calendar-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("calendar");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -135,7 +128,7 @@ public sealed class CustomCalendarSerializerSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.UseSystemTextJsonSerializer(configure);
                 store.ProvisionSchema();
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerRowLockSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/DbLockHandlerRowLockSqliteTest.cs
@@ -68,25 +68,18 @@ public sealed class DbLockHandlerRowLockSqliteTest
     private const string SelectWithoutForUpdate =
         "SELECT * FROM {0}LOCKS WHERE SCHED_NAME = @schedulerName AND LOCK_NAME = @lockName";
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-row-lock-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("row-lock");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     private static IEnumerable<TestCaseData> RowLockHandlers()
@@ -114,7 +107,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
 
         DbLockHandler lockHandler = Initialize(create);
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -139,7 +132,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
 
         DbLockHandler lockHandler = Initialize(create);
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -194,7 +187,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
         DbLockHandler lockHandler = Initialize(create);
         ICountStatements counter = (ICountStatements) lockHandler;
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -227,7 +220,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
 
         DbLockHandler lockHandler = Initialize(create);
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -260,7 +253,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
 
         DbLockHandler lockHandler = Initialize(create);
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -281,7 +274,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
     private DbLockHandler Initialize(Func<IDbProvider, DbLockHandler> create)
     {
         DbMetadata metadata = DbMetadataResolver.BuiltIn().ResolveWithoutTypes("SQLite-Microsoft");
-        ProviderFactoryDbProvider provider = new(metadata, SqliteFactory.Instance, connectionString);
+        ProviderFactoryDbProvider provider = new(metadata, SqliteFactory.Instance, database.ConnectionString);
 
         DbLockHandler lockHandler = create(provider);
         lockHandler.Initialize(new LockHandlerContext
@@ -311,7 +304,7 @@ public sealed class DbLockHandlerRowLockSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/EnlistmentRefusalSqliteTest.cs
@@ -47,15 +47,13 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class EnlistmentRefusalSqliteTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-enlistment-refusal-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("enlistment-refusal");
     }
 
     [TearDown]
@@ -67,12 +65,7 @@ public sealed class EnlistmentRefusalSqliteTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -83,7 +76,7 @@ public sealed class EnlistmentRefusalSqliteTest
         TransactionOptions options = new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted };
         using (new TransactionScope(TransactionScopeOption.RequiresNew, options, TransactionScopeAsyncFlowOption.Enabled))
         {
-            await using SqliteConnection connection = new(connectionString);
+            await using SqliteConnection connection = new(database.ConnectionString);
             await connection.OpenAsync();
 
             Action enlist = () => scheduler.EnlistConnection(connection);
@@ -108,7 +101,7 @@ public sealed class EnlistmentRefusalSqliteTest
         IScheduler scheduler = await GetScheduler(nameof(EnlistingTheConnectionsOwnTransactionStillDiscardsTheScheduleOnRollback));
         JobKey jobKey = new JobKey("enlisted", "sqlite");
 
-        await using (SqliteConnection connection = new(connectionString))
+        await using (SqliteConnection connection = new(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using DbTransaction transaction = await connection.BeginTransactionAsync();
@@ -144,7 +137,7 @@ public sealed class EnlistmentRefusalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
                 store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/PausedJobGroupSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/PausedJobGroupSqliteTest.cs
@@ -55,25 +55,18 @@ public sealed class PausedJobGroupSqliteTest
     private static readonly JobKey jobKey = new("late", PausedGroup);
     private static readonly TriggerKey triggerKey = new("t-late", TriggerGroup);
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-paused-job-group-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("paused-job-group");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -131,7 +124,7 @@ public sealed class PausedJobGroupSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/PreferredNodeConditionalUpdateSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/PreferredNodeConditionalUpdateSqliteTest.cs
@@ -56,15 +56,13 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
 
     private static readonly TriggerKey PinnedTrigger = new("pinned", "affinity");
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-preferred-node-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("preferred-node");
     }
 
     [TearDown]
@@ -76,12 +74,7 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -186,7 +179,7 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });
@@ -224,7 +217,7 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
             ObjectSerializer = new SystemTextJsonObjectSerializer(),
         });
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -237,7 +230,7 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
     private IDbProvider Provider()
     {
         DbMetadata metadata = DbMetadataResolver.BuiltIn().ResolveWithoutTypes("SQLite-Microsoft");
-        return new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, connectionString);
+        return new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, database.ConnectionString);
     }
 
     /// <summary>
@@ -245,7 +238,7 @@ public sealed class PreferredNodeConditionalUpdateSqliteTest
     /// </summary>
     private async Task<(string? Node, bool Automatic)> StoredPin()
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningReportingSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningReportingSqliteTest.cs
@@ -40,25 +40,18 @@ public sealed class SchemaProvisioningReportingSqliteTest
 {
     private const int SchemaCreatedEventId = 3039;
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-provisioning-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("provisioning");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -128,7 +121,7 @@ public sealed class SchemaProvisioningReportingSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 if (provisionSchema)
                 {
                     store.ProvisionSchema();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaProvisioningSqliteTest.cs
@@ -46,27 +46,20 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class SchemaProvisioningSqliteTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
         // Not created here: an empty path is a valid SQLite database the moment something opens it,
         // which is exactly the "nothing is there yet" case provisioning is for.
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-provisioning-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("provisioning");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -95,7 +88,7 @@ public sealed class SchemaProvisioningSqliteTest
         // would fail, and one that recreated a table would take the rows with it.
         await ScheduleFireAndReadBack("second");
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         (await Scalar(connection, "SELECT COUNT(*) FROM QRTZ_JOB_DETAILS")).Should().Be(2,
@@ -108,7 +101,7 @@ public sealed class SchemaProvisioningSqliteTest
     {
         await ScheduleFireAndReadBack(nameof(ProvisioningCreatesEveryObjectUnderTheConfiguredPrefix), tablePrefix: "QRTZP_");
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         (await Scalar(connection, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name LIKE 'QRTZP!_%' ESCAPE '!'"))
@@ -188,7 +181,7 @@ public sealed class SchemaProvisioningSqliteTest
                 // registrations are TryAdd, so the first one to name a delegate is the one that runs.
                 configure?.Invoke(store);
 
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
 
                 if (tablePrefix is not null)
                 {

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SchemaValidationTest.cs
@@ -49,15 +49,13 @@ public sealed class SchemaValidationTest
     /// <summary>The tables the cases below drop one at a time.</summary>
     private static readonly string[] EveryValidatedTable = AdoConstants.AllTableNames;
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-validation-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("validation");
     }
 
     [TearDown]
@@ -69,12 +67,7 @@ public sealed class SchemaValidationTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -227,7 +220,7 @@ public sealed class SchemaValidationTest
 
     private void Execute(string sql)
     {
-        using SqliteConnection connection = new(connectionString);
+        using SqliteConnection connection = new(database.ConnectionString);
         connection.Open();
 
         using SqliteCommand command = connection.CreateCommand();
@@ -248,7 +241,7 @@ public sealed class SchemaValidationTest
 
             // No ProvisionSchema(): SchemaProvisioning.Validate is the default, and validating what
             // somebody else installed is the whole subject here.
-            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, connectionString));
+            q.UsePersistentStore(store => store.UseSqlite(SqliteFactory.Instance, database.ConnectionString));
         });
 
         container = services.BuildServiceProvider();

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SelectJobForTriggerFlagsSqliteTest.cs
@@ -61,25 +61,18 @@ public sealed class SelectJobForTriggerFlagsSqliteTest
     private static readonly JobKey JobKey = new("cleanup", "acme");
     private static readonly TriggerKey TriggerKey = new("cleanup", "acme");
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-select-job-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("select-job");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -146,7 +139,7 @@ public sealed class SelectJobForTriggerFlagsSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });
@@ -182,7 +175,7 @@ public sealed class SelectJobForTriggerFlagsSqliteTest
             ObjectSerializer = new SystemTextJsonObjectSerializer(),
         });
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         using ConnectionAndTransactionHolder holder = new(connection, transaction: null);
 
@@ -192,7 +185,7 @@ public sealed class SelectJobForTriggerFlagsSqliteTest
     private IDbProvider Provider()
     {
         DbMetadata metadata = DbMetadataResolver.BuiltIn().ResolveWithoutTypes("SQLite-Microsoft");
-        return new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, connectionString);
+        return new ProviderFactoryDbProvider(metadata, SqliteFactory.Instance, database.ConnectionString);
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StartupRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StartupRefusalSqliteTest.cs
@@ -45,15 +45,13 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class StartupRefusalSqliteTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-startup-refusal-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("startup-refusal");
     }
 
     [TearDown]
@@ -65,12 +63,7 @@ public sealed class StartupRefusalSqliteTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -88,7 +81,7 @@ public sealed class StartupRefusalSqliteTest
     {
         IScheduler scheduler = await GetScheduler(nameof(StartingFromInsideAnEnlistmentScopeIsRefusedAndSaysSo));
 
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
         await using DbTransaction transaction = await connection.BeginTransactionAsync();
 
@@ -125,7 +118,7 @@ public sealed class StartupRefusalSqliteTest
     {
         IScheduler scheduler = await GetScheduler(nameof(OnceTheScopeIsGoneTheSameSchedulerStarts));
 
-        await using (SqliteConnection connection = new(connectionString))
+        await using (SqliteConnection connection = new(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using DbTransaction transaction = await connection.BeginTransactionAsync();
@@ -173,7 +166,7 @@ public sealed class StartupRefusalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
                 store.UseClustering();
             });
@@ -267,7 +260,7 @@ public sealed class StartupRefusalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
                 store.ConfigureStore(options => options.AcceptEnlistedTransactions = true);
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/StoreJobDataAsStringsTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/StoreJobDataAsStringsTest.cs
@@ -53,15 +53,13 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class StoreJobDataAsStringsTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-job-data-strings-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("job-data-strings");
     }
 
     [TearDown]
@@ -73,12 +71,7 @@ public sealed class StoreJobDataAsStringsTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -279,7 +272,7 @@ public sealed class StoreJobDataAsStringsTest
 
     private async Task<string> ReadJobData(string name, string group)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();
@@ -308,7 +301,7 @@ public sealed class StoreJobDataAsStringsTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
                 store.ConfigureStore(options => options.StoreJobDataAsStrings = storeJobDataAsStrings);
             });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/SubMillisecondIntervalSqliteTest.cs
@@ -58,25 +58,18 @@ public sealed class SubMillisecondIntervalSqliteTest
     /// <summary>Half a millisecond: representable in a <see cref="TimeSpan" />, not in the column.</summary>
     private static readonly TimeSpan SubMillisecond = TimeSpan.FromTicks(TimeSpan.TicksPerMillisecond / 2);
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-submilli-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("submilli");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -172,7 +165,7 @@ public sealed class SubMillisecondIntervalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateStatementsSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/TriggerStateStatementsSqliteTest.cs
@@ -59,31 +59,24 @@ public sealed class TriggerStateStatementsSqliteTest
     private static readonly JobKey jobKey = new("job", Group);
     private static readonly TriggerKey triggerKey = new("trigger", Group);
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-state-statements-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("state-statements");
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
     public async Task AStateWrittenByKeyIsTheStateReadBack()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         (await harness.Delegate.UpdateTriggerState(harness.Connection, triggerKey, StoredTriggerState.Paused))
             .Should().Be(1, "the trigger is there, so the update names a row that exists");
@@ -96,7 +89,7 @@ public sealed class TriggerStateStatementsSqliteTest
     [Test]
     public async Task AConditionalStateChangeAppliesOnlyFromTheStateItNames()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         (await harness.Delegate.UpdateTriggerStateFromOtherState(
                 harness.Connection, triggerKey, StoredTriggerState.Acquired, StoredTriggerState.Blocked))
@@ -112,7 +105,7 @@ public sealed class TriggerStateStatementsSqliteTest
     [Test]
     public async Task AJobsTriggersAreMovedByKeyAndConditionally()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         (await harness.Delegate.UpdateTriggerStatesForJob(harness.Connection, jobKey, StoredTriggerState.Blocked))
             .Should().Be(1, "the job has one trigger, and it is named by the job rather than by its own key");
@@ -131,7 +124,7 @@ public sealed class TriggerStateStatementsSqliteTest
     [Test]
     public async Task MisfiredTriggersAreCountedInTheStateTheyAreIn()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         DateTimeOffset afterTheTrigger = DateTimeOffset.UtcNow.AddDays(2);
 
@@ -151,7 +144,7 @@ public sealed class TriggerStateStatementsSqliteTest
     [Test]
     public async Task AJobWithNoFiredTriggerRowIsNotExecuting()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         (await harness.Delegate.IsJobCurrentlyExecuting(harness.Connection, jobKey)).Should().BeFalse(
             "nothing has fired, so the EXECUTING count over FIRED_TRIGGERS is zero — and the state this "
@@ -161,7 +154,7 @@ public sealed class TriggerStateStatementsSqliteTest
     [Test]
     public async Task ARetryWritesTheAttemptTheNextFireTimeAndTheState()
     {
-        await using Harness harness = await Harness.Create(connectionString);
+        await using Harness harness = await Harness.Create(database.ConnectionString);
 
         IOperableTrigger trigger = (await harness.Delegate.SelectTrigger(harness.Connection, triggerKey))!;
 
@@ -193,7 +186,7 @@ public sealed class TriggerStateStatementsSqliteTest
     public async Task ADialectsOwnClaimOnAnAcquiredTriggerIsTheOneTheStoreWouldReach()
     {
         await using Harness harness = await Harness.Create(
-            connectionString,
+            database.ConnectionString,
             store => store.UseDriverDelegate<ClaimRecordingDelegate>());
 
         ClaimRecordingDelegate dialect = harness.Delegate.Should().BeOfType<ClaimRecordingDelegate>(

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnmigratedSchemaRefusalSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnmigratedSchemaRefusalSqliteTest.cs
@@ -51,15 +51,13 @@ namespace Quartz.Tests.Unit.Impl.AdoJobStore;
 /// </remarks>
 public sealed class UnmigratedSchemaRefusalSqliteTest
 {
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
     private ServiceProvider? container;
 
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-unmigrated-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile}";
+        database = new SqliteTestDatabase("unmigrated");
     }
 
     [TearDown]
@@ -71,12 +69,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
             container = null;
         }
 
-        SqliteConnection.ClearAllPools();
-
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     /// <summary>
@@ -249,7 +242,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
             .Split('\n')
             .Where(line => !line.TrimStart().StartsWith("--", StringComparison.Ordinal)));
 
-        using SqliteConnection connection = new(connectionString);
+        using SqliteConnection connection = new(database.ConnectionString);
         connection.Open();
 
         foreach (string statement in statements.Split(';', StringSplitOptions.RemoveEmptyEntries))
@@ -314,7 +307,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
     /// </summary>
     private void Execute(string sql)
     {
-        using SqliteConnection connection = new(connectionString);
+        using SqliteConnection connection = new(database.ConnectionString);
         connection.Open();
 
         using SqliteCommand command = connection.CreateCommand();
@@ -324,7 +317,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
 
     private bool TableExists(string table)
     {
-        using SqliteConnection connection = new(connectionString);
+        using SqliteConnection connection = new(database.ConnectionString);
         connection.Open();
 
         using SqliteCommand command = connection.CreateCommand();
@@ -346,7 +339,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
 
                 if (provision)
                 {
@@ -376,7 +369,7 @@ public sealed class UnmigratedSchemaRefusalSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/UnwaitedShutdownSqliteTest.cs
@@ -52,31 +52,19 @@ public sealed class UnwaitedShutdownSqliteTest
     private static readonly JobKey jobKey = new("parked", "unwaited");
     private static readonly TriggerKey triggerKey = new("t-parked", "unwaited");
 
-    private string databaseFile = null!;
-    private string connectionString = null!;
+    private SqliteTestDatabase database = null!;
 
-    /// <remarks>
-    /// Pooling is off, which is what lets this fixture clean up after itself without
-    /// <see cref="SqliteConnection.ClearAllPools" />: that call is global, the assembly runs its
-    /// fixtures in parallel, and Microsoft.Data.Sqlite's pool hands out the underlying handle rather
-    /// than a copy — so clearing it disposes connections another fixture is in the middle of using. An
-    /// unpooled connection closes its handle when it is disposed, so the file is deletable anyway.
-    /// </remarks>
     [SetUp]
     public void CreateEmptyDatabase()
     {
-        databaseFile = Path.Combine(Path.GetTempPath(), $"quartz-unwaited-shutdown-{Guid.NewGuid():N}.db");
-        connectionString = $"Data Source={databaseFile};Pooling=False";
+        database = new SqliteTestDatabase("unwaited-shutdown");
         ParkingJob.Reset();
     }
 
     [TearDown]
     public void DeleteDatabase()
     {
-        if (File.Exists(databaseFile))
-        {
-            File.Delete(databaseFile);
-        }
+        database.Dispose();
     }
 
     [Test]
@@ -141,7 +129,7 @@ public sealed class UnwaitedShutdownSqliteTest
 
     private async Task<List<string>> ReadColumn(string sql)
     {
-        await using SqliteConnection connection = new(connectionString);
+        await using SqliteConnection connection = new(database.ConnectionString);
         await connection.OpenAsync();
 
         await using SqliteCommand command = connection.CreateCommand();
@@ -170,7 +158,7 @@ public sealed class UnwaitedShutdownSqliteTest
 
             q.UsePersistentStore(store =>
             {
-                store.UseSqlite(SqliteFactory.Instance, connectionString);
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
                 store.ProvisionSchema();
             });
         });

--- a/src/Quartz.Tests.Unit/Impl/MisfireThroughAStoreTestBase.cs
+++ b/src/Quartz.Tests.Unit/Impl/MisfireThroughAStoreTestBase.cs
@@ -71,7 +71,7 @@ public abstract class MisfireThroughAStoreTestBase
     private const string TablePrefix = "QRTZ_";
     private const string DataSourceName = "misfire-through-a-store-sqlite";
 
-    private string databaseFileName;
+    private SqliteTestDatabase database;
     private IDbProvider dbProvider;
     private readonly List<MisfireStoreUnderTest> stores = [];
     private int storeCounter;
@@ -79,33 +79,22 @@ public abstract class MisfireThroughAStoreTestBase
     [OneTimeSetUp]
     public async Task CreateDatabase()
     {
-        databaseFileName = $"test-misfire-store-{Guid.NewGuid():N}.db";
+        database = new SqliteTestDatabase("misfire-store");
 
-        await using (SqliteConnection connection = new($"Data Source={databaseFileName};"))
+        await using (SqliteConnection connection = new(database.ConnectionString))
         {
             await connection.OpenAsync();
             await using SqliteCommand command = new(LoadSqliteTableScript(), connection);
             await command.ExecuteNonQueryAsync();
         }
 
-        dbProvider = new DbProvider("SQLite-Microsoft", $"Data Source={databaseFileName};");
+        dbProvider = new DbProvider("SQLite-Microsoft", database.ConnectionString);
     }
 
     [OneTimeTearDown]
     public void DropDatabase()
     {
-        SqliteConnection.ClearAllPools();
-        if (File.Exists(databaseFileName))
-        {
-            try
-            {
-                File.Delete(databaseFileName);
-            }
-            catch (IOException)
-            {
-                // the file is only test scratch space, leaving it behind is not worth failing over
-            }
-        }
+        database.Dispose();
     }
 
     [TearDown]

--- a/src/Quartz.Tests.Unit/SqlitePoolClearingTest.cs
+++ b/src/Quartz.Tests.Unit/SqlitePoolClearingTest.cs
@@ -1,3 +1,5 @@
+using Microsoft.Data.Sqlite;
+
 namespace Quartz.Tests.Unit;
 
 /// <summary>
@@ -67,6 +69,42 @@ public class SqlitePoolClearingTest
             + Environment.NewLine
             + "See https://github.com/quartznet/quartznet/issues/3755. A fixture that genuinely needs a pool "
             + "clears its own with SqliteConnection.ClearPool(connection) and says here why it is exempt");
+    }
+
+    /// <summary>
+    /// The replacement keeps the promise the rule above is built on: no pool, and no file left behind.
+    /// </summary>
+    /// <remarks>
+    /// <c>Pooling</c> is asserted through the builder rather than by looking for a substring, because
+    /// what matters is the value the driver reads — a keyword the builder decided was a default and
+    /// dropped would leave every fixture pooling again with nothing to say so.
+    /// </remarks>
+    [Test]
+    public void ASqliteTestDatabaseTurnsPoolingOffAndTakesItsFileWithIt()
+    {
+        string file;
+
+        using (SqliteTestDatabase database = new("pool-clearing"))
+        {
+            SqliteConnectionStringBuilder parsed = new(database.ConnectionString);
+
+            parsed.Pooling.Should().BeFalse(
+                "the fixtures stopped clearing pools because they no longer create one, so a connection "
+                + "string that quietly pooled would put the race back with nothing left to notice it");
+
+            file = database.DatabaseFile;
+            parsed.DataSource.Should().Be(file,
+                "the path a fixture is handed has to be the database its connection string opens");
+
+            using SqliteConnection connection = new(database.ConnectionString);
+            connection.Open();
+
+            File.Exists(file).Should().BeTrue("opening a connection is what creates the file");
+        }
+
+        File.Exists(file).Should().BeFalse(
+            "a fixture that owns its database leaves nothing behind in the temporary directory — which "
+            + "is what the ClearAllPools() call was there to make possible");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.Unit/SqlitePoolClearingTest.cs
+++ b/src/Quartz.Tests.Unit/SqlitePoolClearingTest.cs
@@ -1,0 +1,97 @@
+namespace Quartz.Tests.Unit;
+
+/// <summary>
+/// What a test fixture may do with Microsoft.Data.Sqlite's connection pool, which is: nothing global.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SqliteConnection.ClearAllPools()</c> clears every pool in the process, and the pool hands out the
+/// underlying handle rather than a copy — so with <c>[assembly: Parallelizable(ParallelScope.Fixtures)]</c>
+/// one fixture's teardown disposes a connection another fixture is in the middle of using. What that
+/// looks like from the outside is <c>ObjectDisposedException: SQLitePCL.sqlite3</c> thrown from a setup
+/// that did nothing wrong, in a different fixture each time, and never twice in a row (#3755). Twenty-four
+/// fixtures across three test projects called it, so the fix was not to reason about which of them could
+/// collide.
+/// </para>
+/// <para>
+/// A grep rather than an analyzer, because the rule is about who may call one method and the whole
+/// audience is this repository's own test projects. <c>Quartz.Trimming.Canary</c> still calls it and is
+/// deliberately out of scope: it is a single-purpose executable that owns its process and its one
+/// database, which is the only arrangement in which the global call means what it says.
+/// </para>
+/// </remarks>
+public class SqlitePoolClearingTest
+{
+    /// <summary>
+    /// The call, spelled as a call — <c>&lt;see cref="..." /&gt;</c> and prose mentions carry no
+    /// parenthesis, and this test's own file is skipped anyway.
+    /// </summary>
+    private const string GlobalPoolClear = "SqliteConnection.ClearAllPools(";
+
+    /// <summary>The test projects this rule is about, matched as a prefix of the directory name.</summary>
+    private const string TestProjectPrefix = "Quartz.Tests.";
+
+    /// <summary>
+    /// Build output and tool caches: not ours, and large enough that walking them is a waste.
+    /// </summary>
+    private static readonly string[] NotSearched = ["bin", "obj", "TestResults", ".vs"];
+
+    [Test]
+    public void NoTestFixtureClearsEveryConnectionPoolInTheProcess()
+    {
+        DirectoryInfo root = RepositoryRoot.Find();
+        DirectoryInfo source = new(Path.Combine(root.FullName, "src"));
+
+        List<DirectoryInfo> projects = source.EnumerateDirectories(TestProjectPrefix + "*").ToList();
+
+        projects.Should().NotBeEmpty(
+            "this test walks the test projects by name, so a rename that leaves nothing to walk has to fail "
+            + "here rather than pass by finding nothing");
+
+        List<string> offenders = projects
+            .SelectMany(Discover)
+            .Where(x => !string.Equals(x.Name, ThisFile, StringComparison.Ordinal))
+            .Where(x => File.ReadAllText(x.FullName).Contains(GlobalPoolClear, StringComparison.Ordinal))
+            .Select(x => Path.GetRelativePath(root.FullName, x.FullName).Replace('\\', '/'))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            $"{GlobalPoolClear}) is process-global and the fixtures run in parallel, so it disposes "
+            + "connections other fixtures are still using. A fixture that owns a SQLite file takes a "
+            + "SqliteTestDatabase instead: it names a temporary path of its own, connects with Pooling=False "
+            + "so there is no pool to clear, and deletes the file when it is disposed. These files still "
+            + "call it:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders.Select(x => "    " + x))
+            + Environment.NewLine
+            + "See https://github.com/quartznet/quartznet/issues/3755. A fixture that genuinely needs a pool "
+            + "clears its own with SqliteConnection.ClearPool(connection) and says here why it is exempt");
+    }
+
+    /// <summary>
+    /// This file, which spells the call it is banning and would otherwise report itself.
+    /// </summary>
+    private static string ThisFile => nameof(SqlitePoolClearingTest) + ".cs";
+
+    private static IEnumerable<FileInfo> Discover(DirectoryInfo directory)
+    {
+        foreach (FileInfo file in directory.EnumerateFiles("*.cs"))
+        {
+            yield return file;
+        }
+
+        foreach (DirectoryInfo child in directory.EnumerateDirectories())
+        {
+            if (NotSearched.Contains(child.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (FileInfo file in Discover(child))
+            {
+                yield return file;
+            }
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/SqliteTestDatabase.cs
+++ b/src/Quartz.Tests.Unit/SqliteTestDatabase.cs
@@ -1,0 +1,115 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+
+namespace Quartz;
+
+/// <summary>
+/// A SQLite file database a fixture owns outright: a path of its own under the temporary directory, a
+/// connection string that does not pool, and the file deleted again when the fixture is done with it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pooling being off is the whole of why this type exists. Every fixture that owned a SQLite file used
+/// to end its teardown with <c>SqliteConnection.ClearAllPools</c>, and that call is process-global:
+/// <c>Quartz.Tests.Unit</c> declares <c>[assembly: Parallelizable(ParallelScope.Fixtures)]</c>, so one
+/// fixture's teardown ran it while other fixtures were in the middle of their tests. Microsoft.Data.Sqlite
+/// hands out the underlying handle from its pool rather than a copy, so clearing the pool disposes a
+/// connection somebody else is still using — <c>ObjectDisposedException: SQLitePCL.sqlite3</c> raised
+/// from inside a setup that was doing nothing wrong, seen twice during the 4.1 campaign and never twice
+/// in a row (#3755).
+/// </para>
+/// <para>
+/// An unpooled connection closes its handle when it is disposed, so there is no pool to clear and the
+/// file is deletable as soon as the last connection has gone. <c>SqlitePoolClearingTest</c> is what
+/// keeps the global call from coming back.
+/// </para>
+/// <para>
+/// Compiled into <c>Quartz.Tests.AspNetCore</c> and <c>Quartz.Tests.Integration</c> as well, because
+/// the fixtures that needed this are spread across all three projects and one of them running the
+/// global call would be enough.
+/// </para>
+/// </remarks>
+internal sealed class SqliteTestDatabase : IDisposable
+{
+    /// <summary>
+    /// How many times the file is asked to go away before the fixture gives up on it.
+    /// </summary>
+    /// <remarks>
+    /// On Windows a handle closed a microsecond ago can still fail the delete, so a single attempt
+    /// leaves stray files behind. Twenty of them at fifty milliseconds is a second of patience, which
+    /// is far more than the wait has ever needed.
+    /// </remarks>
+    private const int DeleteAttempts = 20;
+
+    private static readonly TimeSpan deleteRetryDelay = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>
+    /// Names a database no other fixture and no other run can be holding.
+    /// </summary>
+    /// <param name="name">
+    /// What the fixture is about, so that a file left behind by a killed run says where it came from.
+    /// </param>
+    public SqliteTestDatabase(string name)
+    {
+        DatabaseFile = Path.Combine(Path.GetTempPath(), $"quartz-{name}-{Guid.NewGuid():N}.db");
+        ConnectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = DatabaseFile,
+            Pooling = false,
+        }.ToString();
+    }
+
+    /// <summary>
+    /// Where the database is. SQLite creates it on the first connection, so nothing has to exist yet.
+    /// </summary>
+    public string DatabaseFile { get; }
+
+    /// <summary>
+    /// What to hand <c>UseSqlite</c>, a <c>DbProvider</c>, or a connection opened by the test itself.
+    /// </summary>
+    public string ConnectionString { get; }
+
+    /// <summary>
+    /// Deletes the file, giving the last connection a moment to let go of it.
+    /// </summary>
+    /// <remarks>
+    /// A file that will not go away is scratch space in the temporary directory rather than a failure,
+    /// so this gives up quietly rather than failing a test that has already said what it had to say.
+    /// </remarks>
+    public void Dispose()
+    {
+        for (int attempt = 0; attempt < DeleteAttempts && File.Exists(DatabaseFile); attempt++)
+        {
+            try
+            {
+                File.Delete(DatabaseFile);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                Thread.Sleep(deleteRetryDelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3755.

Thirty-six teardowns across `Quartz.Tests.Unit`, `Quartz.Tests.AspNetCore` and `Quartz.Tests.Integration` ended with `SqliteConnection.ClearAllPools()`. The call is process-global, `Quartz.Tests.Unit` declares `[assembly: Parallelizable(ParallelScope.Fixtures)]`, and Microsoft.Data.Sqlite hands out the underlying handle from its pool rather than a copy — so one fixture cleaning up disposed a connection another fixture was still using. The symptom was `ObjectDisposedException: SQLitePCL.sqlite3` from inside `CreateSchema`, in a different fixture each time and never twice in a row.

## What changed

**`src/Quartz.Tests.Unit/SqliteTestDatabase.cs`** — a SQLite file a fixture owns outright: a unique path under the temporary directory, a connection string built with `Pooling=False` so there is no pool to clear, and the file deleted on dispose with a bounded retry (on Windows a handle closed a microsecond ago can still fail the delete). It is compiled into all three test projects through the same `<Compile Include="..\Quartz.Tests.Unit\…">` mechanism `TestConstants.cs` and `PublicApiRendering.cs` already use, because one project still making the global call would be enough to keep the failure.

Every fixture that wrote its own temporary path plus a `ClearAllPools()` teardown now takes one instead — 23 in `Quartz.Tests.Unit`, `SqliteStores` in `Quartz.Tests.AspNetCore` (which backs three fixtures), and 12 in `Quartz.Tests.Integration` — and the per-fixture delete-with-a-retry blocks go with them. `UnwaitedShutdownSqliteTest` (#3754), which already did this by hand, moves onto the shared type so the explanation lives in one place.

**`src/Quartz.Tests.Unit/SqlitePoolClearingTest.cs`** — two guards. The first greps every `.cs` file under `src/Quartz.Tests.*` for the global call, in the style of `SourceEncodingTest`, because the failure it prevents is a different fixture each time and nothing else was ever going to notice a teardown that reached for it again; its message names the helper and the issue. The second holds `SqliteTestDatabase` to the two things that rule rests on — pooling really off (read back through `SqliteConnectionStringBuilder`, so a keyword the builder decided was a default and dropped would fail here rather than silently restore the race) and the file really gone after dispose.

## Anything a reviewer must decide

- **No fixture kept pooling.** Nothing in the suite asserts anything about connection reuse or pool behaviour, and the one `DbDataSource` in it (`TypeFreeDbProviderTest.SqliteDataSource`) constructs a fresh `SqliteConnection` per call, so it does not depend on a pool either. There is no allow-list.
- **`Quartz.Trimming.Canary` still calls `ClearAllPools()`, deliberately out of scope.** It is a single-purpose executable that owns its process and its one database, which is the only arrangement in which the global call means what it says. The convention test only walks `src/Quartz.Tests.*`, and says so.
- **Several fixtures move from a relative path in the test working directory to a temporary file** (`MisfireThroughAStoreTestBase`, `SchedulerAcrossDstTransitionTest`, `MisfireAcrossDstTransitionTest` and the like). `AdoJobStorePagingTest` also stops leaving `test-paging-sqlite-ms.db` behind: it deleted the file on the way in and never on the way out.
- `SqliteTestDatabase.DatabaseFile` has no fixture consumer today — the fixtures all use `ConnectionString`. It is on the type because a fixture that wants to look at the file needs it, and because the guard test asserts on it; say the word and it goes.

## Verification

Test-only; no product code, no public API movement, no docs.

| Run | Result |
|---|---|
| `dotnet build Quartz.slnx` | Build succeeded, 0 Warning(s), 0 Error(s) |
| `build.cmd Compile UnitTest` ×4 | `Quartz.Tests.Unit` 6248 passed / 36 skipped, `Quartz.Tests.AspNetCore` 671 passed — every time |
| `build.cmd Compile IntegrationTest --database sqlite` | 15 passed |
| `build.cmd Compile IntegrationTest --database basic` | 367 passed — the SQLite integration fixtures that carry no `db-*` category, which is most of the ones this touches |

Cost of turning pooling off, on this machine: `Quartz.Tests.Unit` goes from 1 m 8 s (twice, on `b7aa29a9b6`) to 1 m 11–13 s (four times, here) — about 4 seconds on a 68-second suite, ~5 %. The integration legs needed a Docker daemon and had one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
