### PR TITLE
quartz.jobStore.commandTimeout bounds every statement, the lock statement included

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/CommandTimeoutTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/CommandTimeoutTest.cs
@@ -1,0 +1,299 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using System;
+using System.Collections.Specialized;
+using System.Data.Common;
+using System.Threading.Tasks;
+
+using FakeItEasy;
+
+using Quartz.Impl;
+using Quartz.Impl.AdoJobStore;
+using Quartz.Impl.AdoJobStore.Common;
+using Quartz.Simpl;
+using Quartz.Spi;
+using Quartz.Util;
+
+namespace Quartz.Tests.Unit.Impl.AdoJobStore;
+
+/// <summary>
+/// <c>quartz.jobStore.commandTimeout</c> bounds every statement the store issues, the lock statement
+/// included.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A row lock belongs to the database session that took it, so Quartz cannot release one whose client
+/// is gone — a node that loses its network without the server noticing keeps the <c>TRIGGER_ACCESS</c>
+/// row locked (#3763). Every other node's next lock statement then queues behind that dead session,
+/// and with no timeout it waits there forever: the statement never fails, so none of the retry, the
+/// back-off or the <c>SchedulerError</c> paths run and nothing is logged at all.
+/// </para>
+/// <para>
+/// The timeout is what turns that wait into a failed statement the store retries and recovers from
+/// once the server drops the dead session. 4.x has it as <c>JobStore:CommandTimeout</c>; this is the
+/// same setting spelled the way this branch spells settings.
+/// </para>
+/// </remarks>
+public class CommandTimeoutTest
+{
+    /// <summary>
+    /// What a provider would have left on a command of its own, so that "unset" can be told apart from
+    /// "set to zero" — which every provider reads as "wait forever".
+    /// </summary>
+    private const int ProviderDefault = 45;
+
+    [Test]
+    public void APreparedCommandCarriesTheConfiguredTimeout()
+    {
+        StubCommand command = A.Fake<StubCommand>();
+        AdoUtil adoUtil = new AdoUtil(ProviderReturning(command))
+        {
+            CommandTimeout = TimeSpan.FromSeconds(20)
+        };
+
+        adoUtil.PrepareCommand(Connection(), "SELECT 1");
+
+        command.CommandTimeout.Should().Be(20,
+            "the configured timeout is what every statement the store issues runs under");
+    }
+
+    /// <summary>
+    /// ADO.NET counts whole seconds, and rounding down would turn a sub-second timeout into zero —
+    /// which is not a very short wait but an unbounded one, the exact failure the setting exists to
+    /// prevent.
+    /// </summary>
+    [TestCase(1500, 2)]
+    [TestCase(100, 1)]
+    [TestCase(20000, 20)]
+    public void ASubSecondTimeoutIsRoundedUpRatherThanDownToZero(int configuredMilliseconds, int expectedSeconds)
+    {
+        StubCommand command = A.Fake<StubCommand>();
+        AdoUtil adoUtil = new AdoUtil(ProviderReturning(command))
+        {
+            CommandTimeout = TimeSpan.FromMilliseconds(configuredMilliseconds)
+        };
+
+        adoUtil.PrepareCommand(Connection(), "SELECT 1");
+
+        command.CommandTimeout.Should().Be(expectedSeconds,
+            "a timeout rounded down to zero would be read as 'no timeout at all' by every provider");
+    }
+
+    [Test]
+    public void AnUnsetTimeoutLeavesTheCommandAsTheProviderMintedIt()
+    {
+        StubCommand command = A.Fake<StubCommand>();
+        command.CommandTimeout = ProviderDefault;
+        AdoUtil adoUtil = new AdoUtil(ProviderReturning(command));
+
+        adoUtil.PrepareCommand(Connection(), "SELECT 1");
+
+        command.CommandTimeout.Should().Be(ProviderDefault,
+            "an unset timeout is the provider's own default, not zero");
+    }
+
+    /// <summary>
+    /// The driver delegate issues everything the store does apart from the lock statement, and gets the
+    /// timeout through its initialization arguments.
+    /// </summary>
+    [Test]
+    public void TheDelegatePreparesItsCommandsWithTheTimeoutItWasInitializedWith()
+    {
+        StubCommand command = A.Fake<StubCommand>();
+        StdAdoDelegate adoDelegate = new StdAdoDelegate();
+        adoDelegate.Initialize(new DelegateInitializationArgs
+        {
+            TablePrefix = "QRTZ_",
+            InstanceId = "INSTANCE",
+            InstanceName = "TESTSCHED",
+            TypeLoadHelper = new SimpleTypeLoadHelper(),
+            UseProperties = false,
+            InitString = "",
+            DbProvider = ProviderReturning(command),
+            CommandTimeout = TimeSpan.FromSeconds(20)
+        });
+
+        adoDelegate.PrepareCommand(Connection(), "SELECT 1");
+
+        command.CommandTimeout.Should().Be(20,
+            "the store's timeout has to reach the AdoUtil the delegate prepares its commands with");
+    }
+
+    /// <summary>
+    /// The flat key is read the way every other duration on the store is: as a millisecond count. This
+    /// is <c>StdSchedulerFactory</c>'s own binding, and it is why the property is a non-nullable
+    /// <see cref="TimeSpan" /> — a <c>TimeSpan?</c> would fall to the nullable converter and read
+    /// <c>20000</c> as twenty thousand days.
+    /// </summary>
+    [Test]
+    public void TheFlatPropertyIsReadAsMilliseconds()
+    {
+        NameValueCollection properties = new NameValueCollection
+        {
+            ["quartz.jobStore.commandTimeout"] = "20000"
+        };
+        PropertiesParser parser = new PropertiesParser(properties);
+        JobStoreSupportTest.TestJobStoreSupport store = new JobStoreSupportTest.TestJobStoreSupport();
+
+        ObjectUtils.SetObjectProperties(store, parser.GetPropertyGroup(StdSchedulerFactory.PropertyJobStorePrefix, true));
+
+        store.CommandTimeout.Should().Be(TimeSpan.FromSeconds(20),
+            "quartz.jobStore.commandTimeout is a millisecond count, as quartz.jobStore.dbRetryInterval is");
+    }
+
+    [Test]
+    public void TheTimeoutIsUnsetUntilItIsConfigured()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = new JobStoreSupportTest.TestJobStoreSupport();
+
+        store.CommandTimeout.Should().Be(TimeSpan.Zero,
+            "an unconfigured store leaves every statement with whatever default its provider gives a "
+            + "new command");
+    }
+
+    [Test]
+    public void ANegativeTimeoutIsRefusedWhereItIsConfigured()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = new JobStoreSupportTest.TestJobStoreSupport();
+
+        Action act = () => store.CommandTimeout = TimeSpan.FromSeconds(-1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>(
+                "a negative timeout is refused by the command it would be applied to, with nothing to "
+                + "say which setting it came from")
+            .WithMessage("*CommandTimeout*");
+    }
+
+    /// <summary>
+    /// ADO.NET's timeout is a whole number of seconds in an <see cref="int" />, so a longer wait than
+    /// that cannot be applied at all: unchecked, the rounded value overflows into a negative one and
+    /// every statement the store issues fails.
+    /// </summary>
+    [Test]
+    public void ATimeoutNoCommandCanExpressIsRefusedWhereItIsConfigured()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = new JobStoreSupportTest.TestJobStoreSupport();
+
+        Action act = () => store.CommandTimeout = TimeSpan.FromDays(100000);
+
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*CommandTimeout*")
+            .WithMessage("*" + int.MaxValue + " seconds*");
+    }
+
+    /// <summary>
+    /// The lock handler the store picks for itself is the one that takes <c>TRIGGER_ACCESS</c>, and its
+    /// statement is the one a dead session blocks.
+    /// </summary>
+    [Test]
+    public async Task TheStoreBoundsTheLockStatementOfTheHandlerItBuilds()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = StoreUsingDatabaseLocks();
+        store.CommandTimeout = TimeSpan.FromSeconds(20);
+
+        await store.Initialize(A.Fake<ITypeLoadHelper>(), A.Fake<ISchedulerSignaler>());
+
+        store.LockHandler.Should().BeOfType<StdRowLockSemaphore>()
+            .Which.CommandTimeout.Should().Be(TimeSpan.FromSeconds(20),
+                "the lock statement is where an unbounded wait costs the whole cluster its scheduling loop");
+    }
+
+    /// <summary>
+    /// A handler named by <c>quartz.jobStore.lockHandler.type</c> takes the same lock with the same
+    /// kind of statement, so the store's timeout reaches it too — which is what 4.x does by handing
+    /// every handler a <c>LockHandlerContext</c>.
+    /// </summary>
+    [Test]
+    public async Task TheStoreBoundsTheLockStatementOfAHandlerItWasGiven()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = StoreUsingDatabaseLocks();
+        store.CommandTimeout = TimeSpan.FromSeconds(20);
+        store.LockHandler = new UpdateLockRowSemaphore(A.Fake<IDbProvider>());
+
+        await store.Initialize(A.Fake<ITypeLoadHelper>(), A.Fake<ISchedulerSignaler>());
+
+        store.LockHandler.Should().BeOfType<UpdateLockRowSemaphore>()
+            .Which.CommandTimeout.Should().Be(TimeSpan.FromSeconds(20),
+                "a custom handler locks the same row and can wait on the same dead session");
+    }
+
+    [Test]
+    public async Task AnUnsetTimeoutLeavesAHandlerThatWasGivenOneOfItsOwnAlone()
+    {
+        JobStoreSupportTest.TestJobStoreSupport store = StoreUsingDatabaseLocks();
+        store.LockHandler = new UpdateLockRowSemaphore(A.Fake<IDbProvider>())
+        {
+            CommandTimeout = TimeSpan.FromSeconds(5)
+        };
+
+        await store.Initialize(A.Fake<ITypeLoadHelper>(), A.Fake<ISchedulerSignaler>());
+
+        store.LockHandler.Should().BeOfType<UpdateLockRowSemaphore>()
+            .Which.CommandTimeout.Should().Be(TimeSpan.FromSeconds(5),
+                "an unconfigured store has no timeout to impose, so a handler configured with one of "
+                + "its own keeps it");
+    }
+
+    [Test]
+    public void TheBuilderWritesTheTimeoutAsMilliseconds()
+    {
+        SchedulerBuilder builder = SchedulerBuilder.Create();
+        builder.UsePersistentStore(store =>
+        {
+            store.CommandTimeout = TimeSpan.FromSeconds(20);
+        });
+
+        builder.Properties["quartz.jobStore.commandTimeout"].Should().Be("20000",
+            "the fluent builder writes the same flat key the properties file does");
+    }
+
+    /// <summary>
+    /// A store that locks in the database, with everything it reaches for during initialization faked:
+    /// no connection is opened, and the fake driver delegate keeps it out of the SQLite and SQL Server
+    /// special cases.
+    /// </summary>
+    private static JobStoreSupportTest.TestJobStoreSupport StoreUsingDatabaseLocks()
+    {
+        IDbConnectionManager connectionManager = A.Fake<IDbConnectionManager>();
+        A.CallTo(() => connectionManager.GetDbProvider(A<string>._)).Returns(A.Fake<IDbProvider>());
+
+        return new JobStoreSupportTest.TestJobStoreSupport
+        {
+            DataSource = "someDataSource",
+            ConnectionManager = connectionManager,
+            UseDBLocks = true,
+            DirectDelegate = A.Fake<IDriverDelegate>()
+        };
+    }
+
+    private static IDbProvider ProviderReturning(DbCommand command)
+    {
+        IDbProvider provider = A.Fake<IDbProvider>();
+        A.CallTo(() => provider.CreateCommand()).Returns(command);
+        return provider;
+    }
+
+    private static ConnectionAndTransactionHolder Connection()
+    {
+        return new ConnectionAndTransactionHolder(A.Fake<DbConnection>(), A.Fake<DbTransaction>());
+    }
+}

