### PR TITLE
The documentation toolchain takes the smol-toml, js-yaml, svgo and fflate security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5312,9 +5312,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -6423,9 +6423,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -9984,9 +9984,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -10398,9 +10398,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -10650,18 +10650,18 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
-      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.1.0.tgz",
+      "integrity": "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
-        "css-select": "^5.1.0",
+        "css-select": "^6.0.0",
         "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
+        "css-what": "^7.0.0",
         "csso": "^5.0.5",
         "picocolors": "^1.1.1",
-        "sax": "^1.5.0"
+        "sax": "1.6.1"
       },
       "bin": {
         "svgo": "bin/svgo.js"
@@ -10681,6 +10681,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/svgo/node_modules/css-select": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+      "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^7.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "nth-check": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/svgo/node_modules/css-what": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+      "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/sync-child-process": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "picomatch@^2": "^2.3.2",
     "picomatch@^4": "^4.0.4",
     "lodash": "^4.18.0",
-    "smol-toml": "^1.6.1",
+    "smol-toml": "^1.7.1",
     "shell-quote": "^1.9.0",
     "esbuild": "^0.28.1",
     "qs": "^6.16.0",
@@ -65,7 +65,7 @@
     "markdown-it": "^14.2.0",
     "undici": "^7.29.0",
     "http-proxy-middleware": "^3.0.6",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "websocket-driver": "^0.7.5",
     "body-parser": "^1.20.6",
     "browserslist": "^4.28.7",
@@ -73,8 +73,9 @@
     "postcss-selector-parser": "^7.1.3",
     "fast-uri": "^3.1.6",
     "nanoid@^3": "^3.3.17",
-    "svgo": "^4.0.2",
+    "svgo": "^4.1.0",
     "linkify-it": "^5.0.2",
-    "immutable": "^5.1.8"
+    "immutable": "^5.1.8",
+    "fflate": "^0.8.3"
   }
 }


### PR DESCRIPTION
Five Dependabot alerts opened against the root `package-lock.json`, which is the VuePress
documentation site's build tooling. Nothing this repository ships is involved — there is no
`docs/package.json`, the root manifest is the only npm manifest in the tree, and no npm package here
is published.

