### PR TITLE
A failed check-in is retried inside the window its peers give it (3.x)

### DIFF
--- a/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
+++ b/src/Quartz.Tests.Unit/Impl/AdoJobStore/ClusterManagerTest.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,14 +74,20 @@ public class ClusterManagerTest
         completedTask.Should().Be(shutdownTask, "Shutdown should complete");
     }
 
+    private static readonly TimeSpan Interval = TimeSpan.FromMilliseconds(7500);
+    private static readonly TimeSpan Threshold = TimeSpan.FromMilliseconds(7500);
+    private static readonly TimeSpan RetryInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ShortPause = TimeSpan.FromMilliseconds(100);
+
     [Test]
     public void ComputeTimeToSleep_ShouldSubtractTranspiredTime()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromSeconds(2),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
         timeToSleep.Should().Be(TimeSpan.FromMilliseconds(5500));
     }
@@ -89,12 +96,13 @@ public class ClusterManagerTest
     public void ComputeTimeToSleep_ShouldUseShortPause_WhenCheckinIsOverdue()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromSeconds(20),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(100));
+        timeToSleep.Should().Be(ShortPause);
     }
 
     /// <summary>
@@ -106,24 +114,228 @@ public class ClusterManagerTest
     public void ComputeTimeToSleep_ShouldClampToCheckinInterval_WhenClockJumpsBackward()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
+            clusterCheckinInterval: Interval,
             transpiredTime: TimeSpan.FromDays(-1),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 0);
+            dbRetryInterval: RetryInterval,
+            numFails: 0,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(7500));
+        timeToSleep.Should().Be(Interval);
+    }
+
+    /// <summary>
+    /// The peers write this node off once interval + threshold has passed since the row it last wrote,
+    /// and a retry that lands after that arrives convicted. Before #3777 a failed check-in slept the
+    /// full <c>DbRetryInterval</c>: on the defaults the next row went out 22.5 s after the last one,
+    /// 7.5 s after the peers had stopped trusting it, so one database blip during a check-in got a live
+    /// node recovered. The retry is now spent inside the window — half of what is left of it.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldRetryAtHalfTheRemainingWindow_WhenACheckinFails()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(3750),
+            "a check-in that failed at the interval has the whole threshold left, and the retry lands halfway through it rather than DbRetryInterval later");
     }
 
     [Test]
-    public void ComputeTimeToSleep_ShouldPreferDbRetryInterval_WhenCheckinsHaveFailed()
+    public void ComputeTimeToSleep_ShouldKeepHalvingTheWindow_WhileRetriesKeepFailing()
     {
         TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
-            clusterCheckinInterval: TimeSpan.FromMilliseconds(7500),
-            transpiredTime: TimeSpan.FromDays(-1),
-            dbRetryInterval: TimeSpan.FromSeconds(15),
-            numFails: 1);
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(11250),
+            dbRetryInterval: RetryInterval,
+            numFails: 2,
+            clusterCheckinMisfireThreshold: Threshold);
 