--- a/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
+++ b/src/Quartz.Tests.Unit/Verify/PublicApiTest_Quartz.verified.txt
@@ -828,6 +828,7 @@ namespace Quartz
         }
         public class PersistentStoreOptions : Quartz.SchedulerBuilder.StoreOptions
         {
+            public System.TimeSpan CommandTimeout { set; }
             public long IdleWaitTime { set; }
             public int MaxTransientRetries { set; }
             public bool PerformSchemaValidation { set; }
@@ -1398,6 +1399,7 @@ namespace Quartz.Impl.AdoJobStore
     public class AdoUtil
     {
         public AdoUtil(Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider) { }
+        public System.TimeSpan? CommandTimeout { get; set; }
         public void AddCommandParameter(System.Data.IDbCommand cmd, string paramName, object? paramValue) { }
         public void AddCommandParameter(System.Data.IDbCommand cmd, string paramName, object? paramValue, System.Enum? dataType, int? size) { }
         public System.Data.Common.DbCommand PrepareCommand(Quartz.Impl.AdoJobStore.ConnectionAndTransactionHolder cth, string commandText) { }
@@ -1442,6 +1444,7 @@ namespace Quartz.Impl.AdoJobStore
     {
         protected DBSemaphore(string tablePrefix, string? schedName, string defaultSQL, string defaultInsertSQL, Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider) { }
         protected Quartz.Impl.AdoJobStore.AdoUtil AdoUtil { get; }
+        public System.TimeSpan? CommandTimeout { get; set; }
         protected string InsertSQL { set; }
         public bool RequiresConnection { get; }
         protected string SQL { get; set; }
@@ -1464,6 +1467,7 @@ namespace Quartz.Impl.AdoJobStore
     public class DelegateInitializationArgs
     {
         public DelegateInitializationArgs() { }
+        public System.TimeSpan? CommandTimeout { get; set; }
         public Quartz.Impl.AdoJobStore.Common.IDbProvider DbProvider { get; set; }
         public string? InitString { get; set; }
         public string InstanceId { get; set; }
@@ -1642,6 +1646,8 @@ namespace Quartz.Impl.AdoJobStore
         [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Milliseconds)]
         public System.TimeSpan ClusterCheckinMisfireThreshold { get; set; }
         public bool Clustered { get; set; }
+        [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Milliseconds)]
+        public System.TimeSpan CommandTimeout { get; set; }
         public Quartz.Util.IDbConnectionManager ConnectionManager { get; set; }
         public string DataSource { get; set; }
         protected Quartz.Impl.AdoJobStore.Common.DbMetadata DbMetadata { get; }

--- a/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoUtil.cs
@@ -41,6 +41,22 @@ public class AdoUtil
         log = LogProvider.GetLogger("Quartz.SQL");
     }
 
+    /// <summary>
+    /// Gets or sets how long a command prepared here may run before the provider cancels it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see langword="null" />, the default, leaves whatever default the provider gives a new command.
+    /// </para>
+    /// <para>
+    /// <see cref="System.Data.IDbCommand.CommandTimeout" /> counts whole seconds, so the value is
+    /// rounded <em>up</em>: rounding down would turn anything under a second into zero, which every
+    /// provider reads as "wait forever".
+    /// </para>
+    /// </remarks>
+    /// <value>The command timeout, or <see langword="null" /> for the provider's own default.</value>
+    public TimeSpan? CommandTimeout { get; set; }
+
     public void AddCommandParameter(IDbCommand cmd, string paramName, object? paramValue)
     {
         AddCommandParameter(cmd, paramName, paramValue, null, null);
@@ -87,6 +103,12 @@ public class AdoUtil
     {
         DbCommand cmd = dbProvider.CreateCommand();
         cmd.CommandText = commandText;
+
+        if (CommandTimeout is { } commandTimeout)
+        {
+            cmd.CommandTimeout = (int) Math.Ceiling(commandTimeout.TotalSeconds);
+        }
+
         cth.Attach(cmd);
 
         if (log.IsDebugEnabled())

--- a/src/Quartz/Impl/AdoJobStore/DBSemaphore.cs
+++ b/src/Quartz/Impl/AdoJobStore/DBSemaphore.cs
@@ -79,6 +79,29 @@ public abstract class DBSemaphore : StdAdoConstants, ISemaphore, ITablePrefixAwa
     internal ILog Log { get; }
 
     /// <summary>
+    /// Gets or sets how long the statements this handler takes its lock with may run before the
+    /// provider cancels them.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see langword="null" />, the default, leaves whatever default the provider gives a new command.
+    /// The job store writes <c>quartz.jobStore.commandTimeout</c> here once its lock handler is known,
+    /// so a handler configured with <c>quartz.jobStore.lockHandler.type</c> is bounded too.
+    /// </para>
+    /// <para>
+    /// This is the wait that matters most: a node blocked on the lock row behind a session that is
+    /// gone - a connection the database has not yet noticed is dead - waits here, and nothing else
+    /// ends that wait.
+    /// </para>
+    /// </remarks>
+    /// <value>The command timeout, or <see langword="null" /> for the provider's own default.</value>
+    public TimeSpan? CommandTimeout
+    {
+        get => AdoUtil.CommandTimeout;
+        set => AdoUtil.CommandTimeout = value;
+    }
+
+    /// <summary>
     /// Execute the SQL that will lock the proper database row.
     /// </summary>
     protected abstract Task ExecuteSQL(

--- a/src/Quartz/Impl/AdoJobStore/DelegateInitializationArgs.cs
+++ b/src/Quartz/Impl/AdoJobStore/DelegateInitializationArgs.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Specialized;
 
 using Quartz.Impl.AdoJobStore.Common;
@@ -44,6 +45,16 @@ public class DelegateInitializationArgs
     /// Object serializer and deserializer strategy to use.
     /// </summary>
     public IObjectSerializer? ObjectSerializer { get; set; }
+
+    /// <summary>
+    /// How long a statement the delegate issues may run before the provider cancels it, or
+    /// <see langword="null" /> to leave the provider's own default in place.
+    /// </summary>
+    /// <remarks>
+    /// This is <c>quartz.jobStore.commandTimeout</c> as the store received it; the delegate hands it to
+    /// the <see cref="AdoUtil" /> that prepares its commands.
+    /// </remarks>
+    public TimeSpan? CommandTimeout { get; set; }
 
     /// <summary>
     /// Custom driver delegate initialization.

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -70,6 +70,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     private TimeSpan clusterCheckinInterval;
     private TimeSpan dbRetryInterval;
     private TimeSpan transientRetryInterval;
+    private TimeSpan commandTimeout;
 
     private ClusterManager? clusterManager;
     private MisfireHandler? misfireHandler;
@@ -227,6 +228,59 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             dbRetryInterval = value;
         }
     }
+
+    /// <summary>
+    /// Gets or sets how long a statement the job store issues may run before the provider cancels it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to <see cref="TimeSpan.Zero" />, which leaves each statement with whatever default the
+    /// ADO.NET provider gives a new command - 30 seconds for most of them. Configured as
+    /// <c>quartz.jobStore.commandTimeout</c>, in milliseconds.
+    /// </para>
+    /// <para>
+    /// This covers every statement the store issues, including the ones the lock handler takes its row
+    /// lock with, which is where a timeout matters most: a node blocked on the lock row behind a peer
+    /// that stopped without releasing it - or behind a session whose client is gone, which the database
+    /// has not yet cleaned up - waits there with the whole scheduling loop stalled, and nothing else
+    /// ends that wait. Once a statement does fail, the store retries it after
+    /// <see cref="DbRetryInterval" /> and recovers by itself.
+    /// </para>
+    /// <para>
+    /// <see cref="System.Data.IDbCommand.CommandTimeout" /> counts whole seconds, so a value is rounded
+    /// <em>up</em> to the next second - a configured 1500ms is applied as 2 seconds. Rounding up rather
+    /// than down keeps a sub-second value from becoming zero, which every provider reads as "wait
+    /// forever".
+    /// </para>
+    /// </remarks>
+    /// <value>The command timeout, or <see cref="TimeSpan.Zero" /> for the provider's own default.</value>
+    [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
+    public TimeSpan CommandTimeout
+    {
+        get => commandTimeout;
+        set
+        {
+            if (value < TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(CommandTimeout), value,
+                    $"{nameof(CommandTimeout)} cannot be negative. Leave it at TimeSpan.Zero to keep the provider's own default.");
+            }
+
+            if (value.TotalSeconds > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(CommandTimeout), value,
+                    $"{nameof(CommandTimeout)} must be at most {int.MaxValue} seconds, which is the longest wait ADO.NET's whole-second command timeout can express.");
+            }
+
+            commandTimeout = value;
+        }
+    }
+
+    /// <summary>
+    /// What <see cref="CommandTimeout" /> means to the parts that apply it: the configured duration, or
+    /// <see langword="null" /> when it is unset and the provider's own default stands.
+    /// </summary>
+    private TimeSpan? ConfiguredCommandTimeout => commandTimeout == TimeSpan.Zero ? null : commandTimeout;
 
     /// <summary>
     /// Gets or sets the maximum number of retries for transient database exceptions
@@ -641,6 +695,7 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
                         args.TypeLoadHelper = typeLoadHelper;
                         args.ObjectSerializer = ObjectSerializer;
                         args.InitString = DriverDelegateInitString;
+                        args.CommandTimeout = ConfiguredCommandTimeout;
 
                         var ctor = delegateType.GetConstructor(Type.EmptyTypes);
                         if (ctor == null)
@@ -838,6 +893,15 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
             {
                 Log.Warn("Detected usage of SQL Server provider without SqlServerDelegate, SqlServerDelegate would provide better performance");
             }
+        }
+
+        // Whether the handler was chosen here or handed to us by quartz.jobStore.lockHandler.type, the
+        // statements it locks with are the store's statements and are bounded by the store's timeout.
+        // A handler that does not talk to a database has nothing to bound, and an unset timeout leaves
+        // a handler that was given one of its own alone.
+        if (ConfiguredCommandTimeout is { } lockHandlerCommandTimeout && LockHandler is DBSemaphore dbSemaphore)
+        {
+            dbSemaphore.CommandTimeout = lockHandlerCommandTimeout;
         }
 
 #if DIAGNOSTICS_SOURCE