| alert | severity | package | vulnerable | pinned to | how |
|---|---|---|---|---|---|
| [#288](https://github.com/quartznet/quartznet/security/dependabot/288) | high | smol-toml | `<= 1.7.0` ([GHSA-7w5x-hrqm-74c2](https://github.com/advisories/GHSA-7w5x-hrqm-74c2)) | 1.8.0 | `overrides` raised `^1.6.1` → `^1.7.1` |
| [#287](https://github.com/quartznet/quartznet/security/dependabot/287) | high | js-yaml | `>= 4.0.0, < 4.3.2` ([GHSA-2883-xcg3-v3hh](https://github.com/advisories/GHSA-2883-xcg3-v3hh)) | 4.3.2 | `overrides` raised `^4.3.1` → `^4.3.2` |
| [#286](https://github.com/quartznet/quartznet/security/dependabot/286) | high | svgo | `>= 4.0.0, < 4.1.0` ([GHSA-w27v-7q3p-w38r](https://github.com/advisories/GHSA-w27v-7q3p-w38r)) | 4.1.0 | `overrides` raised `^4.0.2` → `^4.1.0` |
| [#285](https://github.com/quartznet/quartznet/security/dependabot/285) | medium | svgo | `>= 4.0.0, < 4.1.0` ([GHSA-4vpr-x523-8j87](https://github.com/advisories/GHSA-4vpr-x523-8j87)) | 4.1.0 | same override as #286 |
| [#284](https://github.com/quartznet/quartznet/security/dependabot/284) | medium | fflate | `>= 0.8.0, < 0.8.3` ([GHSA-px8p-9vwx-vf98](https://github.com/advisories/GHSA-px8p-9vwx-vf98)) | 0.8.3 | new `overrides` entry `^0.8.3` |

## Why an override in every case, and not a dependency bump

`npm ls` says where each vulnerable copy comes from, and none of them is reachable by bumping
something this manifest declares:

- **smol-toml** comes only from `markdownlint-cli2@0.22.0`, which pins it **exactly** at `1.6.0`. No
  release of markdownlint-cli2 can be selected that lifts it — the pin has to be overridden. (npm's
  own `audit fix --force` proposal to move to `markdownlint-cli2@0.23.2` is about js-yaml, not this.)
- **js-yaml** arrives by three separate paths — `markdownlint-cli2` (exact `4.1.1`),
  `@vuepress/bundler-webpack` → `postcss-loader` → `cosmiconfig`, and
  `@vuepress/plugin-back-to-top` → `@vuepress/helper` → `gray-matter`. Only an override reaches all
  three; a markdownlint-cli2 bump would leave the two VuePress paths vulnerable and drag a new lint
  rule set in as a side effect.
- **svgo** comes from `@vuepress/bundler-webpack` → `css-minimizer-webpack-plugin` → `cssnano` →
  `postcss-svgo`, four levels below anything declared here.
- **fflate** comes from `@vuepress/plugin-back-to-top` → `@vuepress/helper`.

So the change is four lines in `overrides` — three raised floors and one new entry — and the lock
regenerated with `npm install --package-lock-only`, proved consistent with `npm ci`.

## What the lock diff contains beyond the four

`svgo@4.1.0` moved to `css-select@^6` / `css-what@^7` and pins `sax` at `1.6.1`, so npm nested those
two under `node_modules/svgo` and lifted the top-level `sax` to 1.6.1. That, plus the four version
lines, is the entire 64-line lock diff. `smol-toml` resolved to `1.8.0` — the highest release
satisfying the `^1.7.1` floor.

## The existing overrides

Both from #3704, both kept:

- **`qs: ^6.16.0` is load-bearing.** `express@4.22.1` asks for `~6.14.0` and `body-parser@1.20.6` for
  `~6.15.1`; without the override, resolution lands back inside the vulnerable range.
- **`fast-uri: ^3.1.6` is currently redundant.** `ajv@8.18.0` asks for `^3.0.1` and resolution reaches
  `3.1.7` unaided. It is left in place as a floor rather than removed, since removing it is unrelated
  churn and re-establishing the argument costs more than the line does.

## Verification

`npm audit` before, on `main`:

```
4 vulnerabilities (1 moderate, 3 high)
```

— fflate, js-yaml and svgo, the two svgo advisories reported under one finding. It did **not** report
smol-toml: GHSA-7w5x-hrqm-74c2 is not yet in the registry's audit endpoint, so alert #288 is fixed on
Dependabot's word rather than npm's, and `npm audit` alone would not have shown it either way.

`npm audit` after:

```
found 0 vulnerabilities
{"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}
```

Nothing is left at moderate or above, and nothing is left below it either.

| step | result |
|---|---|
| `npm ci` (regenerated lock) | 881 packages, patch applied, `found 0 vulnerabilities` |
| `npm run docs:build` | `VuePress build completed in 22.16s`, 225 pages |
| `npm run docs:check-links` | `224 pages, 1450 internal links, 899 fragments — no dead links or anchors` |
| `npm run docs:check-links-test` | 7 passed, 0 failed |
| `npm run docs:lint` | 92 files, `Summary: 0 error(s)` — markdownlint-cli2 0.22.0 runs unchanged against smol-toml 1.8.0 and js-yaml 4.3.2 |
| `dotnet fallout VerifyDocsSnippets` | `Documentation snippets are up to date (115 markdown files checked)` |

Nothing under `src/` or `docs/` changes; `package.json` and `package-lock.json` keep their CRLF
endings.

### One thing a reviewer should know

svgo is only reachable through the **webpack** bundler, which is not the one CI or the deploy uses —
`docs/.vuepress/config.ts` selects it only when `DOCS_BUNDLER=webpack`. That build was already broken
before this change and still is, for an unrelated reason: `@vuepress/bundler-webpack` resolves
`sass-loader`, which has never been in this lock file (`git show origin/main:package-lock.json | grep
-c node_modules/sass-loader` → `0`). It fails at module resolution, well before any CSS minification,
so svgo 4.1.0 is neither the cause nor excused by it. Left alone: fixing the webpack bundler is not
this pull request's job, and `docs:build-webpack` invokes `pnpm` in a repository that installs with
npm, so it has more than one thing wrong with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XXTwomkp4QLt6vbamKxEK