-        timeToSleep.Should().Be(TimeSpan.FromSeconds(15));
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(1875),
+            "3.75 s of the window is left, so the next retry lands halfway through that");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldNotRetryFasterThanTheShortPause_WhenTheWindowIsNearlySpent()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(14950),
+            dbRetryInterval: RetryInterval,
+            numFails: 5,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(ShortPause,
+            "half of 50 ms is under the loop's floor, and the floor is what an overdue check-in already waits");
+    }
+
+    /// <summary>
+    /// The boundary belongs to the back-off: with nothing left of the window the node is already
+    /// convictable, and there is no longer anything to hurry for.
+    /// </summary>
+    [TestCase(15_000)]
+    [TestCase(22_500)]
+    [TestCase(60_000)]
+    public void ComputeTimeToSleep_ShouldBackOffDbRetryInterval_OnceTheWindowIsSpent(int transpiredMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(transpiredMilliseconds),
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(RetryInterval,
+            "past the window the ordinary back-off applies, exactly as before #3777");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldCapTheInWindowRetryAtDbRetryInterval()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: TimeSpan.FromMinutes(1));
+
+        timeToSleep.Should().Be(RetryInterval,
+            "a minute-long threshold leaves 30 s to retry in, but the node still backs off no longer than DbRetryInterval");
+    }
+
+    [Test]
+    public void ComputeTimeToSleep_ShouldHonourAShorterDbRetryInterval_InsideTheWindow()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: TimeSpan.FromSeconds(1),
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromSeconds(1),
+            "an operator who asked for a one-second back-off gets it; the window only ever shortens the wait");
+    }
+
+    /// <summary>
+    /// A zero <c>DbRetryInterval</c> is legal, and before #3777 it already meant "retry an overdue
+    /// check-in every short pause"; it still does, inside the window and after it.
+    /// </summary>
+    [TestCase(7_500)]
+    [TestCase(20_000)]
+    public void ComputeTimeToSleep_ShouldUseTheShortPause_WhenDbRetryIntervalIsZero(int transpiredMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromMilliseconds(transpiredMilliseconds),
+            dbRetryInterval: TimeSpan.Zero,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(ShortPause);
+    }
+
+    /// <summary>
+    /// With no threshold the window closes at the interval, which is when the check-in was attempted,
+    /// so there is nothing to retry inside and the back-off applies as it always did. A negative
+    /// threshold, which nothing refuses here, reads the same way.
+    /// </summary>
+    [TestCase(0)]
+    [TestCase(-5_000)]
+    public void ComputeTimeToSleep_ShouldBackOffDbRetryInterval_WhenThereIsNoWindowToRetryIn(int thresholdMilliseconds)
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: Interval,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: TimeSpan.FromMilliseconds(thresholdMilliseconds));
+
+        timeToSleep.Should().Be(RetryInterval);
+    }
+
+    /// <summary>
+    /// A backward clock jump during a failure streak makes the elapsed time negative. It must not widen
+    /// the window: the real elapsed time is unknown but not less than zero, so the node retries as if
+    /// the whole window were left — within one interval, which is also what the healthy branch does for
+    /// the same jump — rather than sleeping <c>DbRetryInterval</c>, which is what this case used to pin.
+    /// </summary>
+    [Test]
+    public void ComputeTimeToSleep_ShouldRetryWithinOneWindow_WhenTheClockJumpedBackwardDuringAFailure()
+    {
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: TimeSpan.FromDays(-1),
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().Be(TimeSpan.FromMilliseconds(7500),
+            "half of the full 15 s window, capped by nothing since DbRetryInterval is longer");
+    }
+
+    /// <summary>
+    /// Whatever is left of the window, the retry lands inside it and never later than the back-off —
+    /// down to where half of what is left is under the floor, which the floor test above covers.
+    /// </summary>
+    [TestCase(7_500)]
+    [TestCase(9_000)]
+    [TestCase(11_000)]
+    [TestCase(13_000)]
+    [TestCase(14_800)]
+    public void ComputeTimeToSleep_ShouldLandTheRetryInsideTheWindow(int transpiredMilliseconds)
+    {
+        TimeSpan transpired = TimeSpan.FromMilliseconds(transpiredMilliseconds);
+        TimeSpan windowLeft = Interval + Threshold - transpired;
+
+        TimeSpan timeToSleep = ClusterManager.ComputeTimeToSleep(
+            clusterCheckinInterval: Interval,
+            transpiredTime: transpired,
+            dbRetryInterval: RetryInterval,
+            numFails: 1,
+            clusterCheckinMisfireThreshold: Threshold);
+
+        timeToSleep.Should().BeLessThan(windowLeft, "the retry has to be attempted before the peers stop trusting the last row");
+        timeToSleep.Should().BeLessThanOrEqualTo(RetryInterval, "the window only ever shortens the back-off");
+        timeToSleep.Should().BeGreaterThanOrEqualTo(ShortPause, "the loop never spins");
+    }
+
+    /// <summary>
+    /// The timeline #3777 reports, replayed through the sleep computation with every attempt failing
+    /// at once: last row written at 0, first failure at 7.5 s. Before the fix the one retry came at
+    /// 22.5 s. Now every retry before 15 s lands strictly inside the window, and the first one after
+    /// it is the ordinary back-off later. A failure that takes a while to report eats the window it
+    /// is retried in, so a 3-second failure gets two attempts inside it rather than eight.
+    /// </summary>
+    [TestCase(0, 8)]
+    [TestCase(3_000, 2)]
+    public void AFailedCheckinIsRetriedInsideTheWindow_ThenBacksOff(int failureLatencyMilliseconds, int expectedAttemptsInsideTheWindow)
+    {
+        TimeSpan failureLatency = TimeSpan.FromMilliseconds(failureLatencyMilliseconds);
+        TimeSpan windowEnd = Interval + Threshold;
+        List<TimeSpan> attempts = new List<TimeSpan>();
+
+        TimeSpan now = Interval; // the first check-in after the last successful one, at the interval
+        int numFails = 0;
+        while (now < windowEnd)
+        {
+            attempts.Add(now);
+            now += failureLatency; // the attempt fails, taking this long to say so
+            numFails++;
+            now += ClusterManager.ComputeTimeToSleep(Interval, now, RetryInterval, numFails, Threshold);
+        }
+
+        attempts.Should().HaveCount(expectedAttemptsInsideTheWindow);
+        attempts.Should().OnlyContain(t => t >= Interval && t < windowEnd,
+            "every attempt inside the window comes after the check-in that failed and before the peers stop trusting the last row");
+        attempts.Should().BeInAscendingOrder();
+
+        TimeSpan lastRetryDelay = ClusterManager.ComputeTimeToSleep(Interval, now, RetryInterval, numFails, Threshold);
+        lastRetryDelay.Should().Be(RetryInterval,
+            "once the window is spent the node is convictable anyway, and the ordinary back-off applies");
     }
 
     private class TestJobStoreSupport : JobStoreSupport