--- a/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
+++ b/src/Quartz/Impl/AdoJobStore/StdAdoDelegate.cs
@@ -78,7 +78,10 @@ public partial class StdAdoDelegate : StdAdoConstants, IDriverDelegate, IDbAcces
         DbProvider = args.DbProvider;
         typeLoadHelper = args.TypeLoadHelper;
         useProperties = args.UseProperties;
-        adoUtil = new AdoUtil(args.DbProvider);
+        adoUtil = new AdoUtil(args.DbProvider)
+        {
+            CommandTimeout = args.CommandTimeout
+        };
         objectSerializer = args.ObjectSerializer!;
 
         AddDefaultTriggerPersistenceDelegates();

--- a/src/Quartz/SchedulerBuilder.cs
+++ b/src/Quartz/SchedulerBuilder.cs
@@ -451,6 +451,26 @@ public class SchedulerBuilder : PropertiesHolder, IPropertyConfigurationRoot
         }
 
         /// <summary>
+        /// Sets how long a statement the job store issues may run before the provider cancels it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Unset by default, which leaves each statement with whatever default the ADO.NET provider
+        /// gives a new command - 30 seconds for most of them.
+        /// </para>
+        /// <para>
+        /// This covers every statement the store issues, the ones the lock handler takes its row lock
+        /// with included, which is where a timeout matters most: a node blocked on the lock row behind
+        /// a session the database has not yet noticed is dead waits there with the whole scheduling
+        /// loop stalled. Once a statement fails, the store retries it after <see cref="RetryInterval" />.
+        /// </para>
+        /// </remarks>
+        public TimeSpan CommandTimeout
+        {
+            set => SetProperty("quartz.jobStore.commandTimeout", ((int) value.TotalMilliseconds).ToString());
+        }
+
+        /// <summary>
         /// Sets the maximum number of retries for transient database exceptions
         /// (such as deadlocks) before giving up and propagating the exception.
         /// </summary>


