### PR TITLE
The 3.x line's untagged builds say 3.23

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,7 +26,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
 
-    <VersionPrefix>3.22.0</VersionPrefix>
+    <VersionPrefix>3.23.0</VersionPrefix>
 
     <CLSCompliant>True</CLSCompliant>
     <ComVisible>False</ComVisible>


### PR DESCRIPTION
v3.22.0 is tagged at 0e453e9610; the placeholder `VersionPrefix` an untagged build carries moves past it, as after every release. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KL8aYk1AC91GhJECfBB5PG