### PR TITLE
A failed check-in is retried inside the window its peers give it

### DIFF
--- a/docs/documentation/best-practices.md
+++ b/docs/documentation/best-practices.md
@@ -545,10 +545,14 @@ This scheduler instance (…) is still active but was recovered by another insta
 The important part is that **a clock is not the only way to miss a check-in**. A node pinned at 100%
 CPU, a long garbage-collection pause, or a paused virtual machine misses check-ins with a perfect
 clock — and Azure documents its virtual machines being paused "for up to 30 seconds" during
-memory-preserving maintenance, which is twice the default detection window. This is the standard
-distributed-systems caution rather than a Quartz quirk; the literature on leases is unanimous that a
-missed heartbeat is a decision to act as if a node were dead, never evidence that it is, and that
-the safety margin has to cover the environment's worst *pause* rather than its worst clock error.
+memory-preserving maintenance, which is twice the default detection window. A refused database
+connection used to be another way: before 3.22 and 4.1 a single failed check-in backed off the full
+`DbRetryInterval` (15 seconds) and wrote its next row after the peers had stopped trusting it; since
+then the check-in loop retries inside the window, so a blip shorter than the threshold no longer costs
+the node its row. This is the standard distributed-systems caution rather than a Quartz quirk; the
+literature on leases is unanimous that a missed heartbeat is a decision to act as if a node were dead,
+never evidence that it is, and that the safety margin has to cover the environment's worst *pause*
+rather than its worst clock error.
 
 Three things to do about it, in order:
 

