### PR TITLE
An unknown quartz.jobStore.* key is refused by name rather than dropped

### DIFF
--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -779,9 +779,15 @@ migrates in, and the one the removed-key advice is written for. Keys that came o
 `IConfiguration` section are deliberately not checked, because there every key under `Quartz:` becomes
 a `quartz.*` key whether Quartz reads it or not, so a section holding your own settings would be
 rejected. A misspelled key in `appsettings.json` is therefore read by nobody and reported by nothing —
-`Quartz:JobStore:TabelPrefix` configures no table prefix and says so nowhere — so check a key you have
-just typed against the tables above. Casing is not the risk: configuration keys are matched
+`Quartz:Scheduler:IdelWaitTime` waits exactly as long as it did before and says so nowhere — so check a
+key you have just typed against the tables above. Casing is not the risk: configuration keys are matched
 case-insensitively, so `Quartz:Jobstore:TablePrefix` is the same key as `Quartz:JobStore:TablePrefix`.
+
+**The job store is the exception, and it is checked either way.** A persistent store refuses a
+`quartz.jobStore.*` key that nothing reads — see [Unknown job store keys](#unknown-job-store-keys) —
+whether the key was written flat or as `Quartz:JobStore:TabelPrefix`, because the settings under that
+one prefix are known exhaustively: the store's own options, its clustering sub-section, its lock
+handler's keys, and the two keys that select a type.
 
 ## Legacy property keys
 
@@ -893,3 +899,30 @@ Removed in 4.x, with no replacement: `quartz.scheduler.proxy*` and `quartz.sched
 (remoting, which .NET no longer supports) — these two are rejected with an exception naming the
 replacement, rather than accepted and ignored — plus `quartz.threadExecutor*`, which had no
 implementation left to choose between.
+
+### Unknown job store keys
+
+A key under `quartz.jobStore` that nothing reads is refused by name, when a persistent store resolves its
+settings — the startup validation `UsePersistentStore` declares, or the build that constructs the store:
+
+```text
+Unknown configuration property 'quartz.jobStore.dbRetryIntreval'. It is not a setting of the ADO.NET
+job store, and no other reader consults it. Set 'quartz.checkConfiguration' to false to allow keys
+Quartz does not read.
+```
+
+3.x wrote every key under this prefix onto the store object by name and failed startup on one the store
+had no property for. 4.0 read the keys it knew into typed options and did nothing with the rest, so a typo
+— or a key a newer 3.x line had added and 4.x had not translated yet — started the scheduler with the
+default in force and said nothing about it.
+
+What counts as read: every flat key in the tables above, every property of `AdoJobStoreOptions` and of its
+`Clustering` sub-section spelled the way the options type spells it, every `quartz.jobStore.lockHandler.*`
+key — those are written onto the lock handler by name, which reports an unknown one itself — and
+`quartz.jobStore.driverDelegateInitString`, whose contents are checked as they are parsed. Case is not
+part of it: `quartz.jobstore.tableprefix` is the same key as `quartz.jobStore.tablePrefix`.
+
+Two things are deliberately outside it. A store with no options type of its own — one you wrote, or one
+from another package — still has its leftover keys under this prefix written onto it by name, so an
+unknown one fails there instead and says so in the same breath. And an in-memory store refuses nothing,
+because it reads one key under this prefix and the settings the others name are not its.

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -779,9 +779,10 @@ migrates in, and the one the removed-key advice is written for. Keys that came o
 `IConfiguration` section are deliberately not checked, because there every key under `Quartz:` becomes
 a `quartz.*` key whether Quartz reads it or not, so a section holding your own settings would be
 rejected. A misspelled key in `appsettings.json` is therefore read by nobody and reported by nothing —
-`Quartz:Scheduler:IdelWaitTime` waits exactly as long as it did before and says so nowhere — so check a
-key you have just typed against the tables above. Casing is not the risk: configuration keys are matched
-case-insensitively, so `Quartz:Jobstore:TablePrefix` is the same key as `Quartz:JobStore:TablePrefix`.
+`Quartz:Scheduler:IdelWaitTime` leaves the scheduler idling for the default thirty seconds and says so
+nowhere — so check a key you have just typed against the tables above. Casing is not the risk:
+configuration keys are matched case-insensitively, so `Quartz:Jobstore:TablePrefix` is the same key as
+`Quartz:JobStore:TablePrefix`.
 
 **The job store is the exception, and it is checked either way.** A persistent store refuses a
 `quartz.jobStore.*` key that nothing reads — see [Unknown job store keys](#unknown-job-store-keys) —

--- a/docs/documentation/quartz-4.x/configuration/reference.md
+++ b/docs/documentation/quartz-4.x/configuration/reference.md
@@ -903,7 +903,7 @@ implementation left to choose between.
 
 ### Unknown job store keys
 
-A key under `quartz.jobStore` that nothing reads is refused by name, when a persistent store resolves its
+A key under `quartz.jobStore` that nothing reads is refused by name when a persistent store resolves its
 settings — the startup validation `UsePersistentStore` declares, or the build that constructs the store:
 
 ```text
@@ -913,9 +913,9 @@ Quartz does not read.
 ```
 
 3.x wrote every key under this prefix onto the store object by name and failed startup on one the store
-had no property for. 4.0 read the keys it knew into typed options and did nothing with the rest, so a typo
-— or a key a newer 3.x line had added and 4.x had not translated yet — started the scheduler with the
-default in force and said nothing about it.
+had no property for. 4.0 read the keys it knew into typed options and did nothing with the rest, so a
+typo — or a key a newer 3.x line had added and 4.x had not translated yet — started the scheduler with
+the default in force and said nothing about it.
 
 What counts as read: every flat key in the tables above, every property of `AdoJobStoreOptions` and of its
 `Clustering` sub-section spelled the way the options type spells it, every `quartz.jobStore.lockHandler.*`

--- a/docs/documentation/quartz-4.x/migration-guide.md
+++ b/docs/documentation/quartz-4.x/migration-guide.md
@@ -69,7 +69,7 @@ newly possible, that change, and the two cron expressions 4.1 reads differently.
 | `QuartzHttpApiOptions.EventStreamHeartbeatInterval` | How long the event stream may say nothing before it sends a `Heartbeat` frame; fifteen seconds by default, and validated at startup. It is a setting because the thing it has to stay under is not Quartz's: a reverse proxy closes an idle connection after its own read timeout — nginx's is 60 seconds, Azure's front doors 90 — and a deployment is free to configure less |
 | `QuartzHttpApiOptions.ReadOnly` | `false` by default, which is what every earlier release did. Set it and every route that changes something answers `403` with problem details saying the API is read-only — before the handler runs, so no body is read and no scheduler is looked up. Mutation is per route rather than per verb: the two bulk fetches, `POST …/jobs/fetch` and `POST …/triggers/fetch`, are reads and are served. It binds this API only; a dashboard mapped beside it has its own `QuartzDashboardOptions.ReadOnly`. See [Serving reads only](packages/http-api.md#serving-reads-only) |
 
-Thirteen behaviours changed without a signature changing:
+Fourteen behaviours changed without a signature changing:
 
 * **`Shutdown(waitForJobsToComplete: false)` no longer drops a firing, and settles what it can.** It
   stops the scheduler's own firing loop and waits for it before closing the thread pool, so an
@@ -104,6 +104,16 @@ Thirteen behaviours changed without a signature changing:
 * **A health check falls back to the repository** when the container holds no scheduler registration
   under the name it was given, so `AddHealthChecks().AddQuartz("acme")` written at build time reports on
   the tenant added under that name later. Its message when nothing is found names both places it looked.
+* **A misspelled `quartz.jobStore.*` key fails startup where 4.0 ignored it — which is what 3.x always
+  did.** The unknown-key check accepts any key under a supported *prefix*, and `quartz.jobStore` is one,
+  so `quartz.jobStore.dbRetryIntreval` was accepted and then read by nobody: the scheduler started with
+  the default retry interval in force and said nothing. An ADO.NET store now refuses a key under its
+  prefix that nothing reads, by name, when its options are resolved — the startup validation
+  `UsePersistentStore` declares, or the build that constructs the store. `lockHandler.*` and
+  `driverDelegateInitString` keep their own handling, a store with no options type of its own keeps
+  failing in the binder that writes its keys by name, and `quartz.checkConfiguration = false` allows
+  keys of your own as it always did. Unlike the check on a property bag, this one also sees a key that
+  came from an `appsettings.json` `JobStore` section, so `Quartz:JobStore:TabelPrefix` is reported too.
 * **`AddQuartzHttpApi()` records execution history.** It calls `AddQuartzExecutionHistory()`, so a
   worker that maps the API answers the new history routes rather than answering them empty. In memory
   and bounded — 24 hours, 2000 rows per scheduler per feed — as the dashboard's has always been. A

--- a/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
+++ b/docs/documentation/quartz-4.x/packages/multiple-schedulers.md
@@ -259,12 +259,12 @@ builder.Services.AddQuartzSchedulers(builder.Configuration.GetSection("Quartz"))
 ```
 
 Individual flat keys that no typed option covers can still be set on the named options directly, through
-the `Properties` dictionary:
+the `Properties` dictionary — a plugin's own settings, say, which have no options type at all:
 
 <!-- snippet: sample_multiple_named_options -->
 ```csharp
 builder.Services.Configure<QuartzOptions>("DurableScheduler",
-    options => options.Properties["quartz.jobStore.someThirdPartySetting"] = "value");
+    options => options.Properties["quartz.plugin.myPlugin.someSetting"] = "value");
 ```
 <!-- endSnippet -->
 

--- a/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
+++ b/src/Quartz.Documentation.Samples/Packages/MultipleSchedulersSamples.cs
@@ -198,7 +198,7 @@ public static class MultipleSchedulersSamples
         #region sample_multiple_named_options
 
         builder.Services.Configure<QuartzOptions>("DurableScheduler",
-            options => options.Properties["quartz.jobStore.someThirdPartySetting"] = "value");
+            options => options.Properties["quartz.plugin.myPlugin.someSetting"] = "value");
 
         #endregion
     }

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -4,6 +4,8 @@ using System.Collections.Specialized;
 using System.Data.Common;
 using System.Text.Json;
 