--- a/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
+++ b/src/Quartz/Impl/AdoJobStore/ClusterManager.cs
@@ -24,13 +24,33 @@ internal sealed class ClusterManager
     // This prevents hanging if the scheduler was disposed before it could schedule the task.
     private static readonly TimeSpan ShutdownTimeout = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The least the loop sleeps: what an overdue check-in waits before it is attempted, and the floor
+    /// under a retry that has almost no window left to land in.
+    /// </summary>
+    private static readonly TimeSpan ShortPause = TimeSpan.FromMilliseconds(100);
+
     private int numFails;
+
+    /// <summary>
+    /// When this node last wrote a check-in that reached the database — the timestamp its peers read.
+    /// </summary>
+    /// <remarks>
+    /// Kept here rather than read off <see cref="JobStoreSupport.LastCheckin" />, which has a second
+    /// writer: a check-in that fails to <em>read</em> the state table stamps it too, so that
+    /// <c>CalcFailedIfAfter</c> does not count this node's own outage against its peers. The scan runs
+    /// before the write, so that is the stamp a database blip leaves, and a retry timed from it would
+    /// believe it had a whole window left when the peers' clock says otherwise (#3777). Starts at
+    /// construction, as the store's own does.
+    /// </remarks>
+    private DateTimeOffset lastSuccessfulCheckIn;
 
     internal ClusterManager(JobStoreSupport jobStoreSupport)
     {
         this.jobStoreSupport = jobStoreSupport;
         cancellationTokenSource = new CancellationTokenSource();
         log = LogProvider.GetLogger(typeof(ClusterManager));
+        lastSuccessfulCheckIn = SystemTime.UtcNow();
     }
 
     public async Task Initialize()
@@ -82,6 +102,9 @@ internal sealed class ClusterManager
         {
             res = await jobStoreSupport.DoCheckin(requestorId).ConfigureAwait(false);
 
+            // The write's own timestamp, not the clock: a check-in that recovered a peer returns later
+            // than it wrote, and the peers measure from what it wrote.
+            lastSuccessfulCheckIn = jobStoreSupport.LastCheckin;
             numFails = 0;
             log.Debug("Check-in complete.");
         }
@@ -104,9 +127,10 @@ internal sealed class ClusterManager
 
             TimeSpan timeToSleep = ComputeTimeToSleep(
                 jobStoreSupport.ClusterCheckinInterval,
-                SystemTime.UtcNow() - jobStoreSupport.LastCheckin,
+                SystemTime.UtcNow() - lastSuccessfulCheckIn,
                 jobStoreSupport.DbRetryInterval,
-                numFails);
+                numFails,
+                jobStoreSupport.ClusterCheckinMisfireThreshold);
 
             await Task.Delay(timeToSleep, token).ConfigureAwait(false);
 
@@ -124,19 +148,24 @@ internal sealed class ClusterManager
     /// Determines how long to sleep before the next cluster check-in.
     /// </summary>
     /// <param name="clusterCheckinInterval">The configured check-in interval.</param>
-    /// <param name="transpiredTime">Wall clock time elapsed since the last successful check-in.</param>
+    /// <param name="transpiredTime">Wall clock time elapsed since the last check-in that reached the database.</param>
     /// <param name="dbRetryInterval">The configured retry interval used when the last check-ins have failed.</param>
     /// <param name="numFails">Number of consecutive failed check-ins.</param>
