### PR TITLE
Replacing a trigger keeps the fired-trigger rows recovery reads (3.x)

### DIFF
--- a/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
+++ b/src/Quartz.Tests.Integration/Core/RecoverJobsTest.cs
@@ -202,6 +202,133 @@ public class RecoverJobsTest
         await scheduler.Shutdown(true);
     }
 
+    /// <summary>
+    /// A trigger rescheduled before the restarted node starts — which is what re-applying an
+    /// application's <c>AddTrigger</c> registrations on startup does — keeps the record of the execution
+    /// the kill interrupted, so the job that asked to be recovered is (#3759).
+    /// </summary>
+    [Test]
+    public async Task TestRecoveryStillHappensAfterTriggerIsRescheduledBeforeStart()
+    {
+        DatabaseHelper.RegisterDatabaseSettingsForProvider(provider, out _, out var dataSourceName);
+
+        // One store per process: the restarted node is a new process, and a store that has been shut
+        // down refuses work until its scheduler starts, which is after the reschedule under test.
+        JobStoreTX CreateJobStore()
+        {
+            // A recovery trigger carries a data map, and a store without a serializer cannot write one.
+            var serializer = new JsonObjectSerializer();
+            serializer.Initialize();
+
+            return new JobStoreTX
+            {
+                DataSource = dataSourceName,
+                InstanceId = "SINGLE_NODE_TEST",
+                InstanceName = dataSourceName,
+                MisfireThreshold = TimeSpan.FromSeconds(1),
+                ObjectSerializer = serializer
+            };
+        }
+
+        var factory = DirectSchedulerFactory.Instance;
+
+        factory.CreateScheduler(new DefaultThreadPool(), CreateJobStore());
+        var scheduler = await factory.GetScheduler();
+
+        RecoverJobsTestJob.runForever = true;
+
+        await scheduler.Clear();
+
+        var jobKey = new JobKey("rescheduledRecovery", "testGroup");
+        var triggerKey = new TriggerKey("rescheduledRecovery", "testGroup");
+
+        await scheduler.ScheduleJob(
+            JobBuilder.Create<RecoverJobsTestJob>()
+                .WithIdentity(jobKey)
+                .RequestRecovery(true)
+                .Build(),
+            TriggerBuilder.Create()
+                .WithIdentity(triggerKey)
+                .StartNow()
+                .WithSimpleSchedule(x => x
+                    .WithInterval(TimeSpan.FromHours(1))
+                    .RepeatForever()
+                ).Build()
+        );
+
+        await scheduler.Start();
+
+        // wait to be sure job is executing
+        await Task.Delay(TimeSpan.FromSeconds(2));
+
+        // emulate fail over situation
+        await scheduler.Shutdown(false);
+
+        CountFiredTriggers(dataSourceName, scheduler.SchedulerName, triggerKey).Should().Be(1,
+            "the premise: the kill interrupted a firing the store knows about");
+
+        // the restarted node re-applies its declared trigger before it starts
+        factory.CreateScheduler(new DefaultThreadPool(), CreateJobStore());
+        IScheduler restarted = await factory.GetScheduler();
+
+        var declaredAgain = TriggerBuilder.Create()
+            .WithIdentity(triggerKey)
+            .ForJob(jobKey)
+            .StartNow()
+            .WithSimpleSchedule(x => x
+                .WithInterval(TimeSpan.FromHours(1))
+                .RepeatForever()
+            ).Build();
+        (await restarted.RescheduleJob(triggerKey, declaredAgain)).Should().NotBeNull("the trigger was there to replace");
+
+        CountFiredTriggers(dataSourceName, restarted.SchedulerName, triggerKey).Should().Be(1,
+            "a reschedule is not a removal: the interrupted execution's record stays for recovery to read");
+
+        RecoverJobsTestJob.runForever = false;
+
+        var recovered = new ManualResetEventSlim(false);
+        restarted.ListenerManager.AddJobListener(new RecoveryDetectionListener(recovered));
+        await restarted.Start();
+
+        recovered.Wait(TimeSpan.FromSeconds(15)).Should().BeTrue(
+            "the job asked to be recovered and its execution was interrupted; rescheduling its trigger changes neither");
+
+        await restarted.Shutdown(true);
+    }
+
+    private static int CountFiredTriggers(string dataSourceName, string schedulerName, TriggerKey triggerKey)
+    {
+        using var connection = DBConnectionManager.Instance.GetConnection(dataSourceName);
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT count(*) from QRTZ_FIRED_TRIGGERS WHERE SCHED_NAME = '{schedulerName}' AND TRIGGER_NAME = '{triggerKey.Name}' AND TRIGGER_GROUP = '{triggerKey.Group}'";
+        return Convert.ToInt32(command.ExecuteScalar());
+    }
+
+    private sealed class RecoveryDetectionListener : JobListenerSupport
+    {
+        private readonly ManualResetEventSlim recovered;
+
+        public RecoveryDetectionListener(ManualResetEventSlim recovered)
+        {
+            this.recovered = recovered;
+        }
+
+        public override string Name => nameof(RecoveryDetectionListener);
+
+        public override Task JobToBeExecuted(
+            IJobExecutionContext context,
+            CancellationToken cancellationToken = default)
+        {
+            if (context.Recovering)
+            {
+                recovered.Set();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
     [DisallowConcurrentExecution]
     public class RecoverJobsTestJob : IJob
     {

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/JobStoreSupportTest.cs
@@ -252,6 +252,96 @@ public class JobStoreSupportTest
             A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
     }
 
+    /// <summary>
+    /// Replacing a trigger leaves the fired-trigger rows of its executions alone. A replaced trigger keeps
+    /// its identity and its job, so an execution the row records is still one to finish or to recover —
+    /// and re-applying an application's <c>AddTrigger</c> registrations on start replaces every trigger it
+    /// declares, before recovery has read a row of the run the kill interrupted (#3759).
+    /// </summary>
+    [Test]
+    public async Task TestReplaceTrigger_ShouldKeepFiredTriggersForTriggerKey()
+    {
+        var triggerKey = new TriggerKey("t1", "g1");
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IJobDetail job = CreateConcurrentJob();
+
+        A.CallTo(() => driverDelegate.SelectJobForTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<Spi.ITypeLoadHelper>.Ignored,
+            false,
+            A<CancellationToken>.Ignored)).Returns(Task.FromResult<IJobDetail>(job));
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).Returns(Task.FromResult(1));
+
+        (await jobStoreSupport.CallReplaceTrigger(conn, triggerKey, CreateTestTrigger())).Should().BeTrue();
+
+        A.CallTo(() => driverDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+
+        A.CallTo(() => driverDelegate.InsertTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<IOperableTrigger>.That.Matches(t => t.Key.Equals(triggerKey)),
+            AdoConstants.StateWaiting,
+            job,
+            A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+
+        // A replacement is not a removal: the rows record executions of the job, which is still there.
+        A.CallTo(() => driverDelegate.SelectFiredTriggerRecords(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<string>.Ignored,
+            A<string>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+
+        A.CallTo(() => driverDelegate.DeleteFiredTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<string>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+    }
+
+    /// <summary>
+    /// The same rule on the delegate shape that deletes by key in one statement.
+    /// </summary>
+    [Test]
+    public async Task TestReplaceTrigger_NextVersionDelegate_ShouldKeepFiredTriggersForTriggerKey()
+    {
+        IDriverDelegate nvDelegate = A.Fake<IDriverDelegate>(x => x.Implements<INextVersionDelegate>());
+        jobStoreSupport.DirectDelegate = nvDelegate;
+
+        var triggerKey = new TriggerKey("t1", "g1");
+        var conn = new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), null);
+        IJobDetail job = CreateConcurrentJob();
+
+        A.CallTo(() => nvDelegate.SelectJobForTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<Spi.ITypeLoadHelper>.Ignored,
+            false,
+            A<CancellationToken>.Ignored)).Returns(Task.FromResult<IJobDetail>(job));
+
+        A.CallTo(() => nvDelegate.DeleteTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            triggerKey,
+            A<CancellationToken>.Ignored)).Returns(Task.FromResult(1));
+
+        (await jobStoreSupport.CallReplaceTrigger(conn, triggerKey, CreateTestTrigger())).Should().BeTrue();
+
+        A.CallTo(() => ((INextVersionDelegate) nvDelegate).DeleteFiredTriggers(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<TriggerKey>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+
+        A.CallTo(() => nvDelegate.DeleteFiredTrigger(
+            A<ConnectionAndTransactionHolder>.Ignored,
+            A<string>.Ignored,
+            A<CancellationToken>.Ignored)).MustNotHaveHappened();
+    }
+
     [Test]
     public async Task TestRemoveJob_ShouldDeleteFiredTriggersForJobKey()
     {
@@ -1139,6 +1229,11 @@ public class JobStoreSupportTest
         internal Task<bool> CallRemoveTrigger(ConnectionAndTransactionHolder conn, TriggerKey triggerKey)
         {
             return RemoveTrigger(conn, triggerKey, CancellationToken.None);
+        }
+
+        internal Task<bool> CallReplaceTrigger(ConnectionAndTransactionHolder conn, TriggerKey triggerKey, IOperableTrigger newTrigger)
+        {
+            return ReplaceTrigger(conn, triggerKey, newTrigger, CancellationToken.None);
         }
 
         internal Task<TriggerFiredBundle> CallTriggerFired(ConnectionAndTransactionHolder conn, IOperableTrigger trigger)

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -2241,18 +2241,23 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     }
 
     /// <summary>
-    /// Delete a trigger, its listeners, and its Simple/Cron/BLOB sub-table entry.
+    /// Delete a trigger, its listeners, its Simple/Cron/BLOB sub-table entry, and the fired-trigger rows
+    /// of its executions.
     /// </summary>
+    /// <remarks>
+    /// The fired rows go because this is a removal: an execution whose trigger was deliberately
+    /// unscheduled is not one to bring back as a recovery run (#744), and a recovery trigger built from a
+    /// row whose trigger is gone would have no job data to copy (#2083). A <em>replacement</em> is the
+    /// other case and does not come through here — see
+    /// <see cref="ReplaceTrigger(ConnectionAndTransactionHolder, TriggerKey, IOperableTrigger, CancellationToken)" />.
+    /// </remarks>
     /// <seealso cref="RemoveJob(ConnectionAndTransactionHolder, JobKey, bool, CancellationToken)" />
     /// <seealso cref="RemoveTrigger(ConnectionAndTransactionHolder, TriggerKey, IJobDetail, CancellationToken)" />
-    /// <seealso cref="ReplaceTrigger(ConnectionAndTransactionHolder, TriggerKey, IOperableTrigger, CancellationToken)" />
     private async Task<bool> DeleteTriggerAndChildren(
         ConnectionAndTransactionHolder conn,
         TriggerKey key,
         CancellationToken cancellationToken)
     {
-        // Clean up any fired trigger records referencing this trigger
-        // to prevent orphaned records that cause recovery with missing JobData (#2083)
         if (Delegate is INextVersionDelegate nextVersionDelegate)
         {
             await nextVersionDelegate.DeleteFiredTriggers(conn, key, cancellationToken).ConfigureAwait(false);
@@ -2440,6 +2445,26 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
 #endif
     }
 
+    /// <summary>
+    /// Deletes the trigger row and stores the replacement, leaving the fired-trigger rows of the old
+    /// trigger's executions alone.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A replacement is not a removal. The trigger keeps its identity and its job, so an execution the
+    /// row records is still one to finish — its completion deletes the row by fire instance id — or, if
+    /// the node running it died, one to recover. Deleting the rows here is what #3759 was: an application
+    /// that declares its triggers through <c>AddTrigger</c> has them re-applied as a reschedule every time
+    /// it starts, before recovery has read a row of the run the kill interrupted, so a job that asked to
+    /// be recovered never was. Only <see cref="DeleteTriggerAndChildren" /> deletes them.
+    /// </para>
+    /// <para>
+    /// The kept row is a row the store reads: the replacement of a trigger whose job disallows concurrent
+    /// execution is stored <c>BLOCKED</c> behind an execution still in flight, as any trigger of that job
+    /// is, and is released by the execution's completion or by recovery — where deleting the row would
+    /// have let it fire alongside the execution it could not see.
+    /// </para>
+    /// </remarks>
     protected virtual async Task<bool> ReplaceTrigger(
         ConnectionAndTransactionHolder conn,
         TriggerKey triggerKey,
@@ -2466,7 +2491,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                 throw new JobPersistenceException("New trigger is not related to the same job as the old trigger.");
             }
 
-            bool removedTrigger = await DeleteTriggerAndChildren(conn, triggerKey, cancellationToken).ConfigureAwait(false);
+            bool removedTrigger = await Delegate.DeleteTrigger(conn, triggerKey, cancellationToken).ConfigureAwait(false) > 0;
 
             await StoreTrigger(conn, newTrigger, job, false, StateWaiting, false, false, cancellationToken).ConfigureAwait(false);
 
@@ -2474,7 +2499,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         }
         catch (Exception e)
         {
-            throw new JobPersistenceException("Couldn't remove trigger: " + e.Message, e);
+            throw new JobPersistenceException("Couldn't replace trigger: " + e.Message, e);
         }
     }
 
@@ -5174,9 +5199,16 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                     // Once the grace period expires (elapsed time exceeds two failure detection
                     // cycles), full cleanup is performed. This decision is derived entirely from
                     // DB state so all cluster nodes make the same choice (#2817).
+                    //
+                    // Except for this node's own previous run, which its first check-in recovers: there
+                    // is no doubt about whether that one is still alive, and there is no second detection
+                    // to leave the rows for — the check-in that follows writes a fresh timestamp over the
+                    // row every later scan would have judged by. A deferral here is a fired-trigger row
+                    // nothing ever settles and, for a job that disallows concurrent execution, a trigger
+                    // left BLOCKED behind an execution that ended with the process (#3759).
                     bool isOrphanedInstance = rec.CheckinInterval == default && rec.CheckinTimestamp == default;
                     bool canDeferRecovery;
-                    if (isOrphanedInstance)
+                    if (isOrphanedInstance || rec.SchedulerInstanceId.Equals(InstanceId))
                     {
                         canDeferRecovery = false;
                     }


### PR DESCRIPTION
The 3.x counterpart of #3761, for #3759 (reported against 3.20.1).

A job that requested recovery was not recovered after a hard kill when the application declares its jobs and triggers through `AddJob`/`AddTrigger`. Two defects, both needed.

**1. A reschedule deleted the fired-trigger rows of the trigger's executions.** The declared content is applied by `ServiceCollectionSchedulerFactory.GetScheduler` before `Start()`, and a trigger the store already holds is applied as a reschedule (`OverWriteExistingData` defaults to true). `RescheduleJob` → `ReplaceTrigger` → `DeleteTriggerAndChildren`, which deletes every fired-trigger row of the key (added by #2905 for #2083). So by the time the first cluster check-in — or the non-clustered sweep — went looking for the interrupted execution, its row was gone: `Scheduled 0 recoverable job(s)`, exactly as reported. A replacement is not a removal: the trigger keeps its identity and its job, and the row belongs to the execution, which its own completion or recovery settles. `ReplaceTrigger` now deletes the trigger row only; unscheduling still takes the rows with it. A side effect worth naming: replacing a trigger of a `[DisallowConcurrentExecution]` job while it runs on another node used to store the replacement WAITING, letting it fire alongside; it is now stored BLOCKED behind the execution.

**2. The recovery deferral applied to the node's own previous run.** On its first check-in a node hands its own state row to recovery, and the #2817 grace period judged that row by its old timestamp, so after a fast restart under a stable instance id the EXECUTING row of a serial job was "preserved" for a second detection that never comes — the check-in refreshes the row. That left the fired row unsettled and the trigger BLOCKED for good. `ClusterRecover` never defers the node's own record.

Tests: mocked contract tests for both delegate shapes in `JobStoreSupportTest` (fail on the unfixed store), and a restart sibling in the `RecoverJobsTest` integration fixture, green locally on SQL Server and Postgres through Docker. Two things that fixture's hand-built `JobStoreTX` needed for this test and no earlier one: a serializer, because a recovery trigger carries a data map, and one store instance per emulated process, because a store that has been shut down refuses work until its scheduler starts, and the reschedule under test comes before that.

No public API change; no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq5H486gNopfG7wuNXqwXf