+using FakeItEasy;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -846,6 +848,200 @@ public class ConfigurationIsNeverSilentlyDroppedTest
             "bridging the zero literally would turn a working 3.x configuration into a startup failure");
     }
 
+    /// <summary>
+    /// The last silent drop under this prefix. <c>LegacyPropertyKeys.Validate</c> accepts any key under a
+    /// supported <em>prefix</em> and <c>quartz.jobStore</c> is one, so a misspelling underneath it was
+    /// accepted by the check and then consulted by nobody: the ADO.NET store reads the keys it knows into
+    /// its options and does nothing with the rest. 3.x wrote every key under the prefix onto the store by
+    /// name and failed startup on one the store had no property for.
+    /// </summary>
+    [Test]
+    public void AnUnknownJobStoreKeyIsRefusedByName()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection
+            {
+                ["quartz.jobStore.dataSource"] = "test",
+                ["quartz.jobStore.dbRetryIntreval"] = "20000",
+            },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value;
+
+        act.Should().Throw<SchedulerConfigException>(
+                "a key the store never reads leaves the default in force, and a retry interval that is "
+                + "silently not what the file says is indistinguishable from one that is")
+            .WithMessage("*quartz.jobStore.dbRetryIntreval*",
+                "the reader has to be told which key in their file is the problem")
+            .WithMessage("*quartz.checkConfiguration*",
+                "a configuration holding keys of its own has the same escape hatch the unknown-key check has");
+    }
+
+    /// <summary>
+    /// The refusal fires where a misconfiguration fails today — the options the store resolves as it is
+    /// built — rather than at the first statement that would have used the setting.
+    /// </summary>
+    [Test]
+    public void AnUnknownJobStoreKeyStopsTheStoreBeingBuilt()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection { ["quartz.jobStore.maxTransientRetires"] = "10" },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IJobStore>();
+
+        act.Should().Throw<SchedulerConfigException>(
+                "a store built with a default nobody asked for runs for weeks before anyone notices")
+            .WithMessage("*quartz.jobStore.maxTransientRetires*");
+    }
+
+    [Test]
+    public void AnUnknownJobStoreKeyIsAllowedOnceTheCheckIsTurnedOff()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection
+            {
+                ["quartz.checkConfiguration"] = "false",
+                ["quartz.jobStore.dataSource"] = "test",
+                ["quartz.jobStore.dbRetryIntreval"] = "20000",
+            },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value.DataSource.Should().Be("test",
+            "the flag is what a bag carrying keys of Quartz's is not documented to read exists for, and it "
+            + "has to cover this check as it covers the other one");
+    }
+
+    /// <summary>
+    /// A lock handler's settings sit under this prefix and are written onto the handler by name, which
+    /// reports an unknown one itself. Refusing them here would refuse every third-party lock handler.
+    /// </summary>
+    [Test]
+    public void ALockHandlerSettingIsNotTakenForAnUnknownJobStoreKey()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection
+            {
+                ["quartz.jobStore.dataSource"] = "test",
+                ["quartz.jobStore.lockHandler.type"] = typeof(MarkedLockHandler).AssemblyQualifiedName,
+                ["quartz.jobStore.lockHandler.marker"] = "configured",
+            },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value.DataSource.Should().Be("test");
+        provider.GetRequiredService<ILockHandler>().Should().BeOfType<MarkedLockHandler>()
+            .Which.Marker.Should().Be("configured");
+    }
+
+    /// <summary>
+    /// The init string is parsed into trigger persistence delegate registrations, and reports an unknown
+    /// setting of its own — see <see cref="AnUnknownInitStringSettingIsRejectedByName" />.
+    /// </summary>
+    [Test]
+    public void TheInitStringIsNotTakenForAnUnknownJobStoreKey()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection
+            {
+                ["quartz.jobStore.dataSource"] = "test",
+                ["quartz.jobStore.driverDelegateInitString"] =
+                    "triggerPersistenceDelegateTypes=" + typeof(MarkedTriggerPersistenceDelegate).AssemblyQualifiedName,
+            },
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value.DataSource.Should().Be("test");
+        provider.GetServices<ITriggerPersistenceDelegate>().Should().ContainSingle(x => x is MarkedTriggerPersistenceDelegate);
+    }
+
+    /// <summary>
+    /// A hierarchical <c>JobStore</c> section binds onto the typed options <em>and</em> is flattened onto
+    /// the flat keys, so a setting the bridge has no legacy key for still arrives under this prefix.
+    /// <c>LockWaitWarningThreshold</c> is one: refusing it would refuse the spelling its own options type
+    /// gives it.
+    /// </summary>
+    [Test]
+    public void ASettingSpelledAsItsTypedPropertyIsNotRefused()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            Section(new Dictionary<string, string?>
+            {
+                ["JobStore:DataSource"] = "test",
+                ["JobStore:LockWaitWarningThreshold"] = "00:00:05",
+            }),
+            UseStubbedPersistentStore);
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value.LockWaitWarningThreshold
+            .Should().Be(TimeSpan.FromSeconds(5),
+                "the typed binder is this key's reader, so the flat spelling of it is a key something reads");
+    }
+
+    /// <summary>
+    /// The other branch of the same decision, pinned so the two agree in outcome: a store with no typed
+    /// options has its leftover keys written onto it by name, and an unknown one has always failed there.
+    /// </summary>
+    [Test]
+    public void AnUnknownJobStoreKeyAgainstACustomStoreStillFailsWhereItAlwaysDid()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(new NameValueCollection
+        {
+            ["quartz.jobStore.type"] = typeof(StoreWithNoTypedOptions).AssemblyQualifiedName,
+            ["quartz.jobStore.dbRetryIntreval"] = "20000",
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IJobStore>();
+
+        act.Should().Throw<SchedulerConfigException>(
+                "the reflection branch is what the ADO store's refusal was written to agree with, so a "
+                + "change to either must not leave one of them silent")
+            .WithMessage("*dbRetryIntreval*");
+    }
+
+    /// <summary>
+    /// The refusal belongs to the store whose settings the keys describe. An in-memory scheduler reads
+    /// one key under this prefix and none of the rest, and failing it here would refuse a configuration
+    /// 4.0 accepted — a 3.x file that still names a table prefix beside an in-memory store is a report of
+    /// its own, not this one.
+    /// </summary>
+    [Test]
+    public void AnAdoOnlyKeyDoesNotFailAnInMemoryStore()
+    {
+        var services = new ServiceCollection();
+        services.AddQuartz(
+            new NameValueCollection
+            {
+                ["quartz.jobStore.misfireThreshold"] = "30000",
+                ["quartz.jobStore.tablePrefix"] = "QRTZ2_",
+            },
+            q => q.UseInMemoryStore());
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IOptions<InMemoryJobStoreOptions>>().Value.MisfireThreshold
+            .Should().Be(TimeSpan.FromSeconds(30));
+        provider.GetRequiredService<IJobStore>().Should().BeOfType<RAMJobStore>();
+    }
+
     [Test]
     public async Task PluginSettingsInConfigurationFindAPluginAddedInCode()
     {
@@ -1223,6 +1419,22 @@ public class ConfigurationIsNeverSilentlyDroppedTest
             => new(true);
 
         public ValueTask ReleaseLock(Guid requestorId, SchedulerLock lockKind, CancellationToken cancellationToken = default) => default;
+    }
+
+    /// <summary>
+    /// A store of somebody else's: neither the in-memory store nor an ADO.NET one, which is what sends
+    /// its leftover <c>quartz.jobStore.*</c> keys through the by-name binder.
+    /// </summary>
+    /// <remarks>
+    /// The bridge writes them onto whatever <c>JobStores.Unwrap</c> finds, so they land on the innermost
+    /// store — a fake here, because what is under test is the binder's answer to a name no property
+    /// carries, and spelling out <see cref="IJobStore"/>'s fifty members to say that would bury it.
+    /// </remarks>
+    private sealed class StoreWithNoTypedOptions : DelegatingJobStore
+    {
+        public StoreWithNoTypedOptions() : base(A.Fake<IJobStore>())
+        {
+        }
     }
 
     private sealed class RecordingPlugin : ISchedulerPlugin

--- a/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/ConfigurationIsNeverSilentlyDroppedTest.cs
@@ -872,8 +872,8 @@ public class ConfigurationIsNeverSilentlyDroppedTest
         var act = () => provider.GetRequiredService<IOptions<AdoJobStoreOptions>>().Value;
 
         act.Should().Throw<SchedulerConfigException>(
-                "a key the store never reads leaves the default in force, and a retry interval that is "
-                + "silently not what the file says is indistinguishable from one that is")
+                "a key the store never reads leaves the default in force, and a retry interval that is not "
+                + "what the file says — with nothing said about it — is the failure this suite exists for")
             .WithMessage("*quartz.jobStore.dbRetryIntreval*",
                 "the reader has to be told which key in their file is the problem")
             .WithMessage("*quartz.checkConfiguration*",

--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -63,6 +63,7 @@ namespace Quartz.Tests.Unit.Configuration;
 public class LegacyPropertyKeyExhaustivenessTest
 {
     private const string Prefix = "quartz.";
+    private const string JobStorePrefix = "quartz.jobStore.";
     private const string ConfigurationNamespace = "Quartz.Configuration";
 
     private static readonly Assembly quartzAssembly = typeof(IScheduler).Assembly;
@@ -252,8 +253,6 @@ public class LegacyPropertyKeyExhaustivenessTest
     [Test]
     public void EveryJobStoreKeyTheReadersConsultIsAcceptedForAnAdoStore()
     {
-        const string JobStorePrefix = "quartz.jobStore.";
-
         List<string> jobStoreKeys = keysTheReadersConsult
             .Where(key => key.Length > JobStorePrefix.Length
                           && key.StartsWith(JobStorePrefix, StringComparison.OrdinalIgnoreCase))
@@ -280,7 +279,7 @@ public class LegacyPropertyKeyExhaustivenessTest
     public void EveryDocumentedJobStoreKeyIsAcceptedForAnAdoStore()
     {
         List<string> refused = documentedKeys
-            .Where(key => key.StartsWith("quartz.jobStore.", StringComparison.Ordinal))
+            .Where(key => key.StartsWith(JobStorePrefix, StringComparison.Ordinal))
             .Where(key => JobStoreRejection(key) is not null)
             .ToList();
 

--- a/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
+++ b/src/Quartz.Tests.Unit/Configuration/LegacyPropertyKeyExhaustivenessTest.cs
@@ -233,6 +233,91 @@ public class LegacyPropertyKeyExhaustivenessTest
             + "to have at all");
     }
 
+    /// <summary>
+    /// The same completeness property, one prefix down.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An ADO.NET store refuses a <c>quartz.jobStore.*</c> key nothing reads, which is only a kindness
+    /// while the table it checks against covers every such key some reader consults — and those readers
+    /// are spread over four methods of the bridge, none of which the table is derived from. A key added
+    /// to one of them and not to the table is refused although it works, and it is refused for the
+    /// persistent configurations this check exists to protect.
+    /// </para>
+    /// <para>
+    /// Compared mechanically for that reason, against the same IL scan the whole-format test uses rather
+    /// than against a second transcription of the table.
+    /// </para>
+    /// </remarks>
+    [Test]
+    public void EveryJobStoreKeyTheReadersConsultIsAcceptedForAnAdoStore()
+    {
+        const string JobStorePrefix = "quartz.jobStore.";
+
+        List<string> jobStoreKeys = keysTheReadersConsult
+            .Where(key => key.Length > JobStorePrefix.Length
+                          && key.StartsWith(JobStorePrefix, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        jobStoreKeys.Should().HaveCountGreaterThan(20,
+            "the scan finding next to nothing under this prefix would make the assertion below vacuous");
+
+        List<string> refused = [];
+        foreach (string key in jobStoreKeys)
+        {
+            if (JobStoreRejection(key) is { } message)
+            {
+                refused.Add($"{key}: {message}");
+            }
+        }
+
+        refused.Should().BeEmpty(
+            "a key some reader consults is by definition not a misspelling, so refusing it would fail a "
+            + "persistent scheduler whose configuration is correct");
+    }
+
+    [Test]
+    public void EveryDocumentedJobStoreKeyIsAcceptedForAnAdoStore()
+    {
+        List<string> refused = documentedKeys
+            .Where(key => key.StartsWith("quartz.jobStore.", StringComparison.Ordinal))
+            .Where(key => JobStoreRejection(key) is not null)
+            .ToList();
+
+        refused.Should().BeEmpty(
+            "the documentation is the other half of the contract here too: a key it teaches and the store "
+            + "refuses fails a reader who did exactly what they were told");
+    }
+
+    [Test]
+    public void AMisspelledJobStoreKeyIsRefusedByName()
+    {
+        // Guards the guard above: a check that accepted everything would satisfy it silently.
+        JobStoreRejection("quartz.jobStore.dbRetryIntreval")
+            .Should().NotBeNull("this is the misspelling the whole check exists for")
+            .And.Contain("quartz.jobStore.dbRetryIntreval",
+                "the reader has to be told which key in their file is the problem");
+    }
+
+    /// <summary>
+    /// Runs the ADO.NET store's key check over a bag holding just this key, and returns the complaint or
+    /// <see langword="null" /> when the key is accepted.
+    /// </summary>
+    private static string? JobStoreRejection(string key)
+    {
+        NameValueCollection properties = new NameValueCollection { [key] = "value" };
+
+        try
+        {
+            LegacyPropertyKeys.ValidateJobStoreKeys(properties);
+            return null;
+        }
+        catch (SchedulerConfigException exception)
+        {
+            return exception.Message;
+        }
+    }
+
     [Test]
     public void NoKeyTheReadersConsultIsAlsoListedAsRemoved()
     {

--- a/src/Quartz/Configuration/LegacyPropertyKeys.cs
+++ b/src/Quartz/Configuration/LegacyPropertyKeys.cs
@@ -20,6 +20,7 @@
 #endregion
 
 using System.Collections.Specialized;
+using System.Reflection;
 
 using Quartz.Util;
 
@@ -73,6 +74,12 @@ internal static class LegacyPropertyKeys
     internal const string ThreadPoolType = "quartz.threadPool.type";
     internal const string TimeProviderType = "quartz.timeProvider.type";
     internal const string JobStorePrefix = "quartz.jobStore";
+
+    /// <summary>
+    /// The job store prefix with its separator, which is where a key under it starts.
+    /// </summary>
+    private const string JobStoreKeyPrefix = JobStorePrefix + ".";
+
     internal const string JobStoreType = "quartz.jobStore.type";
     internal const string JobStoreDbRetryInterval = "quartz.jobStore.dbRetryInterval";
 
@@ -270,5 +277,161 @@ internal static class LegacyPropertyKeys
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Every <c>quartz.jobStore.*</c> key some reader of the flat format consumes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One table rather than the reading order, because <see cref="ValidateJobStoreKeys" /> has to know
+    /// what was consumed and the readers are spread over four methods of
+    /// <see cref="QuartzPropertyBridge" /> — the ADO.NET store's options, the in-memory store's misfire
+    /// threshold, the clustering options and the registrations. A key added to one of them and not to
+    /// this table is refused although it works, which is why
+    /// <c>EveryJobStoreKeyTheReadersConsultIsAcceptedForAnAdoStore</c> compares the two mechanically.
+    /// </para>
+    /// <para>
+    /// Both spellings of a setting are keys: <c>clustered</c> and <c>clustering.enabled</c> say the same
+    /// thing, as do <c>performSchemaValidation</c> and <c>schemaProvisioning</c>.
+    /// </para>
+    /// </remarks>
+    private static readonly HashSet<string> jobStoreKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        JobStoreType,
+        JobStoreDbRetryInterval,
+        JobStoreCommandTimeout,
+        JobStorePrefix + ".dataSource",
+        JobStorePrefix + ".driverDelegateType",
+        JobStorePrefix + ".driverDelegateInitString",
+        JobStorePrefix + ".tablePrefix",
+        JobStorePrefix + ".useProperties",
+        JobStorePrefix + ".misfireThreshold",
+        JobStorePrefix + ".misfireHandlerFrequency",
+        JobStorePrefix + ".maxMisfiresToHandleAtATime",
+        JobStorePrefix + ".maxTransientRetries",
+        JobStorePrefix + ".transientRetryInterval",
+        JobStorePrefix + ".retryableActionErrorLogThreshold",
+        JobStorePrefix + ".makeThreadsDaemons",
+        JobStorePrefix + ".useDBLocks",
+        JobStorePrefix + ".lockOnInsert",
+        JobStorePrefix + ".acquireTriggersWithinLock",
+        JobStorePrefix + ".acceptEnlistedTransactions",
+        JobStorePrefix + ".openConnection",
+        JobStorePrefix + ".txIsolationLevelSerializable",
+        JobStorePrefix + ".doubleCheckLockMisfireHandler",
+        JobStorePrefix + ".performSchemaValidation",
+        JobStorePrefix + ".schemaProvisioning",
+        JobStorePrefix + ".selectWithLockSQL",
+        JobStorePrefix + ".clustered",
+        JobStorePrefix + ".clusterCheckinInterval",
+        JobStorePrefix + ".clusterCheckinMisfireThreshold",
+        JobStorePrefix + ".clustering.enabled",
+        JobStorePrefix + ".clustering.checkinInterval",
+        JobStorePrefix + ".clustering.checkinMisfireThreshold",
+    };
+
+    /// <summary>
+    /// The same keys under their typed spelling, read off the options types rather than listed.
+    /// </summary>
+    /// <remarks>
+    /// A hierarchical <c>JobStore</c> section binds onto <see cref="AdoJobStoreOptions" /> and is
+    /// flattened onto this prefix as well, so <c>JobStore:StoreJobDataAsStrings</c> arrives as
+    /// <c>quartz.jobStore.storeJobDataAsStrings</c> — a key the bridge never reads and the typed binder
+    /// always does. Taken from the options types so that a property added to either needs no entry here:
+    /// a new setting would otherwise be refused in the very spelling the options type gives it.
+    /// </remarks>
+    private static readonly HashSet<string> typedJobStoreKeys = TypedJobStoreKeys();
+
+    private static HashSet<string> TypedJobStoreKeys()
+    {
+        HashSet<string> keys = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (PropertyInfo property in typeof(AdoJobStoreOptions).GetProperties())
+        {
+            keys.Add(JobStoreKeyPrefix + property.Name);
+        }
+
+        // Clustering is a sub-section of the job store's, which flattens onto this prefix.
+        foreach (PropertyInfo property in typeof(ClusteringOptions).GetProperties())
+        {
+            keys.Add(JobStoreKeyPrefix + "clustering." + property.Name);
+        }
+
+        return keys;
+    }
+
+    /// <summary>
+    /// Rejects a <c>quartz.jobStore.*</c> key the ADO.NET job store does not read.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Validate" /> accepts any key under a supported <em>prefix</em>, and
+    /// <c>quartz.jobStore</c> is one, so a misspelling underneath it was accepted by the check and then
+    /// consulted by nobody: <c>quartz.jobStore.dbRetryIntreval</c> started the scheduler with the
+    /// default retry interval in force and said nothing about it. 3.x wrote every key under this prefix
+    /// onto the store object by name and failed startup on one the store had no property for, and a
+    /// store whose settings arrive as typed options has to give the same answer — a key a newer 3.x line
+    /// adds and 4.x has not bridged is dropped the same way a typo is, which is how
+    /// <see cref="JobStoreCommandTimeout" /> went missing.
+    /// </para>
+    /// <para>
+    /// Called from the ADO.NET store's own options mapping, so it runs when those options are resolved —
+    /// the startup validation a persistent store declares, or the scheduler build that constructs the
+    /// store — and not at all for a store that reads none of them. A third-party store's keys are
+    /// written onto the store object by name, which reports an unknown one itself, so the two kinds of
+    /// store agree in outcome without this being asked about either.
+    /// </para>
+    /// <para>
+    /// Two families under the prefix take their own route and are not refused here: every
+    /// <c>lockHandler.*</c> key is written onto the lock handler by name, and
+    /// <c>driverDelegateInitString</c> is parsed into trigger persistence delegate registrations. Both
+    /// report an unknown setting of their own.
+    /// </para>
+    /// </remarks>
+    internal static void ValidateJobStoreKeys(NameValueCollection properties)
+    {
+        var parser = new PropertiesParser(properties);
+        if (!parser.GetBooleanProperty(CheckConfiguration, defaultValue: true))
+        {
+            return;
+        }
+
+        foreach (var key in properties.AllKeys)
+        {
+            // Case-insensitively, because that is how the bag itself looks a key up: a reader asking for
+            // 'quartz.jobStore.tablePrefix' is answered by a key written 'quartz.jobstore.tableprefix',
+            // so refusing by exact spelling would refuse a key that configures the store.
+            if (key is null
+                || key.Length <= JobStoreKeyPrefix.Length
+                || !key.StartsWith(JobStoreKeyPrefix, StringComparison.OrdinalIgnoreCase)
+                || IsJobStoreKey(key))
+            {
+                continue;
+            }
+
+            Throw.SchedulerConfigException(
+                $"Unknown configuration property '{key}'. It is not a setting of the ADO.NET job store, "
+                + $"and no other reader consults it. Set '{CheckConfiguration}' to false to allow keys Quartz does not read.");
+        }
+    }
+
+    private static bool IsJobStoreKey(string key)
+    {
+        return IsUnderLockHandler(key) || jobStoreKeys.Contains(key) || typedJobStoreKeys.Contains(key);
+    }
+
+    /// <summary>
+    /// Whether the key is the lock handler's prefix or a key beneath it.
+    /// </summary>
+    /// <remarks>
+    /// The separator is required rather than matching the prefix alone, so that
+    /// <c>quartz.jobStore.lockHandlerType</c> — the dot left out — is the unknown key it is rather than
+    /// something a lock handler will be asked about later.
+    /// </remarks>
+    private static bool IsUnderLockHandler(string key)
+    {
+        return key.StartsWith(JobStoreLockHandlerPrefix, StringComparison.OrdinalIgnoreCase)
+               && (key.Length == JobStoreLockHandlerPrefix.Length || key[JobStoreLockHandlerPrefix.Length] == '.');
     }
 }

--- a/src/Quartz/Configuration/QuartzPropertyBridge.cs
+++ b/src/Quartz/Configuration/QuartzPropertyBridge.cs
@@ -687,6 +687,12 @@ internal static class QuartzPropertyBridge
             value => options.SchemaProvisioning = value ? SchemaProvisioning.Validate : SchemaProvisioning.None);
         parser.Enum<SchemaProvisioning>("quartz.jobStore.schemaProvisioning", value => options.SchemaProvisioning = value);
         parser.String("quartz.jobStore.selectWithLockSQL", value => options.SelectWithLockSql = value);
+
+        // Everything under the prefix has now been read, so anything left is a key nothing reads: refused
+        // by name here rather than starting the store with the default in force and saying nothing. This
+        // runs when the store's options are resolved — the startup validation a persistent store declares,
+        // or the build that constructs the store — and never for a store that reads none of them.
+        LegacyPropertyKeys.ValidateJobStoreKeys(parser.Properties);
     }
 
     /// <summary>
@@ -950,6 +956,11 @@ internal static class QuartzPropertyBridge
         }
 
         private readonly ITypeLoader loader;