+    /// <param name="clusterCheckinMisfireThreshold">
+    /// The slack the peers add to the interval before they write this node off. Together with the
+    /// interval it is the window a failed check-in has to be retried in.
+    /// </param>
     internal static TimeSpan ComputeTimeToSleep(
         TimeSpan clusterCheckinInterval,
         TimeSpan transpiredTime,
         TimeSpan dbRetryInterval,
-        int numFails)
+        int numFails,
+        TimeSpan clusterCheckinMisfireThreshold)
     {
         TimeSpan timeToSleep = clusterCheckinInterval - transpiredTime;
         if (timeToSleep <= TimeSpan.Zero)
         {
-            timeToSleep = TimeSpan.FromMilliseconds(100);
+            timeToSleep = ShortPause;
         }
         else if (timeToSleep > clusterCheckinInterval)
         {
@@ -146,9 +175,37 @@ internal sealed class ClusterManager
             timeToSleep = clusterCheckinInterval;
         }
 
-        if (numFails > 0 && dbRetryInterval > timeToSleep)
+        if (numFails > 0)
         {
-            timeToSleep = dbRetryInterval;
+            // The peers write this node off once interval + threshold has passed since the row it
+            // last wrote. A retry that lands after that arrives convicted, so while the window is
+            // still open the retry is spent inside it — half of what is left each time, never longer
+            // than DbRetryInterval, never shorter than the short pause — and only once it has closed
+            // does the ordinary back-off apply. Java's ClusterManager sleeps
+            // max(dbRetryInterval, timeToSleep) here; with the defaults that is a retry 22.5 s after
+            // a row the peers stop trusting at 15 s, which is what #3777 reports, and this branch
+            // departs from it on purpose.
+            TimeSpan elapsed = transpiredTime < TimeSpan.Zero ? TimeSpan.Zero : transpiredTime; // a backward jump must not widen the window
+            TimeSpan windowLeft = clusterCheckinInterval + clusterCheckinMisfireThreshold - elapsed;
+            if (windowLeft > TimeSpan.Zero)
+            {
+                TimeSpan retry = TimeSpan.FromTicks(windowLeft.Ticks / 2); // TimeSpan / int does not exist on net462/net472/netstandard2.0
+                if (retry > dbRetryInterval)
+                {
+                    retry = dbRetryInterval;
+                }
+
+                if (retry < ShortPause)
+                {
+                    retry = ShortPause;
+                }
+
+                timeToSleep = retry;
+            }
+            else if (dbRetryInterval > timeToSleep)
+            {
+                timeToSleep = dbRetryInterval;
+            }
         }
 
         return timeToSleep;

--- a/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
+++ b/src/Quartz/Impl/AdoJobStore/JobStoreSupport.cs
@@ -202,6 +202,21 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     /// other scheduler instances in a cluster can consider a "misfired" scheduler
     /// instance as failed or dead.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// It is also the window this instance's own check-in loop retries a failed check-in inside: a
+    /// check-in that fails is attempted again with half of what is left of the interval plus this
+    /// threshold, never later than <see cref="DbRetryInterval" />, so a database blip shorter than the
+    /// threshold does not get the instance written off. Only once the window has closed does the loop
+    /// back off <see cref="DbRetryInterval" /> between attempts.
+    /// </para>
+    /// <para>
+    /// Raise it past the environment's worst <em>pause</em> — a garbage collection, a virtual machine
+    /// migration, a database failover — rather than its worst clock error: a genuinely dead instance's
+    /// work waits interval plus threshold to be taken over, and a live instance that misses that window
+    /// is recovered while it is still working.
+    /// </para>
+    /// </remarks>
     [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
     public TimeSpan ClusterCheckinMisfireThreshold { get; set; }
 
@@ -216,6 +231,13 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
     /// Gets or sets the database retry interval.
     /// </summary>
     /// <value>The db retry interval.</value>
+    /// <remarks>
+    /// The back-off after a failure that was not transient — a database that is down rather than busy.
+    /// The misfire handler sleeps for it between failing passes. The cluster check-in loop does so only
+    /// once a failed check-in has spent the window its peers give it (<see cref="ClusterCheckinInterval" />
+    /// plus <see cref="ClusterCheckinMisfireThreshold" />); inside that window it retries sooner, and this
+    /// value caps how long it may wait between those retries.
+    /// </remarks>
     [TimeSpanParseRule(TimeSpanParseRule.Milliseconds)]
     public TimeSpan DbRetryInterval
     {
@@ -223,8 +245,9 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
         set
         {
             TimerLimits.EnsureWaitable(value, nameof(DbRetryInterval),
-                "The store waits it out after a database failure, and the misfire handler and the cluster "
-                + "manager both sleep for it while their last pass is failing.");
+                "The store waits it out after a database failure, the misfire handler sleeps for it while "
+                + "its last pass is failing, and the cluster manager does once a failing check-in has spent "
+                + "its window.");
             dbRetryInterval = value;
         }
     }
@@ -4998,6 +5021,12 @@ public abstract class JobStoreSupport : AdoConstants, IJobStore, INextVersionJob
 
     protected bool firstCheckIn = true;
 
+    /// <summary>
+    /// When this node last recorded that it is alive — or last failed to read the state table, which
+    /// stamps it too, so that <see cref="CalcFailedIfAfter" /> does not count this node's own outage
+    /// against its peers. That second writer is why <see cref="ClusterManager" /> keeps its own record
+    /// of the last check-in that reached the database and times its retries from that (#3777).
+    /// </summary>
     protected internal DateTimeOffset LastCheckin { get; set; } = SystemTime.UtcNow();
 
     protected internal virtual async Task<bool> DoCheckin(


### PR DESCRIPTION
The 3.x half of #3777 — the same change as #3778 on `main`, where the documentation for both lines
lives (it fixes the 3.x configuration reference too: `clusterCheckinInterval` defaults to 7500, not
15000, and `quartz.jobStore.clusterCheckinMisfireThreshold` was not listed at all).

A peer writes a node off once `clusterCheckinInterval` + `clusterCheckinMisfireThreshold` has passed
since the row it last wrote — 15 s on the defaults. The cluster manager's sleep after a failed check-in
was floored at `dbRetryInterval`, also 15 s by default, so a check-in that failed at 7.5 s was next
attempted at 22.5 s: 7.5 s after the peers had stopped trusting the row. One database blip during a
check-in got a live node recovered — fired-trigger rows deleted, recovering jobs fired again,
`[DisallowConcurrentExecution]` no longer holding. Inherited from Java Quartz, which sleeps
`max(dbRetryInterval, timeToSleep)` in the same place. `DoCheckin` already retries *transient*
failures 3 × 1 s inside one pass; anything the driver does not flag as transient reached the floor.

## What changes

**The retry respects the window.** While a peer may still not have written this node off, a failed
check-in is retried inside what is left of the window — half of it each time, never later than
`DbRetryInterval`, never sooner than the loop's 100 ms pause — and only once the window has closed
does the ordinary `DbRetryInterval` back-off apply. On the defaults a check-in failing at 7.5 s is
retried at 11.25, 13.1, 14.1, 14.5 … s, then every 15 s as today.

**Timed from the right stamp.** `JobStoreSupport.LastCheckin` is also stamped by a check-in that fails
to *read* the state table — deliberately, so that `CalcFailedIfAfter` does not count this node's own
outage against its peers — and the scan runs before the write, so that is the stamp a blip leaves.
`ClusterManager` keeps its own record of the last check-in that reached the database and times the
window from that; timed from `LastCheckin` it would have believed a whole window was left.

**Defaults unchanged**, no public API change (`ClusterManager` is internal), no new key, nothing
persisted. `TimeSpan.FromTicks(x.Ticks / 2)` because `TimeSpan / int` does not exist on net462,
net472 or netstandard2.0. `MisfireHandler` keeps its `DbRetryInterval` floor: nothing convicts a
misfire handler. XML docs on `ClusterCheckinMisfireThreshold`, `DbRetryInterval` and `LastCheckin`
say what each now does.

Tests: the sleep computation is pinned for the issue's timeline (every retry before 15 s inside the
window, then `DbRetryInterval`), the halving, the floor, the boundary, a shorter or zero
`DbRetryInterval`, a zero or negative threshold, and a backward clock jump during a failure streak;
`net10.0` and `net472`. No loop-level test here: `Task.Delay` on 3.x is wall time and `SystemTime` is
a static — the one on `main` covers the wiring.

Behaviour change worth a release-note line: a node whose check-in fails now makes up to ~9 connection
attempts and logs three error lines (`RetryableActionErrorLogThreshold` = 4) in the first 15 s of an
outage instead of one, then backs off as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WinRBtbAsUdU5RWEPHMkDK
