### PR TITLE
Replacing a trigger keeps the fired-trigger rows recovery reads

### DIFF
--- a/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
+++ b/docs/documentation/quartz-4.x/how-tos/rescheduling-jobs.md
@@ -57,6 +57,14 @@ Because the trigger is replaced, everything derived from the old one is recomput
 starts empty, a `SimpleTrigger`'s repeat count starts over, and a paused trigger comes back in whatever
 state the new trigger's group implies. Use it when the *schedule* changed.
 
+What is *not* touched is any execution already under way. A firing of the old trigger keeps running and
+completes as itself, and in a persistent store its fired-trigger record stays until it does — so a job
+that requested recovery is still recovered if the node dies mid-execution, even when the trigger was
+rescheduled in between. That matters more than it sounds: the jobs and triggers you declare with
+`AddJob` and `AddTrigger` are re-applied as a reschedule every time the process starts, before the
+scheduler starts and recovery runs. Unscheduling a trigger is the other case: it takes the records of its
+executions with it, and nothing is recovered for a trigger you removed on purpose.
+
 ## Changing metadata in place: UpdateTriggerDetails
 
 `UpdateTriggerDetails` patches a stored trigger without rescheduling it. Fire times and trigger state

--- a/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
+++ b/docs/documentation/quartz-4.x/tutorial/more-about-jobs.md
@@ -360,7 +360,9 @@ Here's a quick summary of the other properties which can be defined for a job in
 In other words, non-durable jobs have a life span bounded by the existence of its triggers.
 - `RequestsRecovery` - if a job "requests recovery", and it is executing during the time of a 'hard shutdown' of the scheduler
 (i.e. the process it is running within crashes, or the machine is shut off), then it is re-executed when the scheduler is started again.
-In this case, the `JobExecutionContext.Recovering` property will return true.
+In this case, the `JobExecutionContext.Recovering` property will return true. The interrupted execution is remembered by the
+job store until the scheduler starts and recovers it, and rescheduling its trigger in the meantime — which is what re-applying
+your `AddJob`/`AddTrigger` registrations on startup does — does not forget it. Unscheduling the trigger does.
 
 ## A JobDetail of your own
 

--- a/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
+++ b/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
@@ -239,6 +239,106 @@ public class RecoverJobsTest
             "Job should NOT execute with recovery=true after trigger was explicitly removed");
     }
 