+
+        /// <summary>
+        /// The bag itself, for a reader that has to look at every key rather than at one it can name.
+        /// </summary>
+        public NameValueCollection Properties => properties;
 
         public string? String(string key)
         {


### PR DESCRIPTION
`LegacyPropertyKeys.Validate` accepts any key under a supported *prefix*, and `quartz.jobStore` is one,
so a misspelling underneath it was accepted by the check and then consulted by nobody: the ADO.NET store
reads the keys it knows into `AdoJobStoreOptions` and does nothing with the rest. A configuration saying
`quartz.jobStore.dbRetryIntreval` started the scheduler with the default retry interval in force and said
nothing about it, where 3.x wrote every key under the prefix onto the store object by name and failed
startup on one the store had no property for. The same drop takes a key a newer 3.x line adds and 4.x has
not bridged yet, which is how `quartz.jobStore.commandTimeout` went missing until #3766.

## What changed

`LegacyPropertyKeys.ValidateJobStoreKeys` refuses a `quartz.jobStore.*` key nothing reads, and the
ADO.NET store's options mapping calls it once it has read everything it knows:

```text
Unknown configuration property 'quartz.jobStore.dbRetryIntreval'. It is not a setting of the ADO.NET
job store, and no other reader consults it. Set 'quartz.checkConfiguration' to false to allow keys
Quartz does not read.
```

- **It fires where a misconfiguration already fails**, never at first use: the store's options are
  resolved by the startup validation `UsePersistentStore` declares, or by the build that constructs the
  store. A scheduler that reads none of those options — an in-memory one — never reaches the check, and
  a third-party store's leftover keys keep failing exactly where they did, in the binder that writes them
  onto the store by name. Both branches are pinned by tests.
- **`lockHandler.*` and `driverDelegateInitString` keep their own handling**, so neither is refused here.
- **Which keys count** is one table of the keys the bridge's four readers consume, plus the property names
  of `AdoJobStoreOptions` and `ClusteringOptions` taken off the types themselves. The second half is
  needed because a hierarchical `JobStore` section binds onto those options *and* is flattened onto the
  same flat keys: `JobStore:LockWaitWarningThreshold` has no legacy key and is read by the typed binder,
  so its flattened spelling is a key something reads. Taking it off the type means a property added later
  needs no entry anywhere.
- `EveryJobStoreKeyTheReadersConsultIsAcceptedForAnAdoStore` compares the table with the keys the readers
  actually name — through the same IL scan `LegacyPropertyKeyExhaustivenessTest` already uses — so a key
  bridged in the future cannot be refused by accident.
- The documentation says so in three places: the reference's rejected-key section gains
  an *Unknown job store keys* subsection,
  the migration guide's 4.0-to-4.1 behaviour list gains a bullet, and the Multiple Schedulers page stops
  teaching `quartz.jobStore.someThirdPartySetting` on a scheduler whose store the JSON above it names as
  `LocalTransactionJobStore` — that key was accepted and dropped, so the page was teaching this very bug.

No public API change; the baselines are untouched.

## For the reviewer to decide

- **The check is route-agnostic, so it also catches `Quartz:JobStore:TabelPrefix` in `appsettings.json`**
  when the scheduler has a persistent store. `configuration/reference.md` said a misspelling there is
  "read by nobody and reported by nothing" and used that very example; the paragraph now says the job
  store is the exception and the example moves to a scheduler key, which is still silent. That is more
  than the issue asked for, and it is where half the real misspellings live — but it is the one place a
  section key is checked, so say if it should be narrowed to the flat bag instead.
- **Case is not a misspelling here.** A `NameValueCollection` looks keys up case-insensitively, so
  `quartz.jobStore.clusterCheckInInterval` — the issue's second example — reaches the reader today and
  keeps working; the check compares case-insensitively for that reason. It *was* refused on 3.x, where
  the property was found by a case-sensitive reflection lookup.
- **Scope is the ADO.NET store**, as the issue framed it. An in-memory scheduler whose 3.x file still
  carries `quartz.jobStore.tablePrefix` is still accepted and dropped; refusing it here would fail
  configurations 4.0 accepted. Worth its own issue if it should change.
- Four `AdoJobStoreOptions` properties have no legacy key at all (`StoreJobDataAsStrings`,
  `UseBackgroundThreads`, `TransactionIsolationLevel`, `LockWaitWarningThreshold`), so in a *flat* bag
  their typed spellings are tolerated and dropped. Bridging them is a separate change.

Closes #3767

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL8aYk1AC91GhJECfBB5PG