--- a/docs/documentation/quartz-3.x/configuration/reference.md
+++ b/docs/documentation/quartz-3.x/configuration/reference.md
@@ -353,14 +353,15 @@ JobStoreTX can be tuned with the following properties:
 | Property Name                                | Required | Type    | Default Value                                                                |
 |----------------------------------------------|----------|---------|------------------------------------------------------------------------------|
 | quartz.jobStore.commandTimeout               | no       | long    | 0 (the provider's own default)                                               |
-| quartz.jobStore.dbRetryInterval              | no       | long    | 15000   (15 seconds)                                                         |
+| quartz.jobStore.dbRetryInterval              | no       | long    | 15000 (15 seconds)                                                           |
 | quartz.jobStore.driverDelegateType           | yes      | string  | null                                                                         |
 | quartz.jobStore.dataSource                   | yes      | string  | null                                                                         |
 | quartz.jobStore.tablePrefix                  | no       | string  | "QRTZ_"                                                                      |
 | quartz.jobStore.useProperties                | no       | boolean | false                                                                        |
 | quartz.jobStore.misfireThreshold             | no       | int     | 60000                                                                        |
 | quartz.jobStore.clustered                    | no       | boolean | false                                                                        |
-| quartz.jobStore.clusterCheckinInterval       | no       | long    | 15000                                                                        |
+| quartz.jobStore.clusterCheckinInterval       | no       | long    | 7500 (7.5 seconds)                                                           |
+| quartz.jobStore.clusterCheckinMisfireThreshold | no     | long    | 7500 (7.5 seconds)                                                           |
 | quartz.jobStore.maxMisfiresToHandleAtATime   | no       | int     | 20                                                                           |
 | quartz.jobStore.selectWithLockSQL            | no       | string  | "SELECT * FROM {0}LOCKS WHERE SCHED_NAME = {1} AND LOCK_NAME = ? FOR UPDATE" |
 | quartz.jobStore.txIsolationLevelSerializable | no       | boolean | false                                                                        |
@@ -383,6 +384,9 @@ See [A Lock Held by a Connection That Is Gone](../../troubleshooting.md#a-lock-h
 
 Is the amount of time in milliseconds that the scheduler will wait between re-tries when it has detected a loss of connectivity within the JobStore (e.g. to the database).
 This parameter is obviously not very meaningful when using RamJobStore.
+
+Since 3.22.0 the cluster check-in loop backs off by it only once a failed check-in has spent the window its peers give it (`clusterCheckinInterval` + `clusterCheckinMisfireThreshold`); inside that window it retries sooner, and this value only caps how long it may wait between those retries.
+Before that a single failed check-in slept the full `dbRetryInterval`, which on the defaults wrote the next row 22.5 seconds after the last one — 7.5 seconds after the peers had stopped trusting it — so one database blip during a check-in got a live node recovered by its peers.
 
 ### `quartz.jobStore.driverDelegateType`
 
@@ -428,6 +432,12 @@ See the configuration docs for clustering for more information.
 ### `quartz.jobStore.clusterCheckinInterval`
 
 Set the frequency (in milliseconds) at which this instance "checks-in"* with the other instances of the cluster. Affects the quickness of detecting failed instances.
+
+### `quartz.jobStore.clusterCheckinMisfireThreshold`
+
+Since 3.1. The time in milliseconds a check-in may be late before the other instances consider this instance failed and recover its work: a peer writes an instance off once its last check-in is older than the instance's check-in interval plus this threshold — 15 seconds on the defaults.
+Raise it past your environment's worst *pause* (a long garbage collection, a paused virtual machine, a database failover), at the cost of a genuinely failed instance's work waiting that much longer to be taken over.
+Since 3.22.0 it is also the window this instance's own check-in loop retries a failed check-in inside, so a database blip shorter than the threshold does not get the instance written off.
 
 ### `quartz.jobStore.maxMisfiresToHandleAtATime`
 

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -172,7 +172,7 @@ services.AddQuartz(q => q.UsePersistentStore(store =>
 | `MaxMisfiresToHandleAtATime` | int | `20` | How many misfired triggers are handled per pass. |
 | `CommandTimeout` | TimeSpan? | provider default | How long a statement may run before the provider cancels it, applied to every statement the store issues including the lock handler's. Unset leaves each provider's own default, usually 30 seconds. ADO.NET counts whole seconds, so the value is rounded **up** — `00:00:01.500` is applied as 2 seconds, because rounding down would turn a sub-second value into `0`, which means "no timeout". |
 | `LockWaitWarningThreshold` | TimeSpan? | `00:00:30` | How long one attempt to take a job store lock may go on before it is logged as slow — warning **3716**, once per acquisition, naming the lock and the wait so far. A blocked lock statement returns nothing and throws nothing, so nothing else reports a node that has stopped scheduling; this only reports, and `CommandTimeout` or a wait timeout in the lock statement is what ends the wait. `null` turns it off; zero is refused, because a warning on every lock is the same as no signal. See [A Lock Held by a Connection That Is Gone](../../troubleshooting.md#a-lock-held-by-a-connection-that-is-gone). |
-| `DbRetryInterval` | TimeSpan | `00:00:15` | How long to wait before retrying after a database failure. |
+| `DbRetryInterval` | TimeSpan | `00:00:15` | How long the misfire loop waits before retrying after a database failure, and the check-in loop once a failed check-in has spent the window its peers give it (`CheckinInterval` + `CheckinMisfireThreshold`); inside that window it retries sooner and this only caps the wait. |
 | `MaxTransientRetries` | int | `3` | How many times a transient failure such as a deadlock is retried. Transient means the driver's own `DbException.IsTransient`, a SQLSTATE in class `40` — the standard's "transaction rollback", covering a serialization failure or a deadlock whichever provider reports it, with `40002` excepted because a deferred constraint violation fails identically on every retry — SQL Server's transient error numbers, SQLite's busy and locked codes, or a timeout. |
 | `TransientRetryInterval` | TimeSpan | `00:00:01` | Delay between transient retries. |
 | `RetryableActionErrorLogThreshold` | int | `4` | How many consecutive failures before they are logged as errors. |
@@ -524,7 +524,7 @@ configured: the job store reports whether it is clustered, it does not offer a s
 |---|---|---|---|
 | `Enabled` | bool | `false` | Takes part in a cluster sharing this database. `UseClustering()` sets it. |
 | `CheckinInterval` | TimeSpan | `00:00:07.5` | How often a node records that it is alive. |
-| `CheckinMisfireThreshold` | TimeSpan | `00:00:07.5` | Grace period before a node is treated as failed. |
+| `CheckinMisfireThreshold` | TimeSpan | `00:00:07.5` | Grace period before a node is treated as failed; also the window the node's own failed check-in is retried inside, so a database blip shorter than it does not get the node written off. |
 
 <!-- snippet: sample_reference_clustering -->
 ```csharp

--- a/docs/documentation/quartz-4.x/operations.md
+++ b/docs/documentation/quartz-4.x/operations.md
@@ -408,6 +408,17 @@ self-protection: an observer that has itself been away from its check-in loop fo
 peer a minute of slack. So a database outage that stops the whole cluster checking in does not end with
 the first node back declaring all the others dead.
 
+The node being judged knows the same arithmetic. A check-in that fails is retried inside what is left of
+the window — half of it each time, never later than `DbRetryInterval`, so on the defaults at roughly
+11.25, 13.1, 14.1 and 14.5 seconds after the last row it wrote — and only once the window has closed
+does the loop back off `DbRetryInterval` between attempts. A database blip shorter than the threshold
+therefore costs a node a few error lines, not its row; before 4.1 a single failed check-in slept the
+full `DbRetryInterval` and wrote its next row 22.5 seconds after the last one, 7.5 seconds after its
+peers had stopped trusting it (#3777). The limit is that a check-in can only be retried inside the
+window if the failure *reports* inside it: a connection attempt that hangs for a 15-second connect
+timeout has spent the window by the time it fails, and no retry cadence can help — that is what the
+threshold is for.
+
 Everything else about it is the standard caution about failure detectors, and
 [Clocks in a cluster](../best-practices.md#clocks-in-a-cluster) has it: fifteen seconds is shorter than
 a long garbage-collection pause, shorter than the thirty seconds Azure documents for
@@ -644,8 +655,9 @@ q.UsePersistentStore(store =>
         options.MaxTransientRetries = 3;
         options.TransientRetryInterval = TimeSpan.FromSeconds(1);
 
-        // How long the check-in and misfire loops back off after a failure that was not
-        // transient — a database that is down rather than busy.
+        // How long the misfire loop backs off after a failure that was not transient — a
+        // database that is down rather than busy — and the check-in loop once a failed
+        // check-in has spent the window its peers give it.
         options.DbRetryInterval = TimeSpan.FromSeconds(15);
     });
 });
@@ -699,9 +711,12 @@ only add — answering `false` is the same as not having one, so it cannot switc
 already performs. The exception it is handed is the store's own, so reach the driver's with
 `GetBaseException()`.
 
-`DbRetryInterval` (default 15 seconds) is the different knob: it is how long the check-in and misfire
-loops back off after a failure that was *not* transient — a database that is down rather than busy —
-so that a cluster does not hammer a dead server every 7.5 seconds.
+`DbRetryInterval` (default 15 seconds) is the different knob: it is how long the misfire loop backs off
+after a failure that was *not* transient — a database that is down rather than busy — and how long the
+check-in loop backs off once a failed check-in has spent the window its peers give it, so that a cluster
+does not hammer a dead server every 7.5 seconds. Inside that window the check-in loop retries sooner,
+and `DbRetryInterval` only caps how long it may wait between those retries; see
+[When a peer takes over](#when-a-peer-takes-over).
 
 Retrying is not free of consequence in a cluster. A check-in that fails for longer than the failure
 boundary means the peers write this node off while it is still working, so a database outage long

--- a/src/Quartz.Documentation.Samples/OperationsSamples.cs
+++ b/src/Quartz.Documentation.Samples/OperationsSamples.cs
@@ -109,8 +109,9 @@ public static class OperationsSamples
                     options.MaxTransientRetries = 3;
                     options.TransientRetryInterval = TimeSpan.FromSeconds(1);
 
-                    // How long the check-in and misfire loops back off after a failure that was not
-                    // transient — a database that is down rather than busy.
+                    // How long the misfire loop backs off after a failure that was not transient — a
+                    // database that is down rather than busy — and the check-in loop once a failed
+                    // check-in has spent the window its peers give it.
                     options.DbRetryInterval = TimeSpan.FromSeconds(15);
                 });
             });

--- a/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/OptionsValidationTest.cs
@@ -470,6 +470,29 @@ public class OptionsValidationTest
     }
 
     /// <summary>
+    /// The threshold never reached a timer of its own until the check-in loop started retrying a failed
+    /// check-in inside interval + threshold (#3777); a value past the ceiling would overflow that sum
+    /// in the loop, where nothing catches it, and it already broke every check-in through
+    /// <c>CalcFailedIfAfter</c>'s date arithmetic — so it is refused where the interval is.
+    /// </summary>
+    [Test]
+    public void ACheckinMisfireThresholdPastTheTimerCeilingFailsAtStartup()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(q => q.UsePersistentStore(store =>
+        {
+            store.ConfigureStore(options => options.DataSource = "test");
+            store.UseClustering(clustering => clustering.CheckinMisfireThreshold = TimeSpan.FromDays(90));
+        }));
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IStartupValidator>().Validate();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*CheckinMisfireThreshold*4294967294ms (49.7 days)*");
+    }
+
+    /// <summary>
     /// The idle wait is the one duration in the sweep that gets no ceiling. It is spent on a semaphore
     /// rather than a timer, so that a scheduling change can cut it short, and a semaphore takes a
     /// timeout of any length — so a wait past the timer ceiling is strange to configure but not a thing

--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
@@ -30,6 +30,7 @@ using System.Data.Common;
 
 using FakeItEasy;
 
+using Microsoft.Extensions.Time.Testing;
 
 using Quartz.Impl.AdoJobStore;
 
@@ -99,14 +100,20 @@ public class ClusterManagerTest
             + "a released token source would fail a scheduler that is already down");
     }
 
+    private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(7500);
+    private static readonly TimeSpan Threshold = TimeSpan.FromMilliseconds(7500);
+    private static readonly TimeSpan RetryInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ShortPause = TimeSpan.FromMilliseconds(100);
+
     [Test]
     public void ComputeTimeToSleep_ShouldSubtractTranspiredTime()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromSeconds(2),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
         timeToSleep.Should().Be(TimeSpan.FromMilliseconds(5500));
     }
@@ -115,12 +122,13 @@ public class ClusterManagerTest
     public void ComputeTimeToSleep_ShouldUseShortPause_WhenCheckinIsOverdue()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromSeconds(20),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(100));
+        timeToSleep.Should().Be(ShortPause);
     }
 
     /// <summary>
@@ -132,24 +140,341 @@ public class ClusterManagerTest
     public void ComputeTimeToSleep_ShouldClampToCheckinInterval_WhenClockJumpsBackward()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromDays(-1),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(7500));
+        timeToSleep.Should().Be(Interval);
+    }
+
+    /// <summary>
+    /// The peers write this node off once interval + threshold has passed since the row it last wrote,
+    /// and a retry that lands after that arrives convicted. Before #3777 a failed check-in slept the
+    /// full <c>DbRetryInterval</c>: on the defaults the next row went out 22.5 s after the last one,
+    /// 7.5 s after the peers had stopped trusting it, so one database blip during a check-in got a live
+    /// node recovered. The retry is now spent inside the window — half of what is left of it.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldRetryAtHalfTheRemainingWindow_WhenACheckinFails()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(3750),
+            "a check-in that failed at the interval has the whole threshold left, and the retry lands halfway through it rather than DbRetryInterval later");
     }
 
     [Test]
-    public void ComputeTimeToSleep_ShouldPreferDbRetryInterval_WhenCheckinsHaveFailed()
+    public void ComputeTimeToSleep_ShouldKeepHalvingTheWindow_WhileRetriesKeepFailing()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
-            transpiredTime: TimeSpan.FromDays(-1),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 1);
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(11250),
+            dbRetryInterval: RetryInterval,
+            numFails: 2,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromSeconds(15));
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(1875),
+            "3.75 s of the window is left, so the next retry lands halfway through that");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldNotRetryFasterThanTheShortPause_WhenTheWindowIsNearlySpent()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(14950),
+            dbRetryInterval: RetryInterval,
+            numFails: 5,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(ShortPause,
+            "half of 50 ms is under the loop's floor, and the floor is what an overdue check-in already waits");
+    }
+
+    /// <summary>
+    /// The boundary belongs to the back-off: with nothing left of the window the node is already
+    /// convictable, and there is no longer anything to hurry for.
+    /// </summary>
+    [TestCase(15_000)]
+    [TestCase(22_500)]
+    [TestCase(60_000)]
+    public void ComputeTimeToSleep_ShouldBackOffDbRetryInterval_OnceTheWindowIsSpent(int transpiredMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(transpiredMilliseconds),
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(RetryInterval,
+            "past the window the ordinary back-off applies, exactly as before #3777");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldCapTheInWindowRetryAtDbRetryInterval()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: TimeSpan.FromMinutes(1));
+
+        timeToSleep.Should().Be(RetryInterval,
+            "a minute-long threshold leaves 30 s to retry in, but the node still backs off no longer than DbRetryInterval");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldHonourAShorterDbRetryInterval_InsideTheWindow()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: TimeSpan.FromSeconds(1),
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(1),
+            "an operator who asked for a one-second back-off gets it; the window only ever shortens the wait");
+    }
+
+    /// <summary>
+    /// A zero <c>DbRetryInterval</c> is legal, and before #3777 it already meant "retry an overdue
+    /// check-in every short pause"; it still does, inside the window and after it.
+    /// </summary>
+    [TestCase(7_500)]
+    [TestCase(20_000)]
+    public void ComputeTimeToSleep_ShouldUseTheShortPause_WhenDbRetryIntervalIsZero(int transpiredMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(transpiredMilliseconds),
+            dbRetryInterval: TimeSpan.Zero,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(ShortPause);
+    }
+
+    /// <summary>
+    /// With no threshold the window closes at the interval, which is when the check-in was attempted,
+    /// so there is nothing to retry inside and the back-off applies as it always did. A negative
+    /// threshold, which nothing refuses on 3.x, reads the same way.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(-5_000)]
+    public void ComputeTimeToSleep_ShouldBackOffDbRetryInterval_WhenThereIsNoWindowToRetryIn(int thresholdMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: TimeSpan.FromMilliseconds(thresholdMilliseconds));
+
+        timeToSleep.Should().Be(RetryInterval);
+    }
+
+    /// <summary>
+    /// A backward clock jump during a failure streak makes the elapsed time negative. It must not widen
+    /// the window: the real elapsed time is unknown but not less than zero, so the node retries as if
+    /// the whole window were left — within one interval, which is also what the healthy branch does for
+    /// the same jump — rather than sleeping <c>DbRetryInterval</c>, which is what this case used to pin.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldRetryWithinOneWindow_WhenTheClockJumpedBackwardDuringAFailure()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromDays(-1),
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(7500),
+            "half of the full 15 s window, capped by nothing since DbRetryInterval is longer");
+    }
+
+    /// <summary>
+    /// Whatever is left of the window, the retry lands inside it and never later than the back-off —
+    /// down to where half of what is left is under the floor, which the floor test above covers.
+    /// </summary>
+    [TestCase(7_500)]
+    [TestCase(9_000)]
+    [TestCase(11_000)]
+    [TestCase(13_000)]
+    [TestCase(14_800)]
+    public void ComputeTimeToSleep_ShouldLandTheRetryInsideTheWindow(int transpiredMilliseconds)
+    {
+        TimeSpan transpired = TimeSpan.FromMilliseconds(transpiredMilliseconds);
+        TimeSpan windowLeft = Interval + Threshold - transpired;
+
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: transpired,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().BeLessThan(windowLeft, "the retry has to be attempted before the peers stop trusting the last row");
+        timeToSleep.Should().BeLessThanOrEqualTo(RetryInterval, "the window only ever shortens the back-off");
+        timeToSleep.Should().BeGreaterThanOrEqualTo(ShortPause, "the loop never spins");
+    }
+
+    /// <summary>
+    /// The timeline #3777 reports, replayed through the sleep computation with every attempt failing
+    /// at once: last row written at 0, first failure at 7.5 s. Before the fix the one retry came at
+    /// 22.5 s. Now every retry before 15 s lands strictly inside the window, and the first one after
+    /// it is the ordinary back-off later. A failure that takes a while to report eats the window it
+    /// is retried in, so a 3-second failure gets two attempts inside it rather than eight.
+    /// </summary>
+    [TestCase(0, 8)]
+    [TestCase(3_000, 2)]
+    public void AFailedCheckinIsRetriedInsideTheWindow_ThenBacksOff(int failureLatencyMilliseconds, int expectedAttemptsInsideTheWindow)
+    {
+        TimeSpan failureLatency = TimeSpan.FromMilliseconds(failureLatencyMilliseconds);
+        TimeSpan windowEnd = Interval + Threshold;
+        List<TimeSpan> attempts = [];
+
+        TimeSpan now = Interval; // the first check-in after the last successful one, at the interval
+        int numFails = 0;
+        while (now < windowEnd)
+        {
+            attempts.Add(now);
+            now += failureLatency; // the attempt fails, taking this long to say so
+            numFails++;
+            now += ClusterManager.ComputeTimeToSleep(Interval, now, RetryInterval, numFails, Threshold);
+        }
+
+        attempts.Should().HaveCount(expectedAttemptsInsideTheWindow);
+        attempts.Should().OnlyContain(t => t >= Interval && t < windowEnd,
+            "every attempt inside the window comes after the check-in that failed and before the peers stop trusting the last row");
+        attempts.Should().BeInAscendingOrder();
+
+        TimeSpan lastRetryDelay = ClusterManager.ComputeTimeToSleep(Interval, now, RetryInterval, numFails, Threshold);
+        lastRetryDelay.Should().Be(RetryInterval,
+            "once the window is spent the node is convictable anyway, and the ordinary back-off applies");
+    }
+
+    /// <summary>
+    /// The wiring, which <see cref="ClusterManager.ComputeTimeToSleep" /> cannot pin: the loop has to
+    /// time its retries from the last check-in that reached the database, not from the store's
+    /// <see cref="AdoJobStoreBase.LastCheckin" />. A check-in that fails to read the state table stamps
+    /// that too — on purpose, for <c>CalcFailedIfAfter</c> — and the scan runs before the write, so that
+    /// is the stamp a database blip leaves. A loop timed from it would believe a full window was left
+    /// and sleep 7.5 s, landing on the boundary; timed from the write it sleeps 3.75 s.
+    /// </summary>
+    [Test]
+    public async Task TheLoopTimesItsRetriesFromTheLastCheckinThatReachedTheDatabase_NotFromTheStampAFailedScanLeaves()
+    {
+        DateTimeOffset start = new(2026, 9, 11, 12, 0, 0, TimeSpan.Zero);
+        FakeTimeProvider clock = new(start);
+        RecordingTimeProvider recorder = new(clock);
+        IDriverDelegate driverDelegate = A.Fake<IDriverDelegate>();
+        A.CallTo(() => driverDelegate.SelectSchedulerStateRecords(
+                A<ConnectionAndTransactionHolder>.Ignored,
+                A<string>.Ignored,
+                A<CancellationToken>.Ignored))
+            .Returns(new ValueTask<List<SchedulerStateRecord>>([new SchedulerStateRecord("TestInstanceId", start, Interval)]))
+            .Once()
+            .Then
+            .Throws(new InvalidOperationException("state table unavailable"));
+
+        TestAdoJobStoreBase jobStoreSupport = new(recorder, driverDelegate, Interval);
+        jobStoreSupport.SetFirstCheckIn(false);
+        ClusterManager clusterManager = new(jobStoreSupport, NullLogger<ClusterManager>.Instance);
+
+        try
+        {
+            // The first check-in, inline in Initialize, succeeds and writes the row the peers will read.
+            await clusterManager.Initialize();
+            jobStoreSupport.LastCheckin.Should().Be(start, "the successful check-in stamps the write's own time");
+
+            await WaitUntil(() => recorder.Delays.Count >= 1);
+            recorder.Delays[0].Should().Be(Interval, "a healthy node sleeps one interval");
+
+            // The scan fails at the interval and stamps the store's LastCheckin with the failure time.
+            clock.Advance(Interval);
+            await WaitUntil(() => recorder.Delays.Count >= 2);
+            jobStoreSupport.LastCheckin.Should().Be(start + Interval,
+                "a failed scan stamps LastCheckin so that CalcFailedIfAfter does not count this node's silence against its peers");
+            recorder.Delays[1].Should().Be(TimeSpan.FromMilliseconds(3750),
+                "the retry is timed from the row that reached the database, which was written 7.5 s ago and has 7.5 s of window left");
+
+            clock.Advance(TimeSpan.FromMilliseconds(3750));
+            await WaitUntil(() => recorder.Delays.Count >= 3);
+            recorder.Delays[2].Should().Be(TimeSpan.FromMilliseconds(1875), "half of the 3.75 s that is left");
+        }
+        finally
+        {
+            await clusterManager.Shutdown();
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> condition)
+    {
+        // Real time: the loop's continuation after a fake timer fires runs on a pool thread, and only
+        // wall time reliably lets it get there.
+        for (int i = 0; i < 1000 && !condition(); i++)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(2));
+        }
+
+        condition().Should().BeTrue("the check-in loop was expected to have registered its next sleep by now");
+    }
+
+    /// <summary>
+    /// A <see cref="FakeTimeProvider" /> that also records the due time of every timer created on it.
+    /// The check-in loop sleeps through <c>Task.Delay(…, timeProvider, token)</c>, so the recorded due
+    /// times are exactly the values it computed, and the test can wait for a registration instead of
+    /// guessing when to advance.
+    /// </summary>
+    private sealed class RecordingTimeProvider : TimeProvider
+    {
+        private readonly FakeTimeProvider inner;
+        private readonly List<TimeSpan> delays = [];
+
+        public RecordingTimeProvider(FakeTimeProvider inner)
+        {
+            this.inner = inner;
+        }
+
+        public IReadOnlyList<TimeSpan> Delays
+        {
+            get
+            {
+                lock (delays)
+                {
+                    return delays.ToArray();
+                }
+            }
+        }
+
+        public override DateTimeOffset GetUtcNow() => inner.GetUtcNow();
+
+        public override TimeZoneInfo LocalTimeZone => inner.LocalTimeZone;
+
+        public override long TimestampFrequency => inner.TimestampFrequency;
+
+        public override long GetTimestamp() => inner.GetTimestamp();
+
+        public override ITimer CreateTimer(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+        {
+            lock (delays)
+            {
+                delays.Add(dueTime);
+            }
+
+            return inner.CreateTimer(callback, state, dueTime, period);
+        }
     }
 
     private sealed class TestAdoJobStoreBase : AdoJobStoreBase
@@ -157,10 +482,28 @@ public class ClusterManagerTest
         public TestAdoJobStoreBase()
         // A short check-in interval so that if the Run loop starts, it quickly checks the
         // cancellation token and exits, letting shutdown tests complete faster.
-        : base(TestJobStores.Dependencies(
-            schedulerOptions: TestJobStores.SchedulerOptions("TestInstance", "TestInstanceId"),
-            clusteringOptions: TestJobStores.ClusteringOptions(configure: options => options.CheckinInterval = TimeSpan.FromMilliseconds(100))))
+        : this(TimeProvider.System, driverDelegate: null, checkinInterval: TimeSpan.FromMilliseconds(100))
         {
+        }
+
+        public TestAdoJobStoreBase(TimeProvider timeProvider, IDriverDelegate driverDelegate, TimeSpan checkinInterval)
+            : base(TestJobStores.Dependencies(
+                timeProvider: timeProvider,
+                schedulerOptions: TestJobStores.SchedulerOptions("TestInstance", "TestInstanceId"),
+                clusteringOptions: TestJobStores.ClusteringOptions(configure: options => options.CheckinInterval = checkinInterval),
+                driverDelegate: driverDelegate))
+        {
+        }
+
+        /// <summary>
+        /// Writes the private flag that tells the check-in path this is the node's first pass, so that a
+        /// test can start from the cheap path and never reach the locks.
+        /// </summary>
+        internal void SetFirstCheckIn(bool value)
+        {
+            System.Reflection.FieldInfo fieldInfo = typeof(AdoJobStoreBase).GetField("firstCheckIn", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            fieldInfo.Should().NotBeNull("the first-check-in branch of CheckIn is gated on that field");
+            fieldInfo.SetValue(this, value);
         }
 
         protected override ValueTask<ConnectionAndTransactionHolder> GetLocalTransactionConnection(CancellationToken cancellationToken = default)

--- a/src/Quartz/Configuration/AdoJobStoreOptions.cs
+++ b/src/Quartz/Configuration/AdoJobStoreOptions.cs
@@ -111,6 +111,14 @@ public sealed class AdoJobStoreOptions
     /// <summary>
     /// How long to wait before retrying after a database failure.
     /// </summary>
+    /// <remarks>
+    /// The back-off after a failure that was not transient — a database that is down rather than busy.
+    /// The misfire handler sleeps for it between failing passes. The cluster check-in loop does so only
+    /// once a failed check-in has spent the window its peers give it
+    /// (<see cref="ClusteringOptions.CheckinInterval" /> plus
+    /// <see cref="ClusteringOptions.CheckinMisfireThreshold" />); inside that window it retries sooner,
+    /// and this value caps how long it may wait between those retries.
+    /// </remarks>
     public TimeSpan DbRetryInterval { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>

--- a/src/Quartz/Configuration/ClusteringOptions.cs
+++ b/src/Quartz/Configuration/ClusteringOptions.cs
@@ -40,5 +40,20 @@ public sealed class ClusteringOptions
     /// How long past a missed check-in another scheduler waits before treating this one as dead and
     /// recovering its triggers.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is also the window this scheduler's own check-in loop retries a failed check-in inside: a
+    /// check-in that fails is attempted again with half of what is left of the interval plus this
+    /// threshold, never later than <see cref="AdoJobStoreOptions.DbRetryInterval" />, so a database
+    /// blip shorter than the threshold does not get the node written off. Only once the window has
+    /// closed does the loop back off <see cref="AdoJobStoreOptions.DbRetryInterval" /> between attempts.
+    /// </para>
+    /// <para>
+    /// Raise it past the environment's worst <em>pause</em> — a garbage collection, a virtual machine
+    /// migration, a database failover — rather than its worst clock error: a genuinely dead node's work
+    /// waits interval plus threshold to be taken over, and a live node that misses that window is
+    /// recovered while it is still working.
+    /// </para>
+    /// </remarks>
     public TimeSpan CheckinMisfireThreshold { get; set; } = TimeSpan.FromMilliseconds(7500);
 }

--- a/src/Quartz/Configuration/QuartzOptionsValidators.cs
+++ b/src/Quartz/Configuration/QuartzOptionsValidators.cs
@@ -478,8 +478,9 @@ internal sealed class AdoJobStoreOptionsValidator : IValidateOptions<AdoJobStore
                 nameof(AdoJobStoreOptions.DbRetryInterval),
                 options.DbRetryInterval,
                 TimerLimits.MaxDelay,
-                "The store waits it out after a database failure, and the misfire handler and the cluster "
-                + "manager both sleep for it while their last pass is failing."));
+                "The store waits it out after a database failure, the misfire handler sleeps for it while "
+                + "its last pass is failing, and the cluster manager does once a failing check-in has spent "
+                + "its window."));
         }
 
         if (options.TransientRetryInterval < TimeSpan.Zero)
@@ -556,6 +557,15 @@ internal sealed class ClusteringOptionsValidator : IValidateOptions<ClusteringOp
         if (options.CheckinMisfireThreshold < TimeSpan.Zero)
         {
             (failures ??= []).Add($"{nameof(ClusteringOptions.CheckinMisfireThreshold)} must not be negative.");
+        }
+        else if (options.CheckinMisfireThreshold > TimerLimits.MaxDelay)
+        {
+            (failures ??= []).Add(TimerLimits.TooLong(
+                nameof(ClusteringOptions.CheckinMisfireThreshold),
+                options.CheckinMisfireThreshold,
+                TimerLimits.MaxDelay,
+                "It is added to the check-in interval to bound how long the cluster manager keeps retrying "
+                + "a failed check-in."));
         }
 
         return QuartzSchedulerOptionsValidator.Result(failures);

--- a/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Cluster.cs
+++ b/src/Quartz/Impl/AdoJobStore/AdoJobStoreBase.Cluster.cs
@@ -92,8 +92,12 @@ internal abstract partial class AdoJobStoreBase
     private bool firstCheckIn = true;
 
     /// <summary>
-    /// When this node last recorded that it is alive. Internal: it is bookkeeping the check-in loop
-    /// owns, and a subclass writing it would move the moment every other node decides this one died.
+    /// When this node last recorded that it is alive — or last failed to read the state table, which
+    /// stamps it too, so that <see cref="CalcFailedIfAfter" /> does not count this node's own outage
+    /// against its peers. That second writer is why <see cref="ClusterManager" /> keeps its own record
+    /// of the last check-in that reached the database and times its retries from that (#3777).
+    /// Internal: it is bookkeeping the check-in loop owns, and a subclass writing it would move the
+    /// moment every other node decides this one died.
     /// </summary>
     internal DateTimeOffset LastCheckin { get; set; }
 

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -32,7 +32,26 @@ internal sealed class ClusterManager
     // This prevents hanging if the scheduler was disposed before it could schedule the task.
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The least the loop sleeps: what an overdue check-in waits before it is attempted, and the floor
+    /// under a retry that has almost no window left to land in.
+    /// </summary>
+    private static readonly TimeSpan ShortPause = TimeSpan.FromMilliseconds(100);
+
     private int numFails;
+
+    /// <summary>
+    /// When this node last wrote a check-in that reached the database — the timestamp its peers read.
+    /// </summary>
+    /// <remarks>
+    /// Kept here rather than read off <see cref="AdoJobStoreBase.LastCheckin" />, which has a second
+    /// writer: a check-in that fails to <em>read</em> the state table stamps it too, so that
+    /// <c>CalcFailedIfAfter</c> does not count this node's own outage against its peers. The scan runs
+    /// before the write, so that is the stamp a database blip leaves, and a retry timed from it would
+    /// believe it had a whole window left when the peers' clock says otherwise (#3777). Starts at
+    /// construction, as the store's own does.
+    /// </remarks>
+    private DateTimeOffset lastSuccessfulCheckIn;
 
     /// <remarks>
     /// The logger is handed over rather than created here, because it is the store's - and therefore the
@@ -45,6 +64,7 @@ internal sealed class ClusterManager
         this.logger = logger;
         cancellationTokenSource = new CancellationTokenSource();
         cancellationToken = cancellationTokenSource.Token;
+        lastSuccessfulCheckIn = jobStoreSupport.timeProvider.GetUtcNow();
     }
 
     public async Task Initialize()
@@ -113,6 +133,9 @@ internal sealed class ClusterManager
             // recover work it is still doing. The round trip is short and finishes.
             res = await jobStoreSupport.CheckIn(requestorId, CancellationToken.None).ConfigureAwait(false);
 
+            // The write's own timestamp, not the clock: a check-in that recovered a peer returns later
+            // than it wrote, and the peers measure from what it wrote.
+            lastSuccessfulCheckIn = jobStoreSupport.LastCheckin;
             numFails = 0;
             logger.CheckInComplete();
         }
@@ -143,9 +166,10 @@ internal sealed class ClusterManager
         {
             TimeSpan timeToSleep = ComputeTimeToSleep(
                 jobStoreSupport.ClusterCheckinInterval,
-                jobStoreSupport.timeProvider.GetUtcNow() - jobStoreSupport.LastCheckin,
+                jobStoreSupport.timeProvider.GetUtcNow() - lastSuccessfulCheckIn,
                 jobStoreSupport.DbRetryInterval,
-                numFails);
+                numFails,
+                jobStoreSupport.ClusterCheckinMisfireThreshold);
 
             await Task.Delay(timeToSleep, jobStoreSupport.timeProvider, token).ConfigureAwait(false);
 
@@ -165,19 +189,24 @@ internal sealed class ClusterManager
     /// Determines how long to sleep before the next cluster check-in.
     /// </summary>
     /// <param name="clusterCheckinInterval">The configured check-in interval.</param>
-    /// <param name="transpiredTime">Wall clock time elapsed since the last successful check-in.</param>
+    /// <param name="transpiredTime">Wall clock time elapsed since the last check-in that reached the database.</param>
     /// <param name="dbRetryInterval">The configured retry interval used when the last check-ins have failed.</param>
     /// <param name="numFails">Number of consecutive failed check-ins.</param>
+    /// <param name="clusterCheckinMisfireThreshold">
+    /// The slack the peers add to the interval before they write this node off. Together with the
+    /// interval it is the window a failed check-in has to be retried in.
+    /// </param>
     internal static TimeSpan ComputeTimeToSleep(
         TimeSpan clusterCheckinInterval,
         TimeSpan transpiredTime,
         TimeSpan dbRetryInterval,
-        int numFails)
+        int numFails,
+        TimeSpan clusterCheckinMisfireThreshold)
     {
         TimeSpan timeToSleep = clusterCheckinInterval - transpiredTime;
         if (timeToSleep <= TimeSpan.Zero)
         {
-            timeToSleep = TimeSpan.FromMilliseconds(100);
+            timeToSleep = ShortPause;
         }
         else if (timeToSleep > clusterCheckinInterval)
         {
@@ -187,9 +216,37 @@ internal sealed class ClusterManager
             timeToSleep = clusterCheckinInterval;
         }
 
-        if (numFails > 0 && dbRetryInterval > timeToSleep)
+        if (numFails > 0)
         {
-            timeToSleep = dbRetryInterval;
+            // The peers write this node off once interval + threshold has passed since the row it
+            // last wrote. A retry that lands after that arrives convicted, so while the window is
+            // still open the retry is spent inside it — half of what is left each time, never longer
+            // than DbRetryInterval, never shorter than the short pause — and only once it has closed
+            // does the ordinary back-off apply. Java's ClusterManager sleeps
+            // max(dbRetryInterval, timeToSleep) here; with the defaults that is a retry 22.5 s after
+            // a row the peers stop trusting at 15 s, which is what #3777 reports, and this branch
+            // departs from it on purpose.
+            TimeSpan elapsed = transpiredTime < TimeSpan.Zero ? TimeSpan.Zero : transpiredTime; // a backward jump must not widen the window
+            TimeSpan windowLeft = clusterCheckinInterval + clusterCheckinMisfireThreshold - elapsed;
+            if (windowLeft > TimeSpan.Zero)
+            {
+                TimeSpan retry = TimeSpan.FromTicks(windowLeft.Ticks / 2); // TimeSpan / int does not exist on net462/net472/netstandard2.0
+                if (retry > dbRetryInterval)
+                {
+                    retry = dbRetryInterval;
+                }
+
+                if (retry < ShortPause)
+                {
+                    retry = ShortPause;
+                }
+
+                timeToSleep = retry;
+            }
+            else if (dbRetryInterval > timeToSleep)
+            {
+                timeToSleep = dbRetryInterval;
+            }
         }
 
         return timeToSleep;


### PR DESCRIPTION
A peer writes a node off once `CheckinInterval` + `CheckinMisfireThreshold` has passed since the row
it last wrote — 15 s on the defaults. The cluster manager's sleep after a failed check-in was floored
at `DbRetryInterval`, also 15 s by default, so a check-in that failed at 7.5 s was next attempted at
22.5 s: 7.5 s after the peers had stopped trusting the row. One database blip during a check-in got a
live node recovered — fired-trigger rows deleted, recovering jobs fired again,
`[DisallowConcurrentExecution]` no longer holding. That is #3777, and it is inherited: Java Quartz
sleeps `max(dbRetryInterval, timeToSleep)` in the same place.

One nuance the reporter's timeline does not have: `CheckIn` already retries *transient* failures
3 × 1 s inside one pass, so a sub-3-second blip the driver flags as transient never reached the loop;
anything else — a blip the driver does not flag, a 3–7 s one, a refused connection — did.

## What changes

**The retry respects the window.** While a peer may still not have written this node off, a failed
check-in is retried inside what is left of the window — half of it each time, never later than
`DbRetryInterval`, never sooner than the loop's 100 ms pause — and only once the window has closed
does the ordinary `DbRetryInterval` back-off apply. On the defaults a check-in failing at 7.5 s is
retried at 11.25, 13.1, 14.1, 14.5 … s, then every 15 s as today. Halving rather than a fixed cadence
because the failing attempt's own latency eats the budget and the remaining budget is recomputed from
the clock each pass, so the last retry lands right before the deadline whatever the latency was.

**Timed from the right stamp.** The store's `LastCheckin` is not "the last write that reached the
database": a check-in that fails to *read* the state table stamps it too, deliberately, so that
`CalcFailedIfAfter` does not count this node's own outage against its peers (pinned by
`FindFailedInstances_ShouldWrapDelegateFailures`). The scan runs before the write, so that is the
stamp a blip leaves, and a loop timed from it would believe a whole window was left and land on the
boundary. `ClusterManager` now keeps its own record of the last check-in that reached the database,
and a loop-level test drives the real loop on a fake clock through exactly that path: the scan fails,
`LastCheckin` is stamped, the next sleep is 3.75 s and not 7.5 s.

**Defaults unchanged.** The reporter proposes `threshold ≥ DbRetryInterval` as an invariant. Equal
still ties at the boundary, and doubling the threshold doubles the documented 15-second failover
latency for every deployment. With the retry honouring the window, the relation is no longer one an
operator has to know about, so nothing is validated and nothing moves.

Also in the PR:

- `CheckinMisfireThreshold` is refused past the timer ceiling like `CheckinInterval`, since the loop
  now adds the two; a value that large already broke every check-in through `CalcFailedIfAfter`'s date
  arithmetic, so nothing that worked is refused.
- XML docs on `ClusteringOptions.CheckinMisfireThreshold`, `AdoJobStoreOptions.DbRetryInterval` and
  `LastCheckin` say what each now does; the `DbRetryInterval` ceiling reason no longer claims the
  cluster manager sleeps for it while failing.
- Docs: `operations.md` (the predicate section and the `DbRetryInterval` paragraph), the 4.x
  configuration reference rows, `best-practices.md` "Clocks in a cluster", and the **3.x**
  configuration reference, which said `clusterCheckinInterval` defaulted to 15000 (it is 7500) and did
  not list `quartz.jobStore.clusterCheckinMisfireThreshold` at all — both fixed, with the 3.22 note.
  `docs:check-links` (224 pages, no dead anchors) and `docs:lint` clean; snippets regenerated.

Known costs, stated rather than hidden: up to ~9 connection attempts and three error lines
(`RetryableActionErrorLogThreshold` = 4) in the first 15 s of an outage instead of one, then today's
cadence; a check-in that writes its row and then fails in `ClusterRecover` retries the lock-taking
recovery on the same cadence inside its first window; a node whose local interval or threshold differs
from a peer's estimates the window with its own values, which is the pre-existing condition
`operations.md` already documents.

No public API change — `ClusterManager` is internal on both branches — no option, no schema, no new
log event. `MisfireHandler` keeps its `DbRetryInterval` floor: nothing convicts a misfire handler.

The 3.x half is #3779 against `3.x` (same change shape, `TimeSpan.FromTicks` since
`TimeSpan / int` does not exist on net462/netstandard2.0, no loop-level test since `Task.Delay` there
is wall time); its documentation lives here.

Closes #3777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WinRBtbAsUdU5RWEPHMkDK