### PR DESCRIPTION
A row lock belongs to the database session that took it, so no client can release another session's
lock. In discussion #3763 a node lost its network without the server noticing, kept `TRIGGER_ACCESS`
locked, and every other node's next lock statement queued behind that dead session. Nothing on this
branch bounded that wait: the statement never failed, so the lock handler's retries, the store's
`DbRetryInterval` back-off and the `SchedulerError` notification never ran, and the cluster stopped
firing without logging anything at all.

`quartz.jobStore.commandTimeout` is how long a statement the store issues may run before the provider
cancels it — every statement, the lock statement included. It is a millisecond count like every other
duration on the store, `TimeSpan.Zero` (the default) means the provider's own default, and a negative
value is refused where it is configured. `AdoUtil` applies it as it prepares each command, rounded
**up** to whole seconds: ADO.NET counts seconds, and rounding down would turn a sub-second value into
zero, which every provider reads as "wait forever".

It reaches both things that prepare commands:

- the driver delegate, through `DelegateInitializationArgs.CommandTimeout`;
- the lock handler, through a `CommandTimeout` on `DBSemaphore` that the store writes once its handler
  is known — so a handler named by `quartz.jobStore.lockHandler.type` is bounded too, which is what
  4.x's `LockHandlerContext` does for it.

