### PR TITLE
The API says who changed what, and the dashboard's action log says where it landed

### DIFF
--- a/docs/documentation/quartz-4.x/log-events.md
+++ b/docs/documentation/quartz-4.x/log-events.md
@@ -338,6 +338,7 @@ matching on its text is not.
 | 9004 | Error | `Quartz.AspNetCore` | `"Exception thrown when handling api request to url {Url}"` |
 | 9005 | Warning | `Quartz.AspNetCore` | `"Api request refused: {Reason}"` |
 | 9006 | Debug | `Quartz.AspNetCore` | `"Api request abandoned by the caller: {Url}"` |
+| 9007 | Information | `Quartz.AspNetCore` | `"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"` |
 | 9100 | Information | `Quartz.Dashboard` | `"Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome}"` |
 | 9101 | Information | `Quartz.Dashboard` | `"Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason}"` |
 | 9102 | Debug | `Quartz.Dashboard` | `"Dashboard connection {ConnectionId} opened for user {User}"` |

--- a/docs/documentation/quartz-4.x/log-events.md
+++ b/docs/documentation/quartz-4.x/log-events.md
@@ -339,8 +339,8 @@ matching on its text is not.
 | 9005 | Warning | `Quartz.AspNetCore` | `"Api request refused: {Reason}"` |
 | 9006 | Debug | `Quartz.AspNetCore` | `"Api request abandoned by the caller: {Url}"` |
 | 9007 | Information | `Quartz.AspNetCore` | `"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"` |
