### PR TITLE
The untagged builds on main say 4.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,7 +54,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <!-- The next release. A tag overrides it, so this is only what an untagged preview of main carries — and 4.0.0-preview-* would sort below the released 4.0.0. -->
-    <VersionPrefix>4.1.0</VersionPrefix>
+    <VersionPrefix>4.2.0</VersionPrefix>
 
     <NoWarn>MA0002;MA0006;MA0011;MA0016;MA0021;MA0025;MA0026;MA0048;MA0049;MA0051;MA0056;MA0064;MA0069;MA0074;MA0077;MA0084;MA0096;MA0097;MA0132;MA0144</NoWarn>
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
v4.1.0 is tagged at c4184eb558; the placeholder `VersionPrefix` an untagged build carries moves past it, as after every release. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL8aYk1AC91GhJECfBB5PG