`SchedulerBuilder`'s persistent store options can set it fluently.

4.x has the same setting as `JobStore:CommandTimeout`; this is it spelled the way this branch spells
settings. The companion PR on `main` adds the bridge entry that translates the 3.x key, so an
application upgrading with it in its configuration is not rejected, plus the troubleshooting docs for
the dead-session case (the 3.x reference page lives on `main`, so the documentation for this key is
in that PR — there is no `docs/` on this branch).

Refs #3764.

## Two decisions for the reviewer

1. **A timeout longer than ADO.NET can express is refused too**, beside the negative one. The rounded
   value goes into an `int` of seconds, and unchecked it overflows into a negative timeout that fails
   every statement the store issues. This is one condition more than the plan asked for; it follows
   what #3577's ceiling checks do — refuse a configured duration where it is configured.
2. **An unset store timeout leaves a lock handler that has one of its own alone.** `DBSemaphore`'s new
   property is public, so `quartz.jobStore.lockHandler.commandTimeout` now binds to it as well; the
   store overwrites it only when it has a timeout to impose. The alternative — always writing, `null`
   included — would silently reset a handler configured directly.

## Verification

```
dotnet build Quartz.slnx
  Build succeeded. 0 Warning(s) 0 Error(s)

dotnet test src/Quartz.Tests.Unit/Quartz.Tests.Unit.csproj
  Passed! - Failed: 0, Passed: 2028, Skipped: 4, Total: 2032 (net10.0)
  Passed! - Failed: 0, Passed: 2016, Skipped: 5, Total: 2021 (net472)

dotnet test src/Quartz.Tests.AspNetCore/Quartz.Tests.AspNetCore.csproj
  Passed! - Failed: 0, Passed: 122, Skipped: 0, Total: 122 (net8.0)
```

No integration run: it needs a database, and nothing here changes what a statement says — only how
long it may run.

`PublicApiTest_Quartz.verified.txt` moved and was re-accepted through Verify (received renamed, test
re-run green). The whole diff is five additions and no removals:

```diff
         public class PersistentStoreOptions : Quartz.SchedulerBuilder.StoreOptions
         {
+            public System.TimeSpan CommandTimeout { set; }

     public class AdoUtil
     {
         public AdoUtil(Quartz.Impl.AdoJobStore.Common.IDbProvider dbProvider) { }
+        public System.TimeSpan? CommandTimeout { get; set; }

         protected Quartz.Impl.AdoJobStore.AdoUtil AdoUtil { get; }
+        public System.TimeSpan? CommandTimeout { get; set; }        // DBSemaphore

     public class DelegateInitializationArgs
     {
         public DelegateInitializationArgs() { }
+        public System.TimeSpan? CommandTimeout { get; set; }

         public bool Clustered { get; set; }
+        [Quartz.TimeSpanParseRule(Quartz.TimeSpanParseRule.Milliseconds)]
+        public System.TimeSpan CommandTimeout { get; set; }         // JobStoreSupport
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018U3dwaq6mc9MZRbhJcKkiH