-| 9100 | Information | `Quartz.Dashboard` | `"Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome}"` |
-| 9101 | Information | `Quartz.Dashboard` | `"Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason}"` |
+| 9100 | Information | `Quartz.Dashboard` | `"Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome} (origin {Origin}, node {Node})"` |
+| 9101 | Information | `Quartz.Dashboard` | `"Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason} (origin {Origin}, node {Node})"` |
 | 9102 | Debug | `Quartz.Dashboard` | `"Dashboard connection {ConnectionId} opened for user {User}"` |
 | 9103 | Debug | `Quartz.Dashboard` | `"Dashboard connection {ConnectionId} closed for user {User}"` |
 | 9104 | Warning | `Quartz.Dashboard` | `"Forwarding scheduler {SchedulerName} events to the dashboard hub stopped"` |

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -69,7 +69,7 @@ newly possible, that change, and the two cron expressions 4.1 reads differently.
 | `QuartzHttpApiOptions.EventStreamHeartbeatInterval` | How long the event stream may say nothing before it sends a `Heartbeat` frame; fifteen seconds by default, and validated at startup. It is a setting because the thing it has to stay under is not Quartz's: a reverse proxy closes an idle connection after its own read timeout — nginx's is 60 seconds, Azure's front doors 90 — and a deployment is free to configure less |
 | `QuartzHttpApiOptions.ReadOnly` | `false` by default, which is what every earlier release did. Set it and every route that changes something answers `403` with problem details saying the API is read-only — before the handler runs, so no body is read and no scheduler is looked up. Mutation is per route rather than per verb: the two bulk fetches, `POST …/jobs/fetch` and `POST …/triggers/fetch`, are reads and are served. It binds this API only; a dashboard mapped beside it has its own `QuartzDashboardOptions.ReadOnly`. See [Serving reads only](packages/http-api.md#serving-reads-only) |
 
-Eleven behaviours changed without a signature changing:
+Twelve behaviours changed without a signature changing:
 
 * **`Shutdown(waitForJobsToComplete: false)` no longer drops a firing, and settles what it can.** It
   stops the scheduler's own firing loop and waits for it before closing the thread pool, so an
@@ -126,6 +126,16 @@ Eleven behaviours changed without a signature changing:
   needs to forward `{DashboardPath}/hub` only for clients of your own** — the hub is still served and still
   fed, from the same stream, in the payload records `IQuartzDashboardHubClient` has always declared. The
   plugin is still public and still works; registering it beside the publisher would push every event twice.
+* **The HTTP API logs the mutations that succeed, not only the requests that fail.** Every route that
+  changes something writes one `Information` line when it does — event `9007`,
+  `"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"`, under the
+  `Quartz.HttpApi` category the API's other events are written under. The events it raised before this
+  were failures only, so a `POST …/shutdown` that worked was recorded nowhere at all. The user is
+  `HttpContext.User.Identity.Name` or `(anonymous)`, which for an API mapped with `AllowAnonymous()` is
+  every line; the line is written after the handler and only for an answer in the `2xx` range, so a
+  refusal and a failure are still the `9005` and the `9003`/`9004` they were. A deployment that ships the
+  API's logs somewhere with a volume budget is the one to know about it. See
+  [Production hardening](packages/http-api.md#production-hardening).
 * **`AddQuartzHttpApi()` streams its schedulers' events.** It calls `AddQuartzSchedulerEvents()` for the
   route above, which costs a process nobody is watching nothing: no subscriber means no event is built at
   all. A worker that maps the API is therefore watchable without anything further being written.

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -69,7 +69,7 @@ newly possible, that change, and the two cron expressions 4.1 reads differently.
 | `QuartzHttpApiOptions.EventStreamHeartbeatInterval` | How long the event stream may say nothing before it sends a `Heartbeat` frame; fifteen seconds by default, and validated at startup. It is a setting because the thing it has to stay under is not Quartz's: a reverse proxy closes an idle connection after its own read timeout — nginx's is 60 seconds, Azure's front doors 90 — and a deployment is free to configure less |
 | `QuartzHttpApiOptions.ReadOnly` | `false` by default, which is what every earlier release did. Set it and every route that changes something answers `403` with problem details saying the API is read-only — before the handler runs, so no body is read and no scheduler is looked up. Mutation is per route rather than per verb: the two bulk fetches, `POST …/jobs/fetch` and `POST …/triggers/fetch`, are reads and are served. It binds this API only; a dashboard mapped beside it has its own `QuartzDashboardOptions.ReadOnly`. See [Serving reads only](packages/http-api.md#serving-reads-only) |
 
-Twelve behaviours changed without a signature changing:
+Thirteen behaviours changed without a signature changing:
 
 * **`Shutdown(waitForJobsToComplete: false)` no longer drops a firing, and settles what it can.** It
   stops the scheduler's own firing loop and waits for it before closing the thread pool, so an
@@ -126,6 +126,15 @@ Twelve behaviours changed without a signature changing:
   needs to forward `{DashboardPath}/hub` only for clients of your own** — the hub is still served and still
   fed, from the same stream, in the payload records `IQuartzDashboardHubClient` has always declared. The
   plugin is still public and still works; registering it beside the publisher would push every event twice.
+* **The dashboard's `9100` and `9101` say where the action landed, and the Action Log page shows it.**
+  Both templates gained two placeholders at the end —
+  `"… : {Outcome} (origin {Origin}, node {Node})"` and `"… and it failed: {Reason} (origin {Origin}, node
+  {Node})"` — naming the scheduler's `SchedulerOrigin` and the node behind it, or `(unknown)` where the
+  browser session had listed neither. The ids and everything before those placeholders are unchanged, so a
+  pipeline matching on the id or on a prefix is unaffected; one matching the whole rendered line is not.
+  The page carries the same two beside each row, and interrupting a firing from **Currently Executing** is
+  recorded there at all now — it was the one mutating action a page took without recording anything. See
+  [Action Log](packages/dashboard.md#action-log).
 * **The HTTP API logs the mutations that succeed, not only the requests that fail.** Every route that
   changes something writes one `Information` line when it does — event `9007`,
   `"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"`, under the

--- a/docs/documentation/quartz-4.x/packages/dashboard.md
+++ b/docs/documentation/quartz-4.x/packages/dashboard.md
@@ -246,6 +246,8 @@ machine owns each firing rather than decoration.
 
 Interrupting from here interrupts *the one firing the row names*, not every firing of its job — the
 distinction matters for a job without `[DisallowConcurrentExecution]`, which can have several in flight.
+It is recorded in the [Action Log](#action-log), naming the fire instance and the node it reached, whether
+or not the firing was still running to be interrupted.
 
 A row that will not go away is worth reading
 [Fired triggers: backlog or leak](../operations.md#fired-triggers-backlog-or-leak) about: a firing whose
@@ -327,22 +329,32 @@ pages do.
 
 ### Action Log
 
-`/quartz/actions` — what was done *from this dashboard*: time, scheduler, action, target, whether it succeeded and any
-message, newest first. It is the audit trail for the buttons, and it answers "who paused this" for a
-value of "who" that is the dashboard rather than a user.
+`/quartz/actions` — what was done *from this dashboard*: time, scheduler, action, target, where it landed,
+whether it succeeded and any message, newest first. It is the audit trail for the buttons, and it answers
+"who paused this" for a value of "who" that is the dashboard rather than a user.
 
 The store behind it is in-memory and process-wide, holding the last 250 actions across every scheduler;
 the page takes the most recent 100 of those and shows the ones aimed at the scheduler you have selected,
 so switching schedulers re-filters it. That makes it a recent-activity view rather than an audit store —
-and it records only what *this process's dashboard* did. An action taken through the HTTP API, from
-another node, or by another operator's dashboard is not in it, and nothing in it survives a restart.
+and it records only what *this process's dashboard* did. An action taken through the HTTP API is logged
+where the API is mapped, as event `9007` in *that* process's log, and is not on this page; nor is an
+action from another node or another operator's dashboard, and nothing here survives a restart.
+
+**Where each action landed** is beside it, because the target alone does not say. The scheduler's
+[origin](#fronting-a-scheduler-in-another-process-over-http) is a tag on the row, and a `Remote` one adds
+*in another process* — the action was performed by somebody else's scheduler, and that is where the rest
+of the story about it is. An action that is **node-local** names the node it reached: interrupting a
+firing, and starting, standing by or shutting down. A cluster-wide action — pausing a trigger, deleting a
+job — names no node deliberately: it wrote the store, so every node is bound by it and naming the one that
+served the click would suggest the others were not. A scheduler this browser session never listed says
+nothing at all rather than claiming an origin.
 
 **Every entry is also logged**, at `Information`, through the application's own `ILogger` — event `9100`
 for an action that succeeded and `9101` for one that failed, each naming the visitor, the action, the
-target and the scheduler. That is the copy that survives a restart and reaches whatever your logs go to;
-the page above is the last 250 in this process's memory. A connection opening or closing is logged at
-`Debug` (`9102` and `9103`), which is diagnostic detail rather than a record of what was done. All four
-are in [Log Events](../log-events.md).
+target and the scheduler, and ending with `(origin …, node …)`. That is the copy that survives a restart
+and reaches whatever your logs go to; the page above is the last 250 in this process's memory. A
+connection opening or closing is logged at `Debug` (`9102` and `9103`), which is diagnostic detail rather
+than a record of what was done. All four are in [Log Events](../log-events.md).
 
 The visitor is `ClaimsPrincipal.Identity.Name` — `(anonymous)` where nothing authenticated, which for a
 dashboard mapped with `AllowAnonymous()` is every entry. Authorize the dashboard if the name is what you

--- a/docs/documentation/quartz-4.x/packages/http-api.md
+++ b/docs/documentation/quartz-4.x/packages/http-api.md
@@ -998,6 +998,16 @@ that remains is over the payload rather than over the contract.
   trusted with the whole API**, down to reading every job's data map. `SchedulerAuthorizationPolicy`
   narrows *which schedulers* a caller reaches and `IsJobTypeAllowed` narrows *which job types* they may
   name; anything finer than those two belongs in the policy or in a gateway in front of this
+- **Every successful mutation is logged**, at `Information`, as event `9007`
+  (`"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"`) — the caller's
+  `HttpContext.User.Identity.Name`, or `(anonymous)` where nothing authenticated, the endpoint's name, the
+  scheduler and the request's path, which is where a route's target key is spelled. One line per request,
+  written after the handler and only for an answer in the `2xx` range: a refusal is the `9005` beside it
+  and a failure is a `9003` or a `9004`, so what is in this line is what actually changed. It is the
+  record of who did what — authenticate the API if the name is to say anything — and it is *this*
+  process's log: an action taken through the API is not in the [dashboard](dashboard.md#action-log)'s
+  Action Log, and the dashboard's own actions are not here. All of them are in
+  [Log Events](../log-events.md)
 - Set `ReadOnly` where nothing should write through this API at all — a process that maps it to feed a
   dashboard, a monitoring tool or a report. It refuses every mutating route in one setting, whoever
   asks; see [Serving reads only](#serving-reads-only)

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointConventionBuilderExtensions.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/EndpointConventionBuilderExtensions.cs
@@ -92,10 +92,19 @@ internal static class EndpointConventionBuilderExtensions
 
     private static async Task ExceptionHandlingWrapper(HttpContext context, RequestDelegate next)
     {
+        // Asked once and used twice: a mutating route is the one read-only refuses, and the one whose
+        // success is audited. A read pays this one metadata lookup and nothing else.
+        bool mutation = context.GetEndpoint()?.Metadata.GetMetadata<QuartzMutationMetadata>() is not null;
+
         try
         {
-            RefuseWhenReadOnly(context);
+            RefuseWhenReadOnly(context, mutation);
             await next(context).ConfigureAwait(false);
+
+            if (mutation)
+            {
+                RecordMutation(context);
+            }
         }
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
@@ -124,11 +133,10 @@ internal static class EndpointConventionBuilderExtensions
     /// Inside the wrapper that already turns a <see cref="ForbiddenException" /> into the <c>403</c>
     /// problem details and the <c>9005</c> log line, so a refusal here is the same answer a refused job
     /// type gives — and it is made before the handler, so no body is read and no scheduler is looked up.
-    /// A read pays one metadata lookup on an endpoint that has none of it.
     /// </remarks>
-    private static void RefuseWhenReadOnly(HttpContext context)
+    private static void RefuseWhenReadOnly(HttpContext context, bool mutation)
     {
-        if (context.GetEndpoint()?.Metadata.GetMetadata<QuartzMutationMetadata>() is null)
+        if (!mutation)
         {
             return;
         }
@@ -138,5 +146,30 @@ internal static class EndpointConventionBuilderExtensions
         {
             throw ForbiddenException.ForReadOnlyApi();
         }
+    }
+
+    /// <summary>
+    /// Logs the <c>9007</c> that says this request changed something, and who asked for it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// After the handler and only for an answer in the <c>2xx</c> range, so what is recorded is what the
+    /// scheduler did rather than what was asked of it: a refusal throws before this line is reached, and a
+    /// handler that answered <c>404</c> or <c>400</c> changed nothing. There is one line per request, not
+    /// one per route, so a mutation is counted once however many schedulers or keys it named.
+    /// </para>
+    /// <para>
+    /// In the wrapper rather than in each handler because the marker is already here: an endpoint that says
+    /// it mutates is audited by saying so, which is what keeps "somebody forgot" out of the audit trail.
+    /// </para>
+    /// </remarks>
+    private static void RecordMutation(HttpContext context)
+    {
+        if (context.Response.StatusCode is < StatusCodes.Status200OK or >= StatusCodes.Status300MultipleChoices)
+        {
+            return;
+        }
+
+        context.RequestServices.GetService<MutationAudit>()?.Record(context);
     }
 }

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/ExceptionHandler.cs
@@ -15,7 +15,7 @@ internal sealed class ExceptionHandler
     public ExceptionHandler(IOptions<QuartzHttpApiOptions> options, ILoggerFactory loggerFactory)
     {
         includeStackTrace = options.Value.IncludeStackTraceInProblemDetails;
-        logger = loggerFactory.CreateLogger("Quartz.HttpApi");
+        logger = loggerFactory.CreateLogger(HttpApiLog.Category);
     }
 
     /// <summary>

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/HttpApiLog.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/HttpApiLog.cs
@@ -33,14 +33,25 @@ namespace Quartz.AspNetCore.HttpApi.Util;
 /// <c>LogEventCatalogTest</c> in <c>Quartz.Tests.AspNetCore</c> makes a change to one a reviewed diff.
 /// </para>
 /// <para>
-/// Six of the seven are raised while turning an exception into the problem details a request is answered
+/// Six of the eight are raised while turning an exception into the problem details a request is answered
 /// with, and the level says who has to act: a request the caller got wrong is Debug, a scheduler or a
 /// configured rule that refused is Warning, and anything else is a server fault at Error. The seventh
-/// answers no request at all — there is nobody left to answer.
+/// answers no request at all — there is nobody left to answer. The eighth is the only one a request that
+/// went right raises, and the only one at Information: it is the record of who changed what.
 /// </para>
 /// </remarks>
 internal static partial class HttpApiLog
 {
+    /// <summary>
+    /// The one category everything the API logs about a request is written under, whichever type wrote it.
+    /// </summary>
+    /// <remarks>
+    /// A category is what an operator filters by, so the API has one rather than one per collaborator:
+    /// the refusal, the fault and the audit line of a single request would otherwise arrive under three
+    /// names none of which is the API's.
+    /// </remarks>
+    internal const string Category = "Quartz.HttpApi";
+
     [LoggerMessage(EventId = 9000, Level = LogLevel.Debug, Message = "BadHttpRequestException thrown")]
     public static partial void BadHttpRequest(this ILogger logger, Exception exception);
 
@@ -74,4 +85,21 @@ internal static partial class HttpApiLog
     /// </remarks>
     [LoggerMessage(EventId = 9006, Level = LogLevel.Debug, Message = "Api request abandoned by the caller: {Url}")]
     public static partial void RequestAbandoned(this ILogger logger, string url);
+
+    /// <remarks>
+    /// <para>
+    /// Information, and the only line the API writes about a request that succeeded: after an outage the
+    /// first question is who changed this, and until 4.1 a <c>POST …/shutdown</c> that worked was recorded
+    /// nowhere at all. The dashboard's <c>9100</c> is the same event for the same reason, and this is its
+    /// shape for a caller that came over HTTP.
+    /// </para>
+    /// <para>
+    /// The user is <c>HttpContext.User.Identity.Name</c>, or <c>(anonymous)</c> where nothing
+    /// authenticated — which for an API mapped with <c>AllowAnonymous()</c> is every line, and is the
+    /// truth about it. The operation is the endpoint's name and the route is the request's path, which is
+    /// where the target key of every mutating route is spelled.
+    /// </para>
+    /// </remarks>
+    [LoggerMessage(EventId = 9007, Level = LogLevel.Information, Message = "Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}")]
+    public static partial void MutationPerformed(this ILogger logger, string user, string operation, string schedulerName, string route);
 }

--- a/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/MutationAudit.cs
+++ b/src/Quartz.AspNetCore/AspNetCore/HttpApi/Util/MutationAudit.cs
@@ -1,0 +1,113 @@
+#region License
+
+/*
+ * All content copyright Marko Lahma, unless otherwise indicated. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+#endregion
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.AspNetCore.HttpApi.Util;
+
+/// <summary>
+/// Writes the line that says a request changed something, and who asked for it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Its own type rather than a member of <see cref="ExceptionHandler" />, which is where everything else
+/// the API logs about a request is written from: a mutation that succeeded is not an exception, and a
+/// handler named for them would be the wrong place to look for it. Both write under
+/// <see cref="HttpApiLog.Category" />, so an operator still filters the API by one name.
+/// </para>
+/// <para>
+/// A singleton, because nothing here is a request's: what varies per request is read off the
+/// <see cref="HttpContext" /> it is handed. The alternative — resolving <see cref="ILoggerFactory" />
+/// per request and asking it for the category — takes a lock inside the factory on a path that runs for
+/// every mutation.
+/// </para>
+/// </remarks>
+internal sealed class MutationAudit
+{
+    private readonly ILogger logger;
+
+    public MutationAudit(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        logger = loggerFactory.CreateLogger(HttpApiLog.Category);
+    }
+
+    /// <summary>
+    /// Records that <paramref name="context" />'s request changed something.
+    /// </summary>
+    /// <remarks>
+    /// Called once per successful mutating request, from the wrapper that already decides what a mutating
+    /// request is — so a route added later is audited by carrying the same marker
+    /// <see cref="QuartzHttpApiOptions.ReadOnly" /> refuses it by, and by nothing else.
+    /// </remarks>
+    public void Record(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        logger.MutationPerformed(UserName(context), Operation(context), SchedulerName(context), context.Request.Path.ToString());
+    }
+
+    /// <summary>
+    /// Who made the request, or <c>(anonymous)</c> where nothing authenticated.
+    /// </summary>
+    /// <remarks>
+    /// The name the dashboard's own action log uses for the same absence. An API mapped with
+    /// <c>AllowAnonymous()</c> writes it on every line, which is the record such a deployment has: that
+    /// somebody who could reach the endpoint did this.
+    /// </remarks>
+    private static string UserName(HttpContext context)
+    {
+        string? name = context.User.Identity?.Name;
+        return string.IsNullOrWhiteSpace(name) ? "(anonymous)" : name;
+    }
+
+    /// <summary>
+    /// What was done, as the endpoint's own name — <c>PauseTrigger</c>, <c>Shutdown</c>.
+    /// </summary>
+    /// <remarks>
+    /// The name <c>WithName</c> gave the route rather than the path, because it is the same word in every
+    /// deployment: the path carries whatever <see cref="QuartzHttpApiOptions.ApiPath" /> is and the keys
+    /// of the request's target, so an operator matching on what was done would be matching on those too.
+    /// </remarks>
+    private static string Operation(HttpContext context)
+    {
+        Endpoint? endpoint = context.GetEndpoint();
+        return endpoint?.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName
+               ?? endpoint?.DisplayName
+               ?? "(unknown)";
+    }
+
+    /// <summary>
+    /// Which scheduler the request was for, read from the route.
+    /// </summary>
+    /// <remarks>
+    /// Every mutating route the API maps names one — that is what makes the per-scheduler policy a
+    /// convention over the route pattern rather than a call in each handler — so the fallback is for a
+    /// route of somebody else's that carries the marker without naming a scheduler.
+    /// </remarks>
+    private static string SchedulerName(HttpContext context)
+    {
+        return context.Request.RouteValues[SchedulerAuthorization.SchedulerNameRouteValue] as string ?? "(none)";
+    }
+}

--- a/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
+++ b/src/Quartz.AspNetCore/QuartzAspNetCoreConfigurationExtensions.cs
@@ -52,6 +52,11 @@ public static class QuartzAspNetCoreConfigurationExtensions
         services.TryAddSingleton<ExceptionHandler>();
         services.TryAddSingleton<EndpointHelper>();
 
+        // Who changed what. Every mutating route logs one Information line when it succeeds, which is the
+        // only record a deployment has of an action taken over HTTP - the dashboard's action log holds
+        // what its own buttons did and nothing else.
+        services.TryAddSingleton<MutationAudit>();
+
         // The API serves the history of what its schedulers have run, so something has to record it.
         // In memory and bounded, as the dashboard's has always been: a worker that maps the API answers
         // the history routes rather than answering them empty with nothing to say why. Idempotent, so an

--- a/src/Quartz.Dashboard/Components/Pages/ActionLog.razor
+++ b/src/Quartz.Dashboard/Components/Pages/ActionLog.razor
@@ -29,9 +29,34 @@
                 {
                     <tr>
                         <td>@Scheduler.FormatInSelectedTimeZone(entry.Timestamp, "u")</td>
-                        <td>@entry.SchedulerName</td>
+                        <td>
+                            @entry.SchedulerName
+
+                            @* Where the scheduler was, as the listing had it when the action was taken.
+                               An action on a remote scheduler ran in another process, which is what
+                               decides where to look for the rest of the story about it. *@
+                            @if (entry.Origin is { } origin)
+                            {
+                                <span class="qz-tag">@origin.ToString()</span>
+                            }
+                        </td>
                         <td>@entry.Action</td>
-                        <td>@entry.Target</td>
+                        <td>
+                            @entry.Target
+
+                            @if (entry.Origin == SchedulerOrigin.Remote)
+                            {
+                                <div class="qz-muted" style="font-size: var(--qz-font-size-xs);">in another process</div>
+                            }
+
+                            @* Only for an action that landed on one node: pausing a trigger writes the
+                               store and binds the whole cluster, so naming the node that served the click
+                               would suggest the other nodes were unaffected. *@
+                            @if (entry.NodeLocal)
+                            {
+                                <div class="qz-muted" style="font-size: var(--qz-font-size-xs);">on node @(entry.SchedulerInstanceId ?? "(unknown)")</div>
+                            }
+                        </td>
                         <td><StateIndicator State="@(entry.Succeeded ? "Complete" : "Error")" /></td>
                         <td>@(entry.Message ?? string.Empty)</td>
                     </tr>

--- a/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
+++ b/src/Quartz.Dashboard/Components/Pages/CurrentlyExecuting.razor
@@ -7,6 +7,7 @@
 @inject IQuartzApiClient Api
 @inject SchedulerState Scheduler
 @inject ToastService Toasts
+@inject DashboardActionLog ActionLog
 @inject IOptions<QuartzDashboardOptions> Options
 
 <div class="qz-page">
@@ -208,6 +209,17 @@
             // The one execution the row shows, not every execution of its job: the fire instance id is
             // what tells them apart.
             bool interrupted = await Api.InterruptFireInstance(Scheduler.ActiveSchedulerName, fireInstanceId);
+
+            // Recorded whichever way it went, and recorded as node-local: an interrupt has to reach the
+            // node running the firing, so the record of it is only honest if it says which node that was.
+            ActionLog.Record(
+                Scheduler.ActiveSchedulerName,
+                "InterruptFireInstance",
+                fireInstanceId,
+                succeeded: interrupted,
+                interrupted ? null : "the firing is no longer running on this node",
+                nodeLocal: true);
+
             if (!interrupted)
             {
                 // The row is a snapshot of a list that moves: by the time the button is pressed the
@@ -221,6 +233,13 @@
         catch (Exception ex)
         {
             _error = ex.Message;
+            ActionLog.Record(
+                Scheduler.ActiveSchedulerName,
+                "InterruptFireInstance",
+                fireInstanceId,
+                succeeded: false,
+                ex.Message,
+                nodeLocal: true);
         }
     }
 

--- a/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
+++ b/src/Quartz.Dashboard/Components/Pages/Dashboard.razor
@@ -429,7 +429,8 @@
         return ExecuteSchedulerActionAsync(
             schedulerName => Api.Start(schedulerName),
             "Started scheduler.",
-            actionName: "StartScheduler");
+            actionName: "StartScheduler",
+            nodeLocal: true);
     }
 
     private Task StandbySchedulerAsync()
@@ -437,7 +438,8 @@
         return ExecuteSchedulerActionAsync(
             schedulerName => Api.Standby(schedulerName),
             "Scheduler is in standby.",
-            actionName: "StandbyScheduler");
+            actionName: "StandbyScheduler",
+            nodeLocal: true);
     }
 
     private Task PauseAllAsync()
@@ -462,7 +464,8 @@
             schedulerName => Api.Shutdown(schedulerName),
             "Shutdown scheduler.",
             actionName: "ShutdownScheduler",
-            preferCurrentScheduler: false);
+            preferCurrentScheduler: false,
+            nodeLocal: true);
     }
 
     private Task PromptShutdown()
@@ -483,11 +486,17 @@
         return Task.CompletedTask;
     }
 
+    /// <remarks>
+    /// <paramref name="nodeLocal" /> is true for the three that act on the node that answers rather than
+    /// on the scheduling data every node shares - start, stand-by and shutdown. Pausing and resuming all
+    /// triggers writes the store, so it binds the whole cluster and names no node.
+    /// </remarks>
     private async Task ExecuteSchedulerActionAsync(
         Func<string, ValueTask> operation,
         string successMessage,
         string actionName,
-        bool preferCurrentScheduler = true)
+        bool preferCurrentScheduler = true,
+        bool nodeLocal = false)
     {
         string? schedulerName = Scheduler.ActiveSchedulerName;
         if (IsReadOnly || string.IsNullOrWhiteSpace(schedulerName))
@@ -498,7 +507,7 @@
         try
         {
             await operation(schedulerName);
-            ActionLog.Record(schedulerName, actionName, schedulerName, succeeded: true);
+            ActionLog.Record(schedulerName, actionName, schedulerName, succeeded: true, nodeLocal: nodeLocal);
             Toasts.Success(successMessage);
             await RefreshSchedulersAsync(preferCurrentScheduler ? schedulerName : null);
             await LoadDataAsync();
@@ -507,7 +516,7 @@
         catch (Exception ex)
         {
             _error = ex.Message;
-            ActionLog.Record(schedulerName, actionName, schedulerName, succeeded: false, ex.Message);
+            ActionLog.Record(schedulerName, actionName, schedulerName, succeeded: false, ex.Message, nodeLocal);
             Toasts.Error(ex.Message);
         }
     }

--- a/src/Quartz.Dashboard/Services/DashboardActionLog.cs
+++ b/src/Quartz.Dashboard/Services/DashboardActionLog.cs
@@ -28,9 +28,9 @@ namespace Quartz.Dashboard.Services;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Scoped, because the one thing the store cannot know is who did it — the visitor is a circuit's, and
-/// <see cref="DashboardActionLogService" /> is a singleton shared by every circuit in the process. So
-/// the pages talk to this, and it talks to both.
+/// Scoped, because the two things the store cannot know are a circuit's: who did it, and what the
+/// scheduler picker last listed about the scheduler it was done to. <see cref="DashboardActionLogService" />
+/// is a singleton shared by every circuit in the process. So the pages talk to this, and it talks to both.
 /// </para>
 /// <para>
 /// The Action Log alone was the whole record: 250 entries, in one process's memory, readable only from
@@ -41,40 +41,74 @@ namespace Quartz.Dashboard.Services;
 /// </remarks>
 internal sealed class DashboardActionLog
 {
+    /// <summary>
+    /// What an entry says about a scheduler the last listing did not carry, and about a node nothing has
+    /// named. The circuit knows the name it acted on and nothing else about it.
+    /// </summary>
+    private const string Unknown = "(unknown)";
+
     private readonly DashboardActionLogService store;
     private readonly ILogger<DashboardActionLog> logger;
     private readonly AuthenticationStateProvider authenticationStateProvider;
+    private readonly SchedulerState schedulerState;
 
     public DashboardActionLog(
         DashboardActionLogService store,
         ILogger<DashboardActionLog> logger,
-        AuthenticationStateProvider authenticationStateProvider)
+        AuthenticationStateProvider authenticationStateProvider,
+        SchedulerState schedulerState)
     {
         this.store = store;
         this.logger = logger;
         this.authenticationStateProvider = authenticationStateProvider;
+        this.schedulerState = schedulerState;
     }
 
     /// <summary>
     /// Records one mutating action, in the page's own log and in the application's.
     /// </summary>
+    /// <remarks>
+    /// <c>nodeLocal</c> says the action landed on one node rather than on the scheduling data every node
+    /// shares — interrupting a firing, or starting, standing by or shutting down the scheduler that
+    /// answered. It is the caller's to say, because only the caller knows which member it called.
+    /// </remarks>
     public void Record(
         string schedulerName,
         string action,
         string target,
         bool succeeded,
-        string? message = null)
+        string? message = null,
+        bool nodeLocal = false)
     {
-        store.Record(schedulerName, action, target, succeeded, message);
+        // What the picker last listed, which is where the dashboard's own answer to "where is this
+        // scheduler" comes from. Null for a name the listing does not carry, which the entry records as
+        // such rather than guessing.
+        SchedulerHeaderDto? header = schedulerState.Find(schedulerName);
+
+        store.Record(new DashboardActionLogEntry(
+            Timestamp: DateTimeOffset.UtcNow,
+            SchedulerName: schedulerName,
+            Action: action,
+            Target: target,
+            Succeeded: succeeded,
+            Message: message)
+        {
+            Origin = header?.Origin,
+            SchedulerInstanceId = header?.SchedulerInstanceId,
+            NodeLocal = nodeLocal
+        });
 
         string user = UserName();
+        string origin = header?.Origin.ToString() ?? Unknown;
+        string node = header?.SchedulerInstanceId ?? Unknown;
+
         if (succeeded)
         {
-            logger.ActionPerformed(user, action, target, schedulerName, message ?? "done");
+            logger.ActionPerformed(user, action, target, schedulerName, message ?? "done", origin, node);
         }
         else
         {
-            logger.ActionFailed(user, action, target, schedulerName, message);
+            logger.ActionFailed(user, action, target, schedulerName, message, origin, node);
         }
     }
 

--- a/src/Quartz.Dashboard/Services/DashboardActionLogService.cs
+++ b/src/Quartz.Dashboard/Services/DashboardActionLogService.cs
@@ -25,7 +25,36 @@ internal sealed record DashboardActionLogEntry(
     string Action,
     string Target,
     bool Succeeded,
-    string? Message);
+    string? Message)
+{
+    /// <summary>
+    /// Where the scheduler the action was aimed at is, or <see langword="null" /> when the listing this
+    /// circuit last read said nothing about it.
+    /// </summary>
+    /// <remarks>
+    /// Nullable rather than defaulted to <see cref="SchedulerOrigin.Container" />: a page that acted
+    /// before anything listed the schedulers knows the name and nothing else, and an entry claiming the
+    /// scheduler is this container's would be inventing that.
+    /// </remarks>
+    public SchedulerOrigin? Origin { get; init; }
+
+    /// <summary>
+    /// Which node the action reached, or <see langword="null" /> when nothing has built the scheduler or
+    /// the listing could not ask it.
+    /// </summary>
+    public string? SchedulerInstanceId { get; init; }
+
+    /// <summary>
+    /// Whether the action landed on that one node rather than on the scheduling data every node shares.
+    /// </summary>
+    /// <remarks>
+    /// Said by the page that took the action, the way a mutating route says it mutates: interrupting a
+    /// firing has to reach the node running it, and starting, standing by and shutting down act on the
+    /// node that answered. Pausing a trigger does not — it writes the store, and every node in the
+    /// cluster is bound by it — so naming a node beside it would suggest the other nodes were unaffected.
+    /// </remarks>
+    public bool NodeLocal { get; init; }
+}
 
 internal sealed class DashboardActionLogService
 {
@@ -33,20 +62,17 @@ internal sealed class DashboardActionLogService
     private readonly Lock syncRoot = new();
     private readonly int maxEntries = 250;
 
-    public void Record(
-        string schedulerName,
-        string action,
-        string target,
-        bool succeeded,
-        string? message = null)
+    /// <summary>
+    /// Keeps one action, dropping the oldest once the bound is reached.
+    /// </summary>
+    /// <remarks>
+    /// The finished entry rather than its fields: who took the action and what the last listing said about
+    /// the scheduler are a circuit's, and this store is the process's. <see cref="DashboardActionLog" /> is
+    /// the scoped thing that knows both and builds one.
+    /// </remarks>
+    public void Record(DashboardActionLogEntry entry)
     {
-        DashboardActionLogEntry entry = new(
-            Timestamp: DateTimeOffset.UtcNow,
-            SchedulerName: schedulerName,
-            Action: action,
-            Target: target,
-            Succeeded: succeeded,
-            Message: message);
+        ArgumentNullException.ThrowIfNull(entry);
 
         lock (syncRoot)
         {

--- a/src/Quartz.Dashboard/Services/DashboardLog.cs
+++ b/src/Quartz.Dashboard/Services/DashboardLog.cs
@@ -33,11 +33,22 @@ namespace Quartz.Dashboard.Services;
 /// </remarks>
 internal static partial class DashboardLog
 {
-    [LoggerMessage(EventId = 9100, Level = LogLevel.Information, Message = "Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome}")]
-    public static partial void ActionPerformed(this ILogger logger, string user, string action, string target, string schedulerName, string outcome);
+    /// <remarks>
+    /// <para>
+    /// <c>{Origin}</c> and <c>{Node}</c> were added in 4.1, at the end so that everything the line said
+    /// before still reads the same way and in the same order. Where the action landed is the part an
+    /// operator cannot reconstruct afterwards: a scheduler reached over HTTP was driven in somebody
+    /// else's process, and an action that is node-local — interrupt, start, stand-by, shutdown — reached
+    /// the one node named here and no other. Both are <c>(unknown)</c> when the circuit's last listing
+    /// said nothing about the scheduler.
+    /// </para>
+    /// </remarks>
+    [LoggerMessage(EventId = 9100, Level = LogLevel.Information, Message = "Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome} (origin {Origin}, node {Node})")]
+    public static partial void ActionPerformed(this ILogger logger, string user, string action, string target, string schedulerName, string outcome, string origin, string node);
 
-    [LoggerMessage(EventId = 9101, Level = LogLevel.Information, Message = "Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason}")]
-    public static partial void ActionFailed(this ILogger logger, string user, string action, string target, string schedulerName, string? reason);
+    /// <inheritdoc cref="ActionPerformed" />
+    [LoggerMessage(EventId = 9101, Level = LogLevel.Information, Message = "Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason} (origin {Origin}, node {Node})")]
+    public static partial void ActionFailed(this ILogger logger, string user, string action, string target, string schedulerName, string? reason, string origin, string node);
 
     [LoggerMessage(EventId = 9102, Level = LogLevel.Debug, Message = "Dashboard connection {ConnectionId} opened for user {User}")]
     public static partial void HubConnected(this ILogger logger, string connectionId, string user);

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/DashboardPageTest.cs
@@ -125,8 +125,34 @@ public class DashboardPageTest
 
         A.CallTo(() => context.Api.Standby(TestData.SchedulerName, A<CancellationToken>._)).MustHaveHappened();
         context.Toasts.Messages.Should().ContainSingle().Which.Message.Should().Be("Scheduler is in standby.");
-        context.ActionLog.GetLatest(1).Should().ContainSingle()
-            .Which.Action.Should().Be("StandbyScheduler");
+
+        DashboardActionLogEntry entry = context.ActionLog.GetLatest(1).Should().ContainSingle().Which;
+        entry.Action.Should().Be("StandbyScheduler");
+        entry.NodeLocal.Should().BeTrue(
+            "standing down acts on the node that answered, not on the scheduling data every node shares");
+    }
+
+    /// <summary>
+    /// An action that failed is recorded as one, and is still marked node-local.
+    /// </summary>
+    /// <remarks>
+    /// A shutdown that was refused is the entry an operator most wants afterwards: it says the attempt
+    /// reached that one node and what it answered.
+    /// </remarks>
+    [Test]
+    public void ASchedulerActionThatFailedIsRecordedWithItsReason()
+    {
+        A.CallTo(() => context.Api.Standby(A<string>._, A<CancellationToken>._))
+            .Throws(new SchedulerException("the scheduler has been shut down"));
+
+        IRenderedComponent<DashboardPage> page = context.Render<DashboardPage>();
+
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Standby").Click();
+
+        DashboardActionLogEntry entry = context.ActionLog.GetLatest(1).Should().ContainSingle().Which;
+        entry.Succeeded.Should().BeFalse();
+        entry.Message.Should().Be("the scheduler has been shut down");
+        entry.NodeLocal.Should().BeTrue();
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -61,6 +61,48 @@ public class RemainingPagesTest
             "an empty table reads as a rendering fault");
     }
 
+    /// <summary>
+    /// The Action Log says where each action landed: the scheduler's origin, that a remote one ran
+    /// somewhere else, and — for an action that reached one node — which node that was.
+    /// </summary>
+    /// <remarks>
+    /// "Who paused this" was answerable from this page; "where did it land" was not, and for a scheduler
+    /// fronted over HTTP the answer is another process entirely.
+    /// </remarks>
+    [Test]
+    public void TheActionLogSaysWhereEachActionLanded()
+    {
+        context.SchedulerState.AvailableSchedulers =
+            [TestData.Dashboard.SchedulerHeader(origin: SchedulerOrigin.Remote)];
+
+        context.ActionLog.Record(TestData.SchedulerName, "PauseTrigger", "reports.nightly", succeeded: true);
+        context.ActionLog.Record(TestData.SchedulerName, "ShutdownScheduler", TestData.SchedulerName, succeeded: true, nodeLocal: true);
+
+        IRenderedComponent<ActionLog> page = context.Render<ActionLog>();
+
+        page.Markup.Should().Contain("Remote", "an action on a scheduler in another process says so");
+        page.Markup.Should().Contain("in another process");
+        page.Markup.Should().Contain("on node " + TestData.SchedulerInstanceId,
+            "a shutdown reached the node that answered, and nothing else in the cluster");
+        page.TextOfAll("tbody td").Should().NotContain(text => text.Contains("on node reports.nightly"));
+    }
+
+    /// <summary>
+    /// An action on a scheduler this circuit never listed says nothing about where it landed, rather than
+    /// claiming it was this container's.
+    /// </summary>
+    [Test]
+    public void TheActionLogClaimsNoOriginForASchedulerItNeverListed()
+    {
+        context.ActionLog.Record(TestData.SchedulerName, "PauseTrigger", "reports.nightly", succeeded: true);
+
+        IRenderedComponent<ActionLog> page = context.Render<ActionLog>();
+
+        page.Markup.Should().Contain("reports.nightly");
+        page.Markup.Should().NotContain("Container");
+        page.Markup.Should().NotContain("in another process");
+    }
+
     [Test]
     public void CurrentlyExecutingNamesTheNodeThatOwnsEachFiring()
     {
@@ -100,20 +142,7 @@ public class RemainingPagesTest
     [Test]
     public void InterruptingAFiringThatHasFinishedSaysSoRatherThanLookingLikeItWorked()
     {
-        A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
-            .Returns(TestData.Dashboard.Page<FireInstanceDto>([
-                new FireInstanceDto(
-                    "fire-1",
-                    new TriggerKeyDto("nightly", "trigger-1"),
-                    new JobKeyDto("reports", "job-1"),
-                    "node-a",
-                    FireInstanceState.Executing,
-                    TestData.Dashboard.FiredAt,
-                    TestData.Dashboard.FiredAt,
-                    "batch")
-            ]));
-        A.CallTo(() => context.Api.InterruptFireInstance(A<string>._, "fire-1", A<CancellationToken>._))
-            .Returns(false);
+        GivenRunningFiring(interrupted: false);
 
         IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
         page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
@@ -128,6 +157,45 @@ public class RemainingPagesTest
     [Test]
     public void InterruptingARunningFiringSaysNothingBeyondRefreshingTheListing()
     {
+        GivenRunningFiring(interrupted: true);
+
+        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
+
+        A.CallTo(() => context.Api.InterruptFireInstance(TestData.SchedulerName, "fire-1", A<CancellationToken>._))
+            .MustHaveHappened();
+        context.Toasts.Messages.Should().BeEmpty(
+            "the interrupt was delivered, and the row leaving the listing is the whole of the news");
+    }
+
+    /// <summary>
+    /// An interrupt is recorded in the Action Log, and recorded as node-local.
+    /// </summary>
+    /// <remarks>
+    /// It was the one mutating action a page took without recording anything at all, so "who stopped that
+    /// job" had nowhere to be answered from. Node-local because an interrupt reaches the node running the
+    /// firing and no other, which is what the entry then says.
+    /// </remarks>
+    [Test]
+    public void InterruptingAFiringIsRecordedAsANodeLocalAction()
+    {
+        GivenRunningFiring(interrupted: true);
+
+        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
+
+        DashboardActionLogEntry entry = context.ActionLog.GetLatest(1).Should().ContainSingle().Which;
+        entry.Action.Should().Be("InterruptFireInstance");
+        entry.Target.Should().Be("fire-1", "the fire instance is what tells one execution of a job from another");
+        entry.Succeeded.Should().BeTrue();
+        entry.NodeLocal.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A firing that is running, and what interrupting it answers.
+    /// </summary>
+    private void GivenRunningFiring(bool interrupted)
+    {
         A.CallTo(() => context.Api.QueryFireInstances(A<string>._, A<DashboardFireInstanceQuery>._, A<CancellationToken>._))
             .Returns(TestData.Dashboard.Page<FireInstanceDto>([
                 new FireInstanceDto(
@@ -141,15 +209,7 @@ public class RemainingPagesTest
                     "batch")
             ]));
         A.CallTo(() => context.Api.InterruptFireInstance(A<string>._, "fire-1", A<CancellationToken>._))
-            .Returns(true);
-
-        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
-        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
-
-        A.CallTo(() => context.Api.InterruptFireInstance(TestData.SchedulerName, "fire-1", A<CancellationToken>._))
-            .MustHaveHappened();
-        context.Toasts.Messages.Should().BeEmpty(
-            "the interrupt was delivered, and the row leaving the listing is the whole of the news");
+            .Returns(interrupted);
     }
 
     [Test]

--- a/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/Components/RemainingPagesTest.cs
@@ -192,6 +192,25 @@ public class RemainingPagesTest
     }
 
     /// <summary>
+    /// An interrupt the target refused is recorded as the failure it was, node and reason included.
+    /// </summary>
+    [Test]
+    public void AnInterruptThatFailedIsRecordedWithItsReason()
+    {
+        GivenRunningFiring(interrupted: true);
+        A.CallTo(() => context.Api.InterruptFireInstance(A<string>._, "fire-1", A<CancellationToken>._))
+            .Throws(new SchedulerException("the target is unreachable"));
+
+        IRenderedComponent<CurrentlyExecuting> page = context.Render<CurrentlyExecuting>();
+        page.FindAll("button").First(button => button.TextContent.Trim() == "Interrupt").Click();
+
+        DashboardActionLogEntry entry = context.ActionLog.GetLatest(1).Should().ContainSingle().Which;
+        entry.Succeeded.Should().BeFalse();
+        entry.Message.Should().Be("the target is unreachable");
+        entry.NodeLocal.Should().BeTrue();
+    }
+
+    /// <summary>
     /// A firing that is running, and what interrupting it answers.
     /// </summary>
     private void GivenRunningFiring(bool interrupted)

--- a/src/Quartz.Tests.AspNetCore/Dashboard/DashboardActionLogTest.cs
+++ b/src/Quartz.Tests.AspNetCore/Dashboard/DashboardActionLogTest.cs
@@ -1,5 +1,8 @@
 using System.Security.Claims;
 
+using FakeItEasy;
+
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 using Quartz.Dashboard.Services;
@@ -77,7 +80,79 @@ public class DashboardActionLogTest
             .Which.Action.Should().Be("ResumeTrigger", "the logging is in addition to the page, not instead of it");
     }
 
-    private static DashboardActionLog Create(ILogger<DashboardActionLog> logger, string? userName, DashboardActionLogService? store = null)
+    /// <summary>
+    /// Where the action landed is on the entry and at the end of the log line: the scheduler's origin, and
+    /// the node the listing said was behind it.
+    /// </summary>
+    /// <remarks>
+    /// An operator reading "PauseTrigger on acme" afterwards cannot tell from it whether the action ran in
+    /// this process or in the one a remote registration points at, and the dashboard is the only thing that
+    /// knows — the scheduler it drove is the one its picker last listed.
+    /// </remarks>
+    [Test]
+    public void AnEntrySaysWhereTheSchedulerIsAndWhichNodeAnswered()
+    {
+        RecordingLogger logger = new();
+        DashboardActionLogService store = new();
+        DashboardActionLog log = Create(logger, userName: "ops@example.com", store, SchedulerOrigin.Remote);
+
+        log.Record("acme", "PauseTrigger", "reports.nightly", succeeded: true);
+
+        DashboardActionLogEntry entry = store.GetLatest().Should().ContainSingle().Which;
+        entry.Origin.Should().Be(SchedulerOrigin.Remote);
+        entry.SchedulerInstanceId.Should().Be(Node);
+        entry.NodeLocal.Should().BeFalse("pausing a trigger writes the store, which binds every node");
+
+        logger.Entries.Should().ContainSingle().Which.Message.Should()
+            .Contain("origin Remote").And.Contain("node " + Node);
+    }
+
+    /// <summary>
+    /// An action the page says is node-local is marked as one, and only then.
+    /// </summary>
+    /// <remarks>
+    /// The distinction is what makes naming a node honest: an interrupt, a start, a stand-by and a shutdown
+    /// reach the one node that answered, while pausing a trigger is the whole cluster's.
+    /// </remarks>
+    [Test]
+    public void ANodeLocalActionIsMarkedAsOne()
+    {
+        DashboardActionLogService store = new();
+        DashboardActionLog log = Create(new RecordingLogger(), userName: "ops@example.com", store);
+
+        log.Record("acme", "InterruptFireInstance", "fire-1", succeeded: true, nodeLocal: true);
+
+        store.GetLatest().Should().ContainSingle().Which.NodeLocal.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A scheduler this circuit has not listed is recorded as one nothing is known about, rather than as
+    /// one of this container's.
+    /// </summary>
+    [Test]
+    public void ASchedulerTheListingDoesNotCarryIsRecordedAsUnknown()
+    {
+        RecordingLogger logger = new();
+        DashboardActionLogService store = new();
+        DashboardActionLog log = Create(logger, userName: "ops@example.com", store, origin: null);
+
+        log.Record("acme", "PauseTrigger", "reports.nightly", succeeded: true);
+
+        DashboardActionLogEntry entry = store.GetLatest().Should().ContainSingle().Which;
+        entry.Origin.Should().BeNull("nothing said where this scheduler is, and an entry must not invent it");
+        entry.SchedulerInstanceId.Should().BeNull();
+
+        logger.Entries.Should().ContainSingle().Which.Message.Should()
+            .Contain("origin (unknown)").And.Contain("node (unknown)");
+    }
+
+    private const string Node = "acme-node-1";
+
+    private static DashboardActionLog Create(
+        ILogger<DashboardActionLog> logger,
+        string? userName,
+        DashboardActionLogService? store = null,
+        SchedulerOrigin? origin = SchedulerOrigin.Container)
     {
         TestAuthenticationStateProvider authentication = new();
         if (userName is not null)
@@ -85,7 +160,16 @@ public class DashboardActionLogTest
             authentication.User = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, userName)], "test"));
         }
 
-        return new DashboardActionLog(store ?? new DashboardActionLogService(), logger, authentication);
+        // What the scheduler picker last listed, which is where the dashboard's answer to "where is this
+        // scheduler" comes from. A state with no listing at all is a circuit that acted before anything
+        // read one.
+        SchedulerState schedulerState = new(A.Fake<IHttpContextAccessor>());
+        if (origin is { } listed)
+        {
+            schedulerState.AvailableSchedulers = [new SchedulerHeaderDto("acme", Node, SchedulerStatus.Running, listed)];
+        }
+
+        return new DashboardActionLog(store ?? new DashboardActionLogService(), logger, authentication, schedulerState);
     }
 
     private sealed record RecordedLog(LogLevel Level, EventId EventId, string Message);

--- a/src/Quartz.Tests.AspNetCore/HttpApi/MutationAuditTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/MutationAuditTest.cs
@@ -1,0 +1,320 @@
+using System.Net;
+using System.Text;
+
+using AwesomeAssertions.Execution;
+
+using FakeItEasy;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz.Extensibility;
+using Quartz.Impl.Calendar;
+using Quartz.Tests.AspNetCore.Support;
+
+namespace Quartz.Tests.AspNetCore.HttpApi;
+
+/// <summary>
+/// What the API records about a request that changed something: one <c>9007</c> line naming the caller,
+/// the operation, the scheduler and the route.
+/// </summary>
+/// <remarks>
+/// The events the API raised until 4.1 were failures only, so a <c>POST …/shutdown</c> that worked was
+/// recorded nowhere at all and "who paused this trigger" could not be answered for a caller that came
+/// over HTTP. The line is written in the same wrapper that refuses a mutation while the API is read-only,
+/// off the same marker, which is what ties the two together: a route that is audited is a route that can
+/// be refused, and neither is a list somebody has to remember to add to.
+/// </remarks>
+public sealed class MutationAuditTest
+{
+    private const int AuditEventId = 9007;
+    private const int RefusedEventId = 9005;
+    private const string SchedulerUrl = "schedulers/" + TestData.SchedulerName;
+
+    private readonly List<WebApplicationFactory<Program>> factories = [];
+    private readonly RecordingLoggerProvider logs = new();
+
+    private HttpClient client = null!;
+    private IScheduler fake = null!;
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        client?.Dispose();
+
+        if (fake is not null)
+        {
+            await fake.DisposeAsync();
+        }
+
+        foreach (WebApplicationFactory<Program> factory in factories)
+        {
+            await factory.DisposeAsync();
+        }
+
+        factories.Clear();
+        logs.Clear();
+    }
+
+    /// <summary>
+    /// One route from every family that changes something, driven until it answers <c>2xx</c>: each one
+    /// writes exactly one audit line, and the line says which operation it was.
+    /// </summary>
+    /// <remarks>
+    /// Every shape a mutating route takes is here — the target in the path, the target in the query, the
+    /// targets in a body, and a <c>DELETE</c> — because what decides whether a request is audited is the
+    /// marker on the route rather than anything about the request.
+    /// </remarks>
+    [Test]
+    public async Task EveryMutatingRouteFamilyWritesOneAuditLineWhenItSucceeds()
+    {
+        StartApi();
+
+        using (new AssertionScope())
+        {
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/start", "Start");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/standby", "Standby");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/shutdown", "Shutdown");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/clear", "Clear");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/pause-all", "PauseAll");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/resume-all", "ResumeAll");
+            await Audited(HttpMethod.Delete, $"{SchedulerUrl}/execution-limits", "ClearExecutionLimits");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/pause", "PauseJob");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/resume", "ResumeJob");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/trigger", "TriggerJob");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/group/existing/interrupt", "InterruptJob");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/interrupt/fire-instance-1", "InterruptJobInstance");
+            await Audited(HttpMethod.Delete, $"{SchedulerUrl}/jobs/group/existing", "DeleteJob");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/pause?groupEquals=group", "PauseJobs");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/jobs/keys/pause", "PauseJobKeys",
+                requestJson: """{"jobs":[{"name":"existing","group":"group"}]}""");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/triggers/group/existing/pause", "PauseTrigger");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/triggers/group/existing/reset-from-error-state", "ResetTriggerFromErrorState");
+            await Audited(HttpMethod.Post, $"{SchedulerUrl}/triggers/group/existing/unschedule", "UnscheduleJob");
+            await Audited(HttpMethod.Delete, $"{SchedulerUrl}/calendars/holidays", "DeleteCalendar");
+        }
+    }
+
+    /// <summary>
+    /// The two routes an operator most wants to read afterwards take a body, and are audited by the same
+    /// line: scheduling something, and adding a calendar every trigger is then held to.
+    /// </summary>
+    /// <remarks>
+    /// Driven through <see cref="HttpScheduler" /> rather than with hand-written JSON, because the bodies
+    /// are the whole wire format and the client is what writes it.
+    /// </remarks>
+    [Test]
+    public async Task TheRoutesThatTakeABodyAreAuditedToo()
+    {
+        StartApi();
+        A.CallTo(() => fake.ScheduleJob(A<ITrigger>._, A<ScheduleJobOptions>._, A<CancellationToken>._))
+            .Returns(TestData.Dashboard.FiredAt);
+
+        using HttpClient typedClient = factories[^1].CreateClient();
+        await using HttpScheduler scheduler = new(TestData.SchedulerName, typedClient);
+
+        await scheduler.ScheduleJob(TestData.CronTrigger);
+        await scheduler.AddCalendar("holidays", new HolidayCalendar(), AddCalendarOptions.Replacing);
+
+        logs.WithEventId(AuditEventId).Select(x => x.Properties["Operation"]).Should()
+            .Equal(["ScheduleJob", "AddCalendar"], "a mutation that arrives as a body is a mutation");
+    }
+
+    /// <summary>
+    /// A refusal is not a mutation. Nothing was changed, so the audit line that says something was is not
+    /// written — the <c>9005</c> that says the request was turned away is.
+    /// </summary>
+    [Test]
+    public async Task ARefusedMutationIsNotAudited()
+    {
+        StartApi(readOnly: true);
+
+        using HttpResponseMessage response = await client.PostAsync($"{SchedulerUrl}/pause-all", content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        logs.WithEventId(AuditEventId).Should().BeEmpty(
+            "auditing a refusal would put actions nobody was allowed to take into the record of what was done");
+        logs.WithEventId(RefusedEventId).Should().ContainSingle(
+            "the refusal is still logged, as it was before there was an audit line at all");
+    }
+
+    /// <summary>
+    /// A read writes nothing, whichever verb it arrives with. The two bulk fetches are <c>POST</c>s that
+    /// change nothing, so a rule written per verb would have filled the audit trail with them.
+    /// </summary>
+    [Test]
+    public async Task AReadIsNotAudited()
+    {
+        StartApi();
+
+        using (new AssertionScope())
+        {
+            await Served(HttpMethod.Get, "schedulers");
+            await Served(HttpMethod.Get, $"{SchedulerUrl}/jobs");
+            await Served(HttpMethod.Get, $"{SchedulerUrl}/triggers");
+            await Served(HttpMethod.Post, $"{SchedulerUrl}/jobs/fetch", """[{"name":"existing","group":"group"}]""");
+            await Served(HttpMethod.Post, $"{SchedulerUrl}/triggers/fetch", """[{"name":"existing","group":"group"}]""");
+        }
+
+        logs.WithEventId(AuditEventId).Should().BeEmpty("nothing was changed, so there is nothing to record");
+    }
+
+    /// <summary>
+    /// A mutating route that failed is not audited either: what is recorded is what the scheduler did,
+    /// not what was asked of it.
+    /// </summary>
+    [Test]
+    public async Task AMutationThatFailedIsNotAudited()
+    {
+        StartApi();
+        A.CallTo(() => fake.PauseAll(A<CancellationToken>._)).Throws(new SchedulerException("the store said no"));
+
+        using HttpResponseMessage notFound = await client.PostAsync("schedulers/no-such-scheduler/pause-all", content: null);
+        using HttpResponseMessage failed = await client.PostAsync($"{SchedulerUrl}/pause-all", content: null);
+
+        notFound.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        failed.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        logs.WithEventId(AuditEventId).Should().BeEmpty(
+            "an operator reading the audit trail is reading what happened, and neither of these happened");
+    }
+
+    /// <summary>
+    /// The line names the caller, which is the point of it: the identity the request authenticated as, or
+    /// <c>(anonymous)</c> where nothing did.
+    /// </summary>
+    [Test]
+    public async Task TheAuditLineNamesTheCaller()
+    {
+        StartApi(authenticated: true);
+
+        using HttpRequestMessage identified = new(HttpMethod.Post, $"{SchedulerUrl}/pause-all");
+        identified.Headers.Add(TenantAuthenticationHandler.TenantHeaderName, "ops@example.com");
+        using HttpResponseMessage identifiedResponse = await client.SendAsync(identified);
+        identifiedResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using HttpResponseMessage anonymousResponse = await client.PostAsync($"{SchedulerUrl}/resume-all", content: null);
+        anonymousResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        logs.WithEventId(AuditEventId).Select(x => x.Properties["User"]).Should()
+            .Equal(["ops@example.com", "(anonymous)"],
+                "an API mapped with AllowAnonymous() records that somebody who could reach it did this, which is all it knows");
+    }
+
+    /// <summary>
+    /// The line arrives under the API's own logging category, with the refusals and the faults, and at
+    /// <c>Information</c> — the only level anything about a request that succeeded is written at.
+    /// </summary>
+    [Test]
+    public async Task TheAuditLineIsTheApisOwnCategoryAtInformation()
+    {
+        StartApi();
+
+        using HttpResponseMessage response = await client.PostAsync($"{SchedulerUrl}/pause-all", content: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        RecordedLogEntry entry = logs.WithEventId(AuditEventId).Should().ContainSingle().Which;
+        entry.Category.Should().Be("Quartz.HttpApi",
+            "everything the API logs about a request is filtered by one category, whichever type wrote it");
+        entry.Level.Should().Be(LogLevel.Information);
+        entry.Message.Should().Be($"Api user (anonymous) performed PauseAll on scheduler {TestData.SchedulerName}: /{SchedulerUrl}/pause-all");
+    }
+
+    /// <summary>
+    /// Drives one mutating route and asserts the audit line it wrote.
+    /// </summary>
+    private async Task Audited(HttpMethod method, string url, string operation, string? requestJson = null)
+    {
+        logs.Clear();
+
+        using HttpRequestMessage request = new(method, url);
+        if (requestJson is not null)
+        {
+            request.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        }
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+        string body = await response.Content.ReadAsStringAsync();
+
+        ((int) response.StatusCode).Should().BeInRange(200, 299, $"{method} {url} has to succeed to be audited, body was {body}");
+
+        List<RecordedLogEntry> audited = logs.WithEventId(AuditEventId);
+        audited.Should().ContainSingle($"{method} {url} changed something, exactly once").Which.Properties.Should()
+            .Contain(new KeyValuePair<string, string?>("Operation", operation))
+            .And.Contain(new KeyValuePair<string, string?>("SchedulerName", TestData.SchedulerName))
+            .And.Contain(new KeyValuePair<string, string?>("Route", "/" + url.Split('?')[0]));
+    }
+
+    /// <summary>
+    /// Drives one read and asserts only that it was served, so that the audit assertion the caller makes
+    /// is about a request that reached a handler.
+    /// </summary>
+    private async Task Served(HttpMethod method, string url, string? requestJson = null)
+    {
+        using HttpRequestMessage request = new(method, url);
+        if (requestJson is not null)
+        {
+            request.Content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        }
+
+        using HttpResponseMessage response = await client.SendAsync(request);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, $"{method} {url} is a read, body was {body}");
+    }
+
+    /// <summary>
+    /// The API, its logs captured, with one fake scheduler bound under the test scheduler's name.
+    /// </summary>
+    /// <remarks>
+    /// A fake rather than a real scheduler because what is under test is what the API records, not what
+    /// the scheduler does with it: every route then answers <c>2xx</c> without a store, and <c>shutdown</c>
+    /// does not take the rest of the rows with it.
+    /// </remarks>
+    private void StartApi(bool readOnly = false, bool authenticated = false)
+    {
+        TestContentRoot.Apply();
+
+        WebApplicationFactory<Program> root = new();
+        factories.Add(root);
+
+        WebApplicationFactory<Program> configured = root.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureLogging(logging => logging.AddProvider(logs));
+            builder.ConfigureServices(services =>
+            {
+                services.AddQuartzHttpApi(options => options.ReadOnly = readOnly);
+                if (authenticated)
+                {
+                    services.AddTenantAuthorization();
+                }
+            });
+        });
+
+        factories.Add(configured);
+
+        fake = A.Fake<IScheduler>();
+        A.CallTo(() => fake.SchedulerName).Returns(TestData.SchedulerName);
+        A.CallTo(() => fake.QueryJobs(A<JobQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<JobHeader>([], HasMore: false));
+        A.CallTo(() => fake.QueryTriggers(A<TriggerQuery>._, A<CancellationToken>._))
+            .Returns(new PagedResult<TriggerHeader>([], HasMore: false));
+        A.CallTo(() => fake.PauseJobGroups(A<GroupMatcher<JobKey>>._, A<CancellationToken>._)).Returns(new List<string>());
+        A.CallTo(() => fake.PauseJobs(A<IReadOnlyCollection<JobKey>>._, A<CancellationToken>._)).Returns(new List<JobKey>());
+
+        client = configured.CreateClient();
+
+        ISchedulerRepository repository = configured.Services.GetRequiredService<ISchedulerRepository>();
+        foreach (IScheduler bound in repository.LookupAll())
+        {
+            repository.Remove(bound.SchedulerName);
+        }
+
+        repository.Bind(fake);
+
+        // Nothing the audit line carries comes from the scheduler, so the noise of every other package in
+        // the host is dropped rather than filtered on: what is left is what the API wrote.
+        logs.Clear();
+    }
+}

--- a/src/Quartz.Tests.AspNetCore/HttpApi/MutationAuditTest.cs
+++ b/src/Quartz.Tests.AspNetCore/HttpApi/MutationAuditTest.cs
@@ -5,11 +5,16 @@ using AwesomeAssertions.Execution;
 
 using FakeItEasy;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+using Quartz.AspNetCore.HttpApi.Util;
 using Quartz.Extensibility;
 using Quartz.Impl.Calendar;
 using Quartz.Tests.AspNetCore.Support;
@@ -219,6 +224,56 @@ public sealed class MutationAuditTest
             "everything the API logs about a request is filtered by one category, whichever type wrote it");
         entry.Level.Should().Be(LogLevel.Information);
         entry.Message.Should().Be($"Api user (anonymous) performed PauseAll on scheduler {TestData.SchedulerName}: /{SchedulerUrl}/pause-all");
+    }
+
+    /// <summary>
+    /// Every route that changes something is named, which is what the audit line records as the operation
+    /// — and the name comes from the same <c>WithQuartzDefaults</c> call that installs the wrapper writing
+    /// the line.
+    /// </summary>
+    /// <remarks>
+    /// The rows above drive one route per family; this covers the rest of them. A mutating route mapped
+    /// without <c>WithQuartzDefaults</c> would be audited by nothing and refused by nothing while the API
+    /// is read-only, and a mutating route mapped without a name would be audited as <c>(unknown)</c>.
+    /// </remarks>
+    [Test]
+    public async Task EveryMutatingRouteIsNamedByTheConventionThatAuditsIt()
+    {
+        WebApplicationBuilder builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddQuartz();
+        builder.Services.AddQuartzHttpApi();
+
+        await using WebApplication app = builder.Build();
+        app.MapQuartzHttpApi("/quartz-api");
+
+        List<string> unnamed = [];
+        List<string> mutating = [];
+
+        IEnumerable<RouteEndpoint> endpoints = ((IEndpointRouteBuilder) app).DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>();
+
+        foreach (RouteEndpoint endpoint in endpoints)
+        {
+            if (endpoint.Metadata.GetMetadata<QuartzMutationMetadata>() is null)
+            {
+                continue;
+            }
+
+            string route = $"{string.Join(",", endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? [])} {endpoint.RoutePattern.RawText}";
+            mutating.Add(route);
+
+            if (string.IsNullOrWhiteSpace(endpoint.Metadata.GetMetadata<IEndpointNameMetadata>()?.EndpointName))
+            {
+                unnamed.Add(route);
+            }
+        }
+
+        mutating.Should().HaveCountGreaterThan(30,
+            "the sweep has to find the mutating routes to say anything about them - a near-empty result "
+            + "means the endpoint source stopped answering rather than that the API stopped changing things");
+        unnamed.Should().BeEmpty("the audit line records the endpoint's name as the operation");
     }
 
     /// <summary>

--- a/src/Quartz.Tests.AspNetCore/Support/RecordingLogs.cs
+++ b/src/Quartz.Tests.AspNetCore/Support/RecordingLogs.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+
+using Microsoft.Extensions.Logging;
+
+namespace Quartz.Tests.AspNetCore.Support;
+
+/// <summary>
+/// Everything logged through a host, as a provider a test adds to it: the category, the level, the event
+/// id, the rendered message and the structured properties behind it.
+/// </summary>
+/// <remarks>
+/// The properties as well as the text, because a template's placeholders are the part an operator's
+/// pipeline matches on — asserting only on the rendered string would pass for an event that records
+/// <c>{User}</c> nowhere. A concurrent queue, because a host logs from whichever thread served the
+/// request.
+/// </remarks>
+internal sealed class RecordingLoggerProvider : ILoggerProvider
+{
+    private readonly ConcurrentQueue<RecordedLogEntry> entries = new();
+
+    /// <summary>
+    /// What has been logged so far, as a snapshot taken when the property is read.
+    /// </summary>
+    public List<RecordedLogEntry> Entries => entries.ToList();
+
+    /// <summary>
+    /// The entries carrying <paramref name="eventId" />, which is how a test names the event it is about.
+    /// </summary>
+    public List<RecordedLogEntry> WithEventId(int eventId) => entries.Where(x => x.EventId.Id == eventId).ToList();
+
+    public void Clear()
+    {
+        entries.Clear();
+    }
+
+    public ILogger CreateLogger(string categoryName) => new RecordingLogger(this, categoryName);
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class RecordingLogger(RecordingLoggerProvider provider, string category) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Dictionary<string, string?> properties = [];
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> values)
+            {
+                foreach (KeyValuePair<string, object?> value in values)
+                {
+                    properties[value.Key] = value.Value?.ToString();
+                }
+            }
+
+            provider.entries.Enqueue(new RecordedLogEntry(
+                category,
+                logLevel,
+                eventId,
+                formatter(state, exception),
+                properties));
+        }
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static readonly NullScope Instance = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}
+
+internal sealed record RecordedLogEntry(
+    string Category,
+    LogLevel Level,
+    EventId EventId,
+    string Message,
+    IReadOnlyDictionary<string, string?> Properties);

--- a/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.AspNetCore.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.AspNetCore.verified.txt
@@ -12,3 +12,5 @@
     "Api request refused: {Reason}"
 9006  Debug  HttpApiLog.RequestAbandoned
     "Api request abandoned by the caller: {Url}"
+9007  Information  HttpApiLog.MutationPerformed
+    "Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"

--- a/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.Dashboard.verified.txt
+++ b/src/Quartz.Tests.AspNetCore/Verify/LogEventCatalogTest_Quartz.Dashboard.verified.txt
@@ -1,7 +1,7 @@
 ﻿9100  Information  DashboardLog.ActionPerformed
-    "Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome}"
+    "Dashboard user {User} performed {Action} on {Target} of scheduler {SchedulerName}: {Outcome} (origin {Origin}, node {Node})"
 9101  Information  DashboardLog.ActionFailed
-    "Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason}"
+    "Dashboard user {User} attempted {Action} on {Target} of scheduler {SchedulerName} and it failed: {Reason} (origin {Origin}, node {Node})"
 9102  Debug  DashboardLog.HubConnected
     "Dashboard connection {ConnectionId} opened for user {User}"
 9103  Debug  DashboardLog.HubDisconnected


### PR DESCRIPTION
Closes #3769.

After an outage the first question is "who paused this job?". The HTTP API could not answer it at all —
its log events were failures only, so a `POST …/shutdown` that worked was recorded nowhere — and the
dashboard's Action Log could answer it only for its own buttons, and said nothing about *where* the
action landed: a scheduler fronted over HTTP is driven in another process, and an interrupt, a start, a
stand-by and a shutdown reach one node.

This is the part of #3769 that 4.1 ships. The `IOperatorAuditStore` seam the issue sketches is
deliberately **not** here — it goes with the ADO-backed history store later — so this PR adds no store
seam and no public API.

## The API says who changed what

* New `HttpApiLog` event **9007**, `Information`:
  `"Api user {User} performed {Operation} on scheduler {SchedulerName}: {Route}"`. `User` is
  `HttpContext.User.Identity.Name` or `(anonymous)`, `Operation` is the endpoint's `WithName(…)` value
  (`PauseTrigger`, `Shutdown`), `Route` is the request's path — which is where a mutating route's target
  key is spelled.
* Written in the wrapper that already refuses a mutation while `ReadOnly` is set, off the same
  `QuartzMutationMetadata` marker, which is now read once and used for both: a route that can be refused
  is a route that is audited, and neither is a list somebody has to remember to add to. After the handler
  and only for a `2xx`, so a refusal, a `404`, a `400` and a read write nothing.
* `MutationAudit` is its own internal singleton rather than a member of `ExceptionHandler` — a mutation
  that succeeded is not an exception — and logs under the same `Quartz.HttpApi` category, now
  `HttpApiLog.Category` rather than a string in two places.

## The dashboard's action log says where the action landed

* `DashboardActionLogEntry` gains `Origin` (`SchedulerOrigin?`), `SchedulerInstanceId` and `NodeLocal`,
  filled from `SchedulerState.Find(schedulerName)` — what the visitor's own scheduler picker last listed.
  All three are `init` properties on an **internal** record, so no baseline moves.
* `9100`/`9101` end with `(origin {Origin}, node {Node})`. Same ids, same prefix; a pipeline matching the
  whole rendered line sees the two new placeholders, which is why it is in the migration guide.
* The Action Log page shows the origin as a tag, adds *in another process* for a `Remote` scheduler, and
  names the node for an action that is node-local. A cluster-wide action names no node on purpose: it
  wrote the store, so every node is bound by it.
* `DashboardActionLogService.Record` now takes the finished entry. Who acted and what the listing said are
  a circuit's; the store is the process's.

### One thing a reviewer should decide

**Interrupting a firing from Currently Executing is recorded at all now.** It was the one mutating action
a page took without writing anything to either log, and the brief lists interrupt among the node-local
actions whose node the page is meant to show — so there was nothing for it to show. It records
`InterruptFireInstance` against the fire instance id, node-local, whether or not the firing was still
running (`succeeded: interrupted`, matching what the other pages do with an `applied` flag).

Not changed: the Overview panel's "latest ten" list, which has no scheduler column either and links to
the full page.

## Verification

```
dotnet build Quartz.slnx                → Build succeeded. 0 Warning(s) 0 Error(s)
dotnet test src/Quartz.Tests.Unit       → Passed! Failed: 0, Passed: 6378, Skipped: 36, Total: 6414
dotnet test src/Quartz.Tests.AspNetCore → Passed! Failed: 0, Passed:  739, Skipped:  1, Total:  740
build.cmd Compile UnitTest              → Restore/Compile/UnitTest Succeeded (6378 + 739 passed)
npm run docs:lint                       → 92 files, 0 error(s)
npm run docs:check-links                → 224 pages, 1505 internal links, 950 fragments, no dead links
dotnet fallout VerifyDocsSnippets VerifyDocsLogEvents → both Succeeded
```

`Quartz.Benchmark` references `Quartz` and `Quartz.Jobs` only, so nothing here reaches it and
`BenchmarkSmoke` is not implicated. The integration project is untouched and was not run.

Generated artefacts regenerated, never hand-edited: both `LogEventCatalogTest_*.verified.txt` snapshots
(accepted through Verify) and `docs/documentation/quartz-4.x/log-events.md`
(`dotnet fallout DocsLogEvents`). No `PublicApiTest_*.verified.txt` moved — everything added is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL8aYk1AC91GhJECfBB5PG