+    /// <summary>
+    /// Builds a clustered scheduler sharing one database under a fixed instance id, so a restart under
+    /// the same id recovers its own previous run on its first check-in — the reporter's configuration.
+    /// </summary>
+    private ValueTask<IScheduler> CreateClusteredRecoveryScheduler(string dataSourceName)
+    {
+        return SchedulerHelper.CreateScheduler(
+            provider,
+            options =>
+            {
+                options.InstanceName = dataSourceName;
+                options.InstanceId = "CLUSTERED_NODE_TEST";
+            },
+            store => store.MisfireThreshold = TimeSpan.FromSeconds(1),
+            builder => builder.UseClustering());
+    }
+
+    /// <summary>
+    /// A trigger rescheduled before the restarted node starts — which is what re-applying an
+    /// application's <c>AddTrigger</c> registrations on startup does — keeps the record of the execution
+    /// the kill interrupted, so the job that asked to be recovered is (#3759). The clustered counterpart
+    /// of <c>RecoveryAfterStartupRescheduleSqliteTest</c>, on the reporter's database.
+    /// </summary>
+    [Test]
+    public async Task TestRecoveryStillHappensAfterTriggerIsRescheduledBeforeStart()
+    {
+        var dataSourceName = DatabaseHelper.GetDataSourceName(provider);
+        var scheduler = await CreateClusteredRecoveryScheduler(dataSourceName);
+
+        RecoverJobsTestJob.runForever = true;
+
+        await scheduler.Clear();
+
+        var job = JobBuilder.Create<RecoverJobsTestJob>()
+            .WithIdentity("test-recovery", "test-group")
+            .RequestRecovery()
+            .Build();
+
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("test-trigger", "test-group")
+            .ForJob(job)
+            .StartNow()
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+
+        await scheduler.ScheduleJob(job, trigger);
+        await scheduler.Start();
+
+        // Wait for job to start executing
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        // Simulate scheduler crash (shutdown without waiting for jobs to complete)
+        await scheduler.Shutdown(false);
+
+        (await CountFiredTriggers(scheduler.SchedulerName, "test-trigger")).Should().Be(1,
+            "the premise: the kill interrupted a firing the store knows about");
+
+        // The restarted node re-applies its declared trigger before it starts.
+        var newScheduler = await CreateClusteredRecoveryScheduler(dataSourceName);
+        var declaredAgain = TriggerBuilder.Create()
+            .WithIdentity("test-trigger", "test-group")
+            .ForJob(job)
+            .StartNow()
+            .WithSimpleSchedule(x => x.WithInterval(TimeSpan.FromHours(1)).RepeatForever())
+            .Build();
+        (await newScheduler.RescheduleJob(declaredAgain.Key, declaredAgain)).Should().NotBeNull("the trigger was there to replace");
+
+        (await CountFiredTriggers(newScheduler.SchedulerName, "test-trigger")).Should().Be(1,
+            "a reschedule is not a removal: the interrupted execution's record stays for recovery to read");
+
+        RecoverJobsTestJob.runForever = false;
+
+        var recoveryExecuted = new ManualResetEventSlim(false);
+        newScheduler.ListenerManager.AddJobListener(new RecoveryDetectionListener(recoveryExecuted));
+
+        await newScheduler.Start();
+
+        recoveryExecuted.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue(
+            "the job asked to be recovered and its execution was interrupted; rescheduling its trigger changes neither");
+
+        await newScheduler.Shutdown(true);
+    }
+
+    private async Task<int> CountFiredTriggers(string schedulerName, string triggerName)
+    {
+        using var connection = DatabaseHelper.CreateConnection(provider);
+        await connection.OpenAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT count(*) from QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = @schedulerName AND TRIGGER_NAME = @triggerName";
+        var schedulerNameParameter = command.CreateParameter();
+        schedulerNameParameter.ParameterName = "@schedulerName";
+        schedulerNameParameter.Value = schedulerName;
+        command.Parameters.Add(schedulerNameParameter);
+        var triggerNameParameter = command.CreateParameter();
+        triggerNameParameter.ParameterName = "@triggerName";
+        triggerNameParameter.Value = triggerName;
+        command.Parameters.Add(triggerNameParameter);
+        return Convert.ToInt32(await command.ExecuteScalarAsync());
+    }
+
     private sealed class RecoveryDetectionListener : IJobListener
     {
         private readonly ManualResetEventSlim recoveryExecuted;

--- a/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
+++ b/src/Quartz.Tests.Integration/TestHelpers/SchedulerHelper.cs
@@ -24,10 +24,15 @@ public class SchedulerHelper
     /// <summary>
     /// Builds a database-backed scheduler with explicit scheduler options.
     /// </summary>
+    /// <param name="configureBuilder">
+    /// What the store's options cannot say: clustering, locking, a serializer of the test's own. Runs
+    /// after the database and the default serializer are chosen, so it can override either.
+    /// </param>
     public static ValueTask<IScheduler> CreateScheduler(
         string provider,
         Action<QuartzSchedulerOptions> configureScheduler,
-        Action<AdoJobStoreOptions>? configureStore = null)
+        Action<AdoJobStoreOptions>? configureStore = null,
+        Action<IPersistentStoreBuilder>? configureBuilder = null)
     {
         return QuartzSchedulerBuilder
             .Create(q => q
@@ -42,6 +47,7 @@ public class SchedulerHelper
                         options.TablePrefix = TablePrefix;
                         configureStore?.Invoke(options);
                     });
+                    configureBuilder?.Invoke(store);
                 }))
             .BuildScheduler();
     }

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/AdoJobStoreBaseTest.cs
@@ -205,6 +205,85 @@ public class AdoJobStoreBaseTest
             A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
     }
 
+    /// <summary>
+    /// Removing a trigger takes the fired-trigger rows of its executions with it: an execution whose
+    /// trigger was deliberately unscheduled is not one to recover (#744).
+    /// </summary>
+    [Test]
+    public async Task DeleteTrigger_DeletesTheFiredTriggerRowsOfItsExecutions()
+    {
+        var triggerKey = new TriggerKey("t1", "g1");
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).Returns(new ValueTask<int>(1));
+
+        (await jobStoreSupport.CallDeleteTrigger(conn, triggerKey)).Should().BeTrue();
+
+        A.CallTo(() => driverDelegate.DeleteFiredTriggers(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<FiredTriggerQuery>.That.Matches(x => x.Trigger == triggerKey && x.Job == null && x.InstanceId == null),
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+    }
+
+    /// <summary>
+    /// Replacing a trigger leaves the fired-trigger rows of its executions alone. A replaced trigger keeps
+    /// its identity and its job, so an execution the row records is still one to finish or to recover —
+    /// and re-applying an application's <c>AddTrigger</c> registrations on start replaces every trigger it
+    /// declares, before recovery has read a row of the run the kill interrupted (#3759).
+    /// </summary>
+    [Test]
+    public async Task ReplaceTrigger_KeepsTheFiredTriggerRowsOfItsExecutions()
+    {
+        var triggerKey = new TriggerKey("t1", "g1");
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IJobDetail job = CreateConcurrentJob();
+
+        A.CallTo(() => driverDelegate.SelectJobForTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<ITypeLoader>.Ignored,
+            false,
+            A<CancellationToken>.Ignored)).Returns(new ValueTask<IJobDetail>(job));
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).Returns(new ValueTask<int>(1));
+
+        (await jobStoreSupport.CallReplaceTrigger(conn, triggerKey, CreateTestTrigger())).Should().BeTrue();
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => driverDelegate.InsertTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<IOperableTrigger>.That.Matches(t => t.Key.Equals(triggerKey)),
+            StoredTriggerState.Waiting,
+            job,
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+
+        // A replacement is not a removal: the rows record executions of the job, which is still there.
+        A.CallTo(() => driverDelegate.DeleteFiredTriggers(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<FiredTriggerQuery>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+
+        A.CallTo(() => driverDelegate.DeleteFiredTriggers(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<IReadOnlyCollection<string>>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+
+        A.CallTo(() => driverDelegate.DeleteFiredTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<string>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+    }
+
     [Test]
     public async Task TestExecuteInLocalTransactionLock_RetriesOnTransientException()
     {
@@ -1127,6 +1206,16 @@ public class AdoJobStoreBaseTest
         internal ValueTask<bool> CallRemoveJob(ConnectionAndTransactionHolder conn, JobKey jobKey)
         {
             return DeleteJob(conn, jobKey, true, CancellationToken.None);
+        }
+
+        internal ValueTask<bool> CallDeleteTrigger(ConnectionAndTransactionHolder conn, TriggerKey triggerKey)
+        {
+            return DeleteTrigger(conn, triggerKey, CancellationToken.None);
+        }
+
+        internal ValueTask<bool> CallReplaceTrigger(ConnectionAndTransactionHolder conn, TriggerKey triggerKey, IOperableTrigger newTrigger)
+        {
+            return ReplaceTrigger(conn, triggerKey, newTrigger, CancellationToken.None);
         }
 
         internal ValueTask<TriggerFiredBundle> CallTriggerFired(ConnectionAndTransactionHolder conn, IOperableTrigger trigger)
@@ -3461,6 +3550,51 @@ public class AdoJobStoreBaseTest
                 A<string>.Ignored,
                 A<CancellationToken>.Ignored))
             .MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The one record the grace period never applies to is this node's own, which its first check-in
+    /// hands to recovery. However recent the previous run's last check-in, that run ended with the
+    /// process, and the check-in that follows writes a fresh timestamp over the only thing a later scan
+    /// could judge a deferral by — so a deferral here would never be resolved: the row would sit there
+    /// and the job's triggers would stay BLOCKED behind it (#3759).
+    /// </summary>
+    [Test]
+    public async Task ClusterRecover_ShouldNeverDeferRecoveryOfItsOwnPreviousRun()
+    {
+        ConnectionAndTransactionHolder conn = FakeConnection();
+        GivenStoppedClock(ClusterNow);
+
+        // A second ago: a peer would have granted this row the whole grace period.
+        SchedulerStateRecord own = new(OwnInstanceId, ClusterNow - TimeSpan.FromSeconds(1), CheckinInterval);
+
+        JobKey serial = new("serial", "jg");
+        GivenFiredTriggersForInstance(OwnInstanceId,
+            FiredTrigger("fi-executing", StoredTriggerState.Executing, new TriggerKey("t-executing", "tg"), serial, disallowsConcurrentExecution: true, instanceId: OwnInstanceId));
+
+        await jobStoreSupport.CallClusterRecover(conn, [own]);
+
+        A.CallTo(() => driverDelegate.DeleteFiredTriggers(
+                conn,
+                A<FiredTriggerQuery>.That.Matches(query => query.InstanceId == OwnInstanceId),
+                A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+
+        // Nothing is preserved, so nothing is deleted row by row.
+        A.CallTo(() => driverDelegate.DeleteFiredTriggers(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<IReadOnlyCollection<string>>.Ignored,
+                A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+
+        // The triggers the execution was holding are let go.
+        A.CallTo(() => driverDelegate.UpdateTriggerStatesForJobsFromOtherState(
+                conn,
+                A<IReadOnlyCollection<JobKey>>.That.Matches(jobKeys => jobKeys.Contains(serial)),
+                StoredTriggerState.Waiting,
+                StoredTriggerState.Blocked,
+                A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Test]

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/RecoveryAfterStartupRescheduleSqliteTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/RecoveryAfterStartupRescheduleSqliteTest.cs
@@ -1,0 +1,254 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+#nullable enable
+
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+
+using Quartz.Extensibility;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// A job that asked to be recovered is recovered after a hard kill even though the process that comes
+/// back re-applies its <c>AddJob</c>/<c>AddTrigger</c> registrations before it starts (#3759).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The registrations are applied when the scheduler is created, and a trigger the store already holds is
+/// applied as a reschedule. A reschedule replaces the trigger, and until #3759 the replacement took the
+/// trigger's fired-trigger rows with it — the very row recovery reads once the scheduler starts. Every
+/// restart of an application that declares its triggers therefore erased the evidence of the execution
+/// the kill had interrupted, and recovery found nothing to do.
+/// </para>
+/// <para>
+/// SQLite refuses to be clustered, so this is the non-clustered recovery sweep; the clustered one reads
+/// the same rows after the same reschedule, and is <c>RecoverJobsTest</c> in the integration suite. The
+/// kill is emulated through the store rather than a parked thread: the trigger is acquired and fired and
+/// its completion never arrives, which leaves exactly the row a dead process leaves.
+/// </para>
+/// </remarks>
+[NonParallelizable]
+public sealed class RecoveryAfterStartupRescheduleSqliteTest
+{
+    private static readonly JobKey jobKey = new("interrupted", "recovery");
+    private static readonly TriggerKey triggerKey = new("t-interrupted", "recovery");
+
+    private SqliteTestDatabase database = null!;
+
+    [SetUp]
+    public void CreateEmptyDatabase()
+    {
+        database = new SqliteTestDatabase("recovery-after-reschedule");
+        Recordings.Reset();
+    }
+
+    [TearDown]
+    public void DeleteDatabase()
+    {
+        database.Dispose();
+    }
+
+    [Test]
+    public async Task TheStartupRescheduleKeepsTheInterruptedExecutionAndRecoveryRerunsIt()
+    {
+        await LeaveAnInterruptedExecutionBehind<RecordingJob>();
+
+        await using ServiceProvider restarted = BuildContainer<RecordingJob>();
+        IScheduler scheduler = await restarted.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        (await FiredTriggerStates()).Should().Equal(["EXECUTING"],
+            "creating the scheduler re-applies the declared trigger as a reschedule, and a reschedule "
+            + "has to leave the interrupted execution's row where recovery will look for it");
+
+        await scheduler.Start();
+
+        Recording recovered = await Recordings.Recovered.WaitAsync(TimeSpan.FromSeconds(30));
+        recovered.JobKey.Should().Be(jobKey);
+        recovered.RecoveringTriggerKey.Should().Be(triggerKey,
+            "the recovery run names the trigger whose firing it stands in for");
+
+        await scheduler.Shutdown(waitForJobsToComplete: true);
+    }
+
+    /// <summary>
+    /// The row that is kept is a row the store reads: a replacement trigger of a job that disallows
+    /// concurrent execution is stored behind the interrupted execution, as any trigger of the job would
+    /// be while it runs, and the recovery sweep is what lets it go.
+    /// </summary>
+    [Test]
+    public async Task TheReplacedTriggerOfASerialJobWaitsBehindTheInterruptedExecutionUntilRecovery()
+    {
+        await LeaveAnInterruptedExecutionBehind<SerialRecordingJob>();
+
+        await using ServiceProvider restarted = BuildContainer<SerialRecordingJob>();
+        IScheduler scheduler = await restarted.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        (await ReadColumn("SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE TRIGGER_NAME = 't-interrupted'"))
+            .Should().Equal(["BLOCKED"], "the execution the kept row records is, as far as the store can tell, still running the job");
+        (await scheduler.GetTriggerState(triggerKey)).Should().Be(TriggerState.Executing,
+            "the kept row is the trigger's own execution, and that is what the scheduler reports it as");
+
+        await scheduler.Start();
+
+        Recording recovered = await Recordings.Recovered.WaitAsync(TimeSpan.FromSeconds(30));
+        recovered.JobKey.Should().Be(jobKey);
+
+        await scheduler.Shutdown(waitForJobsToComplete: true);
+
+        (await FiredTriggerStates()).Should().BeEmpty("every execution has been accounted for by now");
+        (await ReadColumn("SELECT TRIGGER_STATE FROM QRTZ_TRIGGERS WHERE TRIGGER_NAME = 't-interrupted'"))
+            .Should().Equal(["WAITING"], "the recovery sweep releases what the dead execution was holding");
+    }
+
+    /// <summary>
+    /// What a process that is killed mid-execution leaves in the database: the declared job and trigger,
+    /// and one fired-trigger row saying the trigger is executing on this instance and asks to be recovered.
+    /// </summary>
+    private async Task LeaveAnInterruptedExecutionBehind<TJob>() where TJob : class, IJob
+    {
+        await using ServiceProvider killed = BuildContainer<TJob>();
+
+        // Created and never started: creating it stores the declared job and trigger.
+        await killed.GetRequiredService<ISchedulerFactory>().GetScheduler();
+
+        IJobStore store = killed.GetRequiredService<IJobStore>();
+        List<IOperableTrigger> acquired = await store.AcquireNextTriggers(new TriggerAcquisitionRequest
+        {
+            NoLaterThan = TimeProvider.System.GetUtcNow().AddMinutes(1),
+            MaxCount = 1,
+            TimeWindow = TimeSpan.Zero,
+        });
+        acquired.Should().ContainSingle().Which.Key.Should().Be(triggerKey);
+
+        List<TriggerFiredResult> fired = await store.TriggersFired(acquired);
+        fired.Should().ContainSingle();
+
+        // No TriggeredJobComplete: this is where the process dies.
+        (await FiredTriggerStates()).Should().Equal(["EXECUTING"], "the premise: the kill interrupted a firing the store knows about");
+        (await ReadColumn("SELECT STATE FROM QRTZ_FIRED_TRIGGERS WHERE REQUESTS_RECOVERY = 1")).Should().Equal(["EXECUTING"],
+            "the premise: the job asked to be recovered, and the row says so");
+    }
+
+    private ServiceProvider BuildContainer<TJob>() where TJob : class, IJob
+    {
+        ServiceCollection services = new();
+        services.AddQuartz(q =>
+        {
+            q.ConfigureScheduler(options =>
+            {
+                options.InstanceName = "recovery-after-reschedule";
+                options.InstanceId = "one";
+            });
+
+            q.UsePersistentStore(store =>
+            {
+                store.UseSqlite(SqliteFactory.Instance, database.ConnectionString);
+                store.ProvisionSchema();
+            });
+
+            q.AddJob<TJob>(job => job.WithIdentity(jobKey).RequestRecovery());
+
+            // Repeating, so that the trigger row is still there to be read once its firings are done.
+            q.AddTrigger(trigger => trigger
+                .WithIdentity(triggerKey)
+                .ForJob(jobKey)
+                .StartNow()
+                .WithSimpleSchedule(schedule => schedule.WithInterval(TimeSpan.FromHours(1)).RepeatForever()));
+        });
+
+        return services.BuildServiceProvider();
+    }
+
+    private Task<List<string>> FiredTriggerStates()
+    {
+        return ReadColumn("SELECT STATE FROM QRTZ_FIRED_TRIGGERS");
+    }
+
+    private async Task<List<string>> ReadColumn(string sql)
+    {
+        await using SqliteConnection connection = new(database.ConnectionString);
+        await connection.OpenAsync();
+
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = sql;
+
+        List<string> values = [];
+        await using SqliteDataReader reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            values.Add(reader.GetString(0));
+        }
+
+        return values;
+    }
+
+    private sealed record Recording(JobKey JobKey, TriggerKey? RecoveringTriggerKey);
+
+    /// <summary>
+    /// The recovery run, once it happens. The replacement trigger fires on its own account as well, and
+    /// that run is not the one this test is about.
+    /// </summary>
+    private static class Recordings
+    {
+        private static TaskCompletionSource<Recording> recovered = NewSource();
+
+        public static Task<Recording> Recovered => recovered.Task;
+
+        public static void Reset()
+        {
+            recovered = NewSource();
+        }
+
+        public static void Record(IJobExecutionContext context)
+        {
+            if (context.Recovering)
+            {
+                recovered.TrySetResult(new Recording(context.JobDetail.Key, context.RecoveringTriggerKey));
+            }
+        }
+
+        private static TaskCompletionSource<Recording> NewSource()
+        {
+            return new TaskCompletionSource<Recording>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+    }
+
+    public sealed class RecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Recordings.Record(context);
+            return default;
+        }
+    }
+
+    [DisallowConcurrentExecution]
+    public sealed class SerialRecordingJob : IJob
+    {
+        public ValueTask Execute(IJobExecutionContext context, CancellationToken cancellationToken = default)
+        {
+            Recordings.Record(context);
+            return default;
+        }
+    }
+}

--- a/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
+++ b/src/Quartz.Tests.Unit/Simpl/RAMJobStoreTest.cs
@@ -847,12 +847,13 @@ public class RAMJobStoreTest
     }
 
     /// <summary>
-    /// ReplaceTrigger deletes rather than updates, so unlike AddTrigger(AddTriggerOptions.Replacing) it does
-    /// not carry the executions over — matching the ADO store, where ReplaceTrigger removes the
-    /// fired-trigger rows and an in-place update leaves them.
+    /// ReplaceTrigger carries the executions over, as AddTrigger(AddTriggerOptions.Replacing) does: a
+    /// replaced trigger keeps its identity and its job, so what was running under the key is still running
+    /// under it — matching the ADO store, where a replacement leaves the fired-trigger rows for the
+    /// execution's own completion, or for recovery, to settle (#3759). Only a removal forgets them.
     /// </summary>
     [Test]
-    public async Task GetTriggerState_ForgetsExecutions_WhenTriggerIsReplacedMidExecution()
+    public async Task GetTriggerState_KeepsExecutions_WhenTriggerIsReplacedMidExecution()
     {
         DateTimeOffset d = TestDates.EvenMinuteDateAfterNow();
         var trigger = ExecutingTestTrigger("replacedWhileExecutingTrigger", d);
@@ -865,8 +866,14 @@ public class RAMJobStoreTest
         var replacement = ExecutingTestTrigger("replacedWhileExecutingTrigger", d);
         (await fJobStore.ReplaceTrigger(trigger.Key, replacement)).Should().BeTrue();
 
-        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal,
-            "the replaced trigger was deleted, so its execution went with it");
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Executing,
+            "the replaced trigger kept its identity, and the execution that started under it is still running");
+
+        // The completion arrives for the execution the replacement inherited, and settles it.
+        var bundle = fired[0].TriggerFiredBundle;
+        await fJobStore.TriggeredJobComplete(bundle.Trigger, bundle.JobDetail, SchedulerInstruction.NoInstruction);
+
+        (await fJobStore.GetTriggerState(trigger.Key)).Should().Be(TriggerState.Normal);
     }
 
     /// <summary>

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Cluster.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Cluster.cs
@@ -586,13 +586,28 @@ internal abstract partial class AdoJobStoreBase
     /// job is held back rather than recovered this pass.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// On the first detection the node may still be alive, so the record is preserved and given a grace
     /// period. Once that expires — elapsed time past two failure detection cycles — full cleanup is
     /// performed. The decision is derived entirely from database state, so every node of the cluster
     /// makes the same one (#2817).
+    /// </para>
+    /// <para>
+    /// Except for this node's own previous run, which its first check-in recovers: there is no doubt
+    /// about whether that one is still alive, and there is no second detection to leave the rows for —
+    /// the check-in that follows writes a fresh timestamp over the row every later scan would have judged
+    /// by. A deferral here is a fired-trigger row nothing ever settles and, for a job that disallows
+    /// concurrent execution, a trigger left <c>BLOCKED</c> behind an execution that ended with the
+    /// process (#3759).
+    /// </para>
     /// </remarks>
     private bool CanDeferRecovery(SchedulerStateRecord record)
     {
+        if (record.SchedulerInstanceId == InstanceId)
+        {
+            return false;
+        }
+
         bool isOrphanedInstance = record.CheckinInterval == default && record.CheckinTimestamp == default;
         if (isOrphanedInstance)
         {

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Store.cs
@@ -380,24 +380,30 @@ internal abstract partial class AdoJobStoreBase
     }
 
     /// <summary>
-    /// Delete a trigger, its listeners, and its Simple/Cron/BLOB sub-table entry.
+    /// Delete a trigger, its listeners, its Simple/Cron/BLOB sub-table entry, and the fired-trigger rows
+    /// of its executions.
     /// </summary>
+    /// <remarks>
+    /// The fired rows go because this is a removal: an execution whose trigger was deliberately
+    /// unscheduled is not one to bring back as a recovery run (#744), and a recovery trigger built from a
+    /// row whose trigger is gone would have no job data to copy (#2083). A <em>replacement</em> is the
+    /// other case and does not come through here — see
+    /// <see cref="ReplaceTrigger(ConnectionAndTransactionHolder, TriggerKey, IOperableTrigger, CancellationToken)" />.
+    /// </remarks>
     /// <seealso cref="DeleteJob(ConnectionAndTransactionHolder, JobKey, bool, CancellationToken)" />
     /// <seealso cref="DeleteTrigger(ConnectionAndTransactionHolder, TriggerKey, IJobDetail, CancellationToken)" />
-    /// <seealso cref="ReplaceTrigger(ConnectionAndTransactionHolder, TriggerKey, IOperableTrigger, CancellationToken)" />
     private async ValueTask<bool> DeleteTriggerAndChildren(
         ConnectionAndTransactionHolder conn,
         TriggerKey key,
         CancellationToken cancellationToken)
     {
         bool deleted = await Delegate.DeleteTrigger(conn, key, cancellationToken).ConfigureAwait(false) > 0;
-        
-        // Also clean up any fired trigger records to prevent recovery triggers from being created
+
         if (deleted)
         {
             await Delegate.DeleteFiredTriggers(conn, new FiredTriggerQuery { Trigger = key }, cancellationToken).ConfigureAwait(false);
         }
-        
+
         return deleted;
     }
 
@@ -499,6 +505,26 @@ internal abstract partial class AdoJobStoreBase
             cancellationToken);
     }
 
+    /// <summary>
+    /// Deletes the trigger row and stores the replacement, leaving the fired-trigger rows of the old
+    /// trigger's executions alone.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A replacement is not a removal. The trigger keeps its identity and its job, so an execution the
+    /// row records is still one to finish — its completion deletes the row by fire instance id — or, if
+    /// the node running it died, one to recover. Deleting the rows here is what #3759 was: an application
+    /// that declares its triggers through <c>AddTrigger</c> has them re-applied as a reschedule every time
+    /// it starts, before recovery has read a row of the run the kill interrupted, so a job that asked to
+    /// be recovered never was. Only <see cref="DeleteTriggerAndChildren" /> deletes them.
+    /// </para>
+    /// <para>
+    /// The kept row is a row the store reads: the replacement of a trigger whose job disallows concurrent
+    /// execution is stored <c>BLOCKED</c> behind an execution still in flight, as any trigger of that job
+    /// is, and is released by the execution's completion or by recovery — where deleting the row would
+    /// have let it fire alongside the execution it could not see.
+    /// </para>
+    /// </remarks>
     protected ValueTask<bool> ReplaceTrigger(
         ConnectionAndTransactionHolder conn,
         TriggerKey triggerKey,
@@ -528,7 +554,7 @@ internal abstract partial class AdoJobStoreBase
                     Throw.JobPersistenceException("New trigger is not related to the same job as the old trigger.");
                 }
 
-                bool removedTrigger = await DeleteTriggerAndChildren(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+                bool removedTrigger = await Delegate.DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false) > 0;
 
                 await AddTrigger(conn, newTrigger, job, false, StoredTriggerState.Waiting, false, false, cancellationToken).ConfigureAwait(false);
 

--- a/src/Quartz/Impl/RAMJobStore.cs
+++ b/src/Quartz/Impl/RAMJobStore.cs
@@ -113,8 +113,8 @@ public sealed class RAMJobStore : IJobStore
     /// in existence is the largest number of triggers that have ever been executing at once, which the
     /// thread pool caps. Only <see cref="ReleaseExecutionNoLock" /> returns one, and only after taking it
     /// out of <see cref="executingFireInstances" /> — the trigger-removal paths drop their maps rather
-    /// than pooling them, because <see cref="ReplaceTrigger" /> keeps a reference to put back should the
-    /// replacement fail. Guarded by the store lock, like everything else here.
+    /// than pooling them, since a removal is rare beside a firing and a map dropped there is one the next
+    /// firing simply allocates. Guarded by the store lock, like everything else here.
     /// </para>
     /// </remarks>
     private readonly Stack<Dictionary<string, FireInstanceEntry>> spareFireInstanceMaps = new();
@@ -684,9 +684,10 @@ public sealed class RAMJobStore : IJobStore
         return deleted;
     }
 
-    // keepExecutions: whether executions already started under this key survive. Only a trigger being
-    // replaced in place keeps them, matching the ADO store, where updating a trigger leaves its
-    // fired-trigger rows alone but deleting one removes them. There is no default: every caller says which.
+    // keepExecutions: whether executions already started under this key survive. A trigger being replaced
+    // keeps them, whether in place or through ReplaceTrigger, matching the ADO store, where a replacement
+    // leaves the trigger's fired-trigger rows alone and only a removal deletes them (#3759). There is no
+    // default: every caller says which.
     private bool RemoveTriggerNoLock(TriggerKey key, bool removeOrphanedJob, bool keepExecutions, ref PendingSignals pending)
     {
         if (!keepExecutions)
@@ -762,14 +763,12 @@ public sealed class RAMJobStore : IJobStore
                     Throw.JobPersistenceException("New trigger is not related to the same job as the old trigger.");
                 }
 
-                // Kept so the rollback below can put them back: the old trigger is still the one running
-                // them until the replacement actually succeeds.
-                executingFireInstances.TryGetValue(triggerKey, out var fireInstances);
-
-                // The old trigger is deleted rather than updated, so its executions go with it, as they do
-                // in the ADO store where ReplaceTrigger deletes the fired-trigger rows. Removing through
-                // the shared path means anything kept per trigger is cleaned up here too.
-                RemoveTriggerNoLock(triggerKey, removeOrphanedJob: false, keepExecutions: false, ref pending);
+                // The old trigger is deleted rather than updated, but its executions stay: a replaced
+                // trigger keeps its identity and its job, so what was running under the key is still
+                // running under it, as in the ADO store where a replacement leaves the fired-trigger rows
+                // for the execution's completion, or for recovery, to settle (#3759). Removing through the
+                // shared path means everything else kept per trigger is cleaned up here too.
+                RemoveTriggerNoLock(triggerKey, removeOrphanedJob: false, keepExecutions: true, ref pending);
 
                 try
                 {
@@ -779,13 +778,6 @@ public sealed class RAMJobStore : IJobStore
                 {
                     // put previous trigger back...
                     AddTriggerNoLock(tw.Trigger, replace: false, ref pending);
-
-                    // ...along with the executions it never stopped running.
-                    if (fireInstances is not null)
-                    {
-                        executingFireInstances[triggerKey] = fireInstances;
-                    }
-
                     throw;
                 }
             }


### PR DESCRIPTION
Fixes #3759.

A job that requested recovery was not recovered after a hard kill when the application declares its jobs and triggers through `AddJob`/`AddTrigger`. Two defects, both needed.

**1. A reschedule deleted the fired-trigger rows of the trigger's executions.** The declared jobs and triggers are applied when the scheduler is created, and a trigger the store already holds is applied as a reschedule (`OverwriteExistingData` defaults to true). `RescheduleJob` → `ReplaceTrigger` → `DeleteTriggerAndChildren`, which deletes every fired-trigger row of the key (added for #744). That runs before `Start()`, so by the time the first cluster check-in — or the non-clustered sweep — went looking for the interrupted execution, its row was gone: `Scheduled 0 recoverable job(s)`, exactly as reported. A replacement is not a removal: the trigger keeps its identity and its job, and the row belongs to the execution, which its own completion or recovery settles. `ReplaceTrigger` now deletes the trigger row only; unscheduling still takes the rows with it (#744, #2083). `RAMJobStore.ReplaceTrigger` keeps executions the same way. A side effect worth naming: replacing a trigger of a `[DisallowConcurrentExecution]` job while it runs on another node used to store the replacement WAITING, letting it fire alongside; it is now stored BLOCKED behind the execution, as any trigger of that job is.

**2. The recovery deferral applied to the node's own previous run.** With the row kept, the clustered variant of the new test still failed: on its first check-in a node hands its own state row to recovery, and the #2817 grace period (two intervals plus the misfire threshold) judged that row by its old timestamp, so after a fast restart the EXECUTING row of a serial job was "preserved" for a second detection that never comes — the check-in refreshes the row. That left the fired row unsettled and the trigger BLOCKED for good. `CanDeferRecovery` never defers the node's own record.

Tests: a mocked contract pair (replace keeps rows, remove deletes them), an end-to-end SQLite reproduction of the reporter's restart without Docker (`RecoveryAfterStartupRescheduleSqliteTest`, non-clustered sweep, since SQLite refuses clustering — both cases fail on the unfixed store for the documented reason), the own-record deferral case in `AdoJobStoreBaseTest`, the flipped RAM-store expectation, and a clustered integration sibling in `RecoverJobsTest` on SQL Server and Postgres (green locally through Docker). Docs: one paragraph each in `rescheduling-jobs.md` and `more-about-jobs.md`.

No public API change; no schema change. Companion 3.x PR: #3762.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq5H486gNopfG7wuNXqwXf